### PR TITLE
Add PartialEq to all component State types

### DIFF
--- a/src/component/accordion/mod.rs
+++ b/src/component/accordion/mod.rs
@@ -54,7 +54,7 @@ use crate::theme::Theme;
 /// let panel = AccordionPanel::new("Title", "Content").expanded();
 /// assert!(panel.is_expanded());
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct AccordionPanel {
     /// The panel header/title.
     title: String,
@@ -153,7 +153,7 @@ pub enum AccordionOutput {
 }
 
 /// State for an Accordion component.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct AccordionState {
     /// The accordion panels.
     panels: Vec<AccordionPanel>,

--- a/src/component/breadcrumb/mod.rs
+++ b/src/component/breadcrumb/mod.rs
@@ -145,7 +145,7 @@ pub enum BreadcrumbOutput {
 /// assert_eq!(state.len(), 3);
 /// assert_eq!(state.separator(), " > ");
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct BreadcrumbState {
     /// The breadcrumb segments.
     segments: Vec<BreadcrumbSegment>,

--- a/src/component/button/mod.rs
+++ b/src/component/button/mod.rs
@@ -46,7 +46,7 @@ pub enum ButtonOutput {
 }
 
 /// State for a Button component.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct ButtonState {
     /// The button label.
     label: String,

--- a/src/component/checkbox/mod.rs
+++ b/src/component/checkbox/mod.rs
@@ -49,7 +49,7 @@ pub enum CheckboxOutput {
 }
 
 /// State for a Checkbox component.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct CheckboxState {
     /// The checkbox label.
     label: String,

--- a/src/component/dialog/mod.rs
+++ b/src/component/dialog/mod.rs
@@ -108,7 +108,7 @@ pub enum DialogOutput {
 ///
 /// Contains all the state needed to render and manage a dialog,
 /// including title, message, buttons, and focus state.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct DialogState {
     /// Dialog title.
     title: String,

--- a/src/component/dropdown/mod.rs
+++ b/src/component/dropdown/mod.rs
@@ -72,7 +72,7 @@ pub enum DropdownOutput {
 }
 
 /// State for a Dropdown component.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct DropdownState {
     /// All available options.
     options: Vec<String>,

--- a/src/component/input_field/mod.rs
+++ b/src/component/input_field/mod.rs
@@ -69,7 +69,7 @@ pub enum InputFieldOutput {
 }
 
 /// State for an InputField component.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct InputFieldState {
     /// The current text value.
     value: String,

--- a/src/component/key_hints/mod.rs
+++ b/src/component/key_hints/mod.rs
@@ -194,7 +194,7 @@ pub enum KeyHintsMessage {
 ///     .hint("Enter", "Select")
 ///     .hint("Esc", "Cancel");
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct KeyHintsState {
     /// All key hints.
     hints: Vec<KeyHint>,

--- a/src/component/loading_list/mod.rs
+++ b/src/component/loading_list/mod.rs
@@ -109,6 +109,12 @@ pub struct LoadingListItem<T: Clone> {
     state: ItemState,
 }
 
+impl<T: Clone + PartialEq> PartialEq for LoadingListItem<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data && self.label == other.label && self.state == other.state
+    }
+}
+
 impl<T: Clone> LoadingListItem<T> {
     /// Creates a new item.
     pub fn new(data: T, label: impl Into<String>) -> Self {
@@ -230,6 +236,18 @@ pub struct LoadingListState<T: Clone> {
     title: Option<String>,
     /// Whether to show loading indicators.
     show_indicators: bool,
+}
+
+impl<T: Clone + PartialEq> PartialEq for LoadingListState<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.items == other.items
+            && self.selected == other.selected
+            && self.focused == other.focused
+            && self.disabled == other.disabled
+            && self.spinner_frame == other.spinner_frame
+            && self.title == other.title
+            && self.show_indicators == other.show_indicators
+    }
 }
 
 impl<T: Clone> Default for LoadingListState<T> {

--- a/src/component/menu/mod.rs
+++ b/src/component/menu/mod.rs
@@ -115,7 +115,7 @@ pub enum MenuOutput {
 }
 
 /// State for a Menu component.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct MenuState {
     /// Menu items.
     items: Vec<MenuItem>,

--- a/src/component/multi_progress/mod.rs
+++ b/src/component/multi_progress/mod.rs
@@ -69,7 +69,7 @@ impl ProgressItemStatus {
 }
 
 /// A single progress item.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ProgressItem {
     /// Unique identifier.
     id: String,
@@ -196,7 +196,7 @@ pub enum MultiProgressOutput {
 }
 
 /// State for the MultiProgress component.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct MultiProgressState {
     /// All progress items.
     items: Vec<ProgressItem>,

--- a/src/component/progress_bar/mod.rs
+++ b/src/component/progress_bar/mod.rs
@@ -55,7 +55,7 @@ pub enum ProgressBarOutput {
 }
 
 /// State for a ProgressBar component.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct ProgressBarState {
     /// The current progress value (0.0 to 1.0).
     progress: f32,

--- a/src/component/radio_group/mod.rs
+++ b/src/component/radio_group/mod.rs
@@ -72,6 +72,15 @@ pub struct RadioGroupState<T: Clone> {
     disabled: bool,
 }
 
+impl<T: Clone + PartialEq> PartialEq for RadioGroupState<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.options == other.options
+            && self.selected == other.selected
+            && self.focused == other.focused
+            && self.disabled == other.disabled
+    }
+}
+
 impl<T: Clone> Default for RadioGroupState<T> {
     fn default() -> Self {
         Self {

--- a/src/component/router/mod.rs
+++ b/src/component/router/mod.rs
@@ -132,6 +132,14 @@ impl<S: Default + Clone + PartialEq> Default for RouterState<S> {
     }
 }
 
+impl<S: Clone + PartialEq> PartialEq for RouterState<S> {
+    fn eq(&self, other: &Self) -> bool {
+        self.current == other.current
+            && self.history == other.history
+            && self.max_history == other.max_history
+    }
+}
+
 impl<S: Clone + PartialEq> RouterState<S> {
     /// Creates a new router state starting at the given screen.
     pub fn new(initial: S) -> Self {

--- a/src/component/select/mod.rs
+++ b/src/component/select/mod.rs
@@ -59,7 +59,7 @@ pub enum SelectOutput {
 }
 
 /// State for a Select component.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct SelectState {
     /// Available options.
     options: Vec<String>,

--- a/src/component/selectable_list/mod.rs
+++ b/src/component/selectable_list/mod.rs
@@ -64,6 +64,15 @@ pub struct SelectableListState<T: Clone> {
     disabled: bool,
 }
 
+impl<T: Clone + PartialEq> PartialEq for SelectableListState<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.items == other.items
+            && self.list_state.selected() == other.list_state.selected()
+            && self.focused == other.focused
+            && self.disabled == other.disabled
+    }
+}
+
 impl<T: Clone> Default for SelectableListState<T> {
     fn default() -> Self {
         Self {

--- a/src/component/spinner/mod.rs
+++ b/src/component/spinner/mod.rs
@@ -132,7 +132,7 @@ pub enum SpinnerMessage {
 }
 
 /// State for a Spinner component.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SpinnerState {
     /// The animation style.
     style: SpinnerStyle,

--- a/src/component/status_bar/mod.rs
+++ b/src/component/status_bar/mod.rs
@@ -173,7 +173,7 @@ pub enum StatusBarMessage {
 }
 
 /// State for a StatusBar component.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct StatusBarState {
     /// Items aligned to the left.
     left: Vec<StatusBarItem>,

--- a/src/component/status_log/mod.rs
+++ b/src/component/status_log/mod.rs
@@ -64,7 +64,7 @@ impl StatusLogLevel {
 }
 
 /// A single status log entry.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct StatusLogEntry {
     /// Unique identifier.
     id: u64,
@@ -177,7 +177,7 @@ pub enum StatusLogOutput {
 ///
 /// state.info("Application started");
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct StatusLogState {
     /// All log entries (stored in insertion order, displayed newest first).
     entries: Vec<StatusLogEntry>,

--- a/src/component/table/mod.rs
+++ b/src/component/table/mod.rs
@@ -110,7 +110,7 @@ pub trait TableRow: Clone {
 /// assert_eq!(col.header(), "Name");
 /// assert!(col.is_sortable());
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Column {
     header: String,
     width: Constraint,
@@ -231,6 +231,18 @@ pub struct TableState<T: TableRow> {
     display_order: Vec<usize>,
     focused: bool,
     disabled: bool,
+}
+
+impl<T: TableRow + PartialEq> PartialEq for TableState<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.rows == other.rows
+            && self.columns == other.columns
+            && self.selected == other.selected
+            && self.sort == other.sort
+            && self.display_order == other.display_order
+            && self.focused == other.focused
+            && self.disabled == other.disabled
+    }
 }
 
 impl<T: TableRow> Default for TableState<T> {

--- a/src/component/tabs/mod.rs
+++ b/src/component/tabs/mod.rs
@@ -75,6 +75,15 @@ pub struct TabsState<T: Clone> {
     disabled: bool,
 }
 
+impl<T: Clone + PartialEq> PartialEq for TabsState<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.tabs == other.tabs
+            && self.selected == other.selected
+            && self.focused == other.focused
+            && self.disabled == other.disabled
+    }
+}
+
 impl<T: Clone> Default for TabsState<T> {
     fn default() -> Self {
         Self {

--- a/src/component/text_area/mod.rs
+++ b/src/component/text_area/mod.rs
@@ -90,7 +90,7 @@ pub enum TextAreaOutput {
 }
 
 /// State for a TextArea component.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TextAreaState {
     /// Lines of text.
     lines: Vec<String>,

--- a/src/component/toast/mod.rs
+++ b/src/component/toast/mod.rs
@@ -57,7 +57,7 @@ pub enum ToastLevel {
 ///
 /// Each toast has a unique ID, message, severity level, and optional
 /// remaining duration for auto-dismiss.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ToastItem {
     /// Unique identifier for this toast.
     id: u64,
@@ -133,7 +133,7 @@ pub enum ToastOutput {
 ///
 /// Manages a collection of toast notifications with support for
 /// auto-dismiss, manual dismiss, and configurable limits.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ToastState {
     /// Active toasts.
     toasts: Vec<ToastItem>,

--- a/src/component/tooltip/mod.rs
+++ b/src/component/tooltip/mod.rs
@@ -99,7 +99,7 @@ pub enum TooltipOutput {
 ///     .with_fg_color(Color::White)
 ///     .with_bg_color(Color::DarkGray);
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TooltipState {
     /// The tooltip content/text.
     content: String,

--- a/src/component/tree/mod.rs
+++ b/src/component/tree/mod.rs
@@ -41,6 +41,15 @@ pub struct TreeNode<T> {
     expanded: bool,
 }
 
+impl<T: PartialEq> PartialEq for TreeNode<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.label == other.label
+            && self.data == other.data
+            && self.children == other.children
+            && self.expanded == other.expanded
+    }
+}
+
 impl<T: Clone> TreeNode<T> {
     /// Creates a new tree node with a label and data.
     ///
@@ -215,6 +224,15 @@ pub struct TreeState<T> {
     focused: bool,
     /// Whether the tree is disabled.
     disabled: bool,
+}
+
+impl<T: Clone + PartialEq> PartialEq for TreeState<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.roots == other.roots
+            && self.selected_index == other.selected_index
+            && self.focused == other.focused
+            && self.disabled == other.disabled
+    }
 }
 
 impl<T: Clone> Default for TreeState<T> {


### PR DESCRIPTION
## Summary

- Add `PartialEq` to all 25 component State types, closing a major trait gap
- Concrete State types (19) use `derive(PartialEq)`, with PartialEq also added to sub-types: `AccordionPanel`, `ToastItem`, `StatusLogEntry`, `ProgressItem`, `Column`, `TreeNode`, `LoadingListItem`
- Generic State types (6) use manual `PartialEq` impls with `T: Clone + PartialEq` bounds, comparing all user-visible fields and skipping internal ratatui state (e.g., `ListState` in `SelectableListState`)
- `RouterState<S>` gets a manual impl since `S` already has `Clone + PartialEq` bounds

## Components Updated

**Concrete (derive):** ButtonState, CheckboxState, InputFieldState, AccordionState, DialogState, SpinnerState, ProgressBarState, ToastState, TooltipState, StatusBarState, StatusLogState, KeyHintsState, MultiProgressState, DropdownState, SelectState, MenuState, TextAreaState, BreadcrumbState

**Generic (manual impl):** SelectableListState\<T\>, RadioGroupState\<T\>, TabsState\<T\>, TableState\<T\>, TreeState\<T\>, LoadingListState\<T\>, RouterState\<S\>

## Test plan

- [x] All existing tests pass (`cargo test` -- 189 passed, 0 failed)
- [x] No clippy warnings (`cargo clippy -- -D warnings`)
- [x] No files exceed 1000 lines

Generated with [Claude Code](https://claude.com/claude-code)