### PR TITLE
Add optional tracing integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tracing",
  "unicode-width 0.2.0",
 ]
 
@@ -1200,6 +1201,37 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,14 @@ categories = ["command-line-interface", "development-tools::testing"]
 [features]
 default = ["serialization"]
 serialization = ["dep:serde", "dep:serde_json", "compact_str/serde"]
+tracing = ["dep:tracing"]
 
 [dependencies]
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
+tracing = { version = "0.1", optional = true }
 unicode-width = "0.2"
 compact_str = "0.8"
 tokio = { version = "1", features = ["sync", "rt", "macros", "time"] }

--- a/src/app/command/mod.rs
+++ b/src/app/command/mod.rs
@@ -320,6 +320,9 @@ impl<M: Send + 'static> CommandHandler<M> {
     /// Async actions are collected for later spawning via [`spawn_pending`](CommandHandler::spawn_pending).
     pub fn execute(&mut self, command: Command<M>) {
         for action in command.into_actions() {
+            #[cfg(feature = "tracing")]
+            tracing::trace!("executing command action");
+
             if let Some(async_action) = self.core.execute_action(action) {
                 match async_action {
                     CommandAction::Async(fut) => {
@@ -346,6 +349,15 @@ impl<M: Send + 'static> CommandHandler<M> {
         err_tx: tokio::sync::mpsc::Sender<BoxedError>,
         cancel: tokio_util::sync::CancellationToken,
     ) {
+        #[cfg(feature = "tracing")]
+        {
+            let regular = self.pending_futures.len();
+            let fallible = self.pending_fallible_futures.len();
+            if regular > 0 || fallible > 0 {
+                tracing::debug!(regular, fallible, "spawning async command tasks");
+            }
+        }
+
         // Spawn regular async futures
         for fut in self.pending_futures.drain(..) {
             let tx = msg_tx.clone();

--- a/src/app/runtime/mod.rs
+++ b/src/app/runtime/mod.rs
@@ -239,6 +239,9 @@ impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
     pub async fn run_terminal(mut self) -> io::Result<()> {
         use futures_util::StreamExt;
 
+        #[cfg(feature = "tracing")]
+        tracing::info!("starting terminal runtime loop");
+
         let mut tick_interval = tokio::time::interval(self.config.tick_rate);
         let mut render_interval = tokio::time::interval(self.config.frame_rate);
         let mut event_stream = crossterm::event::EventStream::new();
@@ -637,6 +640,9 @@ impl<A: App, B: Backend> Runtime<A, B> {
 
     /// Dispatches a message to update the state.
     pub fn dispatch(&mut self, msg: A::Message) {
+        #[cfg(feature = "tracing")]
+        tracing::debug!("dispatch: updating state");
+
         let cmd = A::update(&mut self.core.state, msg);
         self.commands.execute(cmd);
 
@@ -682,6 +688,9 @@ impl<A: App, B: Backend> Runtime<A, B> {
     /// Processes messages received from async tasks.
     fn process_async_messages(&mut self) {
         while let Ok(msg) = self.message_rx.try_recv() {
+            #[cfg(feature = "tracing")]
+            tracing::debug!("processing async message");
+
             self.dispatch(msg);
         }
     }
@@ -727,6 +736,9 @@ impl<A: App, B: Backend> Runtime<A, B> {
     /// - [`process_event`](Runtime::process_event) — Process exactly one event
     /// - [`run_ticks`](Runtime::run_ticks) — Convenience: run N full tick cycles
     pub fn tick(&mut self) -> io::Result<()> {
+        #[cfg(feature = "tracing")]
+        tracing::trace!("tick: start");
+
         // Process pending commands
         self.process_commands();
 
@@ -737,6 +749,11 @@ impl<A: App, B: Backend> Runtime<A, B> {
         let mut messages_processed = 0;
         while self.process_event() && messages_processed < self.core.max_messages_per_tick {
             messages_processed += 1;
+        }
+
+        #[cfg(feature = "tracing")]
+        if messages_processed > 0 {
+            tracing::debug!(messages_processed, "tick: processed events");
         }
 
         // Handle tick

--- a/src/app/runtime_core/mod.rs
+++ b/src/app/runtime_core/mod.rs
@@ -34,6 +34,9 @@ impl<A: App, B: Backend> RuntimeCore<A, B> {
     ///
     /// Renders the main app view first, then any active overlays on top.
     pub(crate) fn render(&mut self) -> io::Result<()> {
+        #[cfg(feature = "tracing")]
+        tracing::trace!("render: drawing frame");
+
         let theme = &self.theme;
         let overlay_stack = &self.overlay_stack;
         self.terminal.draw(|frame| {


### PR DESCRIPTION
## Summary
- Add `tracing` feature flag to Cargo.toml with optional `tracing` dependency
- Instrument key runtime execution points with `#[cfg(feature = "tracing")]` guards
- Zero cost when feature is disabled; structured logging when enabled
- Instrumented: runtime loop, dispatch/update, async messages, tick, render, command execution, task spawning

## Test plan
- [x] `cargo build` — compiles without tracing (default)
- [x] `cargo build --features tracing` — compiles with tracing
- [x] `cargo build --no-default-features` — compiles
- [x] `cargo clippy --features tracing -- -D warnings` — clean
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)