### PR TITLE
Add with_disabled() builder consistency and LoadingList disabled state

### DIFF
--- a/src/component/checkbox/mod.rs
+++ b/src/component/checkbox/mod.rs
@@ -133,6 +133,12 @@ impl CheckboxState {
         self.disabled = disabled;
     }
 
+    /// Sets the disabled state using builder pattern.
+    pub fn with_disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
     /// Returns true if the checkbox is focused.
     pub fn is_focused(&self) -> bool {
         self.focused

--- a/src/component/checkbox/tests.rs
+++ b/src/component/checkbox/tests.rs
@@ -221,3 +221,35 @@ fn test_instance_update() {
     let output = state.update(CheckboxMessage::Toggle);
     assert_eq!(output, Some(CheckboxOutput::Toggled(true)));
 }
+
+// ========================================
+// Builder Tests
+// ========================================
+
+#[test]
+fn test_with_disabled() {
+    let state = CheckboxState::new("Test").with_disabled(true);
+    assert!(state.is_disabled());
+
+    let state = CheckboxState::new("Test").with_disabled(false);
+    assert!(!state.is_disabled());
+}
+
+#[test]
+fn test_with_disabled_prevents_toggle() {
+    let mut state = CheckboxState::new("Test").with_disabled(true);
+    state.set_focused(true);
+    let output = Checkbox::update(&mut state, CheckboxMessage::Toggle);
+    assert_eq!(output, None);
+    assert!(!state.is_checked());
+}
+
+#[test]
+fn test_with_disabled_prevents_handle_event() {
+    let state = CheckboxState::new("Test").with_disabled(true);
+    // Even if we manually set focused, disabled should prevent events
+    let mut state = state;
+    state.set_focused(true);
+    let msg = Checkbox::handle_event(&state, &Event::key(KeyCode::Enter));
+    assert_eq!(msg, None);
+}

--- a/src/component/dropdown/mod.rs
+++ b/src/component/dropdown/mod.rs
@@ -260,6 +260,12 @@ impl DropdownState {
         }
     }
 
