### PR TITLE
Add component group feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,24 @@ keywords = ["tui", "terminal", "ratatui", "testing", "headless"]
 categories = ["command-line-interface", "development-tools::testing"]
 
 [features]
-default = ["serialization"]
+default = ["serialization", "full"]
+
+# Enable all components
+full = [
+    "input-components",
+    "data-components",
+    "display-components",
+    "navigation-components",
+    "overlay-components",
+]
+
+# Component groups
+input-components = []
+data-components = []
+display-components = []
+navigation-components = []
+overlay-components = []
+
 serialization = ["dep:serde", "dep:serde_json", "compact_str/serde"]
 
 [dependencies]
@@ -38,6 +55,14 @@ proptest = "~1.8"
 # Note: fastbreak is used for spec validation via CLI, not as a cargo dependency
 # Run `fastbreak check` to validate specs/main.fbrk
 
+[[example]]
+name = "themed_app"
+required-features = ["input-components", "data-components", "display-components"]
+
+[[example]]
+name = "component_showcase"
+required-features = ["full"]
+
 [[bench]]
 name = "capture_backend"
 harness = false
@@ -49,7 +74,9 @@ harness = false
 [[bench]]
 name = "component_view"
 harness = false
+required-features = ["data-components"]
 
 [[bench]]
 name = "component_events"
 harness = false
+required-features = ["input-components", "data-components"]

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -104,74 +104,146 @@ use ratatui::prelude::*;
 use crate::input::Event;
 use crate::theme::Theme;
 
-mod accordion;
-mod breadcrumb;
+// Input components
+#[cfg(feature = "input-components")]
 mod button;
+#[cfg(feature = "input-components")]
 mod checkbox;
-mod dialog;
+#[cfg(feature = "input-components")]
 mod dropdown;
-mod focus_manager;
+#[cfg(feature = "input-components")]
 mod input_field;
-mod key_hints;
-mod loading_list;
-mod menu;
-mod multi_progress;
-mod progress_bar;
+#[cfg(feature = "input-components")]
 mod radio_group;
-mod router;
+#[cfg(feature = "input-components")]
 mod select;
-mod selectable_list;
-mod spinner;
-mod status_bar;
-mod status_log;
-mod table;
-mod tabs;
+#[cfg(feature = "input-components")]
 mod text_area;
-mod toast;
-mod tooltip;
+
+// Data components
+#[cfg(feature = "data-components")]
+mod loading_list;
+#[cfg(feature = "data-components")]
+mod selectable_list;
+#[cfg(feature = "data-components")]
+mod table;
+#[cfg(feature = "data-components")]
 mod tree;
 
-pub use accordion::{Accordion, AccordionMessage, AccordionOutput, AccordionPanel, AccordionState};
-pub use breadcrumb::{
-    Breadcrumb, BreadcrumbMessage, BreadcrumbOutput, BreadcrumbSegment, BreadcrumbState,
-};
+// Display components
+#[cfg(feature = "display-components")]
+mod key_hints;
+#[cfg(feature = "display-components")]
+mod multi_progress;
+#[cfg(feature = "display-components")]
+mod progress_bar;
+#[cfg(feature = "display-components")]
+mod spinner;
+#[cfg(feature = "display-components")]
+mod status_bar;
+#[cfg(feature = "display-components")]
+mod status_log;
+#[cfg(feature = "display-components")]
+mod toast;
+
+// Navigation components
+#[cfg(feature = "navigation-components")]
+mod accordion;
+#[cfg(feature = "navigation-components")]
+mod breadcrumb;
+#[cfg(feature = "navigation-components")]
+mod menu;
+#[cfg(feature = "navigation-components")]
+mod router;
+#[cfg(feature = "navigation-components")]
+mod tabs;
+
+// Overlay components
+#[cfg(feature = "overlay-components")]
+mod dialog;
+#[cfg(feature = "overlay-components")]
+mod tooltip;
+
+// Always available
+mod focus_manager;
+
+// Input components
+#[cfg(feature = "input-components")]
 pub use button::{Button, ButtonMessage, ButtonOutput, ButtonState};
+#[cfg(feature = "input-components")]
 pub use checkbox::{Checkbox, CheckboxMessage, CheckboxOutput, CheckboxState};
