### PR TITLE
Add comprehensive tests to improve code coverage

### DIFF
--- a/src/component/selectable_list.rs
+++ b/src/component/selectable_list.rs
@@ -434,6 +434,76 @@ mod tests {
     }
 
     #[test]
+    fn test_set_items_to_empty() {
+        let mut state = SelectableListState::with_items(vec!["a", "b", "c"]);
+        assert_eq!(state.selected_index(), Some(0));
+
+        // Set items to empty list
+        state.set_items(vec![]);
+        assert!(state.is_empty());
+        assert_eq!(state.selected_index(), None);
+        assert_eq!(state.selected_item(), None);
+    }
+
+    #[test]
+    fn test_list_state_mut() {
+        let mut state = SelectableListState::with_items(vec!["a", "b", "c"]);
+
+        // Access and modify the internal list state
+        let list_state = state.list_state_mut();
+        list_state.select(Some(2));
+
+        assert_eq!(state.selected_index(), Some(2));
+    }
+
+    #[test]
+    fn test_first_when_already_at_first() {
+        let mut state = SelectableListState::with_items(vec!["a", "b", "c"]);
+        // Already at first item
+        assert_eq!(state.selected_index(), Some(0));
+
+        // First should return None when already at first
+        let output = SelectableList::<&str>::update(&mut state, ListMessage::First);
+        assert_eq!(output, None);
+        assert_eq!(state.selected_index(), Some(0));
+    }
+
+    #[test]
+    fn test_last_when_already_at_last() {
+        let mut state = SelectableListState::with_items(vec!["a", "b", "c"]);
+        state.select(Some(2));
+        assert_eq!(state.selected_index(), Some(2));
+
+        // Last should return None when already at last
+        let output = SelectableList::<&str>::update(&mut state, ListMessage::Last);
+        assert_eq!(output, None);
+        assert_eq!(state.selected_index(), Some(2));
+    }
+
+    #[test]
+    fn test_page_up_when_at_first() {
+        let mut state = SelectableListState::with_items(vec!["a", "b", "c", "d", "e"]);
+        assert_eq!(state.selected_index(), Some(0));
+
+        // PageUp at first should return None
+        let output = SelectableList::<&str>::update(&mut state, ListMessage::PageUp(3));
+        assert_eq!(output, None);
+        assert_eq!(state.selected_index(), Some(0));
+    }
+
+    #[test]
+    fn test_page_down_when_at_last() {
+        let mut state = SelectableListState::with_items(vec!["a", "b", "c", "d", "e"]);
+        state.select(Some(4));
+        assert_eq!(state.selected_index(), Some(4));
+
+        // PageDown at last should return None
+        let output = SelectableList::<&str>::update(&mut state, ListMessage::PageDown(3));
+        assert_eq!(output, None);
+        assert_eq!(state.selected_index(), Some(4));
+    }
+
+    #[test]
     fn test_view() {
         use crate::backend::CaptureBackend;
         use ratatui::Terminal;
@@ -454,5 +524,87 @@ mod tests {
         assert!(output.contains("Item 1"));
         assert!(output.contains("Item 2"));
         assert!(output.contains("Item 3"));
+    }
+
+    #[test]
+    fn test_view_unfocused() {
+        use crate::backend::CaptureBackend;
+        use ratatui::Terminal;
+
+        let mut state = SelectableListState::with_items(vec!["A", "B", "C"]);
+        state.focused = false; // Explicitly unfocused
+
+        let backend = CaptureBackend::new(40, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal
+            .draw(|frame| {
+                SelectableList::<&str>::view(&state, frame, frame.area());
+            })
+            .unwrap();
+
+        let output = terminal.backend().to_string();
+        assert!(output.contains("A"));
+        assert!(output.contains("B"));
+        assert!(output.contains("C"));
+    }
+
+    #[test]
+    fn test_with_items_empty() {
+        let state = SelectableListState::<String>::with_items(vec![]);
+        assert!(state.is_empty());
+        assert_eq!(state.selected_index(), None);
+    }
+
+    #[test]
+    fn test_default_state() {
+        let state: SelectableListState<i32> = SelectableListState::default();
+        assert!(state.is_empty());
+        assert_eq!(state.len(), 0);
+        assert_eq!(state.selected_index(), None);
+        assert!(!state.focused);
+    }
+
+    #[test]
+    fn test_state_debug() {
+        let state = SelectableListState::with_items(vec!["a", "b"]);
+        let debug = format!("{:?}", state);
+        assert!(debug.contains("SelectableListState"));
+    }
+
+    #[test]
+    fn test_list_message_eq() {
+        assert_eq!(ListMessage::Up, ListMessage::Up);
+        assert_eq!(ListMessage::Down, ListMessage::Down);
+        assert_eq!(ListMessage::First, ListMessage::First);
+        assert_eq!(ListMessage::Last, ListMessage::Last);
+        assert_eq!(ListMessage::PageUp(5), ListMessage::PageUp(5));
+        assert_ne!(ListMessage::PageUp(5), ListMessage::PageUp(10));
+        assert_eq!(ListMessage::PageDown(3), ListMessage::PageDown(3));
+        assert_eq!(ListMessage::Select, ListMessage::Select);
+    }
+
+    #[test]
+    fn test_list_message_debug() {
+        let debug = format!("{:?}", ListMessage::Up);
+        assert_eq!(debug, "Up");
+    }
+
+    #[test]
+    fn test_list_output_eq() {
+        let out1: ListOutput<&str> = ListOutput::Selected("a");
+        let out2: ListOutput<&str> = ListOutput::Selected("a");
+        assert_eq!(out1, out2);
+
+        let out3: ListOutput<i32> = ListOutput::SelectionChanged(5);
+        let out4: ListOutput<i32> = ListOutput::SelectionChanged(5);
+        assert_eq!(out3, out4);
+    }
+
+    #[test]
+    fn test_list_output_debug() {
+        let out: ListOutput<&str> = ListOutput::Selected("x");
+        let debug = format!("{:?}", out);
+        assert!(debug.contains("Selected"));
     }
 }


### PR DESCRIPTION
## Summary

- Added 857 lines of tests across 5 component files to improve code coverage
- Coverage improved from 95.91% to 96.51%

### Changes by File

| File | Tests Added | Areas Covered |
|------|-------------|---------------|
| `selectable_list.rs` | 14 | Empty list, list_state_mut, unfocused view, boundary navigation |
| `radio_group.rs` | 12 | Empty vec handling, unfocused view, navigation outputs |
| `tree.rs` | 18 | Focus states, collapse selection adjustment, leaf nodes |
| `table.rs` | 18 | Empty selection, set_rows edge cases, sort indicators |
| `text_area.rs` | 25 | Word movement, delete_line edge cases, scroll, unicode |

## Test plan

- [x] All 1831 tests pass
- [x] Clippy passes with no warnings
- [x] Coverage increased from 95.91% to 96.51%

🤖 Generated with [Claude Code](https://claude.com/claude-code)