### PR TITLE
Replace ratatui imports with envision re-exports in docs and examples

### DIFF
--- a/examples/annotations.rs
+++ b/examples/annotations.rs
@@ -12,10 +12,9 @@
 use envision::annotation::{with_annotations, Annotate, Annotation, WidgetType};
 use envision::backend::CaptureBackend;
 use envision::harness::TestHarness;
-use ratatui::layout::{Alignment, Constraint, Layout};
-use ratatui::style::{Color, Modifier, Style};
+use envision::layout::{Alignment, Constraint, Layout, Terminal};
+use envision::style::{Color, Modifier, Style};
 use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
-use ratatui::Terminal;
 
 fn main() {
     println!("╔══════════════════════════════════════╗");

--- a/examples/async_counter.rs
+++ b/examples/async_counter.rs
@@ -12,9 +12,6 @@ use std::time::Duration;
 
 use envision::app::tick;
 use envision::prelude::*;
-use ratatui::layout::{Alignment, Constraint, Layout};
-use ratatui::style::{Color, Modifier, Style};
-use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 /// The application marker type

--- a/examples/capture_backend.rs
+++ b/examples/capture_backend.rs
@@ -6,11 +6,10 @@
 //! Run with: cargo run --example capture_backend
 
 use envision::backend::CaptureBackend;
-use ratatui::layout::{Constraint, Layout};
-use ratatui::style::{Color, Style};
+use envision::layout::{Constraint, Layout, Terminal};
+use envision::style::{Color, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
-use ratatui::Terminal;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a CaptureBackend - this captures all rendering without a real terminal

--- a/examples/component_showcase.rs
+++ b/examples/component_showcase.rs
@@ -34,8 +34,6 @@ use envision::component::{
     TableOutput, TableRow, TableState, Tabs, TabsState, Toast, ToastMessage, ToastState,
 };
 use envision::prelude::*;
-use ratatui::layout::{Alignment, Constraint, Layout};
-use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 // ---------------------------------------------------------------------------

--- a/examples/counter_app.rs
+++ b/examples/counter_app.rs
@@ -10,9 +10,6 @@
 //! Run with: cargo run --example counter_app
 
 use envision::prelude::*;
-use ratatui::layout::{Alignment, Constraint, Layout};
-use ratatui::style::{Color, Modifier, Style};
-use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 /// The application marker type

--- a/examples/test_harness.rs
+++ b/examples/test_harness.rs
@@ -12,8 +12,6 @@ use std::ops::Not;
 
 use envision::harness::{Assertion, TestHarness};
 use envision::prelude::*;
-use ratatui::layout::{Alignment, Constraint, Layout};
-use ratatui::style::{Color, Modifier, Style};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 // =============================================================================

--- a/examples/themed_app.rs
+++ b/examples/themed_app.rs
@@ -12,9 +12,6 @@ use envision::component::{
     SelectableList, SelectableListMessage, SelectableListState,
 };
 use envision::prelude::*;
-use ratatui::layout::{Alignment, Constraint, Layout};
-use ratatui::style::{Modifier, Style};
-use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 /// The application marker type

--- a/src/adapter/dual/mod.rs
+++ b/src/adapter/dual/mod.rs
@@ -28,8 +28,8 @@ use crate::backend::CaptureBackend;
 /// // requires stdout access for CrosstermBackend
 /// use envision::adapter::DualBackend;
 /// use envision::backend::CaptureBackend;
+/// use envision::layout::Terminal;
 /// use ratatui::backend::CrosstermBackend;
-/// use ratatui::Terminal;
 /// use std::io::stdout;
 ///
 /// let capture = CaptureBackend::new(80, 24);

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -9,8 +9,8 @@
 //! // requires stdout access
 //! use envision::adapter::DualBackend;
 //! use envision::backend::CaptureBackend;
+//! use envision::layout::Terminal;
 //! use ratatui::backend::CrosstermBackend;
-//! use ratatui::Terminal;
 //! use std::io::stdout;
 //!
 //! // Create a dual backend that writes to both terminal and capture

--- a/src/annotation/mod.rs
+++ b/src/annotation/mod.rs
@@ -11,8 +11,8 @@
 //!
 //! ```rust
 //! use envision::annotation::{Annotate, Annotation};
+//! use envision::layout::Frame;
 //! use ratatui::widgets::Paragraph;
-//! use ratatui::Frame;
 //!
 //! fn render(frame: &mut Frame) {
 //!     let area = frame.area();

--- a/src/annotation/widget.rs
+++ b/src/annotation/widget.rs
@@ -150,9 +150,9 @@ thread_local! {
 ///
 /// ```rust
 /// use envision::annotation::{with_annotations, Annotate, Annotation};
-/// use ratatui::widgets::Paragraph;
-/// use ratatui::Terminal;
 /// use envision::backend::CaptureBackend;
+/// use envision::layout::Terminal;
+/// use ratatui::widgets::Paragraph;
 ///
 /// let backend = CaptureBackend::new(80, 24);
 /// let mut terminal = Terminal::new(backend).unwrap();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -36,7 +36,7 @@
 //! ```rust
 //! use envision::app::{App, Command, Update};
 //! use envision::input::Event;
-//! use ratatui::Frame;
+//! use envision::layout::Frame;
 //!
 //! // Define your state
 //! #[derive(Default, Clone)]

--- a/src/app/model/mod.rs
+++ b/src/app/model/mod.rs
@@ -25,7 +25,7 @@ use crate::input::Event;
 ///
 /// ```rust
 /// use envision::app::{App, Command};
-/// use ratatui::Frame;
+/// use envision::layout::Frame;
 ///
 /// struct MyApp;
 ///

--- a/src/backend/capture/mod.rs
+++ b/src/backend/capture/mod.rs
@@ -32,7 +32,7 @@ use super::output::OutputFormat;
 ///
 /// ```rust
 /// use envision::backend::CaptureBackend;
-/// use ratatui::Terminal;
+/// use envision::layout::Terminal;
 /// use ratatui::widgets::Paragraph;
 ///
 /// let backend = CaptureBackend::new(80, 24);

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -36,7 +36,8 @@
 //! ```rust
 //! use envision::component::{Component, Focusable};
 //! use envision::theme::Theme;
-//! use ratatui::prelude::*;
+//! use envision::layout::{Rect, Frame};
+//! use envision::style::Stylize;
 //!
 //! struct Counter;
 //!
@@ -284,7 +285,7 @@ pub trait Component: Sized {
 /// ```rust
 /// use envision::component::{Component, Focusable};
 /// use envision::theme::Theme;
-/// use ratatui::prelude::*;
+/// use envision::layout::{Rect, Frame};
 ///
 /// struct TextInput;
 ///
@@ -351,7 +352,7 @@ pub trait Focusable: Component {
 /// ```rust
 /// use envision::component::{Component, Toggleable};
 /// use envision::theme::Theme;
-/// use ratatui::prelude::*;
+/// use envision::layout::{Rect, Frame};
 ///
 /// struct HelpPanel;
 ///

--- a/src/component/router/mod.rs
+++ b/src/component/router/mod.rs
@@ -33,7 +33,7 @@
 //!
 //! ```rust
 //! use envision::component::RouterState;
-//! use ratatui::Frame;
+//! use envision::layout::Frame;
 //!
 //! #[derive(Clone, Debug, PartialEq, Eq)]
 //! enum Screen { Home, Settings, Profile }

--- a/src/component/table/mod.rs
+++ b/src/component/table/mod.rs
@@ -10,7 +10,7 @@
 //!     Column, Component, Focusable, SortDirection, Table, TableMessage, TableOutput,
 //!     TableRow, TableState,
 //! };
-//! use ratatui::layout::Constraint;
+//! use envision::layout::Constraint;
 //!
 //! // Define your row type
 //! #[derive(Clone, Debug, PartialEq)]
@@ -53,9 +53,10 @@
 
 use std::marker::PhantomData;
 
-use ratatui::layout::Constraint;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Cell, Row};
+
+use crate::layout::Constraint;
 
 use super::{Component, Focusable};
 use crate::input::{Event, KeyCode};
@@ -104,7 +105,7 @@ pub trait TableRow: Clone {
 ///
 /// ```rust
 /// use envision::component::Column;
-/// use ratatui::layout::Constraint;
+/// use envision::layout::Constraint;
 ///
 /// let col = Column::new("Name", Constraint::Length(20)).sortable();
 /// assert_eq!(col.header(), "Name");
@@ -268,7 +269,7 @@ impl<T: TableRow> TableState<T> {
     ///
     /// ```rust
     /// use envision::component::{Column, TableRow, TableState};
-    /// use ratatui::layout::Constraint;
+    /// use envision::layout::Constraint;
     ///
     /// #[derive(Clone)]
     /// struct Item { name: String }
@@ -422,7 +423,7 @@ impl<T: TableRow> TableState<T> {
     ///
     /// ```rust
     /// use envision::component::{Column, TableRow, TableState};
-    /// use ratatui::layout::Constraint;
+    /// use envision::layout::Constraint;
     ///
     /// #[derive(Clone)]
     /// struct Item { name: String }
@@ -527,7 +528,7 @@ impl<T: TableRow + 'static> TableState<T> {
 /// use envision::component::{
 ///     Column, Component, Table, TableMessage, TableRow, TableState,
 /// };
-/// use ratatui::layout::Constraint;
+/// use envision::layout::Constraint;
 ///
 /// #[derive(Clone, Debug, PartialEq)]
 /// struct Person {

--- a/src/component/tooltip/mod.rs
+++ b/src/component/tooltip/mod.rs
@@ -90,7 +90,7 @@ pub enum TooltipOutput {
 ///
 /// ```rust
 /// use envision::component::{TooltipState, TooltipPosition};
-/// use ratatui::style::Color;
+/// use envision::style::Color;
 ///
 /// let state = TooltipState::new("Helpful tooltip text")
 ///     .with_title("Info")
@@ -206,7 +206,7 @@ impl TooltipState {
     ///
     /// ```rust
     /// use envision::component::TooltipState;
-    /// use ratatui::style::Color;
+    /// use envision::style::Color;
     ///
     /// let state = TooltipState::new("Content").with_fg_color(Color::Yellow);
     /// assert_eq!(state.fg_color(), Color::Yellow);
@@ -222,7 +222,7 @@ impl TooltipState {
     ///
     /// ```rust
     /// use envision::component::TooltipState;
-    /// use ratatui::style::Color;
+    /// use envision::style::Color;
     ///
     /// let state = TooltipState::new("Content").with_bg_color(Color::DarkGray);
     /// assert_eq!(state.bg_color(), Color::DarkGray);
@@ -238,7 +238,7 @@ impl TooltipState {
     ///
     /// ```rust
     /// use envision::component::TooltipState;
-    /// use ratatui::style::Color;
+    /// use envision::style::Color;
     ///
     /// let state = TooltipState::new("Content").with_border_color(Color::Yellow);
     /// assert_eq!(state.border_color(), Color::Yellow);
@@ -485,7 +485,6 @@ impl Tooltip {
     ///
     /// ```rust
     /// use envision::component::{Tooltip, TooltipState, Toggleable};
-    /// use ratatui::prelude::*;
     ///
     /// let mut state = TooltipState::new("Button help text");
     /// Tooltip::show(&mut state);

--- a/src/overlay/traits.rs
+++ b/src/overlay/traits.rs
@@ -21,8 +21,7 @@ use super::OverlayAction;
 /// use envision::input::Event;
 /// use envision::theme::Theme;
 /// use crossterm::event::KeyCode;
-/// use ratatui::layout::Rect;
-/// use ratatui::Frame;
+/// use envision::layout::{Rect, Frame};
 ///
 /// struct ConfirmDialog {
 ///     message: String,

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -25,7 +25,7 @@
 //!
 //! ```rust
 //! use envision::theme::Theme;
-//! use ratatui::style::Color;
+//! use envision::style::Color;
 //!
 //! let my_theme = Theme {
 //!     focused: Color::Magenta,


### PR DESCRIPTION
## Summary
- Update all 7 example files to use `envision::layout` and `envision::style` instead of `ratatui::layout` and `ratatui::style`
- Update ~15 public API doc comments to reference envision re-exports
- Examples using `envision::prelude::*` no longer need separate ratatui layout/style imports
- 20 files changed, net reduction of 15 lines

**Depends on**: #82 (layout and style modules)

## Test plan
- [x] All doc tests pass (233 total)
- [x] `cargo build --examples` compiles
- [x] `cargo clippy -- -D warnings` clean
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)