### PR TITLE
Add undo/redo support for text components

### DIFF
--- a/src/component/input_field/mod.rs
+++ b/src/component/input_field/mod.rs
@@ -25,6 +25,14 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 use super::{Component, Focusable};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::theme::Theme;
+use crate::undo::{EditKind, UndoStack};
+
+/// A snapshot of InputField state for undo/redo.
+#[derive(Debug, Clone)]
+struct InputSnapshot {
+    value: String,
+    cursor: usize,
+}
 
 /// Messages that can be sent to an InputField.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -57,6 +65,10 @@ pub enum InputFieldMessage {
     SetValue(String),
     /// Submit the current value.
     Submit,
+    /// Undo the last edit.
+    Undo,
+    /// Redo the last undone edit.
+    Redo,
 }
 
 /// Output messages from an InputField.
@@ -81,6 +93,8 @@ pub struct InputFieldState {
     disabled: bool,
     /// Placeholder text shown when empty.
     placeholder: String,
+    /// Undo/redo history stack.
+    undo_stack: UndoStack<InputSnapshot>,
 }
 
 impl InputFieldState {
@@ -99,6 +113,7 @@ impl InputFieldState {
             focused: false,
             disabled: false,
             placeholder: String::new(),
+            undo_stack: UndoStack::default(),
         }
     }
 
@@ -110,6 +125,7 @@ impl InputFieldState {
             focused: false,
             disabled: false,
             placeholder: placeholder.into(),
+            undo_stack: UndoStack::default(),
         }
     }
 
@@ -164,6 +180,30 @@ impl InputFieldState {
             .nth(clamped)
             .map(|(i, _)| i)
             .unwrap_or(self.value.len());
+    }
+
+    /// Returns true if there are edits that can be undone.
+    pub fn can_undo(&self) -> bool {
+        self.undo_stack.can_undo()
+    }
+
+    /// Returns true if there are edits that can be redone.
+    pub fn can_redo(&self) -> bool {
+        self.undo_stack.can_redo()
+    }
+
+    /// Creates a snapshot of the current state for undo.
+    fn snapshot(&self) -> InputSnapshot {
+        InputSnapshot {
+            value: self.value.clone(),
+            cursor: self.cursor,
+        }
+    }
+
+    /// Restores state from a snapshot.
+    fn restore(&mut self, snapshot: InputSnapshot) {
+        self.value = snapshot.value;
+        self.cursor = snapshot.cursor;
     }
 
     /// Move cursor left by one character.
