### PR TITLE
Add SearchableList compound component

### DIFF
--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -120,6 +120,9 @@ mod select;
 #[cfg(feature = "input-components")]
 mod text_area;
 
+// Compound components
+mod searchable_list;
+
 // Data components
 #[cfg(feature = "data-components")]
 mod loading_list;
@@ -210,6 +213,12 @@ pub use multi_progress::{
 pub use progress_bar::{ProgressBar, ProgressBarMessage, ProgressBarOutput, ProgressBarState};
 #[cfg(feature = "display-components")]
 pub use spinner::{Spinner, SpinnerMessage, SpinnerState, SpinnerStyle};
+
+// Compound components
+pub use searchable_list::{
+    SearchableList, SearchableListMessage, SearchableListOutput, SearchableListState,
+};
+
 #[cfg(feature = "display-components")]
 pub use status_bar::{
     Section, StatusBar, StatusBarItem, StatusBarItemContent, StatusBarMessage, StatusBarState,

--- a/src/component/searchable_list/mod.rs
+++ b/src/component/searchable_list/mod.rs
@@ -1,0 +1,677 @@
+//! A searchable list component combining a text filter with a selectable list.
+//!
+//! `SearchableList` composes an [`InputField`](super::InputField) and a
+//! [`SelectableList`](super::SelectableList) into a single component. Typing
+//! in the filter field narrows the visible items, and keyboard navigation
+//! lets the user select from the filtered results.
+//!
+//! # Example
+//!
+//! ```rust
+//! use envision::component::{
+//!     Component, Focusable, SearchableList, SearchableListState,
+//!     SearchableListMessage, SearchableListOutput,
+//! };
+//!
+//! let mut state = SearchableListState::new(vec![
+//!     "Apple".to_string(),
+//!     "Banana".to_string(),
+//!     "Cherry".to_string(),
+//!     "Date".to_string(),
+//! ]);
+//! SearchableList::set_focused(&mut state, true);
+//!
+//! // Type "an" to filter
+//! SearchableList::update(&mut state, SearchableListMessage::FilterChanged("an".into()));
+//! assert_eq!(state.filtered_items().len(), 1); // "Banana" matches
+//!
+//! // Select the current item
+//! let output = SearchableList::update(&mut state, SearchableListMessage::Select);
+//! assert!(matches!(output, Some(SearchableListOutput::Selected(_))));
+//! ```
+
+use std::fmt::Display;
+use std::marker::PhantomData;
+
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
+
+use super::{Component, Focusable};
+use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::theme::Theme;
+
+/// Messages that can be sent to a SearchableList.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SearchableListMessage {
+    /// The filter text changed.
+    FilterChanged(String),
+    /// A character was typed (forwarded to the filter field).
+    FilterChar(char),
+    /// Delete the character before the cursor in the filter.
+    FilterBackspace,
+    /// Clear the filter text.
+    FilterClear,
+    /// Move selection up in the list.
+    Up,
+    /// Move selection down in the list.
+    Down,
+    /// Move selection to the first item.
+    First,
+    /// Move selection to the last item.
+    Last,
+    /// Move selection up by a page.
+    PageUp(usize),
+    /// Move selection down by a page.
+    PageDown(usize),
+    /// Select the current item (triggers output).
+    Select,
+    /// Switch focus between filter and list.
+    ToggleFocus,
+}
+
+/// Output messages from a SearchableList.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SearchableListOutput<T: Clone> {
+    /// An item was selected (e.g., Enter pressed while list is focused).
+    Selected(T),
+    /// The selection changed to a new filtered index.
+    SelectionChanged(usize),
+    /// The filter text changed.
+    FilterChanged(String),
+}
+
+/// Identifies which sub-component has focus within the SearchableList.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
+enum Focus {
+    /// The filter input field has focus.
+    Filter,
+    /// The selectable list has focus.
+    List,
+}
+
+/// State for a SearchableList component.
+///
+/// Contains the full list of items, the current filter text, and the
+/// filtered subset that is displayed. The filter is case-insensitive.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))]
+pub struct SearchableListState<T: Clone> {
+    /// All items (unfiltered).
+    items: Vec<T>,
+    /// Indices into `items` that match the current filter.
+    filtered_indices: Vec<usize>,
+    /// Current filter text.
+    filter_text: String,
+    /// Index into `filtered_indices` for the currently selected item.
+    selected: Option<usize>,
+    /// Ratatui list state for scroll tracking.
+    #[cfg_attr(feature = "serialization", serde(skip))]
+    list_state: ListState,
+    /// Which sub-component has internal focus.
+    internal_focus: Focus,
+    /// Whether the overall component is focused.
+    focused: bool,
+    /// Whether the component is disabled.
+    disabled: bool,
+    /// Placeholder text for the filter input.
+    placeholder: String,
+}
+
+impl<T: Clone + PartialEq> PartialEq for SearchableListState<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.items == other.items
+            && self.filtered_indices == other.filtered_indices
+            && self.filter_text == other.filter_text
+            && self.selected == other.selected
+            && self.list_state.selected() == other.list_state.selected()
+            && self.internal_focus == other.internal_focus
+            && self.focused == other.focused
+            && self.disabled == other.disabled
+            && self.placeholder == other.placeholder
+    }
+}
+
+impl<T: Clone> Default for SearchableListState<T> {
+    fn default() -> Self {
+        Self {
+            items: Vec::new(),
+            filtered_indices: Vec::new(),
+            filter_text: String::new(),
+            selected: None,
+            list_state: ListState::default(),
+            internal_focus: Focus::Filter,
+            focused: false,
+            disabled: false,
+            placeholder: "Type to filter...".to_string(),
+        }
+    }
+}
+
+impl<T: Clone> SearchableListState<T> {
+    /// Creates a new state with the given items and an empty filter.
+    ///
+    /// All items are initially visible. If the list is non-empty, the
+    /// first item is selected.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SearchableListState;
+    ///
+    /// let state = SearchableListState::new(vec!["Alpha".to_string(), "Beta".to_string()]);
+    /// assert_eq!(state.items().len(), 2);
+    /// assert_eq!(state.filtered_items().len(), 2);
+    /// assert_eq!(state.selected_index(), Some(0));
+    /// ```
+    pub fn new(items: Vec<T>) -> Self {
+        let filtered_indices: Vec<usize> = (0..items.len()).collect();
+        let selected = if items.is_empty() { None } else { Some(0) };
+        let mut list_state = ListState::default();
+        list_state.select(selected);
+        Self {
+            items,
+            filtered_indices,
+            filter_text: String::new(),
+            selected,
+            list_state,
+            internal_focus: Focus::Filter,
+            focused: false,
+            disabled: false,
+            placeholder: "Type to filter...".to_string(),
+        }
+    }
+
+    /// Returns all items (unfiltered).
+    pub fn items(&self) -> &[T] {
+        &self.items
+    }
+
+    /// Returns the items that match the current filter.
+    pub fn filtered_items(&self) -> Vec<&T> {
+        self.filtered_indices
+            .iter()
+            .filter_map(|&i| self.items.get(i))
+            .collect()
+    }
+
+    /// Returns the number of filtered items.
+    pub fn filtered_count(&self) -> usize {
+        self.filtered_indices.len()
+    }
+
+    /// Returns the current filter text.
+    pub fn filter_text(&self) -> &str {
+        &self.filter_text
+    }
+
+    /// Returns the currently selected index within the filtered list.
+    pub fn selected_index(&self) -> Option<usize> {
+        self.selected
+    }
+
+    /// Returns a reference to the currently selected item.
+    pub fn selected_item(&self) -> Option<&T> {
+        self.selected
+            .and_then(|si| self.filtered_indices.get(si))
+            .and_then(|&i| self.items.get(i))
+    }
+
+    /// Returns true if the filter input has focus (vs the list).
+    pub fn is_filter_focused(&self) -> bool {
+        self.internal_focus == Focus::Filter
+    }
+
+    /// Returns true if the list has focus (vs the filter).
+    pub fn is_list_focused(&self) -> bool {
+        self.internal_focus == Focus::List
+    }
+
+    /// Returns the placeholder text for the filter input.
+    pub fn placeholder(&self) -> &str {
+        &self.placeholder
+    }
+
+    /// Sets the placeholder text for the filter input.
+    pub fn set_placeholder(&mut self, placeholder: impl Into<String>) {
+        self.placeholder = placeholder.into();
+    }
+
+    /// Sets the placeholder text (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SearchableListState;
+    ///
+    /// let state = SearchableListState::<String>::new(vec![])
+    ///     .with_placeholder("Search items...");
+    /// assert_eq!(state.placeholder(), "Search items...");
+    /// ```
+    pub fn with_placeholder(mut self, placeholder: impl Into<String>) -> Self {
+        self.placeholder = placeholder.into();
+        self
+    }
+
+    /// Returns true if the component is empty (no items at all).
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// Returns the total number of items (unfiltered).
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Synchronizes the ratatui ListState with our selected index.
+    fn sync_list_state(&mut self) {
+        self.list_state.select(self.selected);
+    }
+}
+
+impl<T: Clone + Display + 'static> SearchableListState<T> {
+    /// Sets the items, recomputing the filter and resetting selection.
+    pub fn set_items(&mut self, items: Vec<T>) {
+        self.items = items;
+        self.refilter();
+    }
+
+    /// Returns true if the component is focused.
+    pub fn is_focused(&self) -> bool {
+        self.focused
+    }
+
+    /// Sets the focus state.
+    pub fn set_focused(&mut self, focused: bool) {
+        self.focused = focused;
+    }
+
+    /// Returns true if the component is disabled.
+    pub fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    /// Sets the disabled state.
+    pub fn set_disabled(&mut self, disabled: bool) {
+        self.disabled = disabled;
+    }
+
+    /// Sets the disabled state (builder pattern).
+    pub fn with_disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    /// Maps an input event to a searchable list message.
+    pub fn handle_event(&self, event: &Event) -> Option<SearchableListMessage> {
+        SearchableList::<T>::handle_event(self, event)
+    }
+
+    /// Dispatches an event, updating state and returning any output.
+    pub fn dispatch_event(&mut self, event: &Event) -> Option<SearchableListOutput<T>> {
+        SearchableList::<T>::dispatch_event(self, event)
+    }
+
+    /// Updates the state with a message, returning any output.
+    pub fn update(&mut self, msg: SearchableListMessage) -> Option<SearchableListOutput<T>> {
+        SearchableList::<T>::update(self, msg)
+    }
+
+    /// Recomputes the filtered indices based on the current filter text.
+    fn refilter(&mut self) {
+        let filter_lower = self.filter_text.to_lowercase();
+        self.filtered_indices = if filter_lower.is_empty() {
+            (0..self.items.len()).collect()
+        } else {
+            self.items
+                .iter()
+                .enumerate()
+                .filter(|(_, item)| {
+                    let text = format!("{}", item).to_lowercase();
+                    text.contains(&filter_lower)
+                })
+                .map(|(i, _)| i)
+                .collect()
+        };
+
+        // Reset selection to first filtered item
+        if self.filtered_indices.is_empty() {
+            self.selected = None;
+        } else {
+            self.selected = Some(0);
+        }
+        self.sync_list_state();
+    }
+}
+
+/// A searchable list component combining a filter input with a selectable list.
+///
+/// This compound component composes an input field for filtering with a
+/// selectable list for browsing and selecting items. The filter is
+/// case-insensitive and matches anywhere in the item's display text.
+///
+/// # Type Parameters
+///
+/// - `T`: The item type. Must implement `Clone` and `Display`.
+///
+/// # Sub-component Focus
+///
+/// The component manages internal focus between the filter input and the list:
+/// - **Tab** toggles focus between filter and list
+/// - When the filter is focused, typing updates the filter and refilters the list
+/// - When the list is focused, Up/Down navigates and Enter selects
+///
+/// # Navigation
+///
+/// - `Up` / `Down` — Move selection (works from either sub-component)
+/// - `Enter` — Select the current item (when list is focused) or move to list (when filter is focused)
+/// - `Tab` — Toggle between filter and list focus
+/// - `Esc` — Clear filter text
+/// - Typing — Updates the filter (when filter is focused)
+///
+/// # Example
+///
+/// ```rust
+/// use envision::component::{
+///     Component, Focusable, SearchableList, SearchableListState,
+///     SearchableListMessage, SearchableListOutput,
+/// };
+///
+/// let items = vec!["Apple".to_string(), "Banana".to_string(), "Cherry".to_string()];
+/// let mut state = SearchableListState::new(items);
+/// SearchableList::set_focused(&mut state, true);
+///
+/// // Filter to items containing "an"
+/// SearchableList::update(&mut state, SearchableListMessage::FilterChanged("an".into()));
+/// assert_eq!(state.filtered_items().len(), 1); // "Banana"
+///
+/// // Select the highlighted item
+/// let output = SearchableList::update(&mut state, SearchableListMessage::Select);
+/// assert_eq!(output, Some(SearchableListOutput::Selected("Banana".to_string())));
+/// ```
+pub struct SearchableList<T: Clone>(PhantomData<T>);
+
+impl<T: Clone + Display + 'static> Component for SearchableList<T> {
+    type State = SearchableListState<T>;
+    type Message = SearchableListMessage;
+    type Output = SearchableListOutput<T>;
+
+    fn init() -> Self::State {
+        SearchableListState::default()
+    }
+
+    fn handle_event(state: &Self::State, event: &Event) -> Option<Self::Message> {
+        if !state.focused || state.disabled {
+            return None;
+        }
+
+        if let Some(key) = event.as_key() {
+            // Tab always toggles focus between filter and list
+            if key.code == KeyCode::Tab || key.code == KeyCode::BackTab {
+                return Some(SearchableListMessage::ToggleFocus);
+            }
+
+            // Esc clears the filter
+            if key.code == KeyCode::Esc {
+                return Some(SearchableListMessage::FilterClear);
+            }
+
+            match state.internal_focus {
+                Focus::Filter => {
+                    match key.code {
+                        // Navigation keys work from filter too
+                        KeyCode::Up | KeyCode::Char('k')
+                            if key.modifiers.contains(KeyModifiers::CONTROL) =>
+                        {
+                            Some(SearchableListMessage::Up)
+                        }
+                        KeyCode::Down | KeyCode::Char('j')
+                            if key.modifiers.contains(KeyModifiers::CONTROL) =>
+                        {
+                            Some(SearchableListMessage::Down)
+                        }
+                        // Enter in filter moves focus to list
+                        KeyCode::Enter => Some(SearchableListMessage::ToggleFocus),
+                        // Backspace deletes from filter
+                        KeyCode::Backspace => Some(SearchableListMessage::FilterBackspace),
+                        // Regular characters go to filter
+                        KeyCode::Char(c) => Some(SearchableListMessage::FilterChar(c)),
+                        _ => None,
+                    }
+                }
+                Focus::List => {
+                    match key.code {
+                        KeyCode::Up | KeyCode::Char('k') => Some(SearchableListMessage::Up),
+                        KeyCode::Down | KeyCode::Char('j') => Some(SearchableListMessage::Down),
+                        KeyCode::Home | KeyCode::Char('g') => Some(SearchableListMessage::First),
+                        KeyCode::End | KeyCode::Char('G') => Some(SearchableListMessage::Last),
+                        KeyCode::PageUp => Some(SearchableListMessage::PageUp(10)),
+                        KeyCode::PageDown => Some(SearchableListMessage::PageDown(10)),
+                        KeyCode::Enter => Some(SearchableListMessage::Select),
+                        // In list mode, typing switches to filter
+                        KeyCode::Char(c) => {
+                            // Let user type to start filtering from list view
+                            Some(SearchableListMessage::FilterChar(c))
+                        }
+                        _ => None,
+                    }
+                }
+            }
+        } else {
+            None
+        }
+    }
+
+    fn update(state: &mut Self::State, msg: Self::Message) -> Option<Self::Output> {
+        if state.disabled {
+            return None;
+        }
+
+        match msg {
+            SearchableListMessage::FilterChanged(text) => {
+                state.filter_text = text.clone();
+                state.refilter();
+                Some(SearchableListOutput::FilterChanged(text))
+            }
+            SearchableListMessage::FilterChar(c) => {
+                // If typing from list, switch focus to filter
+                if state.internal_focus == Focus::List {
+                    state.internal_focus = Focus::Filter;
+                }
+                state.filter_text.push(c);
+                let text = state.filter_text.clone();
+                state.refilter();
+                Some(SearchableListOutput::FilterChanged(text))
+            }
+            SearchableListMessage::FilterBackspace => {
+                if !state.filter_text.is_empty() {
+                    state.filter_text.pop();
+                    let text = state.filter_text.clone();
+                    state.refilter();
+                    Some(SearchableListOutput::FilterChanged(text))
+                } else {
+                    None
+                }
+            }
+            SearchableListMessage::FilterClear => {
+                if !state.filter_text.is_empty() {
+                    state.filter_text.clear();
+                    state.refilter();
+                    Some(SearchableListOutput::FilterChanged(String::new()))
+                } else {
+                    None
+                }
+            }
+            SearchableListMessage::Up => {
+                if let Some(current) = state.selected {
+                    let new_index = current.saturating_sub(1);
+                    if new_index != current {
+                        state.selected = Some(new_index);
+                        state.sync_list_state();
+                        return Some(SearchableListOutput::SelectionChanged(new_index));
+                    }
+                }
+                None
+            }
+            SearchableListMessage::Down => {
+                if let Some(current) = state.selected {
+                    let len = state.filtered_indices.len();
+                    if len > 0 {
+                        let new_index = (current + 1).min(len - 1);
+                        if new_index != current {
+                            state.selected = Some(new_index);
+                            state.sync_list_state();
+                            return Some(SearchableListOutput::SelectionChanged(new_index));
+                        }
+                    }
+                }
+                None
+            }
+            SearchableListMessage::First => {
+                if !state.filtered_indices.is_empty() && state.selected != Some(0) {
+                    state.selected = Some(0);
+                    state.sync_list_state();
+                    return Some(SearchableListOutput::SelectionChanged(0));
+                }
+                None
+            }
+            SearchableListMessage::Last => {
+                let len = state.filtered_indices.len();
+                if len > 0 && state.selected != Some(len - 1) {
+                    state.selected = Some(len - 1);
+                    state.sync_list_state();
+                    return Some(SearchableListOutput::SelectionChanged(len - 1));
+                }
+                None
+            }
+            SearchableListMessage::PageUp(page_size) => {
+                if let Some(current) = state.selected {
+                    let new_index = current.saturating_sub(page_size);
+                    if new_index != current {
+                        state.selected = Some(new_index);
+                        state.sync_list_state();
+                        return Some(SearchableListOutput::SelectionChanged(new_index));
+                    }
+                }
+                None
+            }
+            SearchableListMessage::PageDown(page_size) => {
+                if let Some(current) = state.selected {
+                    let len = state.filtered_indices.len();
+                    if len > 0 {
+                        let new_index = (current + page_size).min(len - 1);
+                        if new_index != current {
+                            state.selected = Some(new_index);
+                            state.sync_list_state();
+                            return Some(SearchableListOutput::SelectionChanged(new_index));
+                        }
+                    }
+                }
+                None
+            }
+            SearchableListMessage::Select => {
+                state
+                    .selected
+                    .and_then(|si| state.filtered_indices.get(si).copied())
+                    .and_then(|i| state.items.get(i).cloned())
+                    .map(SearchableListOutput::Selected)
+            }
+            SearchableListMessage::ToggleFocus => {
+                state.internal_focus = match state.internal_focus {
+                    Focus::Filter => Focus::List,
+                    Focus::List => Focus::Filter,
+                };
+                None
+            }
+        }
+    }
+
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+        // Split area: filter input on top (3 lines), list below
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(3), Constraint::Min(1)])
+            .split(area);
+
+        // Render filter input
+        let filter_focused = state.focused && state.internal_focus == Focus::Filter;
+        let filter_border_style = if state.disabled {
+            theme.disabled_style()
+        } else if filter_focused {
+            theme.focused_border_style()
+        } else {
+            theme.border_style()
+        };
+
+        let filter_display = if state.filter_text.is_empty() {
+            Span::styled(&state.placeholder, theme.disabled_style())
+        } else {
+            Span::styled(&state.filter_text, theme.normal_style())
+        };
+
+        let match_count = format!(" {}/{} ", state.filtered_indices.len(), state.items.len());
+        let filter_block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(filter_border_style)
+            .title(Span::styled(" Filter ", theme.normal_style()))
+            .title_bottom(Line::from(match_count).alignment(Alignment::Right));
+
+        let filter_widget = Paragraph::new(Line::from(filter_display)).block(filter_block);
+        frame.render_widget(filter_widget, chunks[0]);
+
+        // Show cursor in filter when focused
+        if filter_focused && !state.disabled {
+            let cursor_x = chunks[0].x + 1 + state.filter_text.len() as u16;
+            let cursor_y = chunks[0].y + 1;
+            frame.set_cursor_position(Position::new(cursor_x, cursor_y));
+        }
+
+        // Render filtered list
+        let list_focused = state.focused && state.internal_focus == Focus::List;
+        let list_border_style = if state.disabled {
+            theme.disabled_style()
+        } else if list_focused {
+            theme.focused_border_style()
+        } else {
+            theme.border_style()
+        };
+
+        let items: Vec<ListItem> = state
+            .filtered_indices
+            .iter()
+            .filter_map(|&i| state.items.get(i))
+            .map(|item| ListItem::new(format!("{}", item)))
+            .collect();
+
+        let highlight_style = if state.disabled {
+            theme.disabled_style()
+        } else {
+            theme.selected_highlight_style(list_focused)
+        };
+
+        let list_block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(list_border_style);
+
+        let list_widget = List::new(items)
+            .block(list_block)
+            .highlight_style(highlight_style)
+            .highlight_symbol("> ");
+
+        let mut list_state = state.list_state.clone();
+        frame.render_stateful_widget(list_widget, chunks[1], &mut list_state);
+    }
+}
+
+impl<T: Clone + Display + 'static> Focusable for SearchableList<T> {
+    fn is_focused(state: &Self::State) -> bool {
+        state.focused
+    }
+
+    fn set_focused(state: &mut Self::State, focused: bool) {
+        state.focused = focused;
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/component/searchable_list/tests.rs
+++ b/src/component/searchable_list/tests.rs
@@ -1,0 +1,830 @@
+use super::*;
+use crate::component::test_utils;
+
+fn sample_items() -> Vec<String> {
+    vec![
+        "Apple".to_string(),
+        "Banana".to_string(),
+        "Cherry".to_string(),
+        "Date".to_string(),
+        "Elderberry".to_string(),
+    ]
+}
+
+fn focused_state() -> SearchableListState<String> {
+    let mut state = SearchableListState::new(sample_items());
+    SearchableList::set_focused(&mut state, true);
+    state
+}
+
+// =============================================================================
+// Construction and defaults
+// =============================================================================
+
+#[test]
+fn test_new_creates_state_with_all_items_visible() {
+    let state = SearchableListState::new(sample_items());
+    assert_eq!(state.items().len(), 5);
+    assert_eq!(state.filtered_items().len(), 5);
+    assert_eq!(state.filtered_count(), 5);
+}
+
+#[test]
+fn test_new_selects_first_item() {
+    let state = SearchableListState::new(sample_items());
+    assert_eq!(state.selected_index(), Some(0));
+    assert_eq!(state.selected_item(), Some(&"Apple".to_string()));
+}
+
+#[test]
+fn test_new_empty_list_has_no_selection() {
+    let state = SearchableListState::<String>::new(vec![]);
+    assert_eq!(state.selected_index(), None);
+    assert_eq!(state.selected_item(), None);
+    assert!(state.is_empty());
+    assert_eq!(state.len(), 0);
+}
+
+#[test]
+fn test_default_state() {
+    let state = SearchableListState::<String>::default();
+    assert!(state.items().is_empty());
+    assert!(state.filtered_items().is_empty());
+    assert_eq!(state.filter_text(), "");
+    assert!(!state.is_focused());
+    assert!(!state.is_disabled());
+    assert!(state.is_filter_focused());
+}
+
+#[test]
+fn test_default_placeholder() {
+    let state = SearchableListState::<String>::new(vec![]);
+    assert_eq!(state.placeholder(), "Type to filter...");
+}
+
+// =============================================================================
+// Builder methods
+// =============================================================================
+
+#[test]
+fn test_with_placeholder() {
+    let state = SearchableListState::<String>::new(vec![])
+        .with_placeholder("Search...");
+    assert_eq!(state.placeholder(), "Search...");
+}
+
+#[test]
+fn test_set_placeholder() {
+    let mut state = SearchableListState::<String>::new(vec![]);
+    state.set_placeholder("Find items");
+    assert_eq!(state.placeholder(), "Find items");
+}
+
+#[test]
+fn test_with_disabled() {
+    let state = SearchableListState::<String>::new(vec![])
+        .with_disabled(true);
+    assert!(state.is_disabled());
+}
+
+// =============================================================================
+// Focus management
+// =============================================================================
+
+#[test]
+fn test_initial_internal_focus_is_filter() {
+    let state = SearchableListState::new(sample_items());
+    assert!(state.is_filter_focused());
+    assert!(!state.is_list_focused());
+}
+
+#[test]
+fn test_toggle_focus_switches_to_list() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::ToggleFocus);
+    assert!(state.is_list_focused());
+    assert!(!state.is_filter_focused());
+}
+
+#[test]
+fn test_toggle_focus_switches_back_to_filter() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::ToggleFocus);
+    SearchableList::update(&mut state, SearchableListMessage::ToggleFocus);
+    assert!(state.is_filter_focused());
+}
+
+#[test]
+fn test_set_focused_and_is_focused() {
+    let mut state = SearchableListState::new(sample_items());
+    assert!(!state.is_focused());
+    state.set_focused(true);
+    assert!(state.is_focused());
+    state.set_focused(false);
+    assert!(!state.is_focused());
+}
+
+// =============================================================================
+// Filtering
+// =============================================================================
+
+#[test]
+fn test_filter_narrows_items() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::FilterChanged("an".into()));
+    assert_eq!(state.filtered_count(), 1); // "Banana"
+    assert_eq!(state.filtered_items(), vec![&"Banana".to_string()]);
+}
+
+#[test]
+fn test_filter_is_case_insensitive() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::FilterChanged("APPLE".into()));
+    assert_eq!(state.filtered_count(), 1);
+    assert_eq!(state.filtered_items(), vec![&"Apple".to_string()]);
+}
+
+#[test]
+fn test_filter_matches_substring() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::FilterChanged("err".into()));
+    assert_eq!(state.filtered_count(), 2); // Cherry, Elderberry
+}
+
+#[test]
+fn test_filter_no_matches() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::FilterChanged("xyz".into()));
+    assert_eq!(state.filtered_count(), 0);
+    assert_eq!(state.selected_index(), None);
+    assert_eq!(state.selected_item(), None);
+}
+
+#[test]
+fn test_filter_changed_resets_selection_to_first() {
+    let mut state = focused_state();
+    // Move to third item
+    SearchableList::update(&mut state, SearchableListMessage::Down);
+    SearchableList::update(&mut state, SearchableListMessage::Down);
+    assert_eq!(state.selected_index(), Some(2));
+
+    // Filter resets selection to 0
+    SearchableList::update(&mut state, SearchableListMessage::FilterChanged("a".into()));
+    assert_eq!(state.selected_index(), Some(0));
+}
+
+#[test]
+fn test_filter_changed_returns_output() {
+    let mut state = focused_state();
+    let output = SearchableList::update(
+        &mut state,
+        SearchableListMessage::FilterChanged("test".into()),
+    );
+    assert_eq!(
+        output,
+        Some(SearchableListOutput::FilterChanged("test".into()))
+    );
+}
+
+#[test]
+fn test_empty_filter_shows_all_items() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::FilterChanged("app".into()));
+    assert_eq!(state.filtered_count(), 1);
+
+    SearchableList::update(&mut state, SearchableListMessage::FilterChanged("".into()));
+    assert_eq!(state.filtered_count(), 5);
+}
+
+// =============================================================================
+// Filter char-by-char input
+// =============================================================================
+
+#[test]
+fn test_filter_char_appends_to_filter() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::FilterChar('b'));
+    assert_eq!(state.filter_text(), "b");
+    SearchableList::update(&mut state, SearchableListMessage::FilterChar('a'));
+    assert_eq!(state.filter_text(), "ba");
+    assert_eq!(state.filtered_count(), 1); // "Banana"
+}
+
+#[test]
+fn test_filter_char_returns_filter_changed_output() {
+    let mut state = focused_state();
+    let output = SearchableList::update(&mut state, SearchableListMessage::FilterChar('x'));
+    assert_eq!(
+        output,
+        Some(SearchableListOutput::FilterChanged("x".into()))
+    );
+}
+
+#[test]
+fn test_filter_char_from_list_switches_focus_to_filter() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::ToggleFocus);
+    assert!(state.is_list_focused());
+
+    SearchableList::update(&mut state, SearchableListMessage::FilterChar('a'));
+    assert!(state.is_filter_focused());
+    assert_eq!(state.filter_text(), "a");
+}
+
+// =============================================================================
+// Filter backspace and clear
+// =============================================================================
+
+#[test]
+fn test_filter_backspace_removes_last_char() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::FilterChanged("abc".into()));
+    SearchableList::update(&mut state, SearchableListMessage::FilterBackspace);
+    assert_eq!(state.filter_text(), "ab");
+}
+
+#[test]
+fn test_filter_backspace_on_empty_returns_none() {
+    let mut state = focused_state();
+    let output = SearchableList::update(&mut state, SearchableListMessage::FilterBackspace);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_filter_clear_empties_filter() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::FilterChanged("abc".into()));
+    let output = SearchableList::update(&mut state, SearchableListMessage::FilterClear);
+    assert_eq!(state.filter_text(), "");
+    assert_eq!(state.filtered_count(), 5);
+    assert_eq!(
+        output,
+        Some(SearchableListOutput::FilterChanged(String::new()))
+    );
+}
+
+#[test]
+fn test_filter_clear_on_empty_returns_none() {
+    let mut state = focused_state();
+    let output = SearchableList::update(&mut state, SearchableListMessage::FilterClear);
+    assert_eq!(output, None);
+}
+
+// =============================================================================
+// List navigation
+// =============================================================================
+
+#[test]
+fn test_down_moves_selection() {
+    let mut state = focused_state();
+    let output = SearchableList::update(&mut state, SearchableListMessage::Down);
+    assert_eq!(state.selected_index(), Some(1));
+    assert_eq!(output, Some(SearchableListOutput::SelectionChanged(1)));
+}
+
+#[test]
+fn test_up_moves_selection() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::Down);
+    SearchableList::update(&mut state, SearchableListMessage::Down);
+    let output = SearchableList::update(&mut state, SearchableListMessage::Up);
+    assert_eq!(state.selected_index(), Some(1));
+    assert_eq!(output, Some(SearchableListOutput::SelectionChanged(1)));
+}
+
+#[test]
+fn test_up_at_top_returns_none() {
+    let mut state = focused_state();
+    let output = SearchableList::update(&mut state, SearchableListMessage::Up);
+    assert_eq!(state.selected_index(), Some(0));
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_down_at_bottom_returns_none() {
+    let mut state = focused_state();
+    for _ in 0..4 {
+        SearchableList::update(&mut state, SearchableListMessage::Down);
+    }
+    assert_eq!(state.selected_index(), Some(4));
+    let output = SearchableList::update(&mut state, SearchableListMessage::Down);
+    assert_eq!(state.selected_index(), Some(4));
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_first_jumps_to_top() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::Down);
+    SearchableList::update(&mut state, SearchableListMessage::Down);
+    let output = SearchableList::update(&mut state, SearchableListMessage::First);
+    assert_eq!(state.selected_index(), Some(0));
+    assert_eq!(output, Some(SearchableListOutput::SelectionChanged(0)));
+}
+
+#[test]
+fn test_first_at_top_returns_none() {
+    let mut state = focused_state();
+    let output = SearchableList::update(&mut state, SearchableListMessage::First);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_last_jumps_to_bottom() {
+    let mut state = focused_state();
+    let output = SearchableList::update(&mut state, SearchableListMessage::Last);
+    assert_eq!(state.selected_index(), Some(4));
+    assert_eq!(output, Some(SearchableListOutput::SelectionChanged(4)));
+}
+
+#[test]
+fn test_last_at_bottom_returns_none() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::Last);
+    let output = SearchableList::update(&mut state, SearchableListMessage::Last);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_page_up() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::Last);
+    let output = SearchableList::update(&mut state, SearchableListMessage::PageUp(3));
+    assert_eq!(state.selected_index(), Some(1));
+    assert_eq!(output, Some(SearchableListOutput::SelectionChanged(1)));
+}
+
+#[test]
+fn test_page_up_clamps_to_zero() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::Down);
+    let output = SearchableList::update(&mut state, SearchableListMessage::PageUp(10));
+    assert_eq!(state.selected_index(), Some(0));
+    assert_eq!(output, Some(SearchableListOutput::SelectionChanged(0)));
+}
+
+#[test]
+fn test_page_down() {
+    let mut state = focused_state();
+    let output = SearchableList::update(&mut state, SearchableListMessage::PageDown(3));
+    assert_eq!(state.selected_index(), Some(3));
+    assert_eq!(output, Some(SearchableListOutput::SelectionChanged(3)));
+}
+
+#[test]
+fn test_page_down_clamps_to_last() {
+    let mut state = focused_state();
+    let output = SearchableList::update(&mut state, SearchableListMessage::PageDown(100));
+    assert_eq!(state.selected_index(), Some(4));
+    assert_eq!(output, Some(SearchableListOutput::SelectionChanged(4)));
+}
+
+// =============================================================================
+// Selection
+// =============================================================================
+
+#[test]
+fn test_select_returns_selected_item() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::Down);
+    let output = SearchableList::update(&mut state, SearchableListMessage::Select);
+    assert_eq!(
+        output,
+        Some(SearchableListOutput::Selected("Banana".to_string()))
+    );
+}
+
+#[test]
+fn test_select_with_filter_returns_correct_item() {
+    let mut state = focused_state();
+    // Filter to show only "Cherry" and "Elderberry"
+    SearchableList::update(&mut state, SearchableListMessage::FilterChanged("err".into()));
+    assert_eq!(state.filtered_count(), 2);
+
+    // Select first filtered item (Cherry)
+    let output = SearchableList::update(&mut state, SearchableListMessage::Select);
+    assert_eq!(
+        output,
+        Some(SearchableListOutput::Selected("Cherry".to_string()))
+    );
+}
+
+#[test]
+fn test_select_with_filter_second_item() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::FilterChanged("err".into()));
+    SearchableList::update(&mut state, SearchableListMessage::Down);
+    let output = SearchableList::update(&mut state, SearchableListMessage::Select);
+    assert_eq!(
+        output,
+        Some(SearchableListOutput::Selected("Elderberry".to_string()))
+    );
+}
+
+#[test]
+fn test_select_on_empty_filtered_list_returns_none() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::FilterChanged("xyz".into()));
+    let output = SearchableList::update(&mut state, SearchableListMessage::Select);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_select_on_empty_list_returns_none() {
+    let mut state = SearchableListState::<String>::new(vec![]);
+    SearchableList::set_focused(&mut state, true);
+    let output = SearchableList::update(&mut state, SearchableListMessage::Select);
+    assert_eq!(output, None);
+}
+
+// =============================================================================
+// Navigation on filtered list
+// =============================================================================
+
+#[test]
+fn test_navigation_respects_filtered_bounds() {
+    let mut state = focused_state();
+    // Filter to 2 items
+    SearchableList::update(&mut state, SearchableListMessage::FilterChanged("err".into()));
+    assert_eq!(state.filtered_count(), 2);
+
+    // Down should work
+    let output = SearchableList::update(&mut state, SearchableListMessage::Down);
+    assert_eq!(state.selected_index(), Some(1));
+    assert_eq!(output, Some(SearchableListOutput::SelectionChanged(1)));
+
+    // Down at end should not move
+    let output = SearchableList::update(&mut state, SearchableListMessage::Down);
+    assert_eq!(state.selected_index(), Some(1));
+    assert_eq!(output, None);
+}
+
+// =============================================================================
+// Disabled state
+// =============================================================================
+
+#[test]
+fn test_disabled_ignores_all_messages() {
+    let mut state = focused_state();
+    state.set_disabled(true);
+
+    let output = SearchableList::update(&mut state, SearchableListMessage::Down);
+    assert_eq!(output, None);
+
+    let output = SearchableList::update(
+        &mut state,
+        SearchableListMessage::FilterChanged("a".into()),
+    );
+    assert_eq!(output, None);
+
+    let output = SearchableList::update(&mut state, SearchableListMessage::Select);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_disabled_ignores_events() {
+    let mut state = focused_state();
+    state.set_disabled(true);
+
+    let msg = SearchableList::handle_event(&state, &Event::char('a'));
+    assert_eq!(msg, None);
+}
+
+// =============================================================================
+// Unfocused state
+// =============================================================================
+
+#[test]
+fn test_unfocused_ignores_events() {
+    let state = SearchableListState::new(sample_items());
+    assert!(!state.is_focused());
+
+    let msg = SearchableList::handle_event(&state, &Event::char('a'));
+    assert_eq!(msg, None);
+}
+
+// =============================================================================
+// Event mapping
+// =============================================================================
+
+#[test]
+fn test_tab_maps_to_toggle_focus() {
+    let state = focused_state();
+    let msg = SearchableList::handle_event(&state, &Event::key(KeyCode::Tab));
+    assert_eq!(msg, Some(SearchableListMessage::ToggleFocus));
+}
+
+#[test]
+fn test_backtab_maps_to_toggle_focus() {
+    let state = focused_state();
+    let msg = SearchableList::handle_event(&state, &Event::key(KeyCode::BackTab));
+    assert_eq!(msg, Some(SearchableListMessage::ToggleFocus));
+}
+
+#[test]
+fn test_esc_maps_to_filter_clear() {
+    let state = focused_state();
+    let msg = SearchableList::handle_event(&state, &Event::key(KeyCode::Esc));
+    assert_eq!(msg, Some(SearchableListMessage::FilterClear));
+}
+
+#[test]
+fn test_char_in_filter_mode_maps_to_filter_char() {
+    let state = focused_state();
+    assert!(state.is_filter_focused());
+    let msg = SearchableList::handle_event(&state, &Event::char('a'));
+    assert_eq!(msg, Some(SearchableListMessage::FilterChar('a')));
+}
+
+#[test]
+fn test_enter_in_filter_mode_maps_to_toggle_focus() {
+    let state = focused_state();
+    assert!(state.is_filter_focused());
+    let msg = SearchableList::handle_event(&state, &Event::key(KeyCode::Enter));
+    assert_eq!(msg, Some(SearchableListMessage::ToggleFocus));
+}
+
+#[test]
+fn test_backspace_in_filter_mode_maps_to_filter_backspace() {
+    let state = focused_state();
+    let msg = SearchableList::handle_event(&state, &Event::key(KeyCode::Backspace));
+    assert_eq!(msg, Some(SearchableListMessage::FilterBackspace));
+}
+
+#[test]
+fn test_ctrl_j_in_filter_maps_to_down() {
+    let state = focused_state();
+    let msg = SearchableList::handle_event(&state, &Event::ctrl('j'));
+    assert_eq!(msg, Some(SearchableListMessage::Down));
+}
+
+#[test]
+fn test_ctrl_k_in_filter_maps_to_up() {
+    let state = focused_state();
+    let msg = SearchableList::handle_event(&state, &Event::ctrl('k'));
+    assert_eq!(msg, Some(SearchableListMessage::Up));
+}
+
+#[test]
+fn test_arrow_keys_in_list_mode() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::ToggleFocus);
+    assert!(state.is_list_focused());
+
+    let msg = SearchableList::handle_event(&state, &Event::key(KeyCode::Up));
+    assert_eq!(msg, Some(SearchableListMessage::Up));
+
+    let msg = SearchableList::handle_event(&state, &Event::key(KeyCode::Down));
+    assert_eq!(msg, Some(SearchableListMessage::Down));
+}
+
+#[test]
+fn test_vim_keys_in_list_mode() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::ToggleFocus);
+
+    let msg = SearchableList::handle_event(&state, &Event::char('k'));
+    assert_eq!(msg, Some(SearchableListMessage::Up));
+
+    let msg = SearchableList::handle_event(&state, &Event::char('j'));
+    assert_eq!(msg, Some(SearchableListMessage::Down));
+}
+
+#[test]
+fn test_home_end_in_list_mode() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::ToggleFocus);
+
+    let msg = SearchableList::handle_event(&state, &Event::key(KeyCode::Home));
+    assert_eq!(msg, Some(SearchableListMessage::First));
+
+    let msg = SearchableList::handle_event(&state, &Event::key(KeyCode::End));
+    assert_eq!(msg, Some(SearchableListMessage::Last));
+}
+
+#[test]
+fn test_g_and_shift_g_in_list_mode() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::ToggleFocus);
+
+    let msg = SearchableList::handle_event(&state, &Event::char('g'));
+    assert_eq!(msg, Some(SearchableListMessage::First));
+
+    let msg = SearchableList::handle_event(&state, &Event::char('G'));
+    assert_eq!(msg, Some(SearchableListMessage::Last));
+}
+
+#[test]
+fn test_page_keys_in_list_mode() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::ToggleFocus);
+
+    let msg = SearchableList::handle_event(&state, &Event::key(KeyCode::PageUp));
+    assert_eq!(msg, Some(SearchableListMessage::PageUp(10)));
+
+    let msg = SearchableList::handle_event(&state, &Event::key(KeyCode::PageDown));
+    assert_eq!(msg, Some(SearchableListMessage::PageDown(10)));
+}
+
+#[test]
+fn test_enter_in_list_mode_maps_to_select() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::ToggleFocus);
+
+    let msg = SearchableList::handle_event(&state, &Event::key(KeyCode::Enter));
+    assert_eq!(msg, Some(SearchableListMessage::Select));
+}
+
+#[test]
+fn test_char_in_list_mode_maps_to_filter_char() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::ToggleFocus);
+    assert!(state.is_list_focused());
+
+    // Typing in list mode should redirect to filter
+    let msg = SearchableList::handle_event(&state, &Event::char('x'));
+    assert_eq!(msg, Some(SearchableListMessage::FilterChar('x')));
+}
+
+// =============================================================================
+// dispatch_event
+// =============================================================================
+
+#[test]
+fn test_dispatch_event_filters_and_selects() {
+    let mut state = focused_state();
+
+    // Type a character via dispatch_event
+    let output = state.dispatch_event(&Event::char('b'));
+    assert_eq!(
+        output,
+        Some(SearchableListOutput::FilterChanged("b".into()))
+    );
+    assert_eq!(state.filter_text(), "b");
+
+    // Filtered to Banana and Elderberry
+    let output = state.dispatch_event(&Event::char('a'));
+    assert_eq!(
+        output,
+        Some(SearchableListOutput::FilterChanged("ba".into()))
+    );
+    // Only Banana matches "ba"
+    assert_eq!(state.filtered_count(), 1);
+}
+
+// =============================================================================
+// set_items
+// =============================================================================
+
+#[test]
+fn test_set_items_refilters() {
+    let mut state = focused_state();
+    SearchableList::update(&mut state, SearchableListMessage::FilterChanged("a".into()));
+    let count_before = state.filtered_count();
+
+    state.set_items(vec![
+        "Avocado".to_string(),
+        "Artichoke".to_string(),
+        "Zucchini".to_string(),
+    ]);
+    // "a" now matches Avocado and Artichoke
+    assert_eq!(state.filtered_count(), 2);
+    assert_ne!(count_before, state.filtered_count());
+}
+
+// =============================================================================
+// Instance methods
+// =============================================================================
+
+#[test]
+fn test_instance_handle_event() {
+    let state = focused_state();
+    let msg = state.handle_event(&Event::char('x'));
+    assert_eq!(msg, Some(SearchableListMessage::FilterChar('x')));
+}
+
+#[test]
+fn test_instance_update() {
+    let mut state = focused_state();
+    let output = state.update(SearchableListMessage::Down);
+    assert_eq!(output, Some(SearchableListOutput::SelectionChanged(1)));
+}
+
+#[test]
+fn test_instance_dispatch_event() {
+    let mut state = focused_state();
+    let output = state.dispatch_event(&Event::char('a'));
+    assert!(matches!(output, Some(SearchableListOutput::FilterChanged(_))));
+}
+
+// =============================================================================
+// Rendering
+// =============================================================================
+
+#[test]
+fn test_render_unfocused() {
+    let state = SearchableListState::new(sample_items());
+    let (mut terminal, theme) = test_utils::setup_render(40, 15);
+    terminal
+        .draw(|frame| {
+            SearchableList::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_focused_filter() {
+    let mut state = SearchableListState::new(sample_items());
+    SearchableList::set_focused(&mut state, true);
+    let (mut terminal, theme) = test_utils::setup_render(40, 15);
+    terminal
+        .draw(|frame| {
+            SearchableList::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_focused_list() {
+    let mut state = SearchableListState::new(sample_items());
+    SearchableList::set_focused(&mut state, true);
+    SearchableList::update(&mut state, SearchableListMessage::ToggleFocus);
+    let (mut terminal, theme) = test_utils::setup_render(40, 15);
+    terminal
+        .draw(|frame| {
+            SearchableList::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_with_filter() {
+    let mut state = SearchableListState::new(sample_items());
+    SearchableList::set_focused(&mut state, true);
+    SearchableList::update(&mut state, SearchableListMessage::FilterChanged("an".into()));
+    let (mut terminal, theme) = test_utils::setup_render(40, 15);
+    terminal
+        .draw(|frame| {
+            SearchableList::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_disabled() {
+    let mut state = SearchableListState::new(sample_items());
+    state.set_disabled(true);
+    let (mut terminal, theme) = test_utils::setup_render(40, 15);
+    terminal
+        .draw(|frame| {
+            SearchableList::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_empty_list() {
+    let state = SearchableListState::<String>::new(vec![]);
+    let (mut terminal, theme) = test_utils::setup_render(40, 15);
+    terminal
+        .draw(|frame| {
+            SearchableList::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+// =============================================================================
+// Focusable trait
+// =============================================================================
+
+#[test]
+fn test_focusable_trait() {
+    let mut state = SearchableList::<String>::init();
+    assert!(!SearchableList::is_focused(&state));
+
+    SearchableList::focus(&mut state);
+    assert!(SearchableList::is_focused(&state));
+
+    SearchableList::blur(&mut state);
+    assert!(!SearchableList::is_focused(&state));
+}
+
+// =============================================================================
+// PartialEq
+// =============================================================================
+
+#[test]
+fn test_partial_eq() {
+    let state1 = SearchableListState::new(sample_items());
+    let state2 = SearchableListState::new(sample_items());
+    assert_eq!(state1, state2);
+}
+
+#[test]
+fn test_partial_eq_different_filter() {
+    let mut state1 = SearchableListState::new(sample_items());
+    let state2 = SearchableListState::new(sample_items());
+    SearchableList::set_focused(&mut state1, true);
+    SearchableList::update(&mut state1, SearchableListMessage::FilterChanged("a".into()));
+    assert_ne!(state1, state2);
+}


### PR DESCRIPTION
## Summary
- Add `SearchableList<T>` compound component that composes filter input with selectable list navigation
- Tab toggles focus between filter and list sub-components
- Case-insensitive real-time filtering with match count display
- Ctrl+J/K for navigation while filter is focused; typing from list auto-switches to filter
- Implements `Component` and `Focusable` traits with full instance methods

## Details

### Types
- `SearchableListState<T>` — holds items, filter text, filtered indices, internal focus, and selection
- `SearchableListMessage` — filter input (char/backspace/clear/changed), navigation (up/down/first/last/page), select, toggle focus
- `SearchableListOutput<T>` — `Selected(T)`, `SelectionChanged(usize)`, `FilterChanged(String)`

### Rendering
- Filter input with border and match count (`3/10`) in bottom-right
- Scrollable list with highlight indicator
- Visual focus feedback on whichever sub-component is active

### Serialization
- Supports `serialization` feature with conditional serde derives
- `ListState` skipped via `#[serde(skip)]`

## Test plan
- [x] 76 unit tests covering construction, filtering, navigation, selection, focus management, event mapping, disabled state, rendering, and instance methods
- [x] 4 doc tests (module, struct, `new`, `with_placeholder`)
- [x] `cargo clippy -- -D warnings` — clean
- [x] Full suite: 2,156 unit + 230 doc + 11 integration + 13 property tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)