### PR TITLE
Add multi-component integration tests

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7,12 +7,12 @@ use envision::{
     DialogOutput, DialogState, Dropdown, DropdownState, Event, FocusManager, Focusable, InputField,
     InputFieldMessage, InputFieldOutput, InputFieldState, KeyHint, KeyHints, KeyHintsState,
     LoadingList, LoadingListState, Menu, MenuItem, MenuState, MultiProgress, MultiProgressState,
-    ProgressBar, ProgressBarState, RadioGroup, RadioGroupMessage, RadioGroupOutput, RadioGroupState,
-    Select, SelectState, SelectableList, SelectableListMessage, SelectableListOutput,
-    SelectableListState, Spinner, SpinnerState, StatusBar, StatusBarState, StatusLog,
-    StatusLogState, Table, TableRow, TableState, Tabs, TabsMessage, TabsOutput, TabsState,
-    TextArea, TextAreaState, Theme, Toast, ToastState, Toggleable, Tooltip, TooltipState, Tree,
-    TreeNode, TreeState,
+    ProgressBar, ProgressBarState, RadioGroup, RadioGroupMessage, RadioGroupOutput,
+    RadioGroupState, Select, SelectState, SelectableList, SelectableListMessage,
+    SelectableListOutput, SelectableListState, Spinner, SpinnerState, StatusBar, StatusBarState,
+    StatusLog, StatusLogState, Table, TableRow, TableState, Tabs, TabsMessage, TabsOutput,
+    TabsState, TextArea, TextAreaState, Theme, Toast, ToastState, Toggleable, Tooltip,
+    TooltipState, Tree, TreeNode, TreeState,
 };
 use ratatui::prelude::*;
 use ratatui::Terminal;


### PR DESCRIPTION
## Summary
- Add **form workflow test** exercising FocusManager coordinating InputField, Checkbox, and Button with dispatch_event for realistic multi-component interaction
- Add **stress test** with SelectableList of 10,000 items exercising Down events, PageDown(1000), First, and Last navigation
- Add **zero-size area test** verifying all 24 components render to Rect::default() (0x0) without panicking
- Add **AppHarness counter workflow test** using dispatch, render, assert_contains, and assert_not_contains for end-to-end App trait validation

Increases integration test count from 7 to 11.

## Test plan
- [x] `cargo test --test integration` passes all 11 tests
- [x] `cargo test` full suite passes (2064 unit + 11 integration + 13 examples + 189 doc tests)
- [x] No warnings in compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)