@@ -376,18 +416,30 @@ impl Component for InputField {
         }
         match msg {
             InputFieldMessage::Insert(c) => {
+                if c.is_whitespace() {
+                    state.undo_stack.break_group();
+                }
+                let snapshot = state.snapshot();
+                state.undo_stack.save(snapshot, EditKind::Insert);
                 state.insert(c);
+                if c.is_whitespace() {
+                    state.undo_stack.break_group();
+                }
                 Some(InputFieldOutput::Changed(state.value.clone()))
             }
             InputFieldMessage::Backspace => {
+                let snapshot = state.snapshot();
                 if state.backspace() {
+                    state.undo_stack.save(snapshot, EditKind::Delete);
                     Some(InputFieldOutput::Changed(state.value.clone()))
                 } else {
                     None
                 }
             }
             InputFieldMessage::Delete => {
+                let snapshot = state.snapshot();
                 if state.delete() {
+                    state.undo_stack.save(snapshot, EditKind::Delete);
                     Some(InputFieldOutput::Changed(state.value.clone()))
                 } else {
                     None
@@ -418,14 +470,18 @@ impl Component for InputField {
                 None
             }
             InputFieldMessage::DeleteWordBack => {
+                let snapshot = state.snapshot();
                 if state.delete_word_back() {
+                    state.undo_stack.save(snapshot, EditKind::Other);
                     Some(InputFieldOutput::Changed(state.value.clone()))
                 } else {
                     None
                 }
             }
             InputFieldMessage::DeleteWordForward => {
+                let snapshot = state.snapshot();
                 if state.delete_word_forward() {
+                    state.undo_stack.save(snapshot, EditKind::Other);
                     Some(InputFieldOutput::Changed(state.value.clone()))
                 } else {
                     None
@@ -433,6 +489,8 @@ impl Component for InputField {
             }
             InputFieldMessage::Clear => {
                 if !state.value.is_empty() {
+                    let snapshot = state.snapshot();
+                    state.undo_stack.save(snapshot, EditKind::Other);
                     state.value.clear();
                     state.cursor = 0;
                     Some(InputFieldOutput::Changed(state.value.clone()))
@@ -442,6 +500,8 @@ impl Component for InputField {
             }
             InputFieldMessage::SetValue(value) => {
                 if state.value != value {
+                    let snapshot = state.snapshot();
+                    state.undo_stack.save(snapshot, EditKind::Other);
                     state.set_value(value);
                     Some(InputFieldOutput::Changed(state.value.clone()))
                 } else {
@@ -449,6 +509,24 @@ impl Component for InputField {
                 }
             }
             InputFieldMessage::Submit => Some(InputFieldOutput::Submitted(state.value.clone())),
+            InputFieldMessage::Undo => {
+                let snapshot = state.snapshot();
+                if let Some(restored) = state.undo_stack.undo(snapshot) {
+                    state.restore(restored);
+                    Some(InputFieldOutput::Changed(state.value.clone()))
+                } else {
+                    None
+                }
+            }
+            InputFieldMessage::Redo => {
+                let snapshot = state.snapshot();
+                if let Some(restored) = state.undo_stack.redo(snapshot) {
+                    state.restore(restored);
+                    Some(InputFieldOutput::Changed(state.value.clone()))
+                } else {
+                    None
+                }
+            }
         }
     }
 
@@ -459,6 +537,8 @@ impl Component for InputField {
         if let Some(key) = event.as_key() {
             let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
             match key.code {
+                KeyCode::Char('z') if ctrl => Some(InputFieldMessage::Undo),
+                KeyCode::Char('y') if ctrl => Some(InputFieldMessage::Redo),
                 KeyCode::Char(c) if !ctrl => Some(InputFieldMessage::Insert(c)),
                 KeyCode::Backspace if ctrl => Some(InputFieldMessage::DeleteWordBack),
                 KeyCode::Delete if ctrl => Some(InputFieldMessage::DeleteWordForward),

--- a/src/component/input_field/tests.rs
+++ b/src/component/input_field/tests.rs
@@ -627,3 +627,6 @@ fn test_instance_update_disabled() {
     assert_eq!(output, None);
     assert_eq!(state.value(), "hello");
 }
+
+#[path = "undo_tests.rs"]
+mod undo_tests;

--- a/src/component/input_field/undo_tests.rs
+++ b/src/component/input_field/undo_tests.rs
@@ -1,0 +1,332 @@
+use super::*;
+
+fn focused_state(value: &str) -> InputFieldState {
+    let mut state = InputFieldState::with_value(value);
+    state.set_focused(true);
+    state
+}
+
+// =============================================================================
+// Basic undo/redo
+// =============================================================================
+
+#[test]
+fn test_undo_single_insert() {
+    let mut state = InputFieldState::with_value("hello");
+    InputField::update(&mut state, InputFieldMessage::Insert(' '));
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    assert_eq!(state.value(), "hello");
+}
+
+#[test]
+fn test_redo_after_undo() {
+    let mut state = InputFieldState::with_value("hello");
+    InputField::update(&mut state, InputFieldMessage::Insert('!'));
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    assert_eq!(state.value(), "hello");
+
+    InputField::update(&mut state, InputFieldMessage::Redo);
+    assert_eq!(state.value(), "hello!");
+}
+
+#[test]
+fn test_undo_empty_stack_no_change() {
+    let mut state = InputFieldState::with_value("hello");
+    let output = InputField::update(&mut state, InputFieldMessage::Undo);
+    assert_eq!(output, None);
+    assert_eq!(state.value(), "hello");
+}
+
+#[test]
+fn test_redo_empty_stack_no_change() {
+    let mut state = InputFieldState::with_value("hello");
+    let output = InputField::update(&mut state, InputFieldMessage::Redo);
+    assert_eq!(output, None);
+    assert_eq!(state.value(), "hello");
+}
+
+// =============================================================================
+// Insert grouping
+// =============================================================================
+
+#[test]
+fn test_grouped_inserts_undo_together() {
+    let mut state = InputFieldState::new();
+    // Type "hello" - should group into one undo entry
+    for c in "hello".chars() {
+        InputField::update(&mut state, InputFieldMessage::Insert(c));
+    }
+    assert_eq!(state.value(), "hello");
+
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    assert_eq!(state.value(), "");
+}
+
+#[test]
+fn test_whitespace_breaks_insert_group() {
+    let mut state = InputFieldState::new();
+    // Type "hi " - whitespace should break the group
+    for c in "hi ".chars() {
+        InputField::update(&mut state, InputFieldMessage::Insert(c));
+    }
+    // Type "you"
+    for c in "you".chars() {
+        InputField::update(&mut state, InputFieldMessage::Insert(c));
+    }
+    assert_eq!(state.value(), "hi you");
+
+    // Undo "you"
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    assert_eq!(state.value(), "hi ");
+
+    // Undo " " (whitespace is its own group)
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    assert_eq!(state.value(), "hi");
+
+    // Undo "hi"
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    assert_eq!(state.value(), "");
+}
+
+// =============================================================================
+// Delete grouping
+// =============================================================================
+
+#[test]
+fn test_grouped_deletes_undo_together() {
+    let mut state = InputFieldState::with_value("hello");
+    InputField::update(&mut state, InputFieldMessage::Backspace);
+    InputField::update(&mut state, InputFieldMessage::Backspace);
+    assert_eq!(state.value(), "hel");
+
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    assert_eq!(state.value(), "hello");
+}
+
+#[test]
+fn test_delete_forward_grouped() {
+    let mut state = InputFieldState::with_value("hello");
+    state.set_cursor(0);
+    InputField::update(&mut state, InputFieldMessage::Delete);
+    InputField::update(&mut state, InputFieldMessage::Delete);
+    assert_eq!(state.value(), "llo");
+
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    assert_eq!(state.value(), "hello");
+}
+
+// =============================================================================
+// Mixed operations
+// =============================================================================
+
+#[test]
+fn test_insert_then_delete_separate_groups() {
+    let mut state = InputFieldState::new();
+    for c in "hello".chars() {
+        InputField::update(&mut state, InputFieldMessage::Insert(c));
+    }
+    InputField::update(&mut state, InputFieldMessage::Backspace);
+    assert_eq!(state.value(), "hell");
+
+    // Undo delete
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    assert_eq!(state.value(), "hello");
+
+    // Undo insert group
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    assert_eq!(state.value(), "");
+}
+
+#[test]
+fn test_clear_is_own_undo_entry() {
+    let mut state = InputFieldState::with_value("hello");
+    InputField::update(&mut state, InputFieldMessage::Clear);
+    assert_eq!(state.value(), "");
+
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    assert_eq!(state.value(), "hello");
+}
+
+#[test]
+fn test_set_value_is_own_undo_entry() {
+    let mut state = InputFieldState::with_value("hello");
+    InputField::update(&mut state, InputFieldMessage::SetValue("world".into()));
+    assert_eq!(state.value(), "world");
+
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    assert_eq!(state.value(), "hello");
+}
+
+#[test]
+fn test_delete_word_back_is_own_undo_entry() {
+    let mut state = InputFieldState::with_value("hello world");
+    InputField::update(&mut state, InputFieldMessage::DeleteWordBack);
+    assert_eq!(state.value(), "hello ");
+
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    assert_eq!(state.value(), "hello world");
+}
+
+#[test]
+fn test_delete_word_forward_is_own_undo_entry() {
+    let mut state = InputFieldState::with_value("hello world");
+    state.set_cursor(0);
+    InputField::update(&mut state, InputFieldMessage::DeleteWordForward);
+    assert_eq!(state.value(), "world");
+
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    assert_eq!(state.value(), "hello world");
+}
+
+// =============================================================================
+// Cursor position restoration
+// =============================================================================
+
+#[test]
+fn test_undo_restores_cursor_position() {
+    let mut state = InputFieldState::with_value("hello");
+    // Cursor at end (5)
+    InputField::update(&mut state, InputFieldMessage::Insert('!'));
+    // Cursor at 6
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    // Should restore cursor to 5
+    assert_eq!(state.cursor_byte_offset(), 5);
+}
+
+#[test]
+fn test_redo_restores_cursor_position() {
+    let mut state = InputFieldState::new();
+    for c in "hi".chars() {
+        InputField::update(&mut state, InputFieldMessage::Insert(c));
+    }
+    let cursor_after = state.cursor_byte_offset();
+
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    InputField::update(&mut state, InputFieldMessage::Redo);
+    assert_eq!(state.cursor_byte_offset(), cursor_after);
+}
+
+// =============================================================================
+// Redo invalidation
+// =============================================================================
+
+#[test]
+fn test_new_edit_clears_redo() {
+    let mut state = InputFieldState::with_value("hello");
+    InputField::update(&mut state, InputFieldMessage::Insert('!'));
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    assert_eq!(state.value(), "hello");
+
+    // New edit should clear redo
+    InputField::update(&mut state, InputFieldMessage::Insert('?'));
+    let output = InputField::update(&mut state, InputFieldMessage::Redo);
+    assert_eq!(output, None);
+    assert_eq!(state.value(), "hello?");
+}
+
+// =============================================================================
+// Disabled state
+// =============================================================================
+
+#[test]
+fn test_undo_ignored_when_disabled() {
+    let mut state = InputFieldState::with_value("hello");
+    InputField::update(&mut state, InputFieldMessage::Insert('!'));
+    state.set_disabled(true);
+    let output = InputField::update(&mut state, InputFieldMessage::Undo);
+    assert_eq!(output, None);
+    assert_eq!(state.value(), "hello!");
+}
+
+// =============================================================================
+// Event mapping
+// =============================================================================
+
+#[test]
+fn test_ctrl_z_maps_to_undo() {
+    let state = focused_state("hello");
+    let msg = InputField::handle_event(&state, &Event::ctrl('z'));
+    assert_eq!(msg, Some(InputFieldMessage::Undo));
+}
+
+#[test]
+fn test_ctrl_y_maps_to_redo() {
+    let state = focused_state("hello");
+    let msg = InputField::handle_event(&state, &Event::ctrl('y'));
+    assert_eq!(msg, Some(InputFieldMessage::Redo));
+}
+
+// =============================================================================
+// State accessors
+// =============================================================================
+
+#[test]
+fn test_can_undo() {
+    let mut state = InputFieldState::with_value("hello");
+    assert!(!state.can_undo());
+
+    InputField::update(&mut state, InputFieldMessage::Insert('!'));
+    assert!(state.can_undo());
+
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    assert!(!state.can_undo());
+}
+
+#[test]
+fn test_can_redo() {
+    let mut state = InputFieldState::with_value("hello");
+    assert!(!state.can_redo());
+
+    InputField::update(&mut state, InputFieldMessage::Insert('!'));
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    assert!(state.can_redo());
+
+    InputField::update(&mut state, InputFieldMessage::Redo);
+    assert!(!state.can_redo());
+}
+
+// =============================================================================
+// Multiple undo/redo cycles
+// =============================================================================
+
+#[test]
+fn test_multiple_undo_redo_cycles() {
+    let mut state = InputFieldState::new();
+
+    // Type "a"
+    InputField::update(&mut state, InputFieldMessage::Insert('a'));
+    // Type " " (break group)
+    InputField::update(&mut state, InputFieldMessage::Insert(' '));
+    // Type "b"
+    InputField::update(&mut state, InputFieldMessage::Insert('b'));
+
+    assert_eq!(state.value(), "a b");
+
+    // Undo "b"
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    assert_eq!(state.value(), "a ");
+
+    // Redo "b"
+    InputField::update(&mut state, InputFieldMessage::Redo);
+    assert_eq!(state.value(), "a b");
+
+    // Undo "b" again
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    // Undo " "
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    assert_eq!(state.value(), "a");
+}
+
+#[test]
+fn test_clear_history_on_set_value() {
+    let mut state = InputFieldState::with_value("hello");
+    InputField::update(&mut state, InputFieldMessage::Insert('!'));
+
+    // SetValue creates its own undo entry
+    InputField::update(&mut state, InputFieldMessage::SetValue("new".into()));
+    assert_eq!(state.value(), "new");
+
+    // Can undo SetValue
+    InputField::update(&mut state, InputFieldMessage::Undo);
+    assert_eq!(state.value(), "hello!");
+}

--- a/src/component/text_area/mod.rs
+++ b/src/component/text_area/mod.rs
@@ -27,6 +27,15 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 use super::{Component, Focusable};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::theme::Theme;
+use crate::undo::{EditKind, UndoStack};
+
+/// A snapshot of TextArea state for undo/redo.
+#[derive(Debug, Clone)]
+struct TextAreaSnapshot {
+    lines: Vec<String>,
+    cursor_row: usize,
+    cursor_col: usize,
+}
 
 /// Messages that can be sent to a TextArea.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -78,6 +87,12 @@ pub enum TextAreaMessage {
     SetValue(String),
     /// Submit the current value.
     Submit,
+
+    // Undo/Redo
+    /// Undo the last edit.
+    Undo,
+    /// Redo the last undone edit.
+    Redo,
 }
 
 /// Output messages from a TextArea.
@@ -106,6 +121,8 @@ pub struct TextAreaState {
     disabled: bool,
     /// Placeholder text shown when empty.
     placeholder: String,
+    /// Undo/redo history stack.
+    undo_stack: UndoStack<TextAreaSnapshot>,
 }
 
 impl Default for TextAreaState {
@@ -118,6 +135,7 @@ impl Default for TextAreaState {
             focused: false,
             disabled: false,
             placeholder: String::new(),
+            undo_stack: UndoStack::default(),
         }
     }
 }
@@ -173,6 +191,7 @@ impl TextAreaState {
             focused: false,
             disabled: false,
             placeholder: String::new(),
+            undo_stack: UndoStack::default(),
         }
     }
 
@@ -318,6 +337,32 @@ impl TextAreaState {
         if self.cursor_row >= self.scroll_offset + visible_lines {
             self.scroll_offset = self.cursor_row - visible_lines + 1;
         }
+    }
+
+    /// Returns true if there are edits that can be undone.
+    pub fn can_undo(&self) -> bool {
+        self.undo_stack.can_undo()
+    }
+
+    /// Returns true if there are edits that can be redone.
+    pub fn can_redo(&self) -> bool {
+        self.undo_stack.can_redo()
+    }
+
+    /// Creates a snapshot of the current state for undo.
+    fn snapshot(&self) -> TextAreaSnapshot {
+        TextAreaSnapshot {
+            lines: self.lines.clone(),
+            cursor_row: self.cursor_row,
+            cursor_col: self.cursor_col,
+        }
+    }
+
+    /// Restores state from a snapshot.
+    fn restore(&mut self, snapshot: TextAreaSnapshot) {
+        self.lines = snapshot.lines;
+        self.cursor_row = snapshot.cursor_row;
+        self.cursor_col = snapshot.cursor_col;
     }
 
     /// Insert a character at the cursor position.
@@ -639,6 +684,8 @@ impl Component for TextArea {
         if let Some(key) = event.as_key() {
             let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
             match key.code {
+                KeyCode::Char('z') if ctrl => Some(TextAreaMessage::Undo),
+                KeyCode::Char('y') if ctrl => Some(TextAreaMessage::Redo),
                 KeyCode::Char(c) if !ctrl => Some(TextAreaMessage::Insert(c)),
                 KeyCode::Enter => Some(TextAreaMessage::NewLine),
                 KeyCode::Backspace if ctrl => Some(TextAreaMessage::DeleteLine),
@@ -670,22 +717,36 @@ impl Component for TextArea {
 
         match msg {
             TextAreaMessage::Insert(c) => {
+                if c.is_whitespace() {
+                    state.undo_stack.break_group();
+                }
+                let snapshot = state.snapshot();
+                state.undo_stack.save(snapshot, EditKind::Insert);
                 state.insert(c);
+                if c.is_whitespace() {
+                    state.undo_stack.break_group();
+                }
                 Some(TextAreaOutput::Changed(state.value()))
             }
             TextAreaMessage::NewLine => {
+                let snapshot = state.snapshot();
+                state.undo_stack.save(snapshot, EditKind::Other);
                 state.new_line();
                 Some(TextAreaOutput::Changed(state.value()))
             }
             TextAreaMessage::Backspace => {
+                let snapshot = state.snapshot();
                 if state.backspace() {
+                    state.undo_stack.save(snapshot, EditKind::Delete);
                     Some(TextAreaOutput::Changed(state.value()))
                 } else {
                     None
                 }
             }
             TextAreaMessage::Delete => {
+                let snapshot = state.snapshot();
                 if state.delete() {
+                    state.undo_stack.save(snapshot, EditKind::Delete);
                     Some(TextAreaOutput::Changed(state.value()))
                 } else {
                     None
@@ -734,21 +795,27 @@ impl Component for TextArea {
                 None
             }
             TextAreaMessage::DeleteLine => {
+                let snapshot = state.snapshot();
                 if state.delete_line() {
+                    state.undo_stack.save(snapshot, EditKind::Other);
                     Some(TextAreaOutput::Changed(state.value()))
                 } else {
                     None
                 }
             }
             TextAreaMessage::DeleteToEnd => {
+                let snapshot = state.snapshot();
                 if state.delete_to_end() {
+                    state.undo_stack.save(snapshot, EditKind::Other);
                     Some(TextAreaOutput::Changed(state.value()))
                 } else {
                     None
                 }
             }
             TextAreaMessage::DeleteToStart => {
+                let snapshot = state.snapshot();
                 if state.delete_to_start() {
+                    state.undo_stack.save(snapshot, EditKind::Other);
                     Some(TextAreaOutput::Changed(state.value()))
                 } else {
                     None
@@ -756,6 +823,8 @@ impl Component for TextArea {
             }
             TextAreaMessage::Clear => {
                 if !state.is_empty() {
+                    let snapshot = state.snapshot();
+                    state.undo_stack.save(snapshot, EditKind::Other);
                     state.lines = vec![String::new()];
                     state.cursor_row = 0;
                     state.cursor_col = 0;
@@ -768,6 +837,8 @@ impl Component for TextArea {
             TextAreaMessage::SetValue(value) => {
                 let old_value = state.value();
                 if old_value != value {
+                    let snapshot = state.snapshot();
+                    state.undo_stack.save(snapshot, EditKind::Other);
                     state.set_value(value);
                     Some(TextAreaOutput::Changed(state.value()))
                 } else {
@@ -775,6 +846,24 @@ impl Component for TextArea {
                 }
             }
             TextAreaMessage::Submit => Some(TextAreaOutput::Submitted(state.value())),
+            TextAreaMessage::Undo => {
+                let snapshot = state.snapshot();
+                if let Some(restored) = state.undo_stack.undo(snapshot) {
+                    state.restore(restored);
+                    Some(TextAreaOutput::Changed(state.value()))
+                } else {
+                    None
+                }
+            }
+            TextAreaMessage::Redo => {
+                let snapshot = state.snapshot();
+                if let Some(restored) = state.undo_stack.redo(snapshot) {
+                    state.restore(restored);
+                    Some(TextAreaOutput::Changed(state.value()))
+                } else {
+                    None
+                }
+            }
         }
     }
 

--- a/src/component/text_area/tests.rs
+++ b/src/component/text_area/tests.rs
@@ -914,3 +914,6 @@ fn test_instance_update() {
     assert!(matches!(output, Some(TextAreaOutput::Changed(_))));
     assert_eq!(state.value(), "a");
 }
+
+#[path = "undo_tests.rs"]
+mod undo_tests;

--- a/src/component/text_area/undo_tests.rs
+++ b/src/component/text_area/undo_tests.rs
@@ -1,0 +1,366 @@
+use super::*;
+
+fn focused_state(value: &str) -> TextAreaState {
+    let mut state = TextAreaState::with_value(value);
+    state.set_focused(true);
+    state
+}
+
+// =============================================================================
+// Basic undo/redo
+// =============================================================================
+
+#[test]
+fn test_undo_single_insert() {
+    let mut state = TextAreaState::with_value("hello");
+    TextArea::update(&mut state, TextAreaMessage::Insert('!'));
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.value(), "hello");
+}
+
+#[test]
+fn test_redo_after_undo() {
+    let mut state = TextAreaState::with_value("hello");
+    TextArea::update(&mut state, TextAreaMessage::Insert('!'));
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.value(), "hello");
+
+    TextArea::update(&mut state, TextAreaMessage::Redo);
+    assert_eq!(state.value(), "hello!");
+}
+
+#[test]
+fn test_undo_empty_stack_no_change() {
+    let mut state = TextAreaState::with_value("hello");
+    let output = TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(output, None);
+    assert_eq!(state.value(), "hello");
+}
+
+#[test]
+fn test_redo_empty_stack_no_change() {
+    let mut state = TextAreaState::with_value("hello");
+    let output = TextArea::update(&mut state, TextAreaMessage::Redo);
+    assert_eq!(output, None);
+    assert_eq!(state.value(), "hello");
+}
+
+// =============================================================================
+// Insert grouping
+// =============================================================================
+
+#[test]
+fn test_grouped_inserts_undo_together() {
+    let mut state = TextAreaState::new();
+    for c in "hello".chars() {
+        TextArea::update(&mut state, TextAreaMessage::Insert(c));
+    }
+    assert_eq!(state.value(), "hello");
+
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.value(), "");
+}
+
+#[test]
+fn test_whitespace_breaks_insert_group() {
+    let mut state = TextAreaState::new();
+    for c in "hi ".chars() {
+        TextArea::update(&mut state, TextAreaMessage::Insert(c));
+    }
+    for c in "you".chars() {
+        TextArea::update(&mut state, TextAreaMessage::Insert(c));
+    }
+    assert_eq!(state.value(), "hi you");
+
+    // Undo "you"
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.value(), "hi ");
+
+    // Undo " "
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.value(), "hi");
+
+    // Undo "hi"
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.value(), "");
+}
+
+// =============================================================================
+// Delete grouping
+// =============================================================================
+
+#[test]
+fn test_grouped_backspace_undo_together() {
+    let mut state = TextAreaState::with_value("hello");
+    TextArea::update(&mut state, TextAreaMessage::Backspace);
+    TextArea::update(&mut state, TextAreaMessage::Backspace);
+    assert_eq!(state.value(), "hel");
+
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.value(), "hello");
+}
+
+#[test]
+fn test_grouped_delete_undo_together() {
+    let mut state = TextAreaState::with_value("hello");
+    state.set_cursor(0, 0);
+    TextArea::update(&mut state, TextAreaMessage::Delete);
+    TextArea::update(&mut state, TextAreaMessage::Delete);
+    assert_eq!(state.value(), "llo");
+
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.value(), "hello");
+}
+
+// =============================================================================
+// Newline
+// =============================================================================
+
+#[test]
+fn test_newline_is_own_undo_entry() {
+    let mut state = TextAreaState::with_value("hello");
+    TextArea::update(&mut state, TextAreaMessage::NewLine);
+    assert_eq!(state.line_count(), 2);
+
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.value(), "hello");
+    assert_eq!(state.line_count(), 1);
+}
+
+#[test]
+fn test_newline_breaks_insert_group() {
+    let mut state = TextAreaState::new();
+    for c in "abc".chars() {
+        TextArea::update(&mut state, TextAreaMessage::Insert(c));
+    }
+    TextArea::update(&mut state, TextAreaMessage::NewLine);
+    for c in "def".chars() {
+        TextArea::update(&mut state, TextAreaMessage::Insert(c));
+    }
+    assert_eq!(state.value(), "abc\ndef");
+
+    // Undo "def"
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.value(), "abc\n");
+
+    // Undo newline
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.value(), "abc");
+
+    // Undo "abc"
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.value(), "");
+}
+
+// =============================================================================
+// Line operations
+// =============================================================================
+
+#[test]
+fn test_delete_line_undo() {
+    let mut state = TextAreaState::with_value("abc\ndef\nghi");
+    state.set_cursor(1, 0);
+    TextArea::update(&mut state, TextAreaMessage::DeleteLine);
+    assert_eq!(state.value(), "abc\nghi");
+
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.value(), "abc\ndef\nghi");
+}
+
+#[test]
+fn test_delete_to_end_undo() {
+    let mut state = TextAreaState::with_value("hello world");
+    state.set_cursor(0, 5);
+    TextArea::update(&mut state, TextAreaMessage::DeleteToEnd);
+    assert_eq!(state.value(), "hello");
+
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.value(), "hello world");
+}
+
+#[test]
+fn test_delete_to_start_undo() {
+    let mut state = TextAreaState::with_value("hello world");
+    state.set_cursor(0, 6);
+    TextArea::update(&mut state, TextAreaMessage::DeleteToStart);
+    assert_eq!(state.value(), "world");
+
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.value(), "hello world");
+}
+
+// =============================================================================
+// Clear and SetValue
+// =============================================================================
+
+#[test]
+fn test_clear_undo() {
+    let mut state = TextAreaState::with_value("hello\nworld");
+    TextArea::update(&mut state, TextAreaMessage::Clear);
+    assert_eq!(state.value(), "");
+
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.value(), "hello\nworld");
+}
+
+#[test]
+fn test_set_value_undo() {
+    let mut state = TextAreaState::with_value("original");
+    TextArea::update(&mut state, TextAreaMessage::SetValue("replaced".into()));
+    assert_eq!(state.value(), "replaced");
+
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.value(), "original");
+}
+
+// =============================================================================
+// Cursor position restoration
+// =============================================================================
+
+#[test]
+fn test_undo_restores_cursor_position() {
+    let mut state = TextAreaState::with_value("hello");
+    let (row_before, col_before) = (state.cursor_row(), state.cursor_col());
+    TextArea::update(&mut state, TextAreaMessage::Insert('!'));
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.cursor_row(), row_before);
+    assert_eq!(state.cursor_col(), col_before);
+}
+
+#[test]
+fn test_undo_restores_multiline_cursor() {
+    let mut state = TextAreaState::with_value("abc\ndef");
+    // Cursor at end of "def" (row=1, col=3)
+    TextArea::update(&mut state, TextAreaMessage::NewLine);
+    // Now on row 2
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.cursor_row(), 1);
+    assert_eq!(state.cursor_col(), 3);
+}
+
+// =============================================================================
+// Redo invalidation
+// =============================================================================
+
+#[test]
+fn test_new_edit_clears_redo() {
+    let mut state = TextAreaState::with_value("hello");
+    TextArea::update(&mut state, TextAreaMessage::Insert('!'));
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+
+    // New edit clears redo
+    TextArea::update(&mut state, TextAreaMessage::Insert('?'));
+    let output = TextArea::update(&mut state, TextAreaMessage::Redo);
+    assert_eq!(output, None);
+    assert_eq!(state.value(), "hello?");
+}
+
+// =============================================================================
+// Disabled state
+// =============================================================================
+
+#[test]
+fn test_undo_ignored_when_disabled() {
+    let mut state = TextAreaState::with_value("hello");
+    TextArea::update(&mut state, TextAreaMessage::Insert('!'));
+    state.set_disabled(true);
+    let output = TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(output, None);
+    assert_eq!(state.value(), "hello!");
+}
+
+// =============================================================================
+// Event mapping
+// =============================================================================
+
+#[test]
+fn test_ctrl_z_maps_to_undo() {
+    let state = focused_state("hello");
+    let msg = TextArea::handle_event(&state, &Event::ctrl('z'));
+    assert_eq!(msg, Some(TextAreaMessage::Undo));
+}
+
+#[test]
+fn test_ctrl_y_maps_to_redo() {
+    let state = focused_state("hello");
+    let msg = TextArea::handle_event(&state, &Event::ctrl('y'));
+    assert_eq!(msg, Some(TextAreaMessage::Redo));
+}
+
+// =============================================================================
+// State accessors
+// =============================================================================
+
+#[test]
+fn test_can_undo() {
+    let mut state = TextAreaState::with_value("hello");
+    assert!(!state.can_undo());
+
+    TextArea::update(&mut state, TextAreaMessage::Insert('!'));
+    assert!(state.can_undo());
+
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert!(!state.can_undo());
+}
+
+#[test]
+fn test_can_redo() {
+    let mut state = TextAreaState::with_value("hello");
+    assert!(!state.can_redo());
+
+    TextArea::update(&mut state, TextAreaMessage::Insert('!'));
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert!(state.can_redo());
+
+    TextArea::update(&mut state, TextAreaMessage::Redo);
+    assert!(!state.can_redo());
+}
+
+// =============================================================================
+// Backspace joining lines
+// =============================================================================
+
+#[test]
+fn test_backspace_join_lines_undo() {
+    let mut state = TextAreaState::with_value("abc\ndef");
+    state.set_cursor(1, 0);
+    TextArea::update(&mut state, TextAreaMessage::Backspace);
+    assert_eq!(state.value(), "abcdef");
+    assert_eq!(state.line_count(), 1);
+
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.value(), "abc\ndef");
+    assert_eq!(state.line_count(), 2);
+}
+
+// =============================================================================
+// Multiple undo/redo cycles
+// =============================================================================
+
+#[test]
+fn test_multiple_undo_redo_cycles() {
+    let mut state = TextAreaState::new();
+
+    // Type "a"
+    TextArea::update(&mut state, TextAreaMessage::Insert('a'));
+    // Newline
+    TextArea::update(&mut state, TextAreaMessage::NewLine);
+    // Type "b"
+    TextArea::update(&mut state, TextAreaMessage::Insert('b'));
+
+    assert_eq!(state.value(), "a\nb");
+
+    // Undo "b"
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.value(), "a\n");
+
+    // Redo "b"
+    TextArea::update(&mut state, TextAreaMessage::Redo);
+    assert_eq!(state.value(), "a\nb");
+
+    // Undo everything
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    TextArea::update(&mut state, TextAreaMessage::Undo);
+    assert_eq!(state.value(), "");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ pub mod harness;
 pub mod input;
 pub mod overlay;
 pub mod theme;
