### PR TITLE
Add SelectableList and InputField components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-12-31
+
+### Added
+
+- **Component System**: TEA-style composable UI components
+  - `Component` trait for defining reusable components
+  - `Focusable` trait for keyboard focus management
+  - `Toggleable` trait for visibility toggling
+
+- **SelectableList Component**: Generic scrollable list with selection
+  - Keyboard navigation (Up, Down, Home, End, PageUp, PageDown)
+  - Selection tracking with change events
+  - Customizable rendering via `Display` trait
+  - Focusable with visual feedback
+
+- **InputField Component**: Text input with cursor navigation
+  - Character insertion and deletion
+  - Cursor movement (Left, Right, Home, End, word jumps)
+  - Word-level deletion (Ctrl+Backspace, Ctrl+Delete)
+  - Placeholder text support
+  - Unicode support
+  - Submit handling
+
 ## [0.1.0] - 2025-12-29
 
 ### Added
@@ -48,5 +71,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Renders to both a real terminal and CaptureBackend
   - Useful for visual debugging while testing
 
-[Unreleased]: https://github.com/ryanoneill/envision/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/ryanoneill/envision/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/ryanoneill/envision/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/ryanoneill/envision/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envision"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.81"
 description = "A ratatui framework for collaborative TUI development with headless testing support"

