### PR TITLE
Rename inner_terminal() to terminal() in sync runtime

### DIFF
--- a/src/app/runtime/mod.rs
+++ b/src/app/runtime/mod.rs
@@ -12,7 +12,7 @@
 //!
 //! ```ignore
 //! // Simple usage
-//! Runtime::<MyApp>::terminal()?.run()?;
+//! Runtime::<MyApp>::new_terminal()?.run()?;
 //! ```
 //!
 //! This sets up raw mode, alternate screen, and mouse capture, then runs
@@ -151,10 +151,10 @@ impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
     ///
     /// ```ignore
     /// fn main() -> std::io::Result<()> {
-    ///     Runtime::<MyApp>::terminal()?.run()
+    ///     Runtime::<MyApp>::new_terminal()?.run()
     /// }
     /// ```
-    pub fn terminal() -> io::Result<Self> {
+    pub fn new_terminal() -> io::Result<Self> {
         Self::terminal_with_config(RuntimeConfig::default())
     }
 
@@ -183,7 +183,7 @@ impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
     ///
     /// ```ignore
     /// fn main() -> std::io::Result<()> {
-    ///     Runtime::<MyApp>::terminal()?.run()
+    ///     Runtime::<MyApp>::new_terminal()?.run()
     /// }
     /// ```
     pub fn run(mut self) -> io::Result<()> {
@@ -387,12 +387,12 @@ impl<A: App, B: Backend> Runtime<A, B> {
     }
 
     /// Returns a reference to the inner ratatui Terminal.
-    pub fn inner_terminal(&self) -> &Terminal<B> {
+    pub fn terminal(&self) -> &Terminal<B> {
         &self.terminal
     }
 
     /// Returns a mutable reference to the inner ratatui Terminal.
-    pub fn inner_terminal_mut(&mut self) -> &mut Terminal<B> {
+    pub fn terminal_mut(&mut self) -> &mut Terminal<B> {
         &mut self.terminal
     }
 

--- a/src/app/runtime/tests.rs
+++ b/src/app/runtime/tests.rs
@@ -156,17 +156,17 @@ fn test_runtime_state_mut() {
 }
 
 #[test]
-fn test_runtime_inner_terminal_access() {
+fn test_runtime_terminal_access() {
     let runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
-    let terminal = runtime.inner_terminal();
+    let terminal = runtime.terminal();
     assert_eq!(terminal.backend().width(), 80);
     assert_eq!(terminal.backend().height(), 24);
 }
 
 #[test]
-fn test_runtime_inner_terminal_mut() {
+fn test_runtime_terminal_mut() {
     let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
-    let _terminal = runtime.inner_terminal_mut();
+    let _terminal = runtime.terminal_mut();
     // Just verify we can get mutable access
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ```rust,ignore
 //! // Run in a real terminal with keyboard/mouse input
-//! Runtime::<MyApp>::terminal()?.run()
+//! Runtime::<MyApp>::new_terminal()?.run()
 //! ```
 //!
 //! ### Virtual Terminal Mode - For Programmatic Control


### PR DESCRIPTION
## Summary
- Rename constructor `Runtime::terminal()` → `Runtime::new_terminal()` to free the method name
- Rename accessor `Runtime::inner_terminal()` → `Runtime::terminal()`
- Rename accessor `Runtime::inner_terminal_mut()` → `Runtime::terminal_mut()`
- Aligns sync runtime API with async runtime which already uses `terminal()` / `terminal_mut()`

## Why
The async runtime already uses `terminal()` / `terminal_mut()` for accessors. The sync runtime used the confusing `inner_terminal()` / `inner_terminal_mut()` names because `terminal()` was taken by the constructor. Renaming the constructor to `new_terminal()` allows the accessors to use the cleaner, consistent names.

## Breaking change
This is a breaking API change. Call sites using `Runtime::terminal()` as a constructor must change to `Runtime::new_terminal()`. Call sites using `.inner_terminal()` / `.inner_terminal_mut()` must change to `.terminal()` / `.terminal_mut()`.

## Test plan
- [x] `cargo test` — all 176 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo doc --no-deps` — builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)