-pub use dialog::{Dialog, DialogButton, DialogMessage, DialogOutput, DialogState};
+#[cfg(feature = "input-components")]
 pub use dropdown::{Dropdown, DropdownMessage, DropdownOutput, DropdownState};
-pub use focus_manager::FocusManager;
+#[cfg(feature = "input-components")]
 pub use input_field::{InputField, InputFieldMessage, InputFieldOutput, InputFieldState};
-pub use key_hints::{KeyHint, KeyHints, KeyHintsLayout, KeyHintsMessage, KeyHintsState};
+#[cfg(feature = "input-components")]
+pub use radio_group::{RadioGroup, RadioGroupMessage, RadioGroupOutput, RadioGroupState};
+#[cfg(feature = "input-components")]
+pub use select::{Select, SelectMessage, SelectOutput, SelectState};
+#[cfg(feature = "input-components")]
+pub use text_area::{TextArea, TextAreaMessage, TextAreaOutput, TextAreaState};
+
+// Data components
+#[cfg(feature = "data-components")]
 pub use loading_list::{
     ItemState, LoadingList, LoadingListItem, LoadingListMessage, LoadingListOutput,
     LoadingListState,
 };
-pub use menu::{Menu, MenuItem, MenuMessage, MenuOutput, MenuState};
+#[cfg(feature = "data-components")]
+pub use selectable_list::{
+    SelectableList, SelectableListMessage, SelectableListOutput, SelectableListState,
+};
+#[cfg(feature = "data-components")]
+pub use table::{Column, SortDirection, Table, TableMessage, TableOutput, TableRow, TableState};
+#[cfg(feature = "data-components")]
+pub use tree::{Tree, TreeMessage, TreeNode, TreeOutput, TreeState};
+
+// Display components
+#[cfg(feature = "display-components")]
+pub use key_hints::{KeyHint, KeyHints, KeyHintsLayout, KeyHintsMessage, KeyHintsState};
+#[cfg(feature = "display-components")]
 pub use multi_progress::{
     MultiProgress, MultiProgressMessage, MultiProgressOutput, MultiProgressState, ProgressItem,
     ProgressItemStatus,
 };
+#[cfg(feature = "display-components")]
 pub use progress_bar::{ProgressBar, ProgressBarMessage, ProgressBarOutput, ProgressBarState};
-pub use radio_group::{RadioGroup, RadioGroupMessage, RadioGroupOutput, RadioGroupState};
-pub use router::{NavigationMode, Router, RouterMessage, RouterOutput, RouterState};
-pub use select::{Select, SelectMessage, SelectOutput, SelectState};
-pub use selectable_list::{
-    SelectableList, SelectableListMessage, SelectableListOutput, SelectableListState,
-};
+#[cfg(feature = "display-components")]
 pub use spinner::{Spinner, SpinnerMessage, SpinnerState, SpinnerStyle};
+#[cfg(feature = "display-components")]
 pub use status_bar::{
     Section, StatusBar, StatusBarItem, StatusBarItemContent, StatusBarMessage, StatusBarState,
     StatusBarStyle,
 };
+#[cfg(feature = "display-components")]
 pub use status_log::{
     StatusLog, StatusLogEntry, StatusLogLevel, StatusLogMessage, StatusLogOutput, StatusLogState,
 };
-pub use table::{Column, SortDirection, Table, TableMessage, TableOutput, TableRow, TableState};
-pub use tabs::{Tabs, TabsMessage, TabsOutput, TabsState};
-pub use text_area::{TextArea, TextAreaMessage, TextAreaOutput, TextAreaState};
+#[cfg(feature = "display-components")]
 pub use toast::{Toast, ToastItem, ToastLevel, ToastMessage, ToastOutput, ToastState};
+
+// Navigation components
+#[cfg(feature = "navigation-components")]
+pub use accordion::{Accordion, AccordionMessage, AccordionOutput, AccordionPanel, AccordionState};
+#[cfg(feature = "navigation-components")]
+pub use breadcrumb::{
+    Breadcrumb, BreadcrumbMessage, BreadcrumbOutput, BreadcrumbSegment, BreadcrumbState,
+};
+#[cfg(feature = "navigation-components")]
+pub use menu::{Menu, MenuItem, MenuMessage, MenuOutput, MenuState};
+#[cfg(feature = "navigation-components")]
+pub use router::{NavigationMode, Router, RouterMessage, RouterOutput, RouterState};
+#[cfg(feature = "navigation-components")]
+pub use tabs::{Tabs, TabsMessage, TabsOutput, TabsState};
+
+// Overlay components
+#[cfg(feature = "overlay-components")]
+pub use dialog::{Dialog, DialogButton, DialogMessage, DialogOutput, DialogState};
+#[cfg(feature = "overlay-components")]
 pub use tooltip::{Tooltip, TooltipMessage, TooltipOutput, TooltipPosition, TooltipState};
