### PR TITLE
Add DataGrid compound component with inline cell editing

### DIFF
--- a/src/component/data_grid/mod.rs
+++ b/src/component/data_grid/mod.rs
@@ -1,0 +1,639 @@
+//! A data grid with inline cell editing.
+//!
+//! `DataGrid` wraps [`Table`](super::Table) adding column navigation and
+//! inline cell editing. Press Enter to edit a cell, Escape to cancel, and
+//! Enter again to confirm the edit.
+//!
+//! # Example
+//!
+//! ```rust
+//! use envision::component::{
+//!     Component, Focusable, DataGrid, DataGridState,
+//!     DataGridMessage, DataGridOutput, TableRow, Column,
+//! };
+//! use ratatui::layout::Constraint;
+//!
+//! #[derive(Clone, Debug)]
+//! struct Person { name: String, age: String }
+//!
+//! impl TableRow for Person {
+//!     fn cells(&self) -> Vec<String> {
+//!         vec![self.name.clone(), self.age.clone()]
+//!     }
+//! }
+//!
+//! let rows = vec![
+//!     Person { name: "Alice".into(), age: "30".into() },
+//!     Person { name: "Bob".into(), age: "25".into() },
+//! ];
+//! let columns = vec![
+//!     Column::new("Name", Constraint::Min(10)),
+//!     Column::new("Age", Constraint::Min(5)),
+//! ];
+//! let mut state = DataGridState::new(rows, columns);
+//! DataGrid::set_focused(&mut state, true);
+//!
+//! assert_eq!(state.selected_column(), 0);
+//! assert!(!state.is_editing());
+//! ```
+
+use std::marker::PhantomData;
+
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Row, Table as RatatuiTable};
+
+use super::{Column, Component, Focusable, InputFieldMessage, InputFieldState, TableRow};
+use crate::input::{Event, KeyCode};
+use crate::theme::Theme;
+
+/// Messages that can be sent to a DataGrid.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DataGridMessage {
+    /// Move selection up by one row.
+    Up,
+    /// Move selection down by one row.
+    Down,
+    /// Move selection to the first row.
+    First,
+    /// Move selection to the last row.
+    Last,
+    /// Move the column cursor left.
+    Left,
+    /// Move the column cursor right.
+    Right,
+    /// Start editing the current cell, or confirm the edit.
+    Enter,
+    /// Cancel the current edit.
+    Cancel,
+    /// Type a character while editing.
+    Input(char),
+    /// Delete the character before the cursor while editing.
+    Backspace,
+    /// Delete the character after the cursor while editing.
+    Delete,
+    /// Move cursor to the start of the cell while editing.
+    Home,
+    /// Move cursor to the end of the cell while editing.
+    End,
+}
+
+/// Output messages from a DataGrid.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DataGridOutput<T: Clone> {
+    /// A cell was edited. Contains the row index, column index, and new value.
+    CellEdited {
+        /// The row index of the edited cell.
+        row: usize,
+        /// The column index of the edited cell.
+        column: usize,
+        /// The new value as a string.
+        value: String,
+    },
+    /// A row was selected (Enter pressed when not editing).
+    Selected(T),
+    /// The row selection changed.
+    SelectionChanged(usize),
+    /// The column cursor moved.
+    ColumnChanged(usize),
+    /// An edit was cancelled.
+    EditCancelled,
+}
+
+/// State for a DataGrid component.
+///
+/// Contains the table data, column cursor, and inline editor state.
+#[derive(Clone, Debug)]
+pub struct DataGridState<T: TableRow> {
+    /// The rows of data.
+    rows: Vec<T>,
+    /// Column definitions.
+    columns: Vec<Column>,
+    /// Currently selected row index.
+    selected_row: Option<usize>,
+    /// Currently selected column index.
+    selected_column: usize,
+    /// Whether the cell editor is active.
+    editing: bool,
+    /// The inline editor state.
+    editor: InputFieldState,
+    /// Value before editing started (for cancel).
+    original_value: String,
+    /// Whether the overall component is focused.
+    focused: bool,
+    /// Whether the component is disabled.
+    disabled: bool,
+}
+
+impl<T: TableRow + PartialEq> PartialEq for DataGridState<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.rows == other.rows
+            && self.columns == other.columns
+            && self.selected_row == other.selected_row
+            && self.selected_column == other.selected_column
+            && self.editing == other.editing
+            && self.focused == other.focused
+            && self.disabled == other.disabled
+    }
+}
+
+impl<T: TableRow> Default for DataGridState<T> {
+    fn default() -> Self {
+        Self {
+            rows: Vec::new(),
+            columns: Vec::new(),
+            selected_row: None,
+            selected_column: 0,
+            editing: false,
+            editor: InputFieldState::new(),
+            original_value: String::new(),
+            focused: false,
+            disabled: false,
+        }
+    }
+}
+
+impl<T: TableRow> DataGridState<T> {
+    /// Creates a new data grid with the given rows and columns.
+    ///
+    /// The first row is selected by default.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{DataGridState, TableRow, Column};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = DataGridState::new(
+    ///     vec![Item { name: "A".into() }],
+    ///     vec![Column::new("Name", Constraint::Min(10))],
+    /// );
+    /// assert_eq!(state.selected_row_index(), Some(0));
+    /// assert_eq!(state.selected_column(), 0);
+    /// ```
+    pub fn new(rows: Vec<T>, columns: Vec<Column>) -> Self {
+        let selected_row = if rows.is_empty() { None } else { Some(0) };
+        Self {
+            rows,
+            columns,
+            selected_row,
+            selected_column: 0,
+            editing: false,
+            editor: InputFieldState::new(),
+            original_value: String::new(),
+            focused: false,
+            disabled: false,
+        }
+    }
+
+    /// Returns the rows.
+    pub fn rows(&self) -> &[T] {
+        &self.rows
+    }
+
+    /// Returns the columns.
+    pub fn columns(&self) -> &[Column] {
+        &self.columns
+    }
+
+    /// Returns the currently selected row index.
+    pub fn selected_row_index(&self) -> Option<usize> {
+        self.selected_row
+    }
+
+    /// Returns a reference to the currently selected row.
+    pub fn selected_row(&self) -> Option<&T> {
+        self.selected_row.and_then(|i| self.rows.get(i))
+    }
+
+    /// Returns a reference to the currently selected item.
+    pub fn selected_item(&self) -> Option<&T> {
+        self.selected_row()
+    }
+
+    /// Returns the currently selected column index.
+    pub fn selected_column(&self) -> usize {
+        self.selected_column
+    }
+
+    /// Returns true if a cell is currently being edited.
+    pub fn is_editing(&self) -> bool {
+        self.editing
+    }
+
+    /// Returns the current editor value (while editing).
+    pub fn editor_value(&self) -> &str {
+        self.editor.value()
+    }
+
+    /// Returns the value of the currently selected cell.
+    pub fn current_cell_value(&self) -> Option<String> {
+        self.selected_row
+            .and_then(|ri| self.rows.get(ri))
+            .map(|row| {
+                let cells = row.cells();
+                cells
+                    .get(self.selected_column)
+                    .cloned()
+                    .unwrap_or_default()
+            })
+    }
+
+    /// Returns the number of rows.
+    pub fn row_count(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Returns the number of columns.
+    pub fn column_count(&self) -> usize {
+        self.columns.len()
+    }
+
+    /// Returns true if the grid has no rows.
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    /// Sets the rows, resetting selection and cancelling any edit.
+    pub fn set_rows(&mut self, rows: Vec<T>) {
+        self.editing = false;
+        self.rows = rows;
+        if self.rows.is_empty() {
+            self.selected_row = None;
+        } else {
+            let current = self.selected_row.unwrap_or(0);
+            self.selected_row = Some(current.min(self.rows.len() - 1));
+        }
+    }
+}
+
+impl<T: TableRow + 'static> DataGridState<T> {
+    /// Returns true if the component is focused.
+    pub fn is_focused(&self) -> bool {
+        self.focused
+    }
+
+    /// Sets the focus state.
+    pub fn set_focused(&mut self, focused: bool) {
+        self.focused = focused;
+    }
+
+    /// Returns true if the component is disabled.
+    pub fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    /// Sets the disabled state.
+    pub fn set_disabled(&mut self, disabled: bool) {
+        self.disabled = disabled;
+    }
+
+    /// Sets the disabled state (builder pattern).
+    pub fn with_disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    /// Maps an input event to a data grid message.
+    pub fn handle_event(&self, event: &Event) -> Option<DataGridMessage> {
+        DataGrid::<T>::handle_event(self, event)
+    }
+
+    /// Dispatches an event, updating state and returning any output.
+    pub fn dispatch_event(&mut self, event: &Event) -> Option<DataGridOutput<T>> {
+        DataGrid::<T>::dispatch_event(self, event)
+    }
+
+    /// Updates the state with a message, returning any output.
+    pub fn update(&mut self, msg: DataGridMessage) -> Option<DataGridOutput<T>> {
+        DataGrid::<T>::update(self, msg)
+    }
+
+    /// Starts editing the current cell.
+    fn start_editing(&mut self) {
+        if let Some(cell_value) = self.current_cell_value() {
+            self.original_value = cell_value.clone();
+            self.editor.set_value(&cell_value);
+            self.editor.set_focused(true);
+            self.editing = true;
+        }
+    }
+
+    /// Cancels the current edit, restoring the original value.
+    fn cancel_editing(&mut self) {
+        self.editing = false;
+        self.editor.set_focused(false);
+    }
+}
+
+/// A data grid with inline cell editing.
+///
+/// Extends table functionality with column navigation (Left/Right)
+/// and inline cell editing (Enter to edit, Escape to cancel).
+///
+/// # Type Parameters
+///
+/// - `T`: The row type. Must implement [`TableRow`] and `Clone`.
+///
+/// # Navigation
+///
+/// - `Up` / `Down` / `j` / `k` — Move row selection
+/// - `Left` / `Right` / `h` / `l` — Move column cursor
+/// - `Home` / `End` — First/last row (or cursor position when editing)
+/// - `Enter` — Start editing or confirm edit
+/// - `Escape` — Cancel edit
+///
+/// # Editing
+///
+/// When Enter is pressed on a cell, the editor opens with the cell's
+/// current value. The user types to modify, then presses Enter to
+/// confirm or Escape to cancel. On confirm, a `CellEdited` output
+/// is emitted. The parent is responsible for updating the row data.
+pub struct DataGrid<T: Clone>(PhantomData<T>);
+
+impl<T: TableRow + 'static> Component for DataGrid<T> {
+    type State = DataGridState<T>;
+    type Message = DataGridMessage;
+    type Output = DataGridOutput<T>;
+
+    fn init() -> Self::State {
+        DataGridState::default()
+    }
+
+    fn handle_event(state: &Self::State, event: &Event) -> Option<Self::Message> {
+        if !state.focused || state.disabled {
+            return None;
+        }
+
+        if let Some(key) = event.as_key() {
+            if state.editing {
+                // Editing mode key bindings
+                match key.code {
+                    KeyCode::Enter => Some(DataGridMessage::Enter),
+                    KeyCode::Esc => Some(DataGridMessage::Cancel),
+                    KeyCode::Char(c) => Some(DataGridMessage::Input(c)),
+                    KeyCode::Backspace => Some(DataGridMessage::Backspace),
+                    KeyCode::Delete => Some(DataGridMessage::Delete),
+                    KeyCode::Home => Some(DataGridMessage::Home),
+                    KeyCode::End => Some(DataGridMessage::End),
+                    _ => None,
+                }
+            } else {
+                // Navigation mode key bindings
+                match key.code {
+                    KeyCode::Up | KeyCode::Char('k') => Some(DataGridMessage::Up),
+                    KeyCode::Down | KeyCode::Char('j') => Some(DataGridMessage::Down),
+                    KeyCode::Left | KeyCode::Char('h') => Some(DataGridMessage::Left),
+                    KeyCode::Right | KeyCode::Char('l') => Some(DataGridMessage::Right),
+                    KeyCode::Home => Some(DataGridMessage::First),
+                    KeyCode::End => Some(DataGridMessage::Last),
+                    KeyCode::Enter => Some(DataGridMessage::Enter),
+                    KeyCode::Esc => Some(DataGridMessage::Cancel),
+                    _ => None,
+                }
+            }
+        } else {
+            None
+        }
+    }
+
+    fn update(state: &mut Self::State, msg: Self::Message) -> Option<Self::Output> {
+        if state.disabled || state.rows.is_empty() {
+            return None;
+        }
+
+        if state.editing {
+            // Editing mode
+            match msg {
+                DataGridMessage::Enter => {
+                    // Confirm edit
+                    let value = state.editor.value().to_string();
+                    let row = state.selected_row.unwrap_or(0);
+                    let col = state.selected_column;
+                    state.cancel_editing();
+                    Some(DataGridOutput::CellEdited {
+                        row,
+                        column: col,
+                        value,
+                    })
+                }
+                DataGridMessage::Cancel => {
+                    state.cancel_editing();
+                    Some(DataGridOutput::EditCancelled)
+                }
+                DataGridMessage::Input(c) => {
+                    state.editor.update(InputFieldMessage::Insert(c));
+                    None
+                }
+                DataGridMessage::Backspace => {
+                    state.editor.update(InputFieldMessage::Backspace);
+                    None
+                }
+                DataGridMessage::Delete => {
+                    state.editor.update(InputFieldMessage::Delete);
+                    None
+                }
+                DataGridMessage::Home => {
+                    state.editor.update(InputFieldMessage::Home);
+                    None
+                }
+                DataGridMessage::End => {
+                    state.editor.update(InputFieldMessage::End);
+                    None
+                }
+                _ => None,
+            }
+        } else {
+            // Navigation mode
+            let len = state.rows.len();
+            let current_row = state.selected_row.unwrap_or(0);
+            let col_count = state.columns.len();
+
+            match msg {
+                DataGridMessage::Up => {
+                    let new_index = current_row.saturating_sub(1);
+                    if new_index != current_row {
+                        state.selected_row = Some(new_index);
+                        Some(DataGridOutput::SelectionChanged(new_index))
+                    } else {
+                        None
+                    }
+                }
+                DataGridMessage::Down => {
+                    let new_index = (current_row + 1).min(len - 1);
+                    if new_index != current_row {
+                        state.selected_row = Some(new_index);
+                        Some(DataGridOutput::SelectionChanged(new_index))
+                    } else {
+                        None
+                    }
+                }
+                DataGridMessage::First => {
+                    if current_row != 0 {
+                        state.selected_row = Some(0);
+                        Some(DataGridOutput::SelectionChanged(0))
+                    } else {
+                        None
+                    }
+                }
+                DataGridMessage::Last => {
+                    let last = len - 1;
+                    if current_row != last {
+                        state.selected_row = Some(last);
+                        Some(DataGridOutput::SelectionChanged(last))
+                    } else {
+                        None
+                    }
+                }
+                DataGridMessage::Left => {
+                    if col_count > 0 && state.selected_column > 0 {
+                        state.selected_column -= 1;
+                        Some(DataGridOutput::ColumnChanged(state.selected_column))
+                    } else {
+                        None
+                    }
+                }
+                DataGridMessage::Right => {
+                    if col_count > 0 && state.selected_column < col_count - 1 {
+                        state.selected_column += 1;
+                        Some(DataGridOutput::ColumnChanged(state.selected_column))
+                    } else {
+                        None
+                    }
+                }
+                DataGridMessage::Enter => {
+                    state.start_editing();
+                    None
+                }
+                DataGridMessage::Cancel => None,
+                _ => None,
+            }
+        }
+    }
+
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+        if state.columns.is_empty() {
+            return;
+        }
+
+        let widths: Vec<Constraint> = state.columns.iter().map(|c| c.width()).collect();
+
+        // Build header row
+        let headers: Vec<String> = state
+            .columns
+            .iter()
+            .enumerate()
+            .map(|(i, col)| {
+                if !state.editing && state.focused && i == state.selected_column {
+                    format!("[{}]", col.header())
+                } else {
+                    col.header().to_string()
+                }
+            })
+            .collect();
+
+        let header_style = if state.disabled {
+            theme.disabled_style()
+        } else {
+            Style::default().add_modifier(Modifier::BOLD)
+        };
+
+        let header = Row::new(headers).style(header_style).bottom_margin(1);
+
+        // Build data rows
+        let rows: Vec<Row> = state
+            .rows
+            .iter()
+            .enumerate()
+            .map(|(row_idx, row)| {
+                let cells = row.cells();
+                let display_cells: Vec<String> = cells
+                    .iter()
+                    .enumerate()
+                    .map(|(col_idx, cell)| {
+                        if state.editing
+                            && state.selected_row == Some(row_idx)
+                            && col_idx == state.selected_column
+                        {
+                            // Show editor content for the cell being edited
+                            state.editor.value().to_string()
+                        } else {
+                            cell.clone()
+                        }
+                    })
+                    .collect();
+                Row::new(display_cells)
+            })
+            .collect();
+
+        let border_style = if state.disabled {
+            theme.disabled_style()
+        } else if state.focused {
+            theme.focused_border_style()
+        } else {
+            theme.border_style()
+        };
+
+        let highlight_style = if state.disabled {
+            theme.disabled_style()
+        } else {
+            theme.selected_highlight_style(state.focused)
+        };
+
+        let table = RatatuiTable::new(rows, widths)
+            .header(header)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(border_style),
+            )
+            .row_highlight_style(highlight_style)
+            .highlight_symbol("> ");
+
+        let mut table_state = ratatui::widgets::TableState::default();
+        table_state.select(state.selected_row);
+        frame.render_stateful_widget(table, area, &mut table_state);
+
+        // Show cursor when editing
+        if state.editing && state.focused {
+            if let Some(row_idx) = state.selected_row {
+                // Calculate cursor position for the edit cell
+                // This is approximate — exact positioning depends on column widths
+                let content_area = area.inner(Margin::new(1, 1));
+                let col_areas = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints(
+                        state.columns.iter().map(|c| c.width()).collect::<Vec<_>>(),
+                    )
+                    .split(content_area);
+
+                if let Some(col_area) = col_areas.get(state.selected_column) {
+                    // +2 for header row and margin
+                    let cursor_y = content_area.y + 2 + (row_idx as u16);
+                    let cursor_x = col_area.x + state.editor.cursor_position() as u16;
+                    if cursor_y < area.bottom() && cursor_x < col_area.right() {
+                        frame.set_cursor_position(Position::new(cursor_x, cursor_y));
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<T: TableRow + 'static> Focusable for DataGrid<T> {
+    fn is_focused(state: &Self::State) -> bool {
+        state.focused
+    }
+
+    fn set_focused(state: &mut Self::State, focused: bool) {
+        state.focused = focused;
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/component/data_grid/tests.rs
+++ b/src/component/data_grid/tests.rs
@@ -1,0 +1,635 @@
+use super::*;
+use crate::component::test_utils;
+
+#[derive(Clone, Debug, PartialEq)]
+struct Person {
+    name: String,
+    age: String,
+}
+
+impl TableRow for Person {
+    fn cells(&self) -> Vec<String> {
+        vec![self.name.clone(), self.age.clone()]
+    }
+}
+
+fn sample_rows() -> Vec<Person> {
+    vec![
+        Person {
+            name: "Alice".into(),
+            age: "30".into(),
+        },
+        Person {
+            name: "Bob".into(),
+            age: "25".into(),
+        },
+        Person {
+            name: "Charlie".into(),
+            age: "35".into(),
+        },
+    ]
+}
+
+fn sample_columns() -> Vec<Column> {
+    vec![
+        Column::new("Name", Constraint::Min(10)),
+        Column::new("Age", Constraint::Min(5)),
+    ]
+}
+
+fn focused_grid() -> DataGridState<Person> {
+    let mut state = DataGridState::new(sample_rows(), sample_columns());
+    DataGrid::set_focused(&mut state, true);
+    state
+}
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+#[test]
+fn test_new() {
+    let state = DataGridState::new(sample_rows(), sample_columns());
+    assert_eq!(state.row_count(), 3);
+    assert_eq!(state.column_count(), 2);
+    assert_eq!(state.selected_row_index(), Some(0));
+    assert_eq!(state.selected_column(), 0);
+    assert!(!state.is_editing());
+}
+
+#[test]
+fn test_new_empty() {
+    let state = DataGridState::<Person>::new(vec![], sample_columns());
+    assert_eq!(state.selected_row_index(), None);
+    assert!(state.is_empty());
+}
+
+#[test]
+fn test_default() {
+    let state = DataGridState::<Person>::default();
+    assert!(state.is_empty());
+    assert_eq!(state.column_count(), 0);
+    assert!(!state.is_focused());
+    assert!(!state.is_disabled());
+}
+
+// =============================================================================
+// Row and cell accessors
+// =============================================================================
+
+#[test]
+fn test_selected_row() {
+    let state = DataGridState::new(sample_rows(), sample_columns());
+    let row = state.selected_row().unwrap();
+    assert_eq!(row.name, "Alice");
+}
+
+#[test]
+fn test_selected_item() {
+    let state = DataGridState::new(sample_rows(), sample_columns());
+    assert_eq!(state.selected_item(), state.selected_row());
+}
+
+#[test]
+fn test_current_cell_value() {
+    let state = DataGridState::new(sample_rows(), sample_columns());
+    assert_eq!(state.current_cell_value(), Some("Alice".to_string()));
+}
+
+#[test]
+fn test_current_cell_value_second_column() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Right);
+    assert_eq!(state.current_cell_value(), Some("30".to_string()));
+}
+
+// =============================================================================
+// Row navigation
+// =============================================================================
+
+#[test]
+fn test_down() {
+    let mut state = focused_grid();
+    let output = DataGrid::update(&mut state, DataGridMessage::Down);
+    assert_eq!(state.selected_row_index(), Some(1));
+    assert_eq!(output, Some(DataGridOutput::SelectionChanged(1)));
+}
+
+#[test]
+fn test_up() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Down);
+    let output = DataGrid::update(&mut state, DataGridMessage::Up);
+    assert_eq!(state.selected_row_index(), Some(0));
+    assert_eq!(output, Some(DataGridOutput::SelectionChanged(0)));
+}
+
+#[test]
+fn test_up_at_top() {
+    let mut state = focused_grid();
+    let output = DataGrid::update(&mut state, DataGridMessage::Up);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_down_at_bottom() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Down);
+    DataGrid::update(&mut state, DataGridMessage::Down);
+    let output = DataGrid::update(&mut state, DataGridMessage::Down);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_first() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Down);
+    DataGrid::update(&mut state, DataGridMessage::Down);
+    let output = DataGrid::update(&mut state, DataGridMessage::First);
+    assert_eq!(state.selected_row_index(), Some(0));
+    assert_eq!(output, Some(DataGridOutput::SelectionChanged(0)));
+}
+
+#[test]
+fn test_last() {
+    let mut state = focused_grid();
+    let output = DataGrid::update(&mut state, DataGridMessage::Last);
+    assert_eq!(state.selected_row_index(), Some(2));
+    assert_eq!(output, Some(DataGridOutput::SelectionChanged(2)));
+}
+
+// =============================================================================
+// Column navigation
+// =============================================================================
+
+#[test]
+fn test_right() {
+    let mut state = focused_grid();
+    let output = DataGrid::update(&mut state, DataGridMessage::Right);
+    assert_eq!(state.selected_column(), 1);
+    assert_eq!(output, Some(DataGridOutput::ColumnChanged(1)));
+}
+
+#[test]
+fn test_left() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Right);
+    let output = DataGrid::update(&mut state, DataGridMessage::Left);
+    assert_eq!(state.selected_column(), 0);
+    assert_eq!(output, Some(DataGridOutput::ColumnChanged(0)));
+}
+
+#[test]
+fn test_right_at_last_column() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Right);
+    let output = DataGrid::update(&mut state, DataGridMessage::Right);
+    assert_eq!(state.selected_column(), 1);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_left_at_first_column() {
+    let mut state = focused_grid();
+    let output = DataGrid::update(&mut state, DataGridMessage::Left);
+    assert_eq!(state.selected_column(), 0);
+    assert_eq!(output, None);
+}
+
+// =============================================================================
+// Editing
+// =============================================================================
+
+#[test]
+fn test_enter_starts_editing() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Enter);
+    assert!(state.is_editing());
+    assert_eq!(state.editor_value(), "Alice");
+}
+
+#[test]
+fn test_type_while_editing() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Enter);
+    DataGrid::update(&mut state, DataGridMessage::Input('!'));
+    assert!(state.editor_value().contains('!'));
+}
+
+#[test]
+fn test_confirm_edit() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Enter);
+    // Clear and type new value
+    DataGrid::update(&mut state, DataGridMessage::Home);
+    // Select all and type over... simpler to just add to end
+    DataGrid::update(&mut state, DataGridMessage::End);
+    DataGrid::update(&mut state, DataGridMessage::Input('!'));
+
+    let output = DataGrid::update(&mut state, DataGridMessage::Enter);
+    assert!(!state.is_editing());
+    assert_eq!(
+        output,
+        Some(DataGridOutput::CellEdited {
+            row: 0,
+            column: 0,
+            value: "Alice!".into(),
+        })
+    );
+}
+
+#[test]
+fn test_cancel_edit() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Enter);
+    DataGrid::update(&mut state, DataGridMessage::Input('!'));
+    let output = DataGrid::update(&mut state, DataGridMessage::Cancel);
+    assert!(!state.is_editing());
+    assert_eq!(output, Some(DataGridOutput::EditCancelled));
+}
+
+#[test]
+fn test_backspace_while_editing() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Enter);
+    DataGrid::update(&mut state, DataGridMessage::Backspace);
+    assert_eq!(state.editor_value(), "Alic");
+}
+
+#[test]
+fn test_delete_while_editing() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Enter);
+    DataGrid::update(&mut state, DataGridMessage::Home);
+    DataGrid::update(&mut state, DataGridMessage::Delete);
+    assert_eq!(state.editor_value(), "lice");
+}
+
+#[test]
+fn test_edit_second_column() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Right);
+    DataGrid::update(&mut state, DataGridMessage::Enter);
+    assert!(state.is_editing());
+    assert_eq!(state.editor_value(), "30");
+
+    let output = DataGrid::update(&mut state, DataGridMessage::Enter);
+    assert_eq!(
+        output,
+        Some(DataGridOutput::CellEdited {
+            row: 0,
+            column: 1,
+            value: "30".into(),
+        })
+    );
+}
+
+#[test]
+fn test_edit_different_row() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Down);
+    DataGrid::update(&mut state, DataGridMessage::Enter);
+    assert_eq!(state.editor_value(), "Bob");
+
+    let output = DataGrid::update(&mut state, DataGridMessage::Enter);
+    assert_eq!(
+        output,
+        Some(DataGridOutput::CellEdited {
+            row: 1,
+            column: 0,
+            value: "Bob".into(),
+        })
+    );
+}
+
+// =============================================================================
+// Disabled state
+// =============================================================================
+
+#[test]
+fn test_disabled_ignores_messages() {
+    let mut state = focused_grid();
+    state.set_disabled(true);
+    let output = DataGrid::update(&mut state, DataGridMessage::Down);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_disabled_ignores_events() {
+    let mut state = focused_grid();
+    state.set_disabled(true);
+    let msg = DataGrid::handle_event(&state, &Event::key(KeyCode::Down));
+    assert_eq!(msg, None);
+}
+
+#[test]
+fn test_with_disabled() {
+    let state = DataGridState::new(sample_rows(), sample_columns()).with_disabled(true);
+    assert!(state.is_disabled());
+}
+
+// =============================================================================
+// Unfocused state
+// =============================================================================
+
+#[test]
+fn test_unfocused_ignores_events() {
+    let state = DataGridState::new(sample_rows(), sample_columns());
+    let msg = DataGrid::handle_event(&state, &Event::key(KeyCode::Down));
+    assert_eq!(msg, None);
+}
+
+// =============================================================================
+// Event mapping — navigation mode
+// =============================================================================
+
+#[test]
+fn test_up_key_maps() {
+    let state = focused_grid();
+    assert_eq!(
+        DataGrid::handle_event(&state, &Event::key(KeyCode::Up)),
+        Some(DataGridMessage::Up)
+    );
+    assert_eq!(
+        DataGrid::handle_event(&state, &Event::char('k')),
+        Some(DataGridMessage::Up)
+    );
+}
+
+#[test]
+fn test_down_key_maps() {
+    let state = focused_grid();
+    assert_eq!(
+        DataGrid::handle_event(&state, &Event::key(KeyCode::Down)),
+        Some(DataGridMessage::Down)
+    );
+    assert_eq!(
+        DataGrid::handle_event(&state, &Event::char('j')),
+        Some(DataGridMessage::Down)
+    );
+}
+
+#[test]
+fn test_left_right_key_maps() {
+    let state = focused_grid();
+    assert_eq!(
+        DataGrid::handle_event(&state, &Event::key(KeyCode::Left)),
+        Some(DataGridMessage::Left)
+    );
+    assert_eq!(
+        DataGrid::handle_event(&state, &Event::key(KeyCode::Right)),
+        Some(DataGridMessage::Right)
+    );
+    assert_eq!(
+        DataGrid::handle_event(&state, &Event::char('h')),
+        Some(DataGridMessage::Left)
+    );
+    assert_eq!(
+        DataGrid::handle_event(&state, &Event::char('l')),
+        Some(DataGridMessage::Right)
+    );
+}
+
+#[test]
+fn test_home_end_key_maps() {
+    let state = focused_grid();
+    assert_eq!(
+        DataGrid::handle_event(&state, &Event::key(KeyCode::Home)),
+        Some(DataGridMessage::First)
+    );
+    assert_eq!(
+        DataGrid::handle_event(&state, &Event::key(KeyCode::End)),
+        Some(DataGridMessage::Last)
+    );
+}
+
+#[test]
+fn test_enter_key_maps() {
+    let state = focused_grid();
+    assert_eq!(
+        DataGrid::handle_event(&state, &Event::key(KeyCode::Enter)),
+        Some(DataGridMessage::Enter)
+    );
+}
+
+// =============================================================================
+// Event mapping — editing mode
+// =============================================================================
+
+#[test]
+fn test_editing_char_maps_to_input() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Enter);
+    assert!(state.is_editing());
+
+    assert_eq!(
+        DataGrid::handle_event(&state, &Event::char('x')),
+        Some(DataGridMessage::Input('x'))
+    );
+}
+
+#[test]
+fn test_editing_enter_maps() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Enter);
+
+    assert_eq!(
+        DataGrid::handle_event(&state, &Event::key(KeyCode::Enter)),
+        Some(DataGridMessage::Enter)
+    );
+}
+
+#[test]
+fn test_editing_esc_maps_to_cancel() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Enter);
+
+    assert_eq!(
+        DataGrid::handle_event(&state, &Event::key(KeyCode::Esc)),
+        Some(DataGridMessage::Cancel)
+    );
+}
+
+#[test]
+fn test_editing_backspace_maps() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Enter);
+
+    assert_eq!(
+        DataGrid::handle_event(&state, &Event::key(KeyCode::Backspace)),
+        Some(DataGridMessage::Backspace)
+    );
+}
+
+// =============================================================================
+// set_rows
+// =============================================================================
+
+#[test]
+fn test_set_rows() {
+    let mut state = focused_grid();
+    state.set_rows(vec![Person {
+        name: "New".into(),
+        age: "1".into(),
+    }]);
+    assert_eq!(state.row_count(), 1);
+    assert_eq!(state.selected_row_index(), Some(0));
+}
+
+#[test]
+fn test_set_rows_cancels_edit() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Enter);
+    assert!(state.is_editing());
+
+    state.set_rows(sample_rows());
+    assert!(!state.is_editing());
+}
+
+#[test]
+fn test_set_rows_clamps_selection() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Last);
+    assert_eq!(state.selected_row_index(), Some(2));
+
+    state.set_rows(vec![Person {
+        name: "Only".into(),
+        age: "1".into(),
+    }]);
+    assert_eq!(state.selected_row_index(), Some(0));
+}
+
+// =============================================================================
+// Instance methods
+// =============================================================================
+
+#[test]
+fn test_instance_handle_event() {
+    let state = focused_grid();
+    let msg = state.handle_event(&Event::key(KeyCode::Down));
+    assert_eq!(msg, Some(DataGridMessage::Down));
+}
+
+#[test]
+fn test_instance_update() {
+    let mut state = focused_grid();
+    let output = state.update(DataGridMessage::Down);
+    assert_eq!(output, Some(DataGridOutput::SelectionChanged(1)));
+}
+
+#[test]
+fn test_instance_dispatch_event() {
+    let mut state = focused_grid();
+    let output = state.dispatch_event(&Event::key(KeyCode::Down));
+    assert_eq!(output, Some(DataGridOutput::SelectionChanged(1)));
+}
+
+// =============================================================================
+// Rendering
+// =============================================================================
+
+#[test]
+fn test_render_unfocused() {
+    let state = DataGridState::new(sample_rows(), sample_columns());
+    let (mut terminal, theme) = test_utils::setup_render(60, 15);
+    terminal
+        .draw(|frame| {
+            DataGrid::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_focused() {
+    let state = focused_grid();
+    let (mut terminal, theme) = test_utils::setup_render(60, 15);
+    terminal
+        .draw(|frame| {
+            DataGrid::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_editing() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Enter);
+    let (mut terminal, theme) = test_utils::setup_render(60, 15);
+    terminal
+        .draw(|frame| {
+            DataGrid::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_disabled() {
+    let state = DataGridState::new(sample_rows(), sample_columns()).with_disabled(true);
+    let (mut terminal, theme) = test_utils::setup_render(60, 15);
+    terminal
+        .draw(|frame| {
+            DataGrid::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_empty() {
+    let state = DataGridState::<Person>::new(vec![], sample_columns());
+    let (mut terminal, theme) = test_utils::setup_render(60, 15);
+    terminal
+        .draw(|frame| {
+            DataGrid::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+// =============================================================================
+// Focusable trait
+// =============================================================================
+
+#[test]
+fn test_focusable_trait() {
+    let mut state = DataGrid::<Person>::init();
+    assert!(!DataGrid::is_focused(&state));
+
+    DataGrid::focus(&mut state);
+    assert!(DataGrid::is_focused(&state));
+
+    DataGrid::blur(&mut state);
+    assert!(!DataGrid::is_focused(&state));
+}
+
+// =============================================================================
+// PartialEq
+// =============================================================================
+
+#[test]
+fn test_partial_eq() {
+    let state1 = DataGridState::new(sample_rows(), sample_columns());
+    let state2 = DataGridState::new(sample_rows(), sample_columns());
+    assert_eq!(state1, state2);
+}
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
+#[test]
+fn test_empty_grid_ignores_navigation() {
+    let mut state = DataGridState::<Person>::new(vec![], sample_columns());
+    DataGrid::set_focused(&mut state, true);
+
+    let output = DataGrid::update(&mut state, DataGridMessage::Down);
+    assert_eq!(output, None);
+
+    let output = DataGrid::update(&mut state, DataGridMessage::Enter);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_navigation_does_not_change_edit_state() {
+    let mut state = focused_grid();
+    DataGrid::update(&mut state, DataGridMessage::Down);
+    assert!(!state.is_editing());
+}

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -124,6 +124,7 @@ mod text_area;
 mod form;
 mod searchable_list;
 mod split_panel;
+mod data_grid;
 
 // Data components
 #[cfg(feature = "data-components")]
@@ -224,6 +225,7 @@ pub use searchable_list::{
 pub use split_panel::{
     SplitOrientation, SplitPanel, SplitPanelMessage, SplitPanelOutput, SplitPanelState,
 };
+pub use data_grid::{DataGrid, DataGridMessage, DataGridOutput, DataGridState};
 
 #[cfg(feature = "display-components")]
 pub use status_bar::{


### PR DESCRIPTION
## Summary
- Adds `DataGrid<T>` compound component that wraps Table with column navigation and inline cell editing
- Composes `InputFieldState` for the cell editor; Enter starts/confirms editing, Escape cancels
- Navigation: Up/Down/j/k for rows, Left/Right/h/l for columns, Home/End for first/last row
- Types: `DataGridState<T>`, `DataGridMessage`, `DataGridOutput<T>` with `CellEdited`, `Selected`, `SelectionChanged`, `ColumnChanged`, `EditCancelled` variants
- Implements `Focusable` trait with full disabled state support
- Instance methods on `DataGridState<T>` for ergonomic usage without turbofish

## Test plan
- [x] 53 unit tests covering construction, navigation, editing, disabled/unfocused state, event mapping, rendering, and edge cases
- [x] 2 doc tests on module and `DataGridState::new`
- [x] Full test suite: 2,133 unit + 228 doc tests passing
- [x] Clippy clean with `-D warnings`
- [x] Examples build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)