### PR TITLE
Fix Router::init() panic and expand prelude

### DIFF
--- a/src/component/router/mod.rs
+++ b/src/component/router/mod.rs
@@ -241,18 +241,16 @@ impl<S: Clone + PartialEq> RouterState<S> {
 /// ```
 pub struct Router<S: Clone + PartialEq>(std::marker::PhantomData<S>);
 
-impl<S: Clone + PartialEq> Component for Router<S> {
-    type State = RouterState<S>;
-    type Message = RouterMessage<S>;
-    type Output = RouterOutput<S>;
-
-    fn init() -> Self::State {
-        // This will panic because we need an initial screen.
-        // Users should create RouterState directly with RouterState::new(initial_screen)
-        panic!("Router requires an initial screen. Use RouterState::new(initial_screen) instead of Router::init()");
-    }
-
-    fn update(state: &mut Self::State, msg: Self::Message) -> Option<Self::Output> {
+impl<S: Clone + PartialEq> Router<S> {
+    /// Updates the router state.
+    ///
+    /// This inherent method is available for all screen types that implement
+    /// `Clone + PartialEq`. Screen types that also implement `Default` can
+    /// use the [`Component`] trait methods instead.
+    pub fn update(
+        state: &mut RouterState<S>,
+        msg: RouterMessage<S>,
+    ) -> Option<RouterOutput<S>> {
         match msg {
             RouterMessage::Navigate(screen) => {
                 if state.current == screen {
@@ -309,9 +307,31 @@ impl<S: Clone + PartialEq> Component for Router<S> {
         }
     }
 
-    fn view(_state: &Self::State, _frame: &mut Frame, _area: Rect, _theme: &Theme) {
+    /// Renders the router view.
+    ///
+    /// Router is state-only, so this is a no-op. The parent application
+    /// should render based on `state.current()`.
+    pub fn view(_state: &RouterState<S>, _frame: &mut Frame, _area: Rect, _theme: &Theme) {
         // Router is state-only - no view implementation.
         // The parent application should render based on state.current()
+    }
+}
+
+impl<S: Clone + PartialEq + Default> Component for Router<S> {
+    type State = RouterState<S>;
+    type Message = RouterMessage<S>;
+    type Output = RouterOutput<S>;
+
+    fn init() -> Self::State {
+        RouterState::new(S::default())
+    }
+
+    fn update(state: &mut Self::State, msg: Self::Message) -> Option<Self::Output> {
+        Router::update(state, msg)
+    }
+
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+        Router::view(state, frame, area, theme)
     }
 }
 

--- a/src/component/router/tests.rs
+++ b/src/component/router/tests.rs
@@ -1,11 +1,24 @@
 use super::*;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 enum TestScreen {
+    #[default]
     Home,
     Settings,
     Profile,
     About,
+}
+
+// ========================================
+// Init Tests
+// ========================================
+
+#[test]
+fn test_init() {
+    let state: RouterState<TestScreen> = Router::init();
+    assert_eq!(state.current(), &TestScreen::Home); // Default variant
+    assert!(!state.can_go_back());
+    assert_eq!(state.history_len(), 0);
 }
 
 // ========================================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,13 +111,14 @@ pub use theme::Theme;
 
 /// Prelude module for convenient imports.
 ///
-/// Provides the essential framework types needed by most applications.
-/// Individual component types (e.g., `ButtonState`, `CheckboxMessage`) should
-/// be imported directly from their modules:
+/// Provides all framework types and component types needed by most applications.
 ///
 /// ```rust,ignore
 /// use envision::prelude::*;
-/// use envision::component::{Button, ButtonState, ButtonMessage};
+///
+/// // All component types are now available:
+/// let button = ButtonState::new("Submit");
+/// let checkbox = CheckboxState::new("Accept");
 /// ```
 pub mod prelude {
     // Core framework
@@ -135,8 +136,8 @@ pub mod prelude {
     // Theme
     pub use crate::theme::Theme;
 
-    // Component traits (not individual components)
-    pub use crate::component::{Component, Focusable, Toggleable};
+    // All component types (the primary user-facing API)
+    pub use crate::component::*;
 
     // Testing essentials
     pub use crate::backend::{CaptureBackend, EnhancedCell};


### PR DESCRIPTION
## Summary
- **Router::init() no longer panics**: Added `Default` bound to the `Component` trait impl so `init()` returns `RouterState::new(S::default())` instead of panicking
- **Inherent methods preserve flexibility**: Moved `update()` and `view()` logic to inherent methods on `Router<S>` (only requiring `Clone + PartialEq`), so screen types without `Default` can still use Router directly
- **Prelude expanded**: Changed from re-exporting only `Component`/`Focusable`/`Toggleable` traits to `pub use crate::component::*`, making all component types available via `use envision::prelude::*`

## Test plan
- [x] All 1774 unit tests pass (1 new test for `Router::init()`)
- [x] All 176 doc tests pass
- [x] Clippy clean with `-D warnings`
- [x] No `panic!` in `src/component/router/mod.rs`
- [x] Existing tests continue to work (inherent methods shadow trait methods transparently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)