### PR TITLE
Remove broken Command::clone() and fix Theme style methods

### DIFF
--- a/src/app/command/mod.rs
+++ b/src/app/command/mod.rs
@@ -274,25 +274,6 @@ impl<M> Command<M> {
     }
 }
 
-impl<M: Clone> Clone for Command<M> {
-    fn clone(&self) -> Self {
-        // Note: Callbacks, Async, and PushOverlay can't be cloned, so we only clone Message/Batch/Quit/PopOverlay
-        let actions = self
-            .actions
-            .iter()
-            .filter_map(|action| match action {
-                CommandAction::Message(m) => Some(CommandAction::Message(m.clone())),
-                CommandAction::Batch(msgs) => Some(CommandAction::Batch(msgs.clone())),
-                CommandAction::Quit => Some(CommandAction::Quit),
-                CommandAction::PopOverlay => Some(CommandAction::PopOverlay),
-                _ => None, // Skip non-clonable actions
-            })
-            .collect();
-
-        Self { actions }
-    }
-}
-
 impl<M> std::fmt::Debug for Command<M> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Command")

--- a/src/app/command/tests.rs
+++ b/src/app/command/tests.rs
@@ -125,50 +125,6 @@ fn test_command_batch_empty() {
 }
 
 #[test]
-fn test_command_clone_message() {
-    let cmd = Command::message(TestMsg::A);
-    let cloned = cmd.clone();
-
-    let mut handler = CommandHandler::new();
-    handler.execute(cloned);
-
-    let messages = handler.take_messages();
-    assert_eq!(messages, vec![TestMsg::A]);
-}
-
-#[test]
-fn test_command_clone_batch() {
-    let cmd = Command::batch([TestMsg::A, TestMsg::B]);
-    let cloned = cmd.clone();
-
-    let mut handler = CommandHandler::new();
-    handler.execute(cloned);
-
-    let messages = handler.take_messages();
-    assert_eq!(messages, vec![TestMsg::A, TestMsg::B]);
-}
-
-#[test]
-fn test_command_clone_quit() {
-    let cmd: Command<TestMsg> = Command::quit();
-    let cloned = cmd.clone();
-
-    let mut handler = CommandHandler::new();
-    handler.execute(cloned);
-
-    assert!(handler.should_quit());
-}
-
-#[test]
-fn test_command_clone_callback_skipped() {
-    let cmd = Command::perform(|| Some(TestMsg::A));
-    let cloned = cmd.clone();
-
-    // Callbacks can't be cloned, so cloned should have no actions
-    assert!(cloned.is_none());
-}
-
-#[test]
 fn test_command_map_batch() {
     #[derive(Clone, Debug, PartialEq)]
     enum OuterMsg {
@@ -322,15 +278,6 @@ fn test_command_perform_async_fallible_err() {
 }
 
 #[test]
-fn test_command_clone_async_skipped() {
-    let cmd: Command<TestMsg> = Command::perform_async(async { Some(TestMsg::A) });
-    let cloned = cmd.clone();
-
-    // Async actions can't be cloned, so cloned should be empty
-    assert!(cloned.is_none());
-}
-
-#[test]
 fn test_command_map_async() {
     #[derive(Clone, Debug, PartialEq)]
     enum OuterMsg {
@@ -437,19 +384,6 @@ fn test_command_map_async_fallible() {
 
     // Mapped command should still exist
     assert!(!mapped.is_none());
-}
-
-#[test]
-fn test_command_clone_async_fallible_skipped() {
-    let cmd: Command<TestMsg> =
-        Command::try_perform_async(async { Ok::<_, std::io::Error>(42) }, |n| {
-            Some(TestMsg::Value(n))
-        });
-
-    let cloned = cmd.clone();
-
-    // AsyncFallible can't be cloned, so cloned should be empty
-    assert!(cloned.is_none());
 }
 
 #[test]
@@ -640,24 +574,6 @@ mod overlay_tests {
         assert_eq!(handler.take_messages(), vec![TestMsg::A]);
         assert_eq!(handler.take_overlay_pushes().len(), 2);
         assert_eq!(handler.take_overlay_pops(), 1);
-    }
-
-    #[test]
-    fn test_command_clone_push_overlay_skipped() {
-        let cmd: Command<TestMsg> = Command::push_overlay(TestOverlay);
-        let cloned = cmd.clone();
-
-        // PushOverlay can't be cloned, so cloned should be empty
-        assert!(cloned.is_none());
-    }
-
-    #[test]
-    fn test_command_clone_pop_overlay_preserved() {
-        let cmd: Command<TestMsg> = Command::pop_overlay();
-        let cloned = cmd.clone();
-
-        // PopOverlay can be cloned
-        assert!(!cloned.is_none());
     }
 
     #[test]

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -235,8 +235,11 @@ impl Theme {
     }
 
     /// Returns a style for focused borders.
+    ///
+    /// Unlike [`focused_style`](Theme::focused_style), this includes
+    /// the background color so borders render correctly on themed backgrounds.
     pub fn focused_border_style(&self) -> Style {
-        Style::default().fg(self.focused)
+        Style::default().fg(self.focused).bg(self.background)
     }
 
     /// Returns a style for selected items.
@@ -275,8 +278,16 @@ impl Theme {
     }
 
     /// Returns a style for default/normal elements.
+    ///
+    /// Uses the theme's foreground and background colors so components
+    /// render correctly with non-default themes (e.g., Nord).
     pub fn normal_style(&self) -> Style {
-        Style::default()
+        Style::default().fg(self.foreground).bg(self.background)
+    }
+
+    /// Returns a style for primary accent elements.
+    pub fn primary_style(&self) -> Style {
+        Style::default().fg(self.primary)
     }
 
     /// Returns a style for borders (non-focused).

--- a/src/theme/tests.rs
+++ b/src/theme/tests.rs
@@ -125,8 +125,44 @@ fn test_custom_theme() {
 fn test_normal_style() {
     let theme = Theme::default();
     let style = theme.normal_style();
-    assert_eq!(style.fg, None);
-    assert_eq!(style.bg, None);
+    // Default theme uses Color::Reset for fg/bg
+    assert_eq!(style.fg, Some(Color::Reset));
+    assert_eq!(style.bg, Some(Color::Reset));
+}
+
+#[test]
+fn test_normal_style_nord() {
+    let theme = Theme::nord();
+    let style = theme.normal_style();
+    assert_eq!(style.fg, Some(NORD6));
+    assert_eq!(style.bg, Some(NORD0));
+}
+
+#[test]
+fn test_focused_border_style_differs_from_focused_style() {
+    let theme = Theme::nord();
+    let border_style = theme.focused_border_style();
+    let focused_style = theme.focused_style();
+    // Both use focused color for fg
+    assert_eq!(border_style.fg, Some(NORD8));
+    assert_eq!(focused_style.fg, Some(NORD8));
+    // Border style includes background, focused style does not
+    assert_eq!(border_style.bg, Some(NORD0));
+    assert_eq!(focused_style.bg, None);
+}
+
+#[test]
+fn test_primary_style() {
+    let theme = Theme::default();
+    let style = theme.primary_style();
+    assert_eq!(style.fg, Some(Color::Cyan));
+}
+
+#[test]
+fn test_primary_style_nord() {
+    let theme = Theme::nord();
+    let style = theme.primary_style();
+    assert_eq!(style.fg, Some(NORD10));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Remove the `Clone` impl for `Command<M>` which silently dropped `Callback`, `Async`, `AsyncFallible`, and `PushOverlay` actions — Commands contain non-cloneable types and should not pretend to be cloneable
- Fix `Theme::normal_style()` to use foreground/background colors instead of returning bare `Style::default()`
- Differentiate `focused_border_style()` from `focused_style()` by including the background color
- Add missing `primary_style()` method for the `primary` accent color field

## Test plan
- [x] All 8 clone tests removed (they tested the broken behavior)
- [x] Added tests for Nord `normal_style`, `focused_border_style` vs `focused_style` distinction, and `primary_style`
- [x] Full test suite passes: `cargo test`
- [x] No clippy warnings: `cargo clippy -- -D warnings`
- [x] Doc tests pass: `cargo test --doc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)