--- a/src/component/input_field.rs
+++ b/src/component/input_field.rs
@@ -1,0 +1,738 @@
+//! A text input field component with cursor navigation and editing.
+//!
+//! `InputField` provides a single-line text input with cursor movement,
+//! text insertion, deletion, and selection.
+//!
+//! # Example
+//!
+//! ```rust
+//! use envision::component::{Component, Focusable, InputField, InputFieldState, InputMessage};
+//!
+//! // Create an input field
+//! let mut state = InputField::init();
+//!
+//! // Type some text
+//! InputField::update(&mut state, InputMessage::Insert('H'));
+//! InputField::update(&mut state, InputMessage::Insert('i'));
+//!
+//! assert_eq!(state.value(), "Hi");
+//! assert_eq!(state.cursor_position(), 2);
+//! ```
+
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use super::{Component, Focusable};
+
+/// Messages that can be sent to an InputField.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InputMessage {
+    /// Insert a character at the cursor position.
+    Insert(char),
+    /// Delete the character before the cursor (backspace).
+    Backspace,
+    /// Delete the character at the cursor position.
+    Delete,
+    /// Move cursor left by one character.
+    Left,
+    /// Move cursor right by one character.
+    Right,
+    /// Move cursor to the beginning of the input.
+    Home,
+    /// Move cursor to the end of the input.
+    End,
+    /// Move cursor left by one word.
+    WordLeft,
+    /// Move cursor right by one word.
+    WordRight,
+    /// Delete from cursor to beginning of word.
+    DeleteWordBack,
+    /// Delete from cursor to end of word.
+    DeleteWordForward,
+    /// Clear the entire input.
+    Clear,
+    /// Set the entire input value.
+    SetValue(String),
+    /// Submit the current value.
+    Submit,
+}
+
+/// Output messages from an InputField.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InputOutput {
+    /// The value was submitted (e.g., Enter pressed).
+    Submitted(String),
+    /// The value changed.
+    Changed(String),
+}
+
+/// State for an InputField component.
+#[derive(Clone, Debug, Default)]
+pub struct InputFieldState {
+    /// The current text value.
+    value: String,
+    /// Cursor position (byte offset into value).
+    cursor: usize,
+    /// Whether the input is focused.
+    focused: bool,
+    /// Placeholder text shown when empty.
+    placeholder: String,
+}
+
+impl InputFieldState {
+    /// Creates a new state with the given initial value.
+    pub fn with_value(value: impl Into<String>) -> Self {
+        let value = value.into();
+        let cursor = value.len();
+        Self {
+            value,
+            cursor,
+            focused: false,
+            placeholder: String::new(),
+        }
+    }
+
+    /// Creates a new state with placeholder text.
+    pub fn with_placeholder(placeholder: impl Into<String>) -> Self {
+        Self {
+            placeholder: placeholder.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Returns the current value.
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    /// Sets the value and moves cursor to the end.
+    pub fn set_value(&mut self, value: impl Into<String>) {
+        self.value = value.into();
+        self.cursor = self.value.len();
+    }
+
+    /// Returns the cursor position (character index).
+    pub fn cursor_position(&self) -> usize {
+        self.value[..self.cursor].chars().count()
+    }
+
+    /// Returns the cursor byte offset.
+    pub fn cursor_byte_offset(&self) -> usize {
+        self.cursor
+    }
+
+    /// Sets the placeholder text.
+    pub fn set_placeholder(&mut self, placeholder: impl Into<String>) {
+        self.placeholder = placeholder.into();
+    }
+
+    /// Returns the placeholder text.
+    pub fn placeholder(&self) -> &str {
+        &self.placeholder
+    }
+
+    /// Returns true if the input is empty.
+    pub fn is_empty(&self) -> bool {
+        self.value.is_empty()
+    }
+
+    /// Returns the number of characters in the input.
+    pub fn len(&self) -> usize {
+        self.value.chars().count()
+    }
+
+    /// Moves cursor to the given character position.
+    pub fn set_cursor(&mut self, char_pos: usize) {
+        let char_count = self.value.chars().count();
+        let clamped = char_pos.min(char_count);
+        self.cursor = self
+            .value
+            .char_indices()
+            .nth(clamped)
+            .map(|(i, _)| i)
+            .unwrap_or(self.value.len());
+    }
+
+    /// Move cursor left by one character.
+    fn move_left(&mut self) {
+        if self.cursor > 0 {
+            // Find the previous character boundary
+            self.cursor = self.value[..self.cursor]
+                .char_indices()
+                .last()
+                .map(|(i, _)| i)
+                .unwrap_or(0);
+        }
+    }
+
+    /// Move cursor right by one character.
+    fn move_right(&mut self) {
+        if self.cursor < self.value.len() {
+            // Find the next character boundary
+            self.cursor = self.value[self.cursor..]
+                .char_indices()
+                .nth(1)
+                .map(|(i, _)| self.cursor + i)
+                .unwrap_or(self.value.len());
+        }
+    }
+
+    /// Move cursor to the start of the previous word.
+    fn move_word_left(&mut self) {
+        if self.cursor == 0 {
+            return;
+        }
+
+        let before = &self.value[..self.cursor];
+        let chars: Vec<(usize, char)> = before.char_indices().collect();
+
+        // Skip trailing whitespace
+        let mut idx = chars.len() - 1;
+        while idx > 0 && chars[idx].1.is_whitespace() {
+            idx -= 1;
+        }
+
+        // Skip word characters
+        while idx > 0 && !chars[idx - 1].1.is_whitespace() {
+            idx -= 1;
+        }
+
+        self.cursor = chars.get(idx).map(|(i, _)| *i).unwrap_or(0);
+    }
+
+    /// Move cursor to the end of the next word.
+    fn move_word_right(&mut self) {
+        if self.cursor >= self.value.len() {
+            return;
+        }
+
+        let after = &self.value[self.cursor..];
+        let chars: Vec<(usize, char)> = after.char_indices().collect();
+
+        // Skip leading non-whitespace
+        let mut idx = 0;
+        while idx < chars.len() && !chars[idx].1.is_whitespace() {
+            idx += 1;
+        }
+
+        // Skip whitespace
+        while idx < chars.len() && chars[idx].1.is_whitespace() {
+            idx += 1;
+        }
+
+        self.cursor = chars
+            .get(idx)
+            .map(|(i, _)| self.cursor + *i)
+            .unwrap_or(self.value.len());
+    }
+
+    /// Insert a character at the cursor position.
+    fn insert(&mut self, c: char) {
+        self.value.insert(self.cursor, c);
+        self.cursor += c.len_utf8();
+    }
+
+    /// Delete the character before the cursor.
+    fn backspace(&mut self) -> bool {
+        if self.cursor > 0 {
+            let prev_cursor = self.cursor;
+            self.move_left();
+            self.value.drain(self.cursor..prev_cursor);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Delete the character at the cursor.
+    fn delete(&mut self) -> bool {
+        if self.cursor < self.value.len() {
+            let next = self.value[self.cursor..]
+                .char_indices()
+                .nth(1)
+                .map(|(i, _)| self.cursor + i)
+                .unwrap_or(self.value.len());
+            self.value.drain(self.cursor..next);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Delete from cursor back to start of word.
+    fn delete_word_back(&mut self) -> bool {
+        if self.cursor == 0 {
+            return false;
+        }
+
+        let end = self.cursor;
+        self.move_word_left();
+        self.value.drain(self.cursor..end);
+        true
+    }
+
+    /// Delete from cursor forward to end of word.
+    fn delete_word_forward(&mut self) -> bool {
+        if self.cursor >= self.value.len() {
+            return false;
+        }
+
+        let start = self.cursor;
+        self.move_word_right();
+        let end = self.cursor;
+        self.cursor = start;
+        self.value.drain(start..end);
+        true
+    }
+}
+
+/// A text input field component.
+///
+/// This component provides a single-line text input with cursor navigation
+/// and editing capabilities.
+///
+/// # Navigation
+///
+/// - `Left` / `Right` - Move cursor by one character
+/// - `Home` / `End` - Jump to beginning/end
+/// - `WordLeft` / `WordRight` - Move by word
+///
+/// # Editing
+///
+/// - `Insert(char)` - Insert a character
+/// - `Backspace` - Delete before cursor
+/// - `Delete` - Delete at cursor
+/// - `DeleteWordBack` / `DeleteWordForward` - Delete by word
+/// - `Clear` - Clear all text
+/// - `SetValue(String)` - Replace all text
+pub struct InputField;
+
+impl Component for InputField {
+    type State = InputFieldState;
+    type Message = InputMessage;
+    type Output = InputOutput;
+
+    fn init() -> Self::State {
+        InputFieldState::default()
+    }
+
+    fn update(state: &mut Self::State, msg: Self::Message) -> Option<Self::Output> {
+        match msg {
+            InputMessage::Insert(c) => {
+                state.insert(c);
+                Some(InputOutput::Changed(state.value.clone()))
+            }
+            InputMessage::Backspace => {
+                if state.backspace() {
+                    Some(InputOutput::Changed(state.value.clone()))
+                } else {
+                    None
+                }
+            }
+            InputMessage::Delete => {
+                if state.delete() {
+                    Some(InputOutput::Changed(state.value.clone()))
+                } else {
+                    None
+                }
+            }
+            InputMessage::Left => {
+                state.move_left();
+                None
+            }
+            InputMessage::Right => {
+                state.move_right();
+                None
+            }
+            InputMessage::Home => {
+                state.cursor = 0;
+                None
+            }
+            InputMessage::End => {
+                state.cursor = state.value.len();
+                None
+            }
+            InputMessage::WordLeft => {
+                state.move_word_left();
+                None
+            }
+            InputMessage::WordRight => {
+                state.move_word_right();
+                None
+            }
+            InputMessage::DeleteWordBack => {
+                if state.delete_word_back() {
+                    Some(InputOutput::Changed(state.value.clone()))
+                } else {
+                    None
+                }
+            }
+            InputMessage::DeleteWordForward => {
+                if state.delete_word_forward() {
+                    Some(InputOutput::Changed(state.value.clone()))
+                } else {
+                    None
+                }
+            }
+            InputMessage::Clear => {
+                if !state.value.is_empty() {
+                    state.value.clear();
+                    state.cursor = 0;
+                    Some(InputOutput::Changed(state.value.clone()))
+                } else {
+                    None
+                }
+            }
+            InputMessage::SetValue(value) => {
+                if state.value != value {
+                    state.set_value(value);
+                    Some(InputOutput::Changed(state.value.clone()))
+                } else {
+                    None
+                }
+            }
+            InputMessage::Submit => Some(InputOutput::Submitted(state.value.clone())),
+        }
+    }
+
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect) {
+        let display_text = if state.value.is_empty() && !state.placeholder.is_empty() {
+            state.placeholder.clone()
+        } else {
+            state.value.clone()
+        };
+
+        let style = if state.focused {
+            Style::default().fg(Color::Yellow)
+        } else if state.value.is_empty() && !state.placeholder.is_empty() {
+            Style::default().fg(Color::DarkGray)
+        } else {
+            Style::default()
+        };
+
+        let border_style = if state.focused {
+            Style::default().fg(Color::Yellow)
+        } else {
+            Style::default()
+        };
+
+        let paragraph = Paragraph::new(display_text).style(style).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(border_style),
+        );
+
+        frame.render_widget(paragraph, area);
+
+        // Show cursor when focused
+        if state.focused && area.width > 2 && area.height > 2 {
+            // Calculate cursor x position (accounting for border)
+            let cursor_x = area.x + 1 + state.cursor_position() as u16;
+            let cursor_y = area.y + 1;
+
+            // Only show cursor if it's within the visible area
+            if cursor_x < area.x + area.width - 1 {
+                frame.set_cursor_position((cursor_x, cursor_y));
+            }
+        }
+    }
+}
+
+impl Focusable for InputField {
+    fn is_focused(state: &Self::State) -> bool {
+        state.focused
+    }
+
+    fn set_focused(state: &mut Self::State, focused: bool) {
+        state.focused = focused;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_init() {
+        let state = InputField::init();
+        assert!(state.is_empty());
+        assert_eq!(state.value(), "");
+        assert_eq!(state.cursor_position(), 0);
+    }
+
+    #[test]
+    fn test_with_value() {
+        let state = InputFieldState::with_value("hello");
+        assert_eq!(state.value(), "hello");
+        assert_eq!(state.cursor_position(), 5);
+    }
+
+    #[test]
+    fn test_with_placeholder() {
+        let state = InputFieldState::with_placeholder("Enter text...");
+        assert_eq!(state.placeholder(), "Enter text...");
+        assert!(state.is_empty());
+    }
+
+    #[test]
+    fn test_insert_char() {
+        let mut state = InputField::init();
+
+        let output = InputField::update(&mut state, InputMessage::Insert('a'));
+        assert_eq!(state.value(), "a");
+        assert_eq!(state.cursor_position(), 1);
+        assert_eq!(output, Some(InputOutput::Changed("a".to_string())));
+
+        InputField::update(&mut state, InputMessage::Insert('b'));
+        assert_eq!(state.value(), "ab");
+        assert_eq!(state.cursor_position(), 2);
+    }
+
+    #[test]
+    fn test_insert_unicode() {
+        let mut state = InputField::init();
+
+        InputField::update(&mut state, InputMessage::Insert('日'));
+        InputField::update(&mut state, InputMessage::Insert('本'));
+        assert_eq!(state.value(), "日本");
+        assert_eq!(state.cursor_position(), 2);
+        assert_eq!(state.len(), 2);
+    }
+
+    #[test]
+    fn test_backspace() {
+        let mut state = InputFieldState::with_value("abc");
+
+        let output = InputField::update(&mut state, InputMessage::Backspace);
+        assert_eq!(state.value(), "ab");
+        assert_eq!(output, Some(InputOutput::Changed("ab".to_string())));
+
+        InputField::update(&mut state, InputMessage::Backspace);
+        InputField::update(&mut state, InputMessage::Backspace);
+        assert_eq!(state.value(), "");
+
+        // Backspace on empty should return None
+        let output = InputField::update(&mut state, InputMessage::Backspace);
+        assert_eq!(output, None);
+    }
+
+    #[test]
+    fn test_delete() {
+        let mut state = InputFieldState::with_value("abc");
+        state.set_cursor(0);
+
+        let output = InputField::update(&mut state, InputMessage::Delete);
+        assert_eq!(state.value(), "bc");
+        assert_eq!(output, Some(InputOutput::Changed("bc".to_string())));
+
+        // Move to end and delete should return None
+        state.cursor = state.value.len();
+        let output = InputField::update(&mut state, InputMessage::Delete);
+        assert_eq!(output, None);
+    }
+
+    #[test]
+    fn test_cursor_movement() {
+        let mut state = InputFieldState::with_value("hello");
+
+        InputField::update(&mut state, InputMessage::Left);
+        assert_eq!(state.cursor_position(), 4);
+
+        InputField::update(&mut state, InputMessage::Left);
+        assert_eq!(state.cursor_position(), 3);
+
+        InputField::update(&mut state, InputMessage::Right);
+        assert_eq!(state.cursor_position(), 4);
+
+        InputField::update(&mut state, InputMessage::Home);
+        assert_eq!(state.cursor_position(), 0);
+
+        InputField::update(&mut state, InputMessage::End);
+        assert_eq!(state.cursor_position(), 5);
+    }
+
+    #[test]
+    fn test_cursor_bounds() {
+        let mut state = InputFieldState::with_value("hi");
+
+        // Can't go left past beginning
+        state.set_cursor(0);
+        InputField::update(&mut state, InputMessage::Left);
+        assert_eq!(state.cursor_position(), 0);
+
+        // Can't go right past end
+        state.set_cursor(10); // Over the length
+        assert_eq!(state.cursor_position(), 2); // Clamped
+        InputField::update(&mut state, InputMessage::Right);
+        assert_eq!(state.cursor_position(), 2);
+    }
+
+    #[test]
+    fn test_word_navigation() {
+        let mut state = InputFieldState::with_value("hello world test");
+
+        // Start at end
+        InputField::update(&mut state, InputMessage::WordLeft);
+        assert_eq!(state.cursor_position(), 12); // Start of "test"
+
+        InputField::update(&mut state, InputMessage::WordLeft);
+        assert_eq!(state.cursor_position(), 6); // Start of "world"
+
+        InputField::update(&mut state, InputMessage::WordLeft);
+        assert_eq!(state.cursor_position(), 0); // Start of "hello"
+
+        InputField::update(&mut state, InputMessage::WordRight);
+        assert_eq!(state.cursor_position(), 6); // After "hello "
+
+        InputField::update(&mut state, InputMessage::WordRight);
+        assert_eq!(state.cursor_position(), 12); // After "world "
+    }
+
+    #[test]
+    fn test_delete_word_back() {
+        let mut state = InputFieldState::with_value("hello world");
+
+        let output = InputField::update(&mut state, InputMessage::DeleteWordBack);
+        assert_eq!(state.value(), "hello ");
+        assert_eq!(output, Some(InputOutput::Changed("hello ".to_string())));
+
+        InputField::update(&mut state, InputMessage::DeleteWordBack);
+        assert_eq!(state.value(), "");
+
+        // Delete word back on empty
+        let output = InputField::update(&mut state, InputMessage::DeleteWordBack);
+        assert_eq!(output, None);
+    }
+
+    #[test]
+    fn test_delete_word_forward() {
+        let mut state = InputFieldState::with_value("hello world");
+        state.set_cursor(0);
+
+        let output = InputField::update(&mut state, InputMessage::DeleteWordForward);
+        assert_eq!(state.value(), "world");
+        assert_eq!(output, Some(InputOutput::Changed("world".to_string())));
+
+        // Cursor at end
+        state.cursor = state.value.len();
+        let output = InputField::update(&mut state, InputMessage::DeleteWordForward);
+        assert_eq!(output, None);
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut state = InputFieldState::with_value("hello");
+
+        let output = InputField::update(&mut state, InputMessage::Clear);
+        assert_eq!(state.value(), "");
+        assert_eq!(state.cursor_position(), 0);
+        assert_eq!(output, Some(InputOutput::Changed("".to_string())));
+
+        // Clear empty should return None
+        let output = InputField::update(&mut state, InputMessage::Clear);
+        assert_eq!(output, None);
+    }
+
+    #[test]
+    fn test_set_value() {
+        let mut state = InputField::init();
+
+        let output =
+            InputField::update(&mut state, InputMessage::SetValue("new value".to_string()));
+        assert_eq!(state.value(), "new value");
+        assert_eq!(state.cursor_position(), 9);
+        assert_eq!(output, Some(InputOutput::Changed("new value".to_string())));
+
+        // Setting same value returns None
+        let output =
+            InputField::update(&mut state, InputMessage::SetValue("new value".to_string()));
+        assert_eq!(output, None);
+    }
+
+    #[test]
+    fn test_submit() {
+        let mut state = InputFieldState::with_value("submitted text");
+
+        let output = InputField::update(&mut state, InputMessage::Submit);
+        assert_eq!(
+            output,
+            Some(InputOutput::Submitted("submitted text".to_string()))
+        );
+        // Value should remain unchanged
+        assert_eq!(state.value(), "submitted text");
+    }
+
+    #[test]
+    fn test_insert_at_cursor() {
+        let mut state = InputFieldState::with_value("helo");
+        state.set_cursor(3);
+
+        InputField::update(&mut state, InputMessage::Insert('l'));
+        assert_eq!(state.value(), "hello");
+        assert_eq!(state.cursor_position(), 4);
+    }
+
+    #[test]
+    fn test_focusable() {
+        let mut state = InputField::init();
+
+        assert!(!InputField::is_focused(&state));
+
+        InputField::set_focused(&mut state, true);
+        assert!(InputField::is_focused(&state));
+
+        InputField::blur(&mut state);
+        assert!(!InputField::is_focused(&state));
+    }
+
+    #[test]
+    fn test_len() {
+        let state = InputFieldState::with_value("hello");
+        assert_eq!(state.len(), 5);
+
+        let state = InputFieldState::with_value("日本語");
+        assert_eq!(state.len(), 3);
+    }
+
+    #[test]
+    fn test_view() {
+        use crate::backend::CaptureBackend;
+        use ratatui::Terminal;
+
+        let mut state = InputFieldState::with_value("Hello");
+        state.focused = true;
+
+        let backend = CaptureBackend::new(40, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal
+            .draw(|frame| {
+                InputField::view(&state, frame, frame.area());
+            })
+            .unwrap();
+
+        let output = terminal.backend().to_string();
+        assert!(output.contains("Hello"));
+    }
+
+    #[test]
+    fn test_view_placeholder() {
+        use crate::backend::CaptureBackend;
+        use ratatui::Terminal;
+
+        let mut state = InputField::init();
+        state.set_placeholder("Enter text...");
+
+        let backend = CaptureBackend::new(40, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal
+            .draw(|frame| {
+                InputField::view(&state, frame, frame.area());
+            })
+            .unwrap();
+
+        let output = terminal.backend().to_string();
+        assert!(output.contains("Enter text..."));
+    }
+}

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -13,6 +13,11 @@
 //! - [`Focusable`]: Components that can receive keyboard focus
 //! - [`Toggleable`]: Components that can be shown or hidden
 //!
+//! # Built-in Components
+//!
+//! - [`SelectableList`]: A scrollable list with keyboard navigation
+//! - [`InputField`]: A text input field with cursor navigation
+//!
 //! # Component vs App
 //!
 //! | Aspect | App | Component |
@@ -91,6 +96,12 @@
 //! ```
 
 use ratatui::prelude::*;
+
+mod input_field;
+mod selectable_list;
+
+pub use input_field::{InputField, InputFieldState, InputMessage, InputOutput};
+pub use selectable_list::{ListMessage, ListOutput, SelectableList, SelectableListState};
 
 /// A composable UI component with its own state and message handling.
 ///

--- a/src/component/selectable_list.rs
+++ b/src/component/selectable_list.rs
@@ -1,0 +1,458 @@
+//! A generic selectable list component with keyboard navigation.
+//!
+//! `SelectableList` provides a scrollable list of items with selection
+//! tracking and keyboard navigation (vim-style and arrow keys).
+//!
+//! # Example
+//!
+//! ```rust
+//! use envision::component::{Component, Focusable, ListMessage, SelectableList, SelectableListState};
+//!
+//! // Create a list of items
+//! let mut state = SelectableList::<String>::init();
+//! state.set_items(vec!["Item 1".into(), "Item 2".into(), "Item 3".into()]);
+//!
+//! // Navigate down
+//! SelectableList::<String>::update(&mut state, ListMessage::Down);
+//! assert_eq!(state.selected_index(), Some(1));
+//!
+//! // Get selected item
+//! assert_eq!(state.selected_item(), Some(&"Item 2".into()));
+//! ```
+
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
+
+use super::{Component, Focusable};
+
+/// Messages that can be sent to a SelectableList.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ListMessage {
+    /// Move selection up by one.
+    Up,
+    /// Move selection down by one.
+    Down,
+    /// Move selection to the first item.
+    First,
+    /// Move selection to the last item.
+    Last,
+    /// Move selection up by a page.
+    PageUp(usize),
+    /// Move selection down by a page.
+    PageDown(usize),
+    /// Select the current item (triggers output).
+    Select,
+}
+
+/// Output messages from a SelectableList.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ListOutput<T: Clone> {
+    /// An item was selected (e.g., Enter pressed).
+    Selected(T),
+    /// The selection changed to a new index.
+    SelectionChanged(usize),
+}
+
+/// State for a SelectableList component.
+#[derive(Clone, Debug)]
+pub struct SelectableListState<T: Clone> {
+    items: Vec<T>,
+    list_state: ListState,
+    focused: bool,
+}
+
+impl<T: Clone> Default for SelectableListState<T> {
+    fn default() -> Self {
+        Self {
+            items: Vec::new(),
+            list_state: ListState::default(),
+            focused: false,
+        }
+    }
+}
+
+impl<T: Clone> SelectableListState<T> {
+    /// Creates a new state with the given items.
+    pub fn with_items(items: Vec<T>) -> Self {
+        let mut state = Self {
+            items,
+            list_state: ListState::default(),
+            focused: false,
+        };
+        if !state.items.is_empty() {
+            state.list_state.select(Some(0));
+        }
+        state
+    }
+
+    /// Returns a reference to the items.
+    pub fn items(&self) -> &[T] {
+        &self.items
+    }
+
+    /// Sets the items, resetting selection to the first item if any.
+    pub fn set_items(&mut self, items: Vec<T>) {
+        self.items = items;
+        if self.items.is_empty() {
+            self.list_state.select(None);
+        } else {
+            let current = self.list_state.selected().unwrap_or(0);
+            let new_index = current.min(self.items.len().saturating_sub(1));
+            self.list_state.select(Some(new_index));
+        }
+    }
+
+    /// Returns the currently selected index.
+    pub fn selected_index(&self) -> Option<usize> {
+        self.list_state.selected()
+    }
+
+    /// Returns a reference to the currently selected item.
+    pub fn selected_item(&self) -> Option<&T> {
+        self.list_state.selected().and_then(|i| self.items.get(i))
+    }
+
+    /// Selects the item at the given index.
+    pub fn select(&mut self, index: Option<usize>) {
+        match index {
+            Some(i) if i < self.items.len() => self.list_state.select(Some(i)),
+            Some(_) => {} // Index out of bounds, ignore
+            None => self.list_state.select(None),
+        }
+    }
+
+    /// Returns true if the list is empty.
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// Returns the number of items in the list.
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Returns a mutable reference to the internal ListState for rendering.
+    pub fn list_state_mut(&mut self) -> &mut ListState {
+        &mut self.list_state
+    }
+}
+
+/// A generic selectable list component.
+///
+/// This component provides a scrollable list with keyboard navigation.
+/// It's generic over the item type `T`, which must be `Clone`.
+///
+/// # Navigation
+///
+/// - `Up` / `Down` - Move selection by one
+/// - `First` / `Last` - Jump to beginning/end
+/// - `PageUp` / `PageDown` - Move by page size
+/// - `Select` - Emit the selected item
+pub struct SelectableList<T: Clone>(std::marker::PhantomData<T>);
+
+impl<T: Clone + std::fmt::Display + 'static> Component for SelectableList<T> {
+    type State = SelectableListState<T>;
+    type Message = ListMessage;
+    type Output = ListOutput<T>;
+
+    fn init() -> Self::State {
+        SelectableListState::default()
+    }
+
+    fn update(state: &mut Self::State, msg: Self::Message) -> Option<Self::Output> {
+        if state.items.is_empty() {
+            return None;
+        }
+
+        let len = state.items.len();
+        let current = state.list_state.selected().unwrap_or(0);
+
+        match msg {
+            ListMessage::Up => {
+                let new_index = current.saturating_sub(1);
+                if new_index != current {
+                    state.list_state.select(Some(new_index));
+                    return Some(ListOutput::SelectionChanged(new_index));
+                }
+            }
+            ListMessage::Down => {
+                let new_index = (current + 1).min(len - 1);
+                if new_index != current {
+                    state.list_state.select(Some(new_index));
+                    return Some(ListOutput::SelectionChanged(new_index));
+                }
+            }
+            ListMessage::First => {
+                if current != 0 {
+                    state.list_state.select(Some(0));
+                    return Some(ListOutput::SelectionChanged(0));
+                }
+            }
+            ListMessage::Last => {
+                let last = len - 1;
+                if current != last {
+                    state.list_state.select(Some(last));
+                    return Some(ListOutput::SelectionChanged(last));
+                }
+            }
+            ListMessage::PageUp(page_size) => {
+                let new_index = current.saturating_sub(page_size);
+                if new_index != current {
+                    state.list_state.select(Some(new_index));
+                    return Some(ListOutput::SelectionChanged(new_index));
+                }
+            }
+            ListMessage::PageDown(page_size) => {
+                let new_index = (current + page_size).min(len - 1);
+                if new_index != current {
+                    state.list_state.select(Some(new_index));
+                    return Some(ListOutput::SelectionChanged(new_index));
+                }
+            }
+            ListMessage::Select => {
+                if let Some(item) = state.items.get(current).cloned() {
+                    return Some(ListOutput::Selected(item));
+                }
+            }
+        }
+
+        None
+    }
+
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect) {
+        // Default view uses Display trait - users can implement custom rendering
+        let items: Vec<ListItem> = state
+            .items
+            .iter()
+            .map(|item| ListItem::new(format!("{}", item)))
+            .collect();
+
+        let highlight_style = if state.focused {
+            Style::default()
+                .bg(Color::Blue)
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().bg(Color::DarkGray).fg(Color::White)
+        };
+
+        let list = List::new(items)
+            .block(Block::default().borders(Borders::ALL))
+            .highlight_style(highlight_style)
+            .highlight_symbol("> ");
+
+        // We need to clone the state for rendering since StatefulWidget needs &mut
+        let mut list_state = state.list_state.clone();
+        frame.render_stateful_widget(list, area, &mut list_state);
+    }
+}
+
+impl<T: Clone + std::fmt::Display + 'static> Focusable for SelectableList<T> {
+    fn is_focused(state: &Self::State) -> bool {
+        state.focused
+    }
+
+    fn set_focused(state: &mut Self::State, focused: bool) {
+        state.focused = focused;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_init_empty() {
+        let state = SelectableList::<String>::init();
+        assert!(state.is_empty());
+        assert_eq!(state.selected_index(), None);
+        assert_eq!(state.selected_item(), None);
+    }
+
+    #[test]
+    fn test_with_items() {
+        let state = SelectableListState::with_items(vec!["a", "b", "c"]);
+        assert_eq!(state.len(), 3);
+        assert_eq!(state.selected_index(), Some(0));
+        assert_eq!(state.selected_item(), Some(&"a"));
+    }
+
+    #[test]
+    fn test_set_items() {
+        let mut state = SelectableList::<String>::init();
+        state.set_items(vec!["x".into(), "y".into()]);
+        assert_eq!(state.len(), 2);
+        assert_eq!(state.selected_index(), Some(0));
+    }
+
+    #[test]
+    fn test_set_items_preserves_selection() {
+        let mut state = SelectableListState::with_items(vec!["a", "b", "c"]);
+        state.select(Some(1));
+        state.set_items(vec!["x", "y", "z", "w"]);
+        // Selection should be preserved at index 1
+        assert_eq!(state.selected_index(), Some(1));
+    }
+
+    #[test]
+    fn test_set_items_clamps_selection() {
+        let mut state = SelectableListState::with_items(vec!["a", "b", "c"]);
+        state.select(Some(2));
+        state.set_items(vec!["x"]); // Only one item now
+                                    // Selection should be clamped to last valid index
+        assert_eq!(state.selected_index(), Some(0));
+    }
+
+    #[test]
+    fn test_navigate_down() {
+        let mut state = SelectableListState::with_items(vec!["a", "b", "c"]);
+
+        let output = SelectableList::<&str>::update(&mut state, ListMessage::Down);
+        assert_eq!(state.selected_index(), Some(1));
+        assert_eq!(output, Some(ListOutput::SelectionChanged(1)));
+
+        let output = SelectableList::<&str>::update(&mut state, ListMessage::Down);
+        assert_eq!(state.selected_index(), Some(2));
+        assert_eq!(output, Some(ListOutput::SelectionChanged(2)));
+
+        // At the end, should stay at last item
+        let output = SelectableList::<&str>::update(&mut state, ListMessage::Down);
+        assert_eq!(state.selected_index(), Some(2));
+        assert_eq!(output, None);
+    }
+
+    #[test]
+    fn test_navigate_up() {
+        let mut state = SelectableListState::with_items(vec!["a", "b", "c"]);
+        state.select(Some(2));
+
+        let output = SelectableList::<&str>::update(&mut state, ListMessage::Up);
+        assert_eq!(state.selected_index(), Some(1));
+        assert_eq!(output, Some(ListOutput::SelectionChanged(1)));
+
+        let output = SelectableList::<&str>::update(&mut state, ListMessage::Up);
+        assert_eq!(state.selected_index(), Some(0));
+        assert_eq!(output, Some(ListOutput::SelectionChanged(0)));
+
+        // At the beginning, should stay at first item
+        let output = SelectableList::<&str>::update(&mut state, ListMessage::Up);
+        assert_eq!(state.selected_index(), Some(0));
+        assert_eq!(output, None);
+    }
+
+    #[test]
+    fn test_navigate_first_last() {
+        let mut state = SelectableListState::with_items(vec!["a", "b", "c", "d", "e"]);
+        state.select(Some(2));
+
+        let output = SelectableList::<&str>::update(&mut state, ListMessage::Last);
+        assert_eq!(state.selected_index(), Some(4));
+        assert_eq!(output, Some(ListOutput::SelectionChanged(4)));
+
+        let output = SelectableList::<&str>::update(&mut state, ListMessage::First);
+        assert_eq!(state.selected_index(), Some(0));
+        assert_eq!(output, Some(ListOutput::SelectionChanged(0)));
+    }
+
+    #[test]
+    fn test_page_navigation() {
+        let mut state = SelectableListState::with_items(vec!["a", "b", "c", "d", "e", "f", "g"]);
+
+        let output = SelectableList::<&str>::update(&mut state, ListMessage::PageDown(3));
+        assert_eq!(state.selected_index(), Some(3));
+        assert_eq!(output, Some(ListOutput::SelectionChanged(3)));
+
+        let output = SelectableList::<&str>::update(&mut state, ListMessage::PageDown(10));
+        assert_eq!(state.selected_index(), Some(6)); // Clamped to last
+        assert_eq!(output, Some(ListOutput::SelectionChanged(6)));
+
+        let output = SelectableList::<&str>::update(&mut state, ListMessage::PageUp(4));
+        assert_eq!(state.selected_index(), Some(2));
+        assert_eq!(output, Some(ListOutput::SelectionChanged(2)));
+    }
+
+    #[test]
+    fn test_select() {
+        let mut state = SelectableListState::with_items(vec!["a", "b", "c"]);
+        state.select(Some(1));
+
+        let output = SelectableList::<&str>::update(&mut state, ListMessage::Select);
+        assert_eq!(output, Some(ListOutput::Selected("b")));
+    }
+
+    #[test]
+    fn test_empty_list_navigation() {
+        let mut state = SelectableList::<String>::init();
+
+        assert_eq!(
+            SelectableList::<String>::update(&mut state, ListMessage::Down),
+            None
+        );
+        assert_eq!(
+            SelectableList::<String>::update(&mut state, ListMessage::Up),
+            None
+        );
+        assert_eq!(
+            SelectableList::<String>::update(&mut state, ListMessage::Select),
+            None
+        );
+    }
+
+    #[test]
+    fn test_focusable() {
+        let mut state = SelectableList::<String>::init();
+
+        assert!(!SelectableList::<String>::is_focused(&state));
+
+        SelectableList::<String>::set_focused(&mut state, true);
+        assert!(SelectableList::<String>::is_focused(&state));
+
+        SelectableList::<String>::blur(&mut state);
+        assert!(!SelectableList::<String>::is_focused(&state));
+    }
+
+    #[test]
+    fn test_select_method() {
+        let mut state = SelectableListState::with_items(vec!["a", "b", "c"]);
+
+        state.select(Some(2));
+        assert_eq!(state.selected_index(), Some(2));
+
+        state.select(None);
+        assert_eq!(state.selected_index(), None);
+
+        // Out of bounds should be ignored
+        state.select(Some(0));
+        state.select(Some(100));
+        assert_eq!(state.selected_index(), Some(0));
+    }
+
+    #[test]
+    fn test_items_accessor() {
+        let state = SelectableListState::with_items(vec![1, 2, 3]);
+        assert_eq!(state.items(), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn test_view() {
+        use crate::backend::CaptureBackend;
+        use ratatui::Terminal;
+
+        let mut state = SelectableListState::with_items(vec!["Item 1", "Item 2", "Item 3"]);
+        state.focused = true;
+
+        let backend = CaptureBackend::new(40, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal
+            .draw(|frame| {
+                SelectableList::<&str>::view(&state, frame, frame.area());
+            })
+            .unwrap();
+
+        let output = terminal.backend().to_string();
+        assert!(output.contains("Item 1"));
+        assert!(output.contains("Item 2"));
+        assert!(output.contains("Item 3"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,10 @@ pub use app::{
     TickSubscription, TimerSubscription,
 };
 pub use backend::{CaptureBackend, EnhancedCell, FrameSnapshot};
-pub use component::{Component, Focusable, Toggleable};
+pub use component::{
+    Component, Focusable, InputField, InputFieldState, InputMessage, InputOutput, ListMessage,
+    ListOutput, SelectableList, SelectableListState, Toggleable,
+};
 pub use harness::{Assertion, AsyncTestHarness, Snapshot, TestHarness};
 pub use input::{EventQueue, SimulatedEvent};
 
@@ -80,7 +83,10 @@ pub mod prelude {
         RuntimeConfig, Subscription, SubscriptionExt, TickSubscription, TimerSubscription, Update,
     };
     pub use crate::backend::{CaptureBackend, EnhancedCell, FrameSnapshot, OutputFormat};
-    pub use crate::component::{Component, Focusable, Toggleable};
+    pub use crate::component::{
+        Component, Focusable, InputField, InputFieldState, InputMessage, InputOutput, ListMessage,
+        ListOutput, SelectableList, SelectableListState, Toggleable,
+    };
     pub use crate::harness::{
         Assertion, AssertionError, AsyncTestHarness, Snapshot, SnapshotFormat, TestHarness,
     };


### PR DESCRIPTION
## Summary

- Adds `SelectableList<T>` component for scrollable lists with keyboard navigation
- Adds `InputField` component for text input with cursor navigation
- Bumps version to 0.2.0

### SelectableList Features
- Generic over item type (requires `Clone + Display`)
- Navigation: Up, Down, First, Last, PageUp, PageDown
- Selection tracking with `SelectionChanged` and `Selected` output events
- Focusable with visual feedback

### InputField Features
- Character insertion and deletion
- Cursor movement (Left, Right, Home, End, word jumps)
- Word-level deletion (Ctrl+Backspace, Ctrl+Delete)
- Placeholder text support
- Unicode support

## Test plan
- [x] All component tests pass (49 tests)
- [x] Full test suite passes (621 tests)
- [x] Clippy passes
- [x] Formatting passes
- [x] Doc tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)