### PR TITLE
Add selected_item() alias to AccordionState

### DIFF
--- a/src/component/accordion/mod.rs
+++ b/src/component/accordion/mod.rs
@@ -238,6 +238,28 @@ impl AccordionState {
         self.panels.get(self.focused_index)
     }
 
+    /// Returns the currently focused panel.
+    ///
+    /// This is an alias for [`focused_panel()`](Self::focused_panel) that provides a
+    /// consistent accessor name across all selection-based components.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{AccordionPanel, AccordionState};
+    ///
+    /// let panels = vec![
+    ///     AccordionPanel::new("Section 1", "Content 1"),
+    ///     AccordionPanel::new("Section 2", "Content 2"),
+    /// ];
+    /// let state = AccordionState::new(panels);
+    /// let item = state.selected_item().unwrap();
+    /// assert_eq!(item.title(), "Section 1");
+    /// ```
+    pub fn selected_item(&self) -> Option<&AccordionPanel> {
+        self.focused_panel()
+    }
+
     /// Returns whether the accordion is disabled.
     pub fn is_disabled(&self) -> bool {
         self.disabled


### PR DESCRIPTION
## Summary
- Adds `selected_item()` method to `AccordionState` as an alias for `focused_panel()`, providing API consistency with all other selection-based components
- All 10 selection-based components now have a uniform `selected_item()` accessor: SelectableList, RadioGroup, Tabs, Table, Tree, Dropdown, Select, Menu, LoadingList, and Accordion
- Includes a doc test for the new method

## Test plan
- [x] `cargo test` passes (2064 unit tests + 190 doc tests including new `selected_item()` doc test)
- [x] `cargo clippy -- -D warnings` passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)