### PR TITLE
Add integration tests exercising multi-component workflows

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -17,11 +17,8 @@ fn test_focus_manager_tab_navigation() {
         Submit,
     }
 
-    let mut focus = FocusManager::with_initial_focus(vec![
-        Field::Username,
-        Field::Password,
-        Field::Submit,
-    ]);
+    let mut focus =
+        FocusManager::with_initial_focus(vec![Field::Username, Field::Password, Field::Submit]);
 
     // Initially focused on first item
     assert_eq!(focus.focused(), Some(&Field::Username));
@@ -151,16 +148,17 @@ fn test_selectable_list_navigation_200_items() {
 
     // Select at last position
     let output = SelectableList::<String>::update(&mut state, ListMessage::Select);
-    assert_eq!(
-        output,
-        Some(ListOutput::Selected("Item 199".to_string()))
-    );
+    assert_eq!(output, Some(ListOutput::Selected("Item 199".to_string())));
 }
 
 #[test]
 fn test_tabs_and_radio_group_independent_selection() {
-    let mut tabs =
-        TabsState::new(vec!["Home".to_string(), "Settings".to_string(), "Help".to_string(), "About".to_string()]);
+    let mut tabs = TabsState::new(vec![
+        "Home".to_string(),
+        "Settings".to_string(),
+        "Help".to_string(),
+        "About".to_string(),
+    ]);
     let mut radio = RadioGroupState::new(vec![
         "Option A".to_string(),
         "Option B".to_string(),
@@ -191,10 +189,7 @@ fn test_tabs_and_radio_group_independent_selection() {
 
     // Confirm each
     let tab_output = Tabs::<String>::update(&mut tabs, TabMessage::Confirm);
-    assert_eq!(
-        tab_output,
-        Some(TabOutput::Confirmed("Help".to_string()))
-    );
+    assert_eq!(tab_output, Some(TabOutput::Confirmed("Help".to_string())));
 
     let radio_output = RadioGroup::<String>::update(&mut radio, RadioMessage::Confirm);
     assert_eq!(


### PR DESCRIPTION
## Summary

- Add 7 integration tests in `tests/integration.rs` using the public API only
- Tests exercise multi-component workflows that cross component boundaries
- All tests are synchronous and use `Component::update()` directly

### Tests:
1. **FocusManager tab navigation** — `focus_next`/`focus_prev` cycling, wrapping, `blur`, `focus_first`/`focus_last`
2. **Dialog confirm workflow** — Open → navigate buttons → press Cancel → reopen → press OK
3. **InputField type and submit** — Insert chars → verify value/cursor → Submit → verify output
4. **SelectableList 200 items** — Navigate Down 199x → boundary check → PageUp → First/Last → Select
5. **Tabs & RadioGroup independent** — Navigate each independently, verify no interference, confirm each
6. **Dialog 3-button full cycle** — Save/Discard/Cancel → FocusNext wraps → press each button → verify re-open resets
7. **Checkbox toggle sequence** — Multiple checkboxes toggled independently, disabled returns None

## Test plan
- [x] `cargo test --test integration` — 7 tests pass
- [x] `cargo clippy --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

**Note:** This PR is based on `refactor/remove-trivial-tests` (PR #49). Rebase onto `main` after #49 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)