### PR TITLE
Fix cargo fmt formatting after API consistency refactors

### DIFF
--- a/examples/component_showcase.rs
+++ b/examples/component_showcase.rs
@@ -388,22 +388,13 @@ impl App for ShowcaseApp {
 
             // Data
             Msg::ListDown => {
-                SelectableList::<String>::update(
-                    &mut state.list,
-                    SelectableListMessage::Down,
-                );
+                SelectableList::<String>::update(&mut state.list, SelectableListMessage::Down);
             }
             Msg::ListUp => {
-                SelectableList::<String>::update(
-                    &mut state.list,
-                    SelectableListMessage::Up,
-                );
+                SelectableList::<String>::update(&mut state.list, SelectableListMessage::Up);
             }
             Msg::ListSelect => {
-                SelectableList::<String>::update(
-                    &mut state.list,
-                    SelectableListMessage::Select,
-                );
+                SelectableList::<String>::update(&mut state.list, SelectableListMessage::Select);
             }
             Msg::TableDown => {
                 Table::<UserRow>::update(&mut state.table, TableMessage::Down);
@@ -625,7 +616,10 @@ fn sync_focus(state: &mut State) {
     InputField::set_focused(&mut state.input, focused == Some(FocusId::Input));
     Checkbox::set_focused(&mut state.checkbox, focused == Some(FocusId::Checkbox));
     RadioGroup::set_focused(&mut state.radio, focused == Some(FocusId::Radio));
-    Button::set_focused(&mut state.submit_button, focused == Some(FocusId::SubmitButton));
+    Button::set_focused(
+        &mut state.submit_button,
+        focused == Some(FocusId::SubmitButton),
+    );
     SelectableList::<String>::set_focused(&mut state.list, focused == Some(FocusId::List));
     Table::<UserRow>::set_focused(&mut state.table, focused == Some(FocusId::Table));
 }

--- a/examples/themed_app.rs
+++ b/examples/themed_app.rs
@@ -8,8 +8,8 @@
 //! Run with: cargo run --example themed_app
 
 use envision::component::{
-    Button, ButtonState, Checkbox, CheckboxMessage, CheckboxState, SelectableListMessage, ProgressBar,
-    ProgressBarState, SelectableList, SelectableListState,
+    Button, ButtonState, Checkbox, CheckboxMessage, CheckboxState, ProgressBar, ProgressBarState,
+    SelectableList, SelectableListMessage, SelectableListState,
 };
 use envision::prelude::*;
 use ratatui::layout::{Alignment, Constraint, Layout};
@@ -120,7 +120,10 @@ impl App for ThemedApp {
                 state.progress_state.set_progress((current - 0.1).max(0.0));
             }
             Msg::NextItem => {
-                SelectableList::<String>::update(&mut state.list_state, SelectableListMessage::Down);
+                SelectableList::<String>::update(
+                    &mut state.list_state,
+                    SelectableListMessage::Down,
+                );
             }
             Msg::PrevItem => {
                 SelectableList::<String>::update(&mut state.list_state, SelectableListMessage::Up);

--- a/src/component/input_field/tests.rs
+++ b/src/component/input_field/tests.rs
@@ -151,7 +151,10 @@ fn test_delete_word_back() {
 
     let output = InputField::update(&mut state, InputFieldMessage::DeleteWordBack);
     assert_eq!(state.value(), "hello ");
-    assert_eq!(output, Some(InputFieldOutput::Changed("hello ".to_string())));
+    assert_eq!(
+        output,
+        Some(InputFieldOutput::Changed("hello ".to_string()))
+    );
 
     InputField::update(&mut state, InputFieldMessage::DeleteWordBack);
     assert_eq!(state.value(), "");
@@ -194,13 +197,22 @@ fn test_clear() {
 fn test_set_value() {
     let mut state = InputField::init();
 
-    let output = InputField::update(&mut state, InputFieldMessage::SetValue("new value".to_string()));
+    let output = InputField::update(
+        &mut state,
+        InputFieldMessage::SetValue("new value".to_string()),
+    );
     assert_eq!(state.value(), "new value");
     assert_eq!(state.cursor_position(), 9);
-    assert_eq!(output, Some(InputFieldOutput::Changed("new value".to_string())));
+    assert_eq!(
+        output,
+        Some(InputFieldOutput::Changed("new value".to_string()))
+    );
 
     // Setting same value returns None
-    let output = InputField::update(&mut state, InputFieldMessage::SetValue("new value".to_string()));
+    let output = InputField::update(
+        &mut state,
+        InputFieldMessage::SetValue("new value".to_string()),
+    );
     assert_eq!(output, None);
 }
 

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -156,7 +156,9 @@ pub use progress_bar::{ProgressBar, ProgressBarMessage, ProgressBarOutput, Progr
 pub use radio_group::{RadioGroup, RadioGroupMessage, RadioGroupOutput, RadioGroupState};
 pub use router::{NavigationMode, Router, RouterMessage, RouterOutput, RouterState};
 pub use select::{Select, SelectMessage, SelectOutput, SelectState};
-pub use selectable_list::{SelectableList, SelectableListMessage, SelectableListOutput, SelectableListState};
+pub use selectable_list::{
+    SelectableList, SelectableListMessage, SelectableListOutput, SelectableListState,
+};
 pub use spinner::{Spinner, SpinnerMessage, SpinnerState, SpinnerStyle};
 pub use status_bar::{
     Section, StatusBar, StatusBarItem, StatusBarItemContent, StatusBarMessage, StatusBarOutput,

--- a/src/component/router/mod.rs
+++ b/src/component/router/mod.rs
@@ -247,10 +247,7 @@ impl<S: Clone + PartialEq> Router<S> {
     /// This inherent method is available for all screen types that implement
     /// `Clone + PartialEq`. Screen types that also implement `Default` can
     /// use the [`Component`] trait methods instead.
-    pub fn update(
-        state: &mut RouterState<S>,
-        msg: RouterMessage<S>,
-    ) -> Option<RouterOutput<S>> {
+    pub fn update(state: &mut RouterState<S>, msg: RouterMessage<S>) -> Option<RouterOutput<S>> {
         match msg {
             RouterMessage::Navigate(screen) => {
                 if state.current == screen {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,10 +99,9 @@ pub use component::{
     SortDirection, Spinner, SpinnerMessage, SpinnerState, SpinnerStyle, StatusBar, StatusBarItem,
     StatusBarMessage, StatusBarOutput, StatusBarState, StatusBarStyle, Table, TableMessage,
     TableOutput, TableRow, TableState, Tabs, TabsMessage, TabsOutput, TabsState, TextArea,
-    TextAreaMessage, TextAreaOutput,
-    TextAreaState, Toast, ToastItem, ToastLevel, ToastMessage, ToastOutput, ToastState, Toggleable,
-    Tooltip, TooltipMessage, TooltipOutput, TooltipPosition, TooltipState, Tree, TreeMessage,
-    TreeNode, TreeOutput, TreeState,
+    TextAreaMessage, TextAreaOutput, TextAreaState, Toast, ToastItem, ToastLevel, ToastMessage,
+    ToastOutput, ToastState, Toggleable, Tooltip, TooltipMessage, TooltipOutput, TooltipPosition,
+    TooltipState, Tree, TreeMessage, TreeNode, TreeOutput, TreeState,
 };
 pub use harness::{AppHarness, Assertion, Snapshot, TestHarness};
 pub use input::{Event, EventQueue};

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4,8 +4,8 @@ use envision::{
     Checkbox, CheckboxMessage, CheckboxOutput, CheckboxState, Component, Dialog, DialogButton,
     DialogMessage, DialogOutput, DialogState, FocusManager, Focusable, InputField,
     InputFieldMessage, InputFieldOutput, InputFieldState, RadioGroup, RadioGroupMessage,
-    RadioGroupOutput, RadioGroupState, SelectableList, SelectableListMessage,
-    SelectableListOutput, SelectableListState, Tabs, TabsMessage, TabsOutput, TabsState, Toggleable,
+    RadioGroupOutput, RadioGroupState, SelectableList, SelectableListMessage, SelectableListOutput,
+    SelectableListState, Tabs, TabsMessage, TabsOutput, TabsState, Toggleable,
 };
 
 #[test]
@@ -148,7 +148,10 @@ fn test_selectable_list_navigation_200_items() {
 
     // Select at last position
     let output = SelectableList::<String>::update(&mut state, SelectableListMessage::Select);
-    assert_eq!(output, Some(SelectableListOutput::Selected("Item 199".to_string())));
+    assert_eq!(
+        output,
+        Some(SelectableListOutput::Selected("Item 199".to_string()))
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Runs `cargo fmt` to fix formatting drift from the type-naming (PR #53) and navigation-consistency (PR #54) rename PRs
- Affects 7 files: examples, component modules, lib.rs, and integration tests
- No logic changes, formatting only

## Test plan
- [x] `cargo fmt --check` passes clean
- [x] `cargo clippy -- -D warnings` passes clean
- [x] All 1774 unit tests + 176 doc tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)