-pub use tree::{Tree, TreeMessage, TreeNode, TreeOutput, TreeState};
+
+// Always available
+pub use focus_manager::FocusManager;
 
 /// A composable UI component with its own state and message handling.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,28 +115,54 @@ pub use app::{
     ThrottleSubscription, TickSubscription, TimerSubscription,
 };
 pub use backend::{CaptureBackend, EnhancedCell, FrameSnapshot};
+// Core component traits and utilities (always available)
+pub use component::{Component, FocusManager, Focusable, Toggleable};
+
+// Input components
+#[cfg(feature = "input-components")]
+pub use component::{
+    Button, ButtonMessage, ButtonOutput, ButtonState, Checkbox, CheckboxMessage, CheckboxOutput,
+    CheckboxState, Dropdown, DropdownMessage, DropdownOutput, DropdownState, InputField,
+    InputFieldMessage, InputFieldOutput, InputFieldState, RadioGroup, RadioGroupMessage,
+    RadioGroupOutput, RadioGroupState, Select, SelectMessage, SelectOutput, SelectState, TextArea,
+    TextAreaMessage, TextAreaOutput, TextAreaState,
+};
+
+// Data components
+#[cfg(feature = "data-components")]
+pub use component::{
+    Column, ItemState, LoadingList, LoadingListItem, LoadingListMessage, LoadingListOutput,
+    LoadingListState, SelectableList, SelectableListMessage, SelectableListOutput,
+    SelectableListState, SortDirection, Table, TableMessage, TableOutput, TableRow, TableState,
+    Tree, TreeMessage, TreeNode, TreeOutput, TreeState,
+};
+
+// Display components
+#[cfg(feature = "display-components")]
+pub use component::{
+    KeyHint, KeyHints, KeyHintsLayout, KeyHintsMessage, KeyHintsState, MultiProgress,
+    MultiProgressMessage, MultiProgressOutput, MultiProgressState, ProgressBar,
+    ProgressBarMessage, ProgressBarOutput, ProgressBarState, ProgressItem, ProgressItemStatus,
+    Section, Spinner, SpinnerMessage, SpinnerState, SpinnerStyle, StatusBar, StatusBarItem,
+    StatusBarItemContent, StatusBarMessage, StatusBarState, StatusBarStyle, StatusLog,
+    StatusLogEntry, StatusLogLevel, StatusLogMessage, StatusLogOutput, StatusLogState, Toast,
+    ToastItem, ToastLevel, ToastMessage, ToastOutput, ToastState,
+};
+
+// Navigation components
+#[cfg(feature = "navigation-components")]
 pub use component::{
     Accordion, AccordionMessage, AccordionOutput, AccordionPanel, AccordionState, Breadcrumb,
-    BreadcrumbMessage, BreadcrumbOutput, BreadcrumbSegment, BreadcrumbState, Button, ButtonMessage,
-    ButtonOutput, ButtonState, Checkbox, CheckboxMessage, CheckboxOutput, CheckboxState, Column,
-    Component, Dialog, DialogButton, DialogMessage, DialogOutput, DialogState, Dropdown,
-    DropdownMessage, DropdownOutput, DropdownState, FocusManager, Focusable, InputField,
-    InputFieldMessage, InputFieldOutput, InputFieldState, ItemState, KeyHint, KeyHints,
-    KeyHintsLayout, KeyHintsMessage, KeyHintsState, LoadingList, LoadingListItem,
-    LoadingListMessage, LoadingListOutput, LoadingListState, Menu, MenuItem, MenuMessage,
-    MenuOutput, MenuState, MultiProgress, MultiProgressMessage, MultiProgressOutput,
-    MultiProgressState, NavigationMode, ProgressBar, ProgressBarMessage, ProgressBarOutput,
-    ProgressBarState, ProgressItem, ProgressItemStatus, RadioGroup, RadioGroupMessage,
-    RadioGroupOutput, RadioGroupState, Router, RouterMessage, RouterOutput, RouterState, Section,
-    Select, SelectMessage, SelectOutput, SelectState, SelectableList, SelectableListMessage,
-    SelectableListOutput, SelectableListState, SortDirection, Spinner, SpinnerMessage,
-    SpinnerState, SpinnerStyle, StatusBar, StatusBarItem, StatusBarItemContent, StatusBarMessage,
-    StatusBarState, StatusBarStyle, StatusLog, StatusLogEntry, StatusLogLevel, StatusLogMessage,
-    StatusLogOutput, StatusLogState, Table, TableMessage, TableOutput, TableRow, TableState, Tabs,
-    TabsMessage, TabsOutput, TabsState, TextArea, TextAreaMessage, TextAreaOutput, TextAreaState,
-    Toast, ToastItem, ToastLevel, ToastMessage, ToastOutput, ToastState, Toggleable, Tooltip,
-    TooltipMessage, TooltipOutput, TooltipPosition, TooltipState, Tree, TreeMessage, TreeNode,
-    TreeOutput, TreeState,
+    BreadcrumbMessage, BreadcrumbOutput, BreadcrumbSegment, BreadcrumbState, Menu, MenuItem,
+    MenuMessage, MenuOutput, MenuState, NavigationMode, Router, RouterMessage, RouterOutput,
+    RouterState, Tabs, TabsMessage, TabsOutput, TabsState,
+};
+
+// Overlay components
+#[cfg(feature = "overlay-components")]
+pub use component::{
+    Dialog, DialogButton, DialogMessage, DialogOutput, DialogState, Tooltip, TooltipMessage,
+    TooltipOutput, TooltipPosition, TooltipState,
 };
 pub use harness::{AppHarness, Assertion, Snapshot, TestHarness};
 pub use input::{Event, EventQueue};