+    /// Sets the disabled state using builder pattern.
+    pub fn with_disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
     /// Returns true if the dropdown is focused.
     pub fn is_focused(&self) -> bool {
         self.focused

--- a/src/component/dropdown/tests.rs
+++ b/src/component/dropdown/tests.rs
@@ -785,3 +785,25 @@ fn test_selected_item_none() {
     let state = DropdownState::new(vec!["A", "B"]);
     assert_eq!(state.selected_item(), None);
 }
+
+// ========================================
+// Builder Tests
+// ========================================
+
+#[test]
+fn test_with_disabled() {
+    let state = DropdownState::new(vec!["A", "B", "C"]).with_disabled(true);
+    assert!(state.is_disabled());
+
+    let state = DropdownState::new(vec!["A", "B", "C"]).with_disabled(false);
+    assert!(!state.is_disabled());
+}
+
+#[test]
+fn test_with_disabled_prevents_open() {
+    let mut state = DropdownState::new(vec!["A", "B", "C"]).with_disabled(true);
+    state.set_focused(true);
+    let output = Dropdown::update(&mut state, DropdownMessage::Open);
+    assert_eq!(output, None);
+    assert!(!state.is_open());
+}

--- a/src/component/loading_list/mod.rs
+++ b/src/component/loading_list/mod.rs
@@ -222,10 +222,10 @@ pub struct LoadingListState<T: Clone> {
     selected: Option<usize>,
     /// Whether the component is focused.
     focused: bool,
+    /// Whether the component is disabled.
+    disabled: bool,
     /// Current spinner animation frame.
     spinner_frame: usize,
-    /// Label extractor function (stored as a result of initial extraction).
-    /// Note: We can't store the function, so labels are extracted at construction time.
     /// Optional title.
     title: Option<String>,
     /// Whether to show loading indicators.
@@ -238,6 +238,7 @@ impl<T: Clone> Default for LoadingListState<T> {
             items: Vec::new(),
             selected: None,
             focused: false,
+            disabled: false,
             spinner_frame: 0,
             title: None,
             show_indicators: true,
@@ -285,6 +286,7 @@ impl<T: Clone> LoadingListState<T> {
             items: list_items,
             selected: None,
             focused: false,
+            disabled: false,
             spinner_frame: 0,
             title: None,
             show_indicators: true,
@@ -300,6 +302,12 @@ impl<T: Clone> LoadingListState<T> {
     /// Sets whether to show loading indicators.
     pub fn with_indicators(mut self, show: bool) -> Self {
         self.show_indicators = show;
+        self
+    }
+
+    /// Sets the disabled state using builder pattern.
+    pub fn with_disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
         self
     }
 
@@ -437,6 +445,18 @@ impl<T: Clone + 'static> LoadingListState<T> {
         self.focused = focused;
     }
 
+    /// Returns true if the loading list is disabled.
+    pub fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    /// Sets the disabled state.
+    ///
+    /// Disabled loading lists do not respond to input events.
+    pub fn set_disabled(&mut self, disabled: bool) {
+        self.disabled = disabled;
+    }
+
     /// Maps an input event to a loading list message.
     pub fn handle_event(&self, event: &Event) -> Option<LoadingListMessage<T>> {
         LoadingList::handle_event(self, event)
@@ -477,6 +497,19 @@ impl<T: Clone> Component for LoadingList<T> {
     }
 
     fn update(state: &mut Self::State, msg: Self::Message) -> Option<Self::Output> {
+        // Block user-initiated navigation/selection when disabled.
+        // Programmatic state changes (SetItems, SetLoading, etc.) still work.
+        if state.disabled {
+            match msg {
+                LoadingListMessage::Up
+                | LoadingListMessage::Down
+                | LoadingListMessage::First
+                | LoadingListMessage::Last
+                | LoadingListMessage::Select => return None,
+                _ => {}
+            }
+        }
+
         match msg {
             LoadingListMessage::SetItems(items) => {
                 // Convert items without a label function - uses Debug if available
@@ -606,7 +639,7 @@ impl<T: Clone> Component for LoadingList<T> {
     }
 
     fn handle_event(state: &Self::State, event: &Event) -> Option<Self::Message> {
-        if !state.focused {
+        if !state.focused || state.disabled {
             return None;
         }
         if let Some(key) = event.as_key() {

--- a/src/component/loading_list/tests.rs
+++ b/src/component/loading_list/tests.rs
@@ -985,3 +985,113 @@ fn test_instance_methods() {
     ));
     assert_eq!(state.selected(), Some(1));
 }
+
+// ========================================
+// Disabled State Tests
+// ========================================
+
+#[test]
+fn test_with_disabled() {
+    let items = make_items();
+    let state = LoadingListState::with_items(items, |i| i.name.clone()).with_disabled(true);
+    assert!(state.is_disabled());
+
+    let items = make_items();
+    let state = LoadingListState::with_items(items, |i| i.name.clone()).with_disabled(false);
+    assert!(!state.is_disabled());
+}
+
+#[test]
+fn test_set_disabled() {
+    let items = make_items();
+    let mut state = LoadingListState::with_items(items, |i| i.name.clone());
+    assert!(!state.is_disabled());
+    state.set_disabled(true);
+    assert!(state.is_disabled());
+    state.set_disabled(false);
+    assert!(!state.is_disabled());
+}
+
+#[test]
+fn test_disabled_prevents_handle_event() {
+    let items = make_items();
+    let mut state = LoadingListState::with_items(items, |i| i.name.clone());
+    state.set_focused(true);
+    state.set_disabled(true);
+    let msg = LoadingList::<TestItem>::handle_event(&state, &Event::key(KeyCode::Down));
+    assert_eq!(msg, None);
+}
+
+#[test]
+fn test_disabled_prevents_navigation() {
+    let items = make_items();
+    let mut state =
+        LoadingListState::with_items(items, |i| i.name.clone()).with_disabled(true);
+    state.set_focused(true);
+
+    let output = LoadingList::<TestItem>::update(&mut state, LoadingListMessage::Down);
+    assert_eq!(output, None);
+    assert_eq!(state.selected(), None);
+
+    let output = LoadingList::<TestItem>::update(&mut state, LoadingListMessage::Up);
+    assert_eq!(output, None);
+
+    let output = LoadingList::<TestItem>::update(&mut state, LoadingListMessage::First);
+    assert_eq!(output, None);
+
+    let output = LoadingList::<TestItem>::update(&mut state, LoadingListMessage::Last);
+    assert_eq!(output, None);
+
+    let output = LoadingList::<TestItem>::update(&mut state, LoadingListMessage::Select);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_disabled_allows_programmatic_state_changes() {
+    let items = make_items();
+    let mut state =
+        LoadingListState::with_items(items, |i| i.name.clone()).with_disabled(true);
+
+    // SetLoading should still work when disabled
+    let output = LoadingList::<TestItem>::update(&mut state, LoadingListMessage::SetLoading(0));
+    assert!(output.is_some());
+    assert!(state.get(0).unwrap().is_loading());
+
+    // SetReady should still work when disabled
+    let output = LoadingList::<TestItem>::update(&mut state, LoadingListMessage::SetReady(0));
+    assert!(output.is_some());
+    assert!(state.get(0).unwrap().is_ready());
+
+    // Tick should still work when disabled
+    let output = LoadingList::<TestItem>::update(&mut state, LoadingListMessage::Tick);
+    assert!(output.is_none());
+}
+
+#[test]
+fn test_disabled_dispatch_event_returns_none() {
+    let items = make_items();
+    let mut state =
+        LoadingListState::with_items(items, |i| i.name.clone()).with_disabled(true);
+    state.set_focused(true);
+
+    let output = state.dispatch_event(&Event::key(KeyCode::Down));
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_disabled_default_is_false() {
+    let state = LoadingListState::<TestItem>::new();
+    assert!(!state.is_disabled());
+}
+
+#[test]
+fn test_builder_chaining_with_disabled() {
+    let items = make_items();
+    let state = LoadingListState::with_items(items, |i| i.name.clone())
+        .with_title("Test")
+        .with_indicators(true)
+        .with_disabled(true);
+    assert!(state.is_disabled());
+    assert_eq!(state.title(), Some("Test"));
+    assert!(state.show_indicators());
+}

--- a/src/component/select/mod.rs
+++ b/src/component/select/mod.rs
@@ -213,6 +213,12 @@ impl SelectState {
         }
     }
 
+    /// Sets the disabled state using builder pattern.
+    pub fn with_disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
     /// Returns true if the select is focused.
     pub fn is_focused(&self) -> bool {
         self.focused

--- a/src/component/select/tests.rs
+++ b/src/component/select/tests.rs
@@ -420,3 +420,25 @@ fn test_selected_item_none() {
     let state = SelectState::new(vec!["A", "B"]);
     assert_eq!(state.selected_item(), None);
 }
+
+// ========================================
+// Builder Tests
+// ========================================
+
+#[test]
+fn test_with_disabled() {
+    let state = SelectState::new(vec!["A", "B", "C"]).with_disabled(true);
+    assert!(state.is_disabled());
+
+    let state = SelectState::new(vec!["A", "B", "C"]).with_disabled(false);
+    assert!(!state.is_disabled());
+}
+
+#[test]
+fn test_with_disabled_prevents_open() {
+    let mut state = SelectState::new(vec!["A", "B", "C"]).with_disabled(true);
+    state.set_focused(true);
+    let output = Select::update(&mut state, SelectMessage::Open);
+    assert_eq!(output, None);
+    assert!(!state.is_open());
+}


### PR DESCRIPTION
## Summary
- Add `with_disabled()` builder to Checkbox, Dropdown, and Select (all three had `is_disabled()`/`set_disabled()` but were missing the builder method, breaking the pattern used by all other components)
- Add full disabled state to LoadingList: `disabled` field, `is_disabled()`, `set_disabled()`, `with_disabled()`, `handle_event` guard, `update` guard
- LoadingList disabled state blocks user navigation/selection but still allows programmatic state changes (`SetLoading`, `SetReady`, `SetError`, `Tick`)
- Comprehensive tests for all four components

## Test plan
- [x] All 2064+ tests pass (was 2049, added 15 new tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] Checkbox: `with_disabled(true/false)`, prevents toggle, prevents handle_event
- [x] Dropdown: `with_disabled(true/false)`, prevents open
- [x] Select: `with_disabled(true/false)`, prevents open
- [x] LoadingList: full disabled lifecycle, navigation blocked, programmatic state changes still work, builder chaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)