### PR TITLE
Add no-default-features CI job and example build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,37 @@ jobs:
       - name: Run tests
         run: cargo test --all-features --verbose
 
+      - name: Build examples
+        run: cargo build --examples
+
+  no-default-features:
+    name: No Default Features
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-no-default-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-no-default-
+
+      - name: Check without default features
+        run: cargo check --no-default-features
+
+      - name: Test without default features
+        run: cargo test --no-default-features
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add a dedicated `no-default-features` CI job that runs `cargo check --no-default-features` and `cargo test --no-default-features`, enforcing what CONTRIBUTING.md already documents but CI did not previously verify
- Add a `cargo build --examples` step to the test matrix to catch broken examples before merge

## Test plan
- [ ] Verify the new `no-default-features` job appears in CI and passes
- [ ] Verify `cargo build --examples` step runs in the test matrix
- [ ] Verify existing CI jobs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)