@@ -150,9 +176,9 @@ pub use theme::Theme;
 /// ```rust
 /// use envision::prelude::*;
 ///
-/// // All component types are now available:
-/// let button = ButtonState::new("Submit");
-/// let checkbox = CheckboxState::new("Accept");
+/// // Core framework types are available:
+/// let focus: FocusManager<&str> = FocusManager::new(vec!["a", "b"]);
+/// assert_eq!(focus.len(), 2);
 /// ```
 pub mod prelude {
     // Core framework

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "full")]
 //! Integration tests exercising multi-component workflows through the public API.
 
 use envision::{

--- a/tests/property.rs
+++ b/tests/property.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "full")]
 //! Property-based tests for envision components using proptest.
 //!
 //! These tests verify invariants that must hold for arbitrary sequences


### PR DESCRIPTION
## Summary
- Introduce five component feature groups: `input-components`, `data-components`, `display-components`, `navigation-components`, `overlay-components`
- Add `full` feature that enables all groups, included in default features for backwards compatibility
- Gate all 26 component modules and their re-exports behind `#[cfg(feature = "...")]`
- Core traits (`Component`, `Focusable`, `Toggleable`) and `FocusManager` remain always available
- Add `required-features` to examples and benchmarks that depend on specific component groups
- Gate integration and property tests behind `#![cfg(feature = "full")]`

## Feature Groups

| Feature | Components |
|---------|-----------|
| `input-components` | Button, Checkbox, Dropdown, InputField, RadioGroup, Select, TextArea |
| `data-components` | SelectableList, Table, Tree, LoadingList |
| `display-components` | ProgressBar, Spinner, StatusBar, StatusLog, MultiProgress, KeyHints, Toast |
| `navigation-components` | Tabs, Menu, Breadcrumb, Accordion, Router |
| `overlay-components` | Dialog, Tooltip |

## Usage

```toml
# Default: all components (via `full`)
envision = "0.5"

# Only data display components
envision = { version = "0.5", default-features = false, features = ["data-components", "display-components"] }
```

## Test plan
- [x] `cargo test --all-features` passes (all 2000+ tests)
- [x] `cargo test --no-default-features` passes (core framework tests only)
- [x] Each individual feature group compiles independently
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo doc --no-deps --all-features` builds
- [x] `cargo build --examples` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)