+pub(crate) mod undo;
 
 // Re-export commonly used types
 pub use adapter::{DualBackend, DualBackendBuilder};

--- a/src/undo.rs
+++ b/src/undo.rs
@@ -1,0 +1,329 @@
+//! Undo/redo history stack for text editing components.
+//!
+//! Provides a generic [`UndoStack`] that tracks snapshots of component state
+//! before text modifications. Consecutive edits of the same kind (e.g.,
+//! character insertions) are grouped into a single undo step.
+
+/// Identifies the kind of edit for grouping consecutive same-type operations.
+///
+/// Consecutive edits with the same `EditKind` are merged into a single undo
+/// step. For example, typing "hello" produces one undo entry (not five).
+/// [`EditKind::Other`] is never grouped — each such edit is its own step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EditKind {
+    /// Character insertion (non-whitespace).
+    Insert,
+    /// Character deletion (backspace, delete).
+    Delete,
+    /// Non-groupable operation (clear, set_value, paste, etc.).
+    Other,
+}
+
+/// Generic undo/redo history stack.
+///
+/// Stores snapshots of state before modifications. Supports grouping of
+/// consecutive same-kind edits and configurable maximum history depth.
+#[derive(Debug, Clone)]
+pub(crate) struct UndoStack<T> {
+    undo: Vec<T>,
+    redo: Vec<T>,
+    max_size: usize,
+    last_kind: Option<EditKind>,
+}
+
+impl<T> Default for UndoStack<T> {
+    fn default() -> Self {
+        Self::new(100)
+    }
+}
+
+impl<T> UndoStack<T> {
+    /// Creates a new undo stack with the given maximum history depth.
+    pub fn new(max_size: usize) -> Self {
+        Self {
+            undo: Vec::new(),
+            redo: Vec::new(),
+            max_size,
+            last_kind: None,
+        }
+    }
+
+    /// Returns true if there are entries to undo.
+    pub fn can_undo(&self) -> bool {
+        !self.undo.is_empty()
+    }
+
+    /// Returns true if there are entries to redo.
+    pub fn can_redo(&self) -> bool {
+        !self.redo.is_empty()
+    }
+
+    /// Saves a snapshot before a text modification.
+    ///
+    /// If `kind` matches the previous edit kind and is groupable (Insert or
+    /// Delete), the snapshot is skipped (grouped with the previous entry).
+    /// The redo stack is always cleared on new edits.
+    pub fn save(&mut self, snapshot: T, kind: EditKind) {
+        self.redo.clear();
+
+        let should_push = match kind {
+            EditKind::Other => true,
+            _ => self.last_kind != Some(kind),
+        };
+
+        if should_push {
+            self.undo.push(snapshot);
+            self.enforce_limit();
+        }
+
+        self.last_kind = Some(kind);
+    }
+
+    /// Breaks the current edit group.
+    ///
+    /// The next call to [`save`](Self::save) will always create a new undo
+    /// entry, even if the edit kind matches the previous one. Use this to
+    /// create word boundaries (e.g., on whitespace insertion).
+    pub fn break_group(&mut self) {
+        self.last_kind = None;
+    }
+
+    /// Undoes the last edit group, returning the saved snapshot.
+    ///
+    /// The `current` state is pushed onto the redo stack before restoring.
+    pub fn undo(&mut self, current: T) -> Option<T> {
+        let snapshot = self.undo.pop()?;
+        self.redo.push(current);
+        self.last_kind = None;
+        Some(snapshot)
+    }
+
+    /// Redoes the last undone edit, returning the saved snapshot.
+    ///
+    /// The `current` state is pushed onto the undo stack before restoring.
+    pub fn redo(&mut self, current: T) -> Option<T> {
+        let snapshot = self.redo.pop()?;
+        self.undo.push(current);
+        self.last_kind = None;
+        Some(snapshot)
+    }
+
+    /// Clears all undo and redo history.
+    #[allow(dead_code)]
+    pub fn clear(&mut self) {
+        self.undo.clear();
+        self.redo.clear();
+        self.last_kind = None;
+    }
+
+    fn enforce_limit(&mut self) {
+        while self.undo.len() > self.max_size {
+            self.undo.remove(0);
+        }
+    }
+}
+
+// PartialEq: undo history is not part of logical equality.
+// Two states with different undo histories but same content are equal.
+impl<T> PartialEq for UndoStack<T> {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_stack_empty() {
+        let stack: UndoStack<String> = UndoStack::new(100);
+        assert!(!stack.can_undo());
+        assert!(!stack.can_redo());
+    }
+
+    #[test]
+    fn test_default_stack() {
+        let stack: UndoStack<String> = UndoStack::default();
+        assert!(!stack.can_undo());
+        assert!(!stack.can_redo());
+    }
+
+    #[test]
+    fn test_save_and_undo() {
+        let mut stack = UndoStack::new(100);
+        stack.save("before".to_string(), EditKind::Other);
+        assert!(stack.can_undo());
+
+        let restored = stack.undo("after".to_string());
+        assert_eq!(restored, Some("before".to_string()));
+        assert!(!stack.can_undo());
+        assert!(stack.can_redo());
+    }
+
+    #[test]
+    fn test_undo_then_redo() {
+        let mut stack = UndoStack::new(100);
+        stack.save("initial".to_string(), EditKind::Other);
+
+        let restored = stack.undo("modified".to_string()).unwrap();
+        assert_eq!(restored, "initial");
+
+        let redone = stack.redo("initial".to_string()).unwrap();
+        assert_eq!(redone, "modified");
+    }
+
+    #[test]
+    fn test_undo_empty_returns_none() {
+        let mut stack: UndoStack<String> = UndoStack::new(100);
+        assert_eq!(stack.undo("current".to_string()), None);
+    }
+
+    #[test]
+    fn test_redo_empty_returns_none() {
+        let mut stack: UndoStack<String> = UndoStack::new(100);
+        assert_eq!(stack.redo("current".to_string()), None);
+    }
+
+    #[test]
+    fn test_grouping_same_insert_kind() {
+        let mut stack = UndoStack::new(100);
+        // Multiple Insert saves with same kind → only first is saved
+        stack.save("state0".to_string(), EditKind::Insert);
+        stack.save("state1".to_string(), EditKind::Insert);
+        stack.save("state2".to_string(), EditKind::Insert);
+
+        // Only one undo entry (the first save)
+        let restored = stack.undo("state3".to_string());
+        assert_eq!(restored, Some("state0".to_string()));
+        assert!(!stack.can_undo());
+    }
+
+    #[test]
+    fn test_grouping_same_delete_kind() {
+        let mut stack = UndoStack::new(100);
+        stack.save("state0".to_string(), EditKind::Delete);
+        stack.save("state1".to_string(), EditKind::Delete);
+
+        let restored = stack.undo("state2".to_string());
+        assert_eq!(restored, Some("state0".to_string()));
+        assert!(!stack.can_undo());
+    }
+
+    #[test]
+    fn test_other_never_grouped() {
+        let mut stack = UndoStack::new(100);
+        stack.save("state0".to_string(), EditKind::Other);
+        stack.save("state1".to_string(), EditKind::Other);
+        stack.save("state2".to_string(), EditKind::Other);
+
+        // Three separate undo entries
+        assert_eq!(stack.undo("state3".to_string()), Some("state2".to_string()));
+        assert_eq!(stack.undo("state2".to_string()), Some("state1".to_string()));
+        assert_eq!(stack.undo("state1".to_string()), Some("state0".to_string()));
+        assert!(!stack.can_undo());
+    }
+
+    #[test]
+    fn test_kind_change_breaks_group() {
+        let mut stack = UndoStack::new(100);
+        stack.save("empty".to_string(), EditKind::Insert);
+        stack.save("h".to_string(), EditKind::Insert); // grouped
+        stack.save("he".to_string(), EditKind::Delete); // new group (kind changed)
+
+        // Two undo entries
+        assert_eq!(stack.undo("h".to_string()), Some("he".to_string()));
+        assert_eq!(stack.undo("he".to_string()), Some("empty".to_string()));
+        assert!(!stack.can_undo());
+    }
+
+    #[test]
+    fn test_break_group() {
+        let mut stack = UndoStack::new(100);
+        stack.save("state0".to_string(), EditKind::Insert);
+        stack.break_group();
+        stack.save("state1".to_string(), EditKind::Insert); // new group despite same kind
+
+        // Two separate undo entries
+        assert_eq!(stack.undo("state2".to_string()), Some("state1".to_string()));
+        assert_eq!(stack.undo("state1".to_string()), Some("state0".to_string()));
+    }
+
+    #[test]
+    fn test_new_edit_clears_redo() {
+        let mut stack = UndoStack::new(100);
+        stack.save("state0".to_string(), EditKind::Other);
+        stack.undo("state1".to_string());
+        assert!(stack.can_redo());
+
+        // New edit clears redo stack
+        stack.save("state0_again".to_string(), EditKind::Other);
+        assert!(!stack.can_redo());
+    }
+
+    #[test]
+    fn test_max_size_enforced() {
+        let mut stack = UndoStack::new(3);
+        stack.save("a".to_string(), EditKind::Other);
+        stack.save("b".to_string(), EditKind::Other);
+        stack.save("c".to_string(), EditKind::Other);
+        stack.save("d".to_string(), EditKind::Other);
+
+        // Oldest entry ("a") dropped, 3 remain
+        assert_eq!(stack.undo("e".to_string()), Some("d".to_string()));
+        assert_eq!(stack.undo("d".to_string()), Some("c".to_string()));
+        assert_eq!(stack.undo("c".to_string()), Some("b".to_string()));
+        assert!(!stack.can_undo()); // "a" was dropped
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut stack = UndoStack::new(100);
+        stack.save("state0".to_string(), EditKind::Other);
+        stack.undo("state1".to_string());
+        stack.clear();
+        assert!(!stack.can_undo());
+        assert!(!stack.can_redo());
+    }
+
+    #[test]
+    fn test_multiple_undo_redo_cycles() {
+        let mut stack = UndoStack::new(100);
+        stack.save("v0".to_string(), EditKind::Other);
+        stack.save("v1".to_string(), EditKind::Other);
+
+        // Undo twice
+        let r1 = stack.undo("v2".to_string()).unwrap();
+        assert_eq!(r1, "v1");
+        let r2 = stack.undo("v1".to_string()).unwrap();
+        assert_eq!(r2, "v0");
+
+        // Redo twice
+        let f1 = stack.redo("v0".to_string()).unwrap();
+        assert_eq!(f1, "v1");
+        let f2 = stack.redo("v1".to_string()).unwrap();
+        assert_eq!(f2, "v2");
+    }
+
+    #[test]
+    fn test_undo_resets_last_kind() {
+        let mut stack = UndoStack::new(100);
+        stack.save("before_insert".to_string(), EditKind::Insert);
+
+        // Undo resets kind tracking
+        stack.undo("after_insert".to_string());
+
+        // Next Insert should create a new group (not be skipped)
+        stack.save("new_insert".to_string(), EditKind::Insert);
+        assert!(stack.can_undo());
+    }
+
+    #[test]
+    fn test_partial_eq_always_equal() {
+        let mut stack1: UndoStack<String> = UndoStack::new(100);
+        stack1.save("a".to_string(), EditKind::Other);
+
+        let stack2: UndoStack<String> = UndoStack::new(50);
+        assert_eq!(stack1, stack2);
+    }
+}


### PR DESCRIPTION
## Summary
- Add generic `UndoStack<T>` with edit grouping (consecutive same-kind edits merge into one undo step, whitespace breaks insert groups for word-level granularity)
- Add Ctrl+Z (undo) and Ctrl+Y (redo) to InputField and TextArea
- Configurable max history depth (default 100)
- Snapshots preserve cursor position for faithful restoration

## Test plan
- [x] All 2,145 unit tests pass (65 new: 17 UndoStack + 23 InputField + 25 TextArea)
- [x] All 226 doc tests pass
- [x] All 11 integration tests pass
- [x] All 13 property tests pass
- [x] Clippy clean with `-D warnings`
- [x] Examples compile
- [x] Insert grouping: "hello world" creates 3 undo entries (word, space, word)
- [x] Delete grouping: consecutive backspace/delete operations undo together
- [x] Non-groupable operations: Clear, SetValue, DeleteLine, etc. each create own entry
- [x] Redo invalidation: new edit after undo clears redo stack
- [x] Cursor restoration: undo/redo restores exact cursor position
- [x] Disabled state: undo/redo ignored when disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)