### PR TITLE
Clarify git workflow: one branch per independent change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,4 @@
 - All changes must be made via Pull Requests (PRs)
 - Do not commit directly to the main branch
 - Create a feature branch for each change, then open a PR
+- Each independent piece of work gets its own feature branch and PR. Do not bundle unrelated changes into a single branch. If there are 5 independent improvements to make, that means 5 branches and 5 PRs.


### PR DESCRIPTION
## Summary
- Adds explicit rule to CLAUDE.md that each independent piece of work gets its own feature branch and PR
- Prevents bundling unrelated changes into a single branch

## Test plan
- [x] No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)