### PR TITLE
Unify navigation variant naming across components

### DIFF
--- a/src/component/accordion/mod.rs
+++ b/src/component/accordion/mod.rs
@@ -25,7 +25,7 @@
 //! assert!(state.panels()[0].is_expanded());
 //!
 //! // Navigate to next panel and toggle
-//! Accordion::update(&mut state, AccordionMessage::Next);
+//! Accordion::update(&mut state, AccordionMessage::Down);
 //! Accordion::update(&mut state, AccordionMessage::Toggle);
 //! // Now panels 0 and 1 are both expanded
 //! ```
@@ -118,10 +118,10 @@ impl AccordionPanel {
 /// Messages that can be sent to an Accordion.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AccordionMessage {
-    /// Move focus to the next panel.
-    Next,
-    /// Move focus to the previous panel.
-    Previous,
+    /// Move focus down to the next panel.
+    Down,
+    /// Move focus up to the previous panel.
+    Up,
     /// Jump to the first panel.
     First,
     /// Jump to the last panel.
@@ -303,8 +303,8 @@ impl AccordionState {
 ///
 /// The accordion itself doesn't handle keyboard events directly. Your application
 /// should map:
-/// - Up arrow to [`AccordionMessage::Previous`]
-/// - Down arrow to [`AccordionMessage::Next`]
+/// - Down arrow to [`AccordionMessage::Down`]
+/// - Up arrow to [`AccordionMessage::Up`]
 /// - Enter/Space to [`AccordionMessage::Toggle`]
 /// - Home to [`AccordionMessage::First`]
 /// - End to [`AccordionMessage::Last`]
@@ -337,7 +337,7 @@ impl AccordionState {
 /// assert!(state.panels()[0].is_expanded());
 ///
 /// // Navigate and toggle second
-/// Accordion::update(&mut state, AccordionMessage::Next);
+/// Accordion::update(&mut state, AccordionMessage::Down);
 /// Accordion::update(&mut state, AccordionMessage::Toggle);
 /// // Both panels are now expanded
 /// assert_eq!(state.expanded_count(), 2);
@@ -359,7 +359,7 @@ impl Component for Accordion {
         }
 
         match msg {
-            AccordionMessage::Next => {
+            AccordionMessage::Down => {
                 if !state.panels.is_empty() {
                     state.focused_index = (state.focused_index + 1) % state.panels.len();
                     Some(AccordionOutput::FocusChanged(state.focused_index))
@@ -367,7 +367,7 @@ impl Component for Accordion {
                     None
                 }
             }
-            AccordionMessage::Previous => {
+            AccordionMessage::Up => {
                 if !state.panels.is_empty() {
                     if state.focused_index == 0 {
                         state.focused_index = state.panels.len() - 1;

--- a/src/component/accordion/tests.rs
+++ b/src/component/accordion/tests.rs
@@ -223,34 +223,34 @@ fn test_next() {
     let mut state = AccordionState::from_pairs(vec![("A", "1"), ("B", "2"), ("C", "3")]);
     assert_eq!(state.focused_index(), 0);
 
-    Accordion::update(&mut state, AccordionMessage::Next);
+    Accordion::update(&mut state, AccordionMessage::Down);
     assert_eq!(state.focused_index(), 1);
 
-    Accordion::update(&mut state, AccordionMessage::Next);
+    Accordion::update(&mut state, AccordionMessage::Down);
     assert_eq!(state.focused_index(), 2);
 }
 
 #[test]
 fn test_previous() {
     let mut state = AccordionState::from_pairs(vec![("A", "1"), ("B", "2"), ("C", "3")]);
-    Accordion::update(&mut state, AccordionMessage::Next);
-    Accordion::update(&mut state, AccordionMessage::Next);
+    Accordion::update(&mut state, AccordionMessage::Down);
+    Accordion::update(&mut state, AccordionMessage::Down);
     assert_eq!(state.focused_index(), 2);
 
-    Accordion::update(&mut state, AccordionMessage::Previous);
+    Accordion::update(&mut state, AccordionMessage::Up);
     assert_eq!(state.focused_index(), 1);
 
-    Accordion::update(&mut state, AccordionMessage::Previous);
+    Accordion::update(&mut state, AccordionMessage::Up);
     assert_eq!(state.focused_index(), 0);
 }
 
 #[test]
 fn test_next_wraps() {
     let mut state = AccordionState::from_pairs(vec![("A", "1"), ("B", "2")]);
-    Accordion::update(&mut state, AccordionMessage::Next);
+    Accordion::update(&mut state, AccordionMessage::Down);
     assert_eq!(state.focused_index(), 1);
 
-    Accordion::update(&mut state, AccordionMessage::Next);
+    Accordion::update(&mut state, AccordionMessage::Down);
     assert_eq!(state.focused_index(), 0); // Wrapped
 }
 
@@ -259,15 +259,15 @@ fn test_previous_wraps() {
     let mut state = AccordionState::from_pairs(vec![("A", "1"), ("B", "2")]);
     assert_eq!(state.focused_index(), 0);
 
-    Accordion::update(&mut state, AccordionMessage::Previous);
+    Accordion::update(&mut state, AccordionMessage::Up);
     assert_eq!(state.focused_index(), 1); // Wrapped to end
 }
 
 #[test]
 fn test_first() {
     let mut state = AccordionState::from_pairs(vec![("A", "1"), ("B", "2"), ("C", "3")]);
-    Accordion::update(&mut state, AccordionMessage::Next);
-    Accordion::update(&mut state, AccordionMessage::Next);
+    Accordion::update(&mut state, AccordionMessage::Down);
+    Accordion::update(&mut state, AccordionMessage::Down);
     assert_eq!(state.focused_index(), 2);
 
     let output = Accordion::update(&mut state, AccordionMessage::First);
@@ -289,10 +289,10 @@ fn test_last() {
 fn test_navigation_empty() {
     let mut state = AccordionState::default();
 
-    let output = Accordion::update(&mut state, AccordionMessage::Next);
+    let output = Accordion::update(&mut state, AccordionMessage::Down);
     assert_eq!(output, None);
 
-    let output = Accordion::update(&mut state, AccordionMessage::Previous);
+    let output = Accordion::update(&mut state, AccordionMessage::Up);
     assert_eq!(output, None);
 
     let output = Accordion::update(&mut state, AccordionMessage::First);
@@ -306,7 +306,7 @@ fn test_navigation_empty() {
 fn test_navigation_returns_focus_changed() {
     let mut state = AccordionState::from_pairs(vec![("A", "1"), ("B", "2")]);
 
-    let output = Accordion::update(&mut state, AccordionMessage::Next);
+    let output = Accordion::update(&mut state, AccordionMessage::Down);
     assert_eq!(output, Some(AccordionOutput::FocusChanged(1)));
 }
 
@@ -443,7 +443,7 @@ fn test_disabled_ignores_messages() {
     assert_eq!(output, None);
     assert!(!state.panels()[0].is_expanded());
 
-    let output = Accordion::update(&mut state, AccordionMessage::Next);
+    let output = Accordion::update(&mut state, AccordionMessage::Down);
     assert_eq!(output, None);
     assert_eq!(state.focused_index(), 0);
 }
@@ -580,7 +580,7 @@ fn test_full_workflow() {
     assert_eq!(state.expanded_count(), 1);
 
     // Navigate to next and toggle
-    Accordion::update(&mut state, AccordionMessage::Next);
+    Accordion::update(&mut state, AccordionMessage::Down);
     assert_eq!(state.focused_index(), 1);
     Accordion::update(&mut state, AccordionMessage::Toggle);
     assert_eq!(state.expanded_count(), 2);

--- a/src/component/dropdown/mod.rs
+++ b/src/component/dropdown/mod.rs
@@ -21,7 +21,7 @@
 //! let _ = Dropdown::update(&mut state, DropdownMessage::Insert('a'));
 //!
 //! // Navigate to second filtered option and confirm
-//! let _ = Dropdown::update(&mut state, DropdownMessage::SelectNext);
+//! let _ = Dropdown::update(&mut state, DropdownMessage::Down);
 //! let output = Dropdown::update(&mut state, DropdownMessage::Confirm);
 //! assert_eq!(output, Some(DropdownOutput::Selected("Banana".to_string()))); // Banana selected
 //! ```
@@ -47,10 +47,10 @@ pub enum DropdownMessage {
     Backspace,
     /// Clear the filter text.
     ClearFilter,
-    /// Move highlight to next filtered option.
-    SelectNext,
-    /// Move highlight to previous filtered option.
-    SelectPrevious,
+    /// Move highlight down to the next filtered option.
+    Down,
+    /// Move highlight up to the previous filtered option.
+    Up,
     /// Confirm current highlighted selection.
     Confirm,
     /// Set the filter text directly.
@@ -293,8 +293,8 @@ impl DropdownState {
 /// should map:
 /// - Characters to [`DropdownMessage::Insert`]
 /// - Backspace to [`DropdownMessage::Backspace`]
-/// - Up arrow to [`DropdownMessage::SelectPrevious`]
-/// - Down arrow to [`DropdownMessage::SelectNext`]
+/// - Down arrow to [`DropdownMessage::Down`]
+/// - Up arrow to [`DropdownMessage::Up`]
 /// - Enter to [`DropdownMessage::Confirm`]
 /// - Escape to [`DropdownMessage::Close`]
 ///
@@ -336,7 +336,7 @@ impl DropdownState {
 /// Dropdown::update(&mut state, DropdownMessage::Insert('a'));
 ///
 /// // Navigate and select
-/// Dropdown::update(&mut state, DropdownMessage::SelectNext);
+/// Dropdown::update(&mut state, DropdownMessage::Down);
 /// let output = Dropdown::update(&mut state, DropdownMessage::Confirm);
 /// assert_eq!(output, Some(DropdownOutput::Selected("Banana".to_string()))); // Banana
 /// ```
@@ -438,7 +438,7 @@ impl Component for Dropdown {
                     None
                 }
             }
-            DropdownMessage::SelectNext => {
+            DropdownMessage::Down => {
                 if state.is_open && !state.filtered_indices.is_empty() {
                     state.highlighted_index =
                         (state.highlighted_index + 1) % state.filtered_indices.len();
@@ -448,7 +448,7 @@ impl Component for Dropdown {
                     None
                 }
             }
-            DropdownMessage::SelectPrevious => {
+            DropdownMessage::Up => {
                 if state.is_open && !state.filtered_indices.is_empty() {
                     if state.highlighted_index == 0 {
                         state.highlighted_index = state.filtered_indices.len() - 1;

--- a/src/component/dropdown/tests.rs
+++ b/src/component/dropdown/tests.rs
@@ -261,7 +261,7 @@ fn test_filter_resets_highlight() {
     Dropdown::update(&mut state, DropdownMessage::Open);
 
     // Navigate to second item
-    Dropdown::update(&mut state, DropdownMessage::SelectNext);
+    Dropdown::update(&mut state, DropdownMessage::Down);
     assert_eq!(state.highlighted_index, 1);
 
     // Filter - should reset highlight to 0
@@ -276,11 +276,11 @@ fn test_select_next() {
     let mut state = DropdownState::new(vec!["A", "B", "C"]);
     Dropdown::update(&mut state, DropdownMessage::Open);
 
-    let output = Dropdown::update(&mut state, DropdownMessage::SelectNext);
+    let output = Dropdown::update(&mut state, DropdownMessage::Down);
     assert_eq!(output, Some(DropdownOutput::SelectionChanged(1)));
     assert_eq!(state.highlighted_index, 1);
 
-    let output = Dropdown::update(&mut state, DropdownMessage::SelectNext);
+    let output = Dropdown::update(&mut state, DropdownMessage::Down);
     assert_eq!(output, Some(DropdownOutput::SelectionChanged(2)));
     assert_eq!(state.highlighted_index, 2);
 }
@@ -289,15 +289,15 @@ fn test_select_next() {
 fn test_select_previous() {
     let mut state = DropdownState::new(vec!["A", "B", "C"]);
     Dropdown::update(&mut state, DropdownMessage::Open);
-    Dropdown::update(&mut state, DropdownMessage::SelectNext);
-    Dropdown::update(&mut state, DropdownMessage::SelectNext);
+    Dropdown::update(&mut state, DropdownMessage::Down);
+    Dropdown::update(&mut state, DropdownMessage::Down);
     assert_eq!(state.highlighted_index, 2);
 
-    let output = Dropdown::update(&mut state, DropdownMessage::SelectPrevious);
+    let output = Dropdown::update(&mut state, DropdownMessage::Up);
     assert_eq!(output, Some(DropdownOutput::SelectionChanged(1)));
     assert_eq!(state.highlighted_index, 1);
 
-    let output = Dropdown::update(&mut state, DropdownMessage::SelectPrevious);
+    let output = Dropdown::update(&mut state, DropdownMessage::Up);
     assert_eq!(output, Some(DropdownOutput::SelectionChanged(0)));
     assert_eq!(state.highlighted_index, 0);
 }
@@ -307,9 +307,9 @@ fn test_select_next_wraps() {
     let mut state = DropdownState::new(vec!["A", "B", "C"]);
     Dropdown::update(&mut state, DropdownMessage::Open);
 
-    Dropdown::update(&mut state, DropdownMessage::SelectNext);
-    Dropdown::update(&mut state, DropdownMessage::SelectNext);
-    let output = Dropdown::update(&mut state, DropdownMessage::SelectNext);
+    Dropdown::update(&mut state, DropdownMessage::Down);
+    Dropdown::update(&mut state, DropdownMessage::Down);
+    let output = Dropdown::update(&mut state, DropdownMessage::Down);
     assert_eq!(output, Some(DropdownOutput::SelectionChanged(0)));
     assert_eq!(state.highlighted_index, 0); // Wrapped
 }
@@ -319,7 +319,7 @@ fn test_select_previous_wraps() {
     let mut state = DropdownState::new(vec!["A", "B", "C"]);
     Dropdown::update(&mut state, DropdownMessage::Open);
 
-    let output = Dropdown::update(&mut state, DropdownMessage::SelectPrevious);
+    let output = Dropdown::update(&mut state, DropdownMessage::Up);
     assert_eq!(output, Some(DropdownOutput::SelectionChanged(2)));
     assert_eq!(state.highlighted_index, 2); // Wrapped to end
 }
@@ -331,7 +331,7 @@ fn test_navigation_empty_filter() {
     Dropdown::update(&mut state, DropdownMessage::SetFilter("xyz".to_string()));
 
     // No matches - navigation should be no-op
-    Dropdown::update(&mut state, DropdownMessage::SelectNext);
+    Dropdown::update(&mut state, DropdownMessage::Down);
     assert_eq!(state.highlighted_index, 0);
 }
 
@@ -339,7 +339,7 @@ fn test_navigation_empty_filter() {
 fn test_navigation_when_closed() {
     let mut state = DropdownState::new(vec!["A", "B", "C"]);
     // Closed - navigation should be no-op
-    Dropdown::update(&mut state, DropdownMessage::SelectNext);
+    Dropdown::update(&mut state, DropdownMessage::Down);
     assert_eq!(state.highlighted_index, 0);
 }
 
@@ -349,7 +349,7 @@ fn test_navigation_when_closed() {
 fn test_confirm() {
     let mut state = DropdownState::new(vec!["A", "B", "C"]);
     Dropdown::update(&mut state, DropdownMessage::Open);
-    Dropdown::update(&mut state, DropdownMessage::SelectNext);
+    Dropdown::update(&mut state, DropdownMessage::Down);
 
     Dropdown::update(&mut state, DropdownMessage::Confirm);
     assert_eq!(state.selected_index(), Some(1));
@@ -360,7 +360,7 @@ fn test_confirm() {
 fn test_confirm_returns_selected() {
     let mut state = DropdownState::new(vec!["A", "B", "C"]);
     Dropdown::update(&mut state, DropdownMessage::Open);
-    Dropdown::update(&mut state, DropdownMessage::SelectNext);
+    Dropdown::update(&mut state, DropdownMessage::Down);
 
     let output = Dropdown::update(&mut state, DropdownMessage::Confirm);
     assert_eq!(output, Some(DropdownOutput::Selected("B".to_string())));
@@ -410,7 +410,7 @@ fn test_confirm_with_filter() {
     Dropdown::update(&mut state, DropdownMessage::Open);
     Dropdown::update(&mut state, DropdownMessage::Insert('a'));
     // Filtered: Apple (0), Banana (1)
-    Dropdown::update(&mut state, DropdownMessage::SelectNext);
+    Dropdown::update(&mut state, DropdownMessage::Down);
     // Highlight on Banana (index 1 in filtered = original index 1)
 
     let output = Dropdown::update(&mut state, DropdownMessage::Confirm);
@@ -513,7 +513,7 @@ fn test_view_open_with_filter() {
 fn test_view_highlight() {
     let mut state = DropdownState::new(vec!["Apple", "Banana", "Cherry"]);
     Dropdown::update(&mut state, DropdownMessage::Open);
-    Dropdown::update(&mut state, DropdownMessage::SelectNext);
+    Dropdown::update(&mut state, DropdownMessage::Down);
 
     let (mut terminal, theme) = crate::component::test_utils::setup_render(30, 15);
 
@@ -585,7 +585,7 @@ fn test_full_workflow() {
     assert_eq!(state.filtered_count(), 2); // Apple, Apricot
 
     // Navigate
-    Dropdown::update(&mut state, DropdownMessage::SelectNext);
+    Dropdown::update(&mut state, DropdownMessage::Down);
     assert_eq!(state.highlighted_index, 1); // Apricot
 
     // Confirm
@@ -627,17 +627,17 @@ fn test_large_dropdown_navigation() {
 
     // Navigate down through 50 options
     for _ in 0..50 {
-        Dropdown::update(&mut state, DropdownMessage::SelectNext);
+        Dropdown::update(&mut state, DropdownMessage::Down);
     }
     assert_eq!(state.highlighted_index, 50);
 
     // Navigate 50 more to wrap back to 0
     for _ in 0..50 {
-        Dropdown::update(&mut state, DropdownMessage::SelectNext);
+        Dropdown::update(&mut state, DropdownMessage::Down);
     }
     assert_eq!(state.highlighted_index, 0);
 
-    // SelectPrevious from 0 wraps to last
-    Dropdown::update(&mut state, DropdownMessage::SelectPrevious);
+    // Up from 0 wraps to last
+    Dropdown::update(&mut state, DropdownMessage::Up);
     assert_eq!(state.highlighted_index, 99);
 }

--- a/src/component/menu/tests.rs
+++ b/src/component/menu/tests.rs
@@ -193,16 +193,16 @@ fn test_select_next() {
         MenuItem::new("C"),
     ]);
 
-    let output = Menu::update(&mut state, MenuMessage::SelectNext);
+    let output = Menu::update(&mut state, MenuMessage::Right);
     assert_eq!(output, Some(MenuOutput::SelectionChanged(1)));
     assert_eq!(state.selected_index(), Some(1));
 
-    let output = Menu::update(&mut state, MenuMessage::SelectNext);
+    let output = Menu::update(&mut state, MenuMessage::Right);
     assert_eq!(output, Some(MenuOutput::SelectionChanged(2)));
     assert_eq!(state.selected_index(), Some(2));
 
     // Wrap around
-    let output = Menu::update(&mut state, MenuMessage::SelectNext);
+    let output = Menu::update(&mut state, MenuMessage::Right);
     assert_eq!(output, Some(MenuOutput::SelectionChanged(0)));
     assert_eq!(state.selected_index(), Some(0));
 }
@@ -216,15 +216,15 @@ fn test_select_previous() {
     ]);
 
     // Wrap around from start
-    let output = Menu::update(&mut state, MenuMessage::SelectPrevious);
+    let output = Menu::update(&mut state, MenuMessage::Left);
     assert_eq!(output, Some(MenuOutput::SelectionChanged(2)));
     assert_eq!(state.selected_index(), Some(2));
 
-    let output = Menu::update(&mut state, MenuMessage::SelectPrevious);
+    let output = Menu::update(&mut state, MenuMessage::Left);
     assert_eq!(output, Some(MenuOutput::SelectionChanged(1)));
     assert_eq!(state.selected_index(), Some(1));
 
-    let output = Menu::update(&mut state, MenuMessage::SelectPrevious);
+    let output = Menu::update(&mut state, MenuMessage::Left);
     assert_eq!(output, Some(MenuOutput::SelectionChanged(0)));
     assert_eq!(state.selected_index(), Some(0));
 }
@@ -237,11 +237,11 @@ fn test_select_item() {
         MenuItem::new("C"),
     ]);
 
-    let output = Menu::update(&mut state, MenuMessage::SelectItem(2));
+    let output = Menu::update(&mut state, MenuMessage::SelectIndex(2));
     assert_eq!(output, Some(MenuOutput::SelectionChanged(2)));
     assert_eq!(state.selected_index(), Some(2));
 
-    let output = Menu::update(&mut state, MenuMessage::SelectItem(0));
+    let output = Menu::update(&mut state, MenuMessage::SelectIndex(0));
     assert_eq!(output, Some(MenuOutput::SelectionChanged(0)));
     assert_eq!(state.selected_index(), Some(0));
 }
@@ -250,7 +250,7 @@ fn test_select_item() {
 fn test_select_item_same() {
     let mut state = MenuState::new(vec![MenuItem::new("A"), MenuItem::new("B")]);
 
-    let output = Menu::update(&mut state, MenuMessage::SelectItem(0));
+    let output = Menu::update(&mut state, MenuMessage::SelectIndex(0));
     assert_eq!(output, None); // Already selected
 }
 
@@ -258,7 +258,7 @@ fn test_select_item_same() {
 fn test_select_item_out_of_bounds() {
     let mut state = MenuState::new(vec![MenuItem::new("A"), MenuItem::new("B")]);
 
-    let output = Menu::update(&mut state, MenuMessage::SelectItem(10));
+    let output = Menu::update(&mut state, MenuMessage::SelectIndex(10));
     assert_eq!(output, None);
     // Should remain at 0
     assert_eq!(state.selected_index(), Some(0));
@@ -268,15 +268,15 @@ fn test_select_item_out_of_bounds() {
 fn test_activate_enabled() {
     let mut state = MenuState::new(vec![MenuItem::new("File"), MenuItem::new("Edit")]);
 
-    let output = Menu::update(&mut state, MenuMessage::Activate);
-    assert_eq!(output, Some(MenuOutput::ItemActivated(0)));
+    let output = Menu::update(&mut state, MenuMessage::Select);
+    assert_eq!(output, Some(MenuOutput::Selected(0)));
 }
 
 #[test]
 fn test_activate_disabled() {
     let mut state = MenuState::new(vec![MenuItem::disabled("File"), MenuItem::new("Edit")]);
 
-    let output = Menu::update(&mut state, MenuMessage::Activate);
+    let output = Menu::update(&mut state, MenuMessage::Select);
     assert_eq!(output, None);
 }
 
@@ -284,7 +284,7 @@ fn test_activate_disabled() {
 fn test_activate_empty() {
     let mut state = MenuState::new(vec![]);
 
-    let output = Menu::update(&mut state, MenuMessage::Activate);
+    let output = Menu::update(&mut state, MenuMessage::Select);
     assert_eq!(output, None);
 }
 
@@ -292,10 +292,10 @@ fn test_activate_empty() {
 fn test_empty_menu_ignores_navigation() {
     let mut state = MenuState::new(vec![]);
 
-    let output = Menu::update(&mut state, MenuMessage::SelectNext);
+    let output = Menu::update(&mut state, MenuMessage::Right);
     assert_eq!(output, None);
 
-    let output = Menu::update(&mut state, MenuMessage::SelectPrevious);
+    let output = Menu::update(&mut state, MenuMessage::Left);
     assert_eq!(output, None);
 }
 
@@ -384,20 +384,20 @@ fn test_large_menu_navigation() {
         .collect();
     let mut state = MenuState::new(items);
 
-    // Navigate to middle using SelectNext
+    // Navigate to middle using Right
     for _ in 0..50 {
-        Menu::update(&mut state, MenuMessage::SelectNext);
+        Menu::update(&mut state, MenuMessage::Right);
     }
     assert_eq!(state.selected_index(), Some(50));
 
     // Navigate to last by wrapping: 50 more to reach 100, which wraps to 0
     for _ in 0..50 {
-        Menu::update(&mut state, MenuMessage::SelectNext);
+        Menu::update(&mut state, MenuMessage::Right);
     }
     assert_eq!(state.selected_index(), Some(0));
 
-    // SelectPrevious from 0 wraps to last
-    Menu::update(&mut state, MenuMessage::SelectPrevious);
+    // Left from 0 wraps to last
+    Menu::update(&mut state, MenuMessage::Left);
     assert_eq!(state.selected_index(), Some(99));
 }
 
@@ -411,9 +411,9 @@ fn test_unicode_labels() {
     let mut state = MenuState::new(items);
 
     // Navigation works with unicode labels
-    Menu::update(&mut state, MenuMessage::SelectNext);
+    Menu::update(&mut state, MenuMessage::Right);
     assert_eq!(state.selected_index(), Some(1));
 
-    Menu::update(&mut state, MenuMessage::SelectNext);
+    Menu::update(&mut state, MenuMessage::Right);
     assert_eq!(state.selected_index(), Some(2));
 }

--- a/src/component/select/mod.rs
+++ b/src/component/select/mod.rs
@@ -18,7 +18,7 @@
 //! let _ = Select::update(&mut state, SelectMessage::Open);
 //!
 //! // Select an option (navigating to index 1, then confirming)
-//! let _ = Select::update(&mut state, SelectMessage::SelectNext);
+//! let _ = Select::update(&mut state, SelectMessage::Down);
 //! let output = Select::update(&mut state, SelectMessage::Confirm);
 //! assert_eq!(output, Some(SelectOutput::Selected("Green".to_string())));
 //! ```
@@ -38,10 +38,10 @@ pub enum SelectMessage {
     Close,
     /// Toggle the dropdown open/closed.
     Toggle,
-    /// Move selection to next option.
-    SelectNext,
-    /// Move selection to previous option.
-    SelectPrevious,
+    /// Move selection down to the next option.
+    Down,
+    /// Move selection up to the previous option.
+    Up,
     /// Confirm current selection.
     Confirm,
 }
@@ -217,8 +217,8 @@ impl SelectState {
 /// The select itself doesn't handle keyboard events directly. Your application
 /// should map:
 /// - Enter/Space to [`SelectMessage::Toggle`] (open/close)
-/// - Up arrow to [`SelectMessage::SelectPrevious`]
-/// - Down arrow to [`SelectMessage::SelectNext`]
+/// - Down arrow to [`SelectMessage::Down`]
+/// - Up arrow to [`SelectMessage::Up`]
 /// - Enter to [`SelectMessage::Confirm`] (when open)
 /// - Escape to [`SelectMessage::Close`]
 ///
@@ -253,7 +253,7 @@ impl SelectState {
 /// Select::update(&mut state, SelectMessage::Open);
 ///
 /// // Navigate to index 1 and confirm (selection changes from None to Some(1))
-/// Select::update(&mut state, SelectMessage::SelectNext);
+/// Select::update(&mut state, SelectMessage::Down);
 /// let output = Select::update(&mut state, SelectMessage::Confirm);
 /// assert_eq!(output, Some(SelectOutput::Selected("Medium".to_string())));
 /// ```
@@ -295,7 +295,7 @@ impl Component for Select {
                 }
                 None
             }
-            SelectMessage::SelectNext => {
+            SelectMessage::Down => {
                 if state.is_open && !state.options.is_empty() {
                     state.highlighted_index = (state.highlighted_index + 1) % state.options.len();
                     Some(SelectOutput::SelectionChanged(state.highlighted_index))
@@ -303,7 +303,7 @@ impl Component for Select {
                     None
                 }
             }
-            SelectMessage::SelectPrevious => {
+            SelectMessage::Up => {
                 if state.is_open && !state.options.is_empty() {
                     if state.highlighted_index == 0 {
                         state.highlighted_index = state.options.len() - 1;

--- a/src/component/select/tests.rs
+++ b/src/component/select/tests.rs
@@ -94,16 +94,16 @@ fn test_select_next() {
     let mut state = SelectState::new(vec!["A", "B", "C"]);
     Select::update(&mut state, SelectMessage::Open);
 
-    let output = Select::update(&mut state, SelectMessage::SelectNext);
+    let output = Select::update(&mut state, SelectMessage::Down);
     assert_eq!(output, Some(SelectOutput::SelectionChanged(1)));
     assert_eq!(state.highlighted_index, 1);
 
-    let output = Select::update(&mut state, SelectMessage::SelectNext);
+    let output = Select::update(&mut state, SelectMessage::Down);
     assert_eq!(output, Some(SelectOutput::SelectionChanged(2)));
     assert_eq!(state.highlighted_index, 2);
 
     // Wrap around
-    let output = Select::update(&mut state, SelectMessage::SelectNext);
+    let output = Select::update(&mut state, SelectMessage::Down);
     assert_eq!(output, Some(SelectOutput::SelectionChanged(0)));
     assert_eq!(state.highlighted_index, 0);
 }
@@ -114,15 +114,15 @@ fn test_select_previous() {
     Select::update(&mut state, SelectMessage::Open);
 
     // Wrap around from start
-    let output = Select::update(&mut state, SelectMessage::SelectPrevious);
+    let output = Select::update(&mut state, SelectMessage::Up);
     assert_eq!(output, Some(SelectOutput::SelectionChanged(2)));
     assert_eq!(state.highlighted_index, 2);
 
-    let output = Select::update(&mut state, SelectMessage::SelectPrevious);
+    let output = Select::update(&mut state, SelectMessage::Up);
     assert_eq!(output, Some(SelectOutput::SelectionChanged(1)));
     assert_eq!(state.highlighted_index, 1);
 
-    let output = Select::update(&mut state, SelectMessage::SelectPrevious);
+    let output = Select::update(&mut state, SelectMessage::Up);
     assert_eq!(output, Some(SelectOutput::SelectionChanged(0)));
     assert_eq!(state.highlighted_index, 0);
 }
@@ -131,7 +131,7 @@ fn test_select_previous() {
 fn test_confirm_selection() {
     let mut state = SelectState::new(vec!["A", "B", "C"]);
     Select::update(&mut state, SelectMessage::Open);
-    Select::update(&mut state, SelectMessage::SelectNext);
+    Select::update(&mut state, SelectMessage::Down);
 
     let output = Select::update(&mut state, SelectMessage::Confirm);
     assert_eq!(output, Some(SelectOutput::Selected("B".to_string())));
@@ -166,7 +166,7 @@ fn test_disabled_ignores_messages() {
     assert_eq!(output, None);
     assert!(!state.is_open());
 
-    let output = Select::update(&mut state, SelectMessage::SelectNext);
+    let output = Select::update(&mut state, SelectMessage::Down);
     assert_eq!(output, None);
 }
 
@@ -260,18 +260,18 @@ fn test_large_select_navigation() {
 
     // Navigate to middle
     for _ in 0..50 {
-        Select::update(&mut state, SelectMessage::SelectNext);
+        Select::update(&mut state, SelectMessage::Down);
     }
     assert_eq!(state.highlighted_index, 50);
 
     // Navigate 50 more to wrap back to 0
     for _ in 0..50 {
-        Select::update(&mut state, SelectMessage::SelectNext);
+        Select::update(&mut state, SelectMessage::Down);
     }
     assert_eq!(state.highlighted_index, 0);
 
-    // SelectPrevious from 0 wraps to last
-    Select::update(&mut state, SelectMessage::SelectPrevious);
+    // Up from 0 wraps to last
+    Select::update(&mut state, SelectMessage::Up);
     assert_eq!(state.highlighted_index, 99);
 
     // Confirm selection at index 99

--- a/src/component/tree/mod.rs
+++ b/src/component/tree/mod.rs
@@ -18,7 +18,7 @@
 //!
 //! // Navigate and expand
 //! Tree::update(&mut state, TreeMessage::Expand);
-//! Tree::update(&mut state, TreeMessage::SelectNext);
+//! Tree::update(&mut state, TreeMessage::Down);
 //! ```
 
 use ratatui::prelude::*;
@@ -174,10 +174,10 @@ struct FlatNode {
 /// Messages that can be sent to a Tree component.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TreeMessage {
-    /// Move selection to the next visible node.
-    SelectNext,
-    /// Move selection to the previous visible node.
-    SelectPrevious,
+    /// Move selection down to the next visible node.
+    Down,
+    /// Move selection up to the previous visible node.
+    Up,
     /// Expand the currently selected node.
     Expand,
     /// Collapse the currently selected node.
@@ -426,7 +426,7 @@ impl<T: Clone> TreeState<T> {
 /// let mut state = TreeState::new(vec![docs, projects]);
 ///
 /// // Navigate
-/// Tree::update(&mut state, TreeMessage::SelectNext);
+/// Tree::update(&mut state, TreeMessage::Down);
 /// Tree::update(&mut state, TreeMessage::Expand);
 /// ```
 pub struct Tree<T>(std::marker::PhantomData<T>);
@@ -490,13 +490,13 @@ impl<T: Clone + 'static> Component for Tree<T> {
         let selected = state.selected_index?;
 
         match msg {
-            TreeMessage::SelectNext => {
+            TreeMessage::Down => {
                 if selected < flat.len() - 1 {
                     state.selected_index = Some(selected + 1);
                 }
                 None
             }
-            TreeMessage::SelectPrevious => {
+            TreeMessage::Up => {
                 if selected > 0 {
                     state.selected_index = Some(selected - 1);
                 }

--- a/src/component/tree/tests.rs
+++ b/src/component/tree/tests.rs
@@ -289,7 +289,7 @@ fn test_select_next() {
     let mut state = TreeState::new(vec![root]);
     assert_eq!(state.selected_index(), Some(0));
 
-    Tree::update(&mut state, TreeMessage::SelectNext);
+    Tree::update(&mut state, TreeMessage::Down);
     assert_eq!(state.selected_index(), Some(1));
 }
 
@@ -298,7 +298,7 @@ fn test_select_next_at_end() {
     let state_roots = vec![TreeNode::new("Root", ())];
     let mut state = TreeState::new(state_roots);
 
-    Tree::<()>::update(&mut state, TreeMessage::SelectNext);
+    Tree::<()>::update(&mut state, TreeMessage::Down);
     assert_eq!(state.selected_index(), Some(0)); // Stays at 0
 }
 
@@ -310,7 +310,7 @@ fn test_select_previous() {
     let mut state = TreeState::new(vec![root]);
     state.selected_index = Some(1);
 
-    Tree::update(&mut state, TreeMessage::SelectPrevious);
+    Tree::update(&mut state, TreeMessage::Up);
     assert_eq!(state.selected_index(), Some(0));
 }
 
@@ -319,7 +319,7 @@ fn test_select_previous_at_start() {
     let state_roots = vec![TreeNode::new("Root", ())];
     let mut state = TreeState::new(state_roots);
 
-    Tree::<()>::update(&mut state, TreeMessage::SelectPrevious);
+    Tree::<()>::update(&mut state, TreeMessage::Up);
     assert_eq!(state.selected_index(), Some(0)); // Stays at 0
 }
 
@@ -388,7 +388,7 @@ fn test_collapse_adjusts_selection() {
     let mut state = TreeState::new(vec![root]);
     state.selected_index = Some(1); // Select child
 
-    Tree::update(&mut state, TreeMessage::SelectPrevious); // Go to root
+    Tree::update(&mut state, TreeMessage::Up); // Go to root
     Tree::update(&mut state, TreeMessage::Collapse);
 
     // Selection should still be valid
@@ -477,7 +477,7 @@ fn test_empty_tree() {
     let mut state: TreeState<()> = TreeState::new(Vec::new());
 
     // Should not panic
-    let output = Tree::update(&mut state, TreeMessage::SelectNext);
+    let output = Tree::update(&mut state, TreeMessage::Down);
     assert_eq!(output, None);
 
     let output = Tree::update(&mut state, TreeMessage::Select);
@@ -592,7 +592,7 @@ fn test_file_tree_workflow() {
     Tree::focus(&mut state);
 
     // Navigate to src
-    Tree::update(&mut state, TreeMessage::SelectNext);
+    Tree::update(&mut state, TreeMessage::Down);
     assert_eq!(state.selected_node().unwrap().label(), "src");
 
     // Expand src
@@ -600,7 +600,7 @@ fn test_file_tree_workflow() {
     assert_eq!(state.visible_count(), 6); // project, src, main.rs, lib.rs, tests, Cargo.toml
 
     // Navigate to main.rs and select
-    Tree::update(&mut state, TreeMessage::SelectNext);
+    Tree::update(&mut state, TreeMessage::Down);
     let output = Tree::update(&mut state, TreeMessage::Select);
     assert_eq!(output, Some(TreeOutput::Selected(vec![0, 0, 0])));
     assert_eq!(state.selected_node().unwrap().data(), &"/src/main.rs");
@@ -783,21 +783,21 @@ fn test_large_tree_navigation() {
 
     // Navigate down to middle
     for _ in 0..50 {
-        Tree::<()>::update(&mut state, TreeMessage::SelectNext);
+        Tree::<()>::update(&mut state, TreeMessage::Down);
     }
     assert_eq!(state.selected_index(), Some(50));
     assert_eq!(state.selected_node().unwrap().label(), "Node 50");
 
-    // SelectPrevious back to start
+    // Up back to start
     for _ in 0..50 {
-        Tree::<()>::update(&mut state, TreeMessage::SelectPrevious);
+        Tree::<()>::update(&mut state, TreeMessage::Up);
     }
     assert_eq!(state.selected_index(), Some(0));
     assert_eq!(state.selected_node().unwrap().label(), "Node 0");
 
     // Navigate to last
     for _ in 0..99 {
-        Tree::<()>::update(&mut state, TreeMessage::SelectNext);
+        Tree::<()>::update(&mut state, TreeMessage::Down);
     }
     assert_eq!(state.selected_index(), Some(99));
     assert_eq!(state.selected_node().unwrap().label(), "Node 99");
@@ -820,7 +820,7 @@ fn test_deep_tree_navigation() {
     // Expand all levels and navigate down
     for _ in 0..49 {
         Tree::<i32>::update(&mut state, TreeMessage::Expand);
-        Tree::<i32>::update(&mut state, TreeMessage::SelectNext);
+        Tree::<i32>::update(&mut state, TreeMessage::Down);
     }
 
     // Should be at the leaf node
@@ -837,7 +837,7 @@ fn test_unicode_node_labels() {
 
     let mut state = TreeState::new(vec![folder, TreeNode::new("설정", ())]);
 
-    Tree::<()>::update(&mut state, TreeMessage::SelectNext);
+    Tree::<()>::update(&mut state, TreeMessage::Down);
     // Should navigate through unicode-labeled nodes without issue
     assert_eq!(state.selected_index(), Some(1));
     assert_eq!(state.selected_node().unwrap().label(), "설정");


### PR DESCRIPTION
## Summary
- Vertical components (Accordion, Dropdown, Select, Tree) now use `Up`/`Down` for navigation instead of inconsistent `Next`/`Previous`/`SelectNext`/`SelectPrevious`
- Horizontal component (Menu) now uses `Left`/`Right` instead of `SelectNext`/`SelectPrevious`
- Menu's `Activate` renamed to `Select` and `SelectItem` to `SelectIndex` for consistency with other components
- Menu's `ItemActivated` output renamed to `Selected` to match other components

## Test plan
- [x] All 1773 unit tests pass
- [x] All 176 doc tests pass
- [x] Clippy clean with `-D warnings`
- [x] No references to old variant names remain in the codebase
- [x] Doc comments and test comments updated to reflect new names

🤖 Generated with [Claude Code](https://claude.com/claude-code)