### PR TITLE
Add LogViewer compound component with search and severity filters

### DIFF
--- a/src/component/log_viewer/mod.rs
+++ b/src/component/log_viewer/mod.rs
@@ -1,0 +1,980 @@
+//! A searchable log viewer with severity filtering.
+//!
+//! `LogViewer` composes a [`StatusLog`](super::StatusLog) with an
+//! [`InputField`](super::InputField) search bar and severity-level toggle
+//! filters. Press `/` to focus the search bar, `Escape` to clear and return
+//! to the log, and `1`-`4` to toggle Info/Success/Warning/Error filters.
+//!
+//! # Example
+//!
+//! ```rust
+//! use envision::component::{
+//!     Component, Focusable, LogViewer, LogViewerState,
+//!     LogViewerMessage, LogViewerOutput,
+//! };
+//!
+//! let mut state = LogViewerState::new();
+//! state.push_info("Application started");
+//! state.push_warning("Disk space low");
+//! state.push_error("Connection failed");
+//!
+//! assert_eq!(state.visible_entries().len(), 3);
+//!
+//! // Filter to errors only (toggle off Info, Success, Warning)
+//! LogViewer::update(&mut state, LogViewerMessage::ToggleInfo);
+//! LogViewer::update(&mut state, LogViewerMessage::ToggleSuccess);
+//! LogViewer::update(&mut state, LogViewerMessage::ToggleWarning);
+//! assert_eq!(state.visible_entries().len(), 1);
+//! ```
+
+use std::marker::PhantomData;
+
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+
+use super::{
+    Component, Focusable, InputFieldMessage, InputFieldState, StatusLogEntry, StatusLogLevel,
+};
+use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::theme::Theme;
+
+/// Internal focus target for the log viewer.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+enum Focus {
+    /// The log list is focused.
+    #[default]
+    Log,
+    /// The search bar is focused.
+    Search,
+}
+
+/// Messages that can be sent to a LogViewer.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LogViewerMessage {
+    /// Scroll the log up by one line.
+    ScrollUp,
+    /// Scroll the log down by one line.
+    ScrollDown,
+    /// Scroll to the top of the log.
+    ScrollToTop,
+    /// Scroll to the bottom of the log.
+    ScrollToBottom,
+    /// Focus the search bar.
+    FocusSearch,
+    /// Return focus to the log (and optionally clear search).
+    FocusLog,
+    /// Type a character in the search bar.
+    SearchInput(char),
+    /// Delete character before cursor in search bar.
+    SearchBackspace,
+    /// Delete character at cursor in search bar.
+    SearchDelete,
+    /// Move search cursor left.
+    SearchLeft,
+    /// Move search cursor right.
+    SearchRight,
+    /// Move search cursor to start.
+    SearchHome,
+    /// Move search cursor to end.
+    SearchEnd,
+    /// Clear the search text.
+    ClearSearch,
+    /// Toggle the Info level filter.
+    ToggleInfo,
+    /// Toggle the Success level filter.
+    ToggleSuccess,
+    /// Toggle the Warning level filter.
+    ToggleWarning,
+    /// Toggle the Error level filter.
+    ToggleError,
+    /// Add an entry to the log.
+    Push {
+        /// The message text.
+        message: String,
+        /// The severity level.
+        level: StatusLogLevel,
+        /// Optional timestamp.
+        timestamp: Option<String>,
+    },
+    /// Clear all log entries.
+    Clear,
+    /// Remove a specific entry by ID.
+    Remove(u64),
+}
+
+/// Output messages from a LogViewer.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LogViewerOutput {
+    /// A log entry was added.
+    Added(u64),
+    /// A log entry was removed.
+    Removed(u64),
+    /// All entries were cleared.
+    Cleared,
+    /// An old entry was evicted due to max_entries limit.
+    Evicted(u64),
+    /// The search text changed.
+    SearchChanged(String),
+    /// A filter toggle changed.
+    FilterChanged,
+}
+
+/// State for a LogViewer component.
+///
+/// Contains the log entries, search state, and severity filter toggles.
+#[derive(Clone, Debug)]
+pub struct LogViewerState {
+    /// All log entries in insertion order.
+    entries: Vec<StatusLogEntry>,
+    /// Next entry ID counter.
+    next_id: u64,
+    /// Maximum number of entries to keep.
+    max_entries: usize,
+    /// The search input field state.
+    search: InputFieldState,
+    /// The current search text (cached for filtering).
+    search_text: String,
+    /// Scroll offset for the visible log.
+    scroll_offset: usize,
+    /// Severity filter toggles (true = show).
+    show_info: bool,
+    /// Whether to show success entries.
+    show_success: bool,
+    /// Whether to show warning entries.
+    show_warning: bool,
+    /// Whether to show error entries.
+    show_error: bool,
+    /// Whether to show timestamps.
+    show_timestamps: bool,
+    /// Optional title for the log block.
+    title: Option<String>,
+    /// Internal focus state.
+    focus: Focus,
+    /// Whether the component is focused.
+    focused: bool,
+    /// Whether the component is disabled.
+    disabled: bool,
+}
+
+impl Default for LogViewerState {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+            next_id: 0,
+            max_entries: 1000,
+            search: InputFieldState::new(),
+            search_text: String::new(),
+            scroll_offset: 0,
+            show_info: true,
+            show_success: true,
+            show_warning: true,
+            show_error: true,
+            show_timestamps: false,
+            title: None,
+            focus: Focus::Log,
+            focused: false,
+            disabled: false,
+        }
+    }
+}
+
+impl PartialEq for LogViewerState {
+    fn eq(&self, other: &Self) -> bool {
+        self.entries == other.entries
+            && self.next_id == other.next_id
+            && self.max_entries == other.max_entries
+            && self.search_text == other.search_text
+            && self.scroll_offset == other.scroll_offset
+            && self.show_info == other.show_info
+            && self.show_success == other.show_success
+            && self.show_warning == other.show_warning
+            && self.show_error == other.show_error
+            && self.show_timestamps == other.show_timestamps
+            && self.title == other.title
+            && self.focus == other.focus
+            && self.focused == other.focused
+            && self.disabled == other.disabled
+    }
+}
+
+impl LogViewerState {
+    /// Creates a new empty log viewer state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let state = LogViewerState::new();
+    /// assert!(state.is_empty());
+    /// assert_eq!(state.max_entries(), 1000);
+    /// ```
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the maximum number of entries (builder pattern).
+    pub fn with_max_entries(mut self, max: usize) -> Self {
+        self.max_entries = max;
+        self
+    }
+
+    /// Sets whether to show timestamps (builder pattern).
+    pub fn with_timestamps(mut self, show: bool) -> Self {
+        self.show_timestamps = show;
+        self
+    }
+
+    /// Sets the title (builder pattern).
+    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Sets the disabled state (builder pattern).
+    pub fn with_disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    // ---- Entry manipulation ----
+
+    /// Adds an info-level entry, returning its ID.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new();
+    /// let id = state.push_info("Server started");
+    /// assert_eq!(state.len(), 1);
+    /// ```
+    pub fn push_info(&mut self, message: impl Into<String>) -> u64 {
+        self.push_entry(message.into(), StatusLogLevel::Info, None)
+    }
+
+    /// Adds a success-level entry, returning its ID.
+    pub fn push_success(&mut self, message: impl Into<String>) -> u64 {
+        self.push_entry(message.into(), StatusLogLevel::Success, None)
+    }
+
+    /// Adds a warning-level entry, returning its ID.
+    pub fn push_warning(&mut self, message: impl Into<String>) -> u64 {
+        self.push_entry(message.into(), StatusLogLevel::Warning, None)
+    }
+
+    /// Adds an error-level entry, returning its ID.
+    pub fn push_error(&mut self, message: impl Into<String>) -> u64 {
+        self.push_entry(message.into(), StatusLogLevel::Error, None)
+    }
+
+    /// Adds an info-level entry with a timestamp, returning its ID.
+    pub fn push_info_with_timestamp(
+        &mut self,
+        message: impl Into<String>,
+        timestamp: impl Into<String>,
+    ) -> u64 {
+        self.push_entry(message.into(), StatusLogLevel::Info, Some(timestamp.into()))
+    }
+
+    /// Adds a success-level entry with a timestamp, returning its ID.
+    pub fn push_success_with_timestamp(
+        &mut self,
+        message: impl Into<String>,
+        timestamp: impl Into<String>,
+    ) -> u64 {
+        self.push_entry(
+            message.into(),
+            StatusLogLevel::Success,
+            Some(timestamp.into()),
+        )
+    }
+
+    /// Adds a warning-level entry with a timestamp, returning its ID.
+    pub fn push_warning_with_timestamp(
+        &mut self,
+        message: impl Into<String>,
+        timestamp: impl Into<String>,
+    ) -> u64 {
+        self.push_entry(
+            message.into(),
+            StatusLogLevel::Warning,
+            Some(timestamp.into()),
+        )
+    }
+
+    /// Adds an error-level entry with a timestamp, returning its ID.
+    pub fn push_error_with_timestamp(
+        &mut self,
+        message: impl Into<String>,
+        timestamp: impl Into<String>,
+    ) -> u64 {
+        self.push_entry(
+            message.into(),
+            StatusLogLevel::Error,
+            Some(timestamp.into()),
+        )
+    }
+
+    /// Internal method to add an entry.
+    fn push_entry(
+        &mut self,
+        message: String,
+        level: StatusLogLevel,
+        timestamp: Option<String>,
+    ) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        let entry = match timestamp {
+            Some(ts) => StatusLogEntry::with_timestamp(id, message, level, ts),
+            None => StatusLogEntry::new(id, message, level),
+        };
+        self.entries.push(entry);
+        // Evict oldest if over limit
+        while self.entries.len() > self.max_entries {
+            self.entries.remove(0);
+        }
+        id
+    }
+
+    /// Removes an entry by ID. Returns true if the entry was found.
+    pub fn remove(&mut self, id: u64) -> bool {
+        if let Some(pos) = self.entries.iter().position(|e| e.id() == id) {
+            self.entries.remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Clears all entries.
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.scroll_offset = 0;
+    }
+
+    // ---- Accessors ----
+
+    /// Returns all entries in insertion order.
+    pub fn entries(&self) -> &[StatusLogEntry] {
+        &self.entries
+    }
+
+    /// Returns the number of entries.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns true if there are no entries.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Returns the maximum number of entries.
+    pub fn max_entries(&self) -> usize {
+        self.max_entries
+    }
+
+    /// Sets the maximum number of entries.
+    pub fn set_max_entries(&mut self, max: usize) {
+        self.max_entries = max;
+        while self.entries.len() > self.max_entries {
+            self.entries.remove(0);
+        }
+    }
+
+    /// Returns the current search text.
+    pub fn search_text(&self) -> &str {
+        &self.search_text
+    }
+
+    /// Returns the scroll offset.
+    pub fn scroll_offset(&self) -> usize {
+        self.scroll_offset
+    }
+
+    /// Sets the scroll offset.
+    pub fn set_scroll_offset(&mut self, offset: usize) {
+        let max = self.visible_entries().len().saturating_sub(1);
+        self.scroll_offset = offset.min(max);
+    }
+
+    /// Returns whether timestamps are shown.
+    pub fn show_timestamps(&self) -> bool {
+        self.show_timestamps
+    }
+
+    /// Sets whether timestamps are shown.
+    pub fn set_show_timestamps(&mut self, show: bool) {
+        self.show_timestamps = show;
+    }
+
+    /// Returns the title.
+    pub fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    /// Sets the title.
+    pub fn set_title(&mut self, title: Option<String>) {
+        self.title = title;
+    }
+
+    /// Returns true if info entries are shown.
+    pub fn show_info(&self) -> bool {
+        self.show_info
+    }
+
+    /// Returns true if success entries are shown.
+    pub fn show_success(&self) -> bool {
+        self.show_success
+    }
+
+    /// Returns true if warning entries are shown.
+    pub fn show_warning(&self) -> bool {
+        self.show_warning
+    }
+
+    /// Returns true if error entries are shown.
+    pub fn show_error(&self) -> bool {
+        self.show_error
+    }
+
+    /// Sets the info filter.
+    pub fn set_show_info(&mut self, show: bool) {
+        self.show_info = show;
+    }
+
+    /// Sets the success filter.
+    pub fn set_show_success(&mut self, show: bool) {
+        self.show_success = show;
+    }
+
+    /// Sets the warning filter.
+    pub fn set_show_warning(&mut self, show: bool) {
+        self.show_warning = show;
+    }
+
+    /// Sets the error filter.
+    pub fn set_show_error(&mut self, show: bool) {
+        self.show_error = show;
+    }
+
+    /// Returns whether the search bar is focused.
+    pub fn is_search_focused(&self) -> bool {
+        self.focus == Focus::Search
+    }
+
+    // ---- Filtering ----
+
+    /// Returns the entries that match the current filters and search text.
+    ///
+    /// Entries are returned newest-first.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new();
+    /// state.push_info("hello world");
+    /// state.push_error("connection failed");
+    /// state.push_info("hello again");
+    ///
+    /// assert_eq!(state.visible_entries().len(), 3);
+    /// ```
+    pub fn visible_entries(&self) -> Vec<&StatusLogEntry> {
+        self.entries
+            .iter()
+            .rev()
+            .filter(|entry| self.matches_filters(entry))
+            .collect()
+    }
+
+    /// Returns true if an entry passes both the level filter and search filter.
+    fn matches_filters(&self, entry: &StatusLogEntry) -> bool {
+        // Level filter
+        let level_ok = match entry.level() {
+            StatusLogLevel::Info => self.show_info,
+            StatusLogLevel::Success => self.show_success,
+            StatusLogLevel::Warning => self.show_warning,
+            StatusLogLevel::Error => self.show_error,
+        };
+
+        if !level_ok {
+            return false;
+        }
+
+        // Search text filter (case-insensitive)
+        if self.search_text.is_empty() {
+            return true;
+        }
+
+        let search_lower = self.search_text.to_lowercase();
+        entry.message().to_lowercase().contains(&search_lower)
+    }
+
+    // ---- Instance methods ----
+
+    /// Returns true if the component is focused.
+    pub fn is_focused(&self) -> bool {
+        self.focused
+    }
+
+    /// Sets the focus state.
+    pub fn set_focused(&mut self, focused: bool) {
+        self.focused = focused;
+    }
+
+    /// Returns true if the component is disabled.
+    pub fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    /// Sets the disabled state.
+    pub fn set_disabled(&mut self, disabled: bool) {
+        self.disabled = disabled;
+    }
+
+    /// Maps an input event to a log viewer message.
+    pub fn handle_event(&self, event: &Event) -> Option<LogViewerMessage> {
+        LogViewer::handle_event(self, event)
+    }
+
+    /// Dispatches an event, updating state and returning any output.
+    pub fn dispatch_event(&mut self, event: &Event) -> Option<LogViewerOutput> {
+        LogViewer::dispatch_event(self, event)
+    }
+
+    /// Updates the state with a message, returning any output.
+    pub fn update(&mut self, msg: LogViewerMessage) -> Option<LogViewerOutput> {
+        LogViewer::update(self, msg)
+    }
+}
+
+/// A searchable log viewer with severity filtering.
+///
+/// Composes a log display with a search input field and severity-level
+/// toggle filters. The search is case-insensitive and matches against
+/// entry messages.
+///
+/// # Key Bindings (Log Mode)
+///
+/// - `Up` / `k` — Scroll up
+/// - `Down` / `j` — Scroll down
+/// - `Home` — Scroll to top (newest)
+/// - `End` — Scroll to bottom (oldest)
+/// - `/` — Focus search bar
+/// - `1` — Toggle Info filter
+/// - `2` — Toggle Success filter
+/// - `3` — Toggle Warning filter
+/// - `4` — Toggle Error filter
+///
+/// # Key Bindings (Search Mode)
+///
+/// - `Escape` — Clear search and return to log
+/// - `Enter` — Return to log (keep search text)
+/// - Standard text editing keys
+pub struct LogViewer(PhantomData<()>);
+
+impl Component for LogViewer {
+    type State = LogViewerState;
+    type Message = LogViewerMessage;
+    type Output = LogViewerOutput;
+
+    fn init() -> Self::State {
+        LogViewerState::default()
+    }
+
+    fn handle_event(state: &Self::State, event: &Event) -> Option<Self::Message> {
+        if !state.focused || state.disabled {
+            return None;
+        }
+
+        let key = event.as_key()?;
+
+        match state.focus {
+            Focus::Log => match key.code {
+                KeyCode::Up | KeyCode::Char('k') => Some(LogViewerMessage::ScrollUp),
+                KeyCode::Down | KeyCode::Char('j') => Some(LogViewerMessage::ScrollDown),
+                KeyCode::Home => Some(LogViewerMessage::ScrollToTop),
+                KeyCode::End => Some(LogViewerMessage::ScrollToBottom),
+                KeyCode::Char('/') => Some(LogViewerMessage::FocusSearch),
+                KeyCode::Char('1') => Some(LogViewerMessage::ToggleInfo),
+                KeyCode::Char('2') => Some(LogViewerMessage::ToggleSuccess),
+                KeyCode::Char('3') => Some(LogViewerMessage::ToggleWarning),
+                KeyCode::Char('4') => Some(LogViewerMessage::ToggleError),
+                _ => None,
+            },
+            Focus::Search => match key.code {
+                KeyCode::Esc => Some(LogViewerMessage::ClearSearch),
+                KeyCode::Enter => Some(LogViewerMessage::FocusLog),
+                KeyCode::Char(c) => {
+                    if key.modifiers.contains(KeyModifiers::CONTROL) {
+                        None
+                    } else {
+                        Some(LogViewerMessage::SearchInput(c))
+                    }
+                }
+                KeyCode::Backspace => Some(LogViewerMessage::SearchBackspace),
+                KeyCode::Delete => Some(LogViewerMessage::SearchDelete),
+                KeyCode::Left => Some(LogViewerMessage::SearchLeft),
+                KeyCode::Right => Some(LogViewerMessage::SearchRight),
+                KeyCode::Home => Some(LogViewerMessage::SearchHome),
+                KeyCode::End => Some(LogViewerMessage::SearchEnd),
+                _ => None,
+            },
+        }
+    }
+
+    fn update(state: &mut Self::State, msg: Self::Message) -> Option<Self::Output> {
+        if state.disabled {
+            return None;
+        }
+
+        match msg {
+            LogViewerMessage::ScrollUp => {
+                if state.scroll_offset > 0 {
+                    state.scroll_offset -= 1;
+                }
+                None
+            }
+            LogViewerMessage::ScrollDown => {
+                let max = state.visible_entries().len().saturating_sub(1);
+                if state.scroll_offset < max {
+                    state.scroll_offset += 1;
+                }
+                None
+            }
+            LogViewerMessage::ScrollToTop => {
+                state.scroll_offset = 0;
+                None
+            }
+            LogViewerMessage::ScrollToBottom => {
+                let max = state.visible_entries().len().saturating_sub(1);
+                state.scroll_offset = max;
+                None
+            }
+            LogViewerMessage::FocusSearch => {
+                state.focus = Focus::Search;
+                state.search.set_focused(true);
+                None
+            }
+            LogViewerMessage::FocusLog => {
+                state.focus = Focus::Log;
+                state.search.set_focused(false);
+                None
+            }
+            LogViewerMessage::SearchInput(c) => {
+                state.search.update(InputFieldMessage::Insert(c));
+                state.search_text = state.search.value().to_string();
+                state.scroll_offset = 0;
+                Some(LogViewerOutput::SearchChanged(state.search_text.clone()))
+            }
+            LogViewerMessage::SearchBackspace => {
+                state.search.update(InputFieldMessage::Backspace);
+                state.search_text = state.search.value().to_string();
+                state.scroll_offset = 0;
+                Some(LogViewerOutput::SearchChanged(state.search_text.clone()))
+            }
+            LogViewerMessage::SearchDelete => {
+                state.search.update(InputFieldMessage::Delete);
+                state.search_text = state.search.value().to_string();
+                state.scroll_offset = 0;
+                Some(LogViewerOutput::SearchChanged(state.search_text.clone()))
+            }
+            LogViewerMessage::SearchLeft => {
+                state.search.update(InputFieldMessage::Left);
+                None
+            }
+            LogViewerMessage::SearchRight => {
+                state.search.update(InputFieldMessage::Right);
+                None
+            }
+            LogViewerMessage::SearchHome => {
+                state.search.update(InputFieldMessage::Home);
+                None
+            }
+            LogViewerMessage::SearchEnd => {
+                state.search.update(InputFieldMessage::End);
+                None
+            }
+            LogViewerMessage::ClearSearch => {
+                state.search.update(InputFieldMessage::Clear);
+                state.search_text.clear();
+                state.scroll_offset = 0;
+                state.focus = Focus::Log;
+                state.search.set_focused(false);
+                Some(LogViewerOutput::SearchChanged(String::new()))
+            }
+            LogViewerMessage::ToggleInfo => {
+                state.show_info = !state.show_info;
+                state.scroll_offset = 0;
+                Some(LogViewerOutput::FilterChanged)
+            }
+            LogViewerMessage::ToggleSuccess => {
+                state.show_success = !state.show_success;
+                state.scroll_offset = 0;
+                Some(LogViewerOutput::FilterChanged)
+            }
+            LogViewerMessage::ToggleWarning => {
+                state.show_warning = !state.show_warning;
+                state.scroll_offset = 0;
+                Some(LogViewerOutput::FilterChanged)
+            }
+            LogViewerMessage::ToggleError => {
+                state.show_error = !state.show_error;
+                state.scroll_offset = 0;
+                Some(LogViewerOutput::FilterChanged)
+            }
+            LogViewerMessage::Push {
+                message,
+                level,
+                timestamp,
+            } => {
+                let id = state.push_entry(message, level, timestamp);
+                // Check if eviction happened
+                if state.entries.len() > state.max_entries {
+                    // Already evicted in push_entry
+                }
+                Some(LogViewerOutput::Added(id))
+            }
+            LogViewerMessage::Clear => {
+                state.clear();
+                Some(LogViewerOutput::Cleared)
+            }
+            LogViewerMessage::Remove(id) => {
+                if state.remove(id) {
+                    Some(LogViewerOutput::Removed(id))
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+        if area.height < 3 {
+            return;
+        }
+
+        // Layout: search bar (1 line) + filter bar (1 line) + log area
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Min(1),
+            ])
+            .split(area);
+
+        let search_area = chunks[0];
+        let filter_area = chunks[1];
+        let log_area = chunks[2];
+
+        // Render search bar
+        render_search_bar(state, frame, search_area, theme);
+
+        // Render filter bar
+        render_filter_bar(state, frame, filter_area, theme);
+
+        // Render log entries
+        render_log(state, frame, log_area, theme);
+    }
+}
+
+impl Focusable for LogViewer {
+    fn is_focused(state: &Self::State) -> bool {
+        state.focused
+    }
+
+    fn set_focused(state: &mut Self::State, focused: bool) {
+        state.focused = focused;
+    }
+}
+
+/// Renders the search bar area.
+fn render_search_bar(
+    state: &LogViewerState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+) {
+    let search_style = if state.disabled {
+        theme.disabled_style()
+    } else if state.focus == Focus::Search {
+        theme.focused_style()
+    } else {
+        theme.normal_style()
+    };
+
+    let prefix = if state.search_text.is_empty() {
+        "/ Search..."
+    } else {
+        ""
+    };
+
+    let display = if state.search_text.is_empty() {
+        prefix.to_string()
+    } else {
+        format!("/ {}", state.search.value())
+    };
+
+    let paragraph = Paragraph::new(display).style(search_style);
+    frame.render_widget(paragraph, area);
+
+    // Show cursor when search is focused
+    if state.focused && state.focus == Focus::Search && !state.disabled {
+        let cursor_x = area.x + 2 + state.search.cursor_position() as u16;
+        if cursor_x < area.right() {
+            frame.set_cursor_position(Position::new(cursor_x, area.y));
+        }
+    }
+}
+
+/// Renders the filter bar showing which severity levels are active.
+fn render_filter_bar(
+    state: &LogViewerState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+) {
+    let filter_style = if state.disabled {
+        theme.disabled_style()
+    } else {
+        theme.normal_style()
+    };
+
+    let info_marker = if state.show_info { "●" } else { "○" };
+    let success_marker = if state.show_success { "●" } else { "○" };
+    let warning_marker = if state.show_warning { "●" } else { "○" };
+    let error_marker = if state.show_error { "●" } else { "○" };
+
+    let spans = vec![
+        Span::styled(
+            format!("1:{} Info ", info_marker),
+            if state.disabled {
+                filter_style
+            } else {
+                Style::default().fg(StatusLogLevel::Info.color())
+            },
+        ),
+        Span::styled(
+            format!("2:{} Success ", success_marker),
+            if state.disabled {
+                filter_style
+            } else {
+                Style::default().fg(StatusLogLevel::Success.color())
+            },
+        ),
+        Span::styled(
+            format!("3:{} Warning ", warning_marker),
+            if state.disabled {
+                filter_style
+            } else {
+                Style::default().fg(StatusLogLevel::Warning.color())
+            },
+        ),
+        Span::styled(
+            format!("4:{} Error", error_marker),
+            if state.disabled {
+                filter_style
+            } else {
+                Style::default().fg(StatusLogLevel::Error.color())
+            },
+        ),
+    ];
+
+    let line = Line::from(spans);
+    let paragraph = Paragraph::new(line);
+    frame.render_widget(paragraph, area);
+}
+
+/// Renders the log entries area.
+fn render_log(
+    state: &LogViewerState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+) {
+    let visible = state.visible_entries();
+
+    let border_style = if state.disabled {
+        theme.disabled_style()
+    } else if state.focused && state.focus == Focus::Log {
+        theme.focused_border_style()
+    } else {
+        theme.border_style()
+    };
+
+    let mut block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(border_style);
+
+    if let Some(ref title) = state.title {
+        let match_count = visible.len();
+        let total_count = state.entries.len();
+        if match_count < total_count {
+            block = block.title(format!("{} ({}/{})", title, match_count, total_count));
+        } else {
+            block = block.title(format!("{} ({})", title, total_count));
+        }
+    }
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if inner.height == 0 || inner.width == 0 {
+        return;
+    }
+
+    let items: Vec<ListItem> = visible
+        .iter()
+        .skip(state.scroll_offset)
+        .take(inner.height as usize)
+        .map(|entry| {
+            let style = if state.disabled {
+                theme.disabled_style()
+            } else {
+                Style::default().fg(entry.level().color())
+            };
+
+            let mut text = String::new();
+            text.push_str(entry.level().prefix());
+            text.push(' ');
+
+            if state.show_timestamps {
+                if let Some(ts) = entry.timestamp() {
+                    text.push_str(ts);
+                    text.push(' ');
+                }
+            }
+
+            text.push_str(entry.message());
+
+            // Highlight search matches
+            if !state.search_text.is_empty() && !state.disabled {
+                let msg_lower = text.to_lowercase();
+                let search_lower = state.search_text.to_lowercase();
+                if msg_lower.contains(&search_lower) {
+                    // For simplicity, apply a highlight style to the entire line
+                    // when it contains a match
+                    let style = style.add_modifier(Modifier::BOLD);
+                    return ListItem::new(text).style(style);
+                }
+            }
+
+            ListItem::new(text).style(style)
+        })
+        .collect();
+
+    let list = List::new(items);
+    frame.render_widget(list, inner);
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/component/log_viewer/tests.rs
+++ b/src/component/log_viewer/tests.rs
@@ -1,0 +1,919 @@
+use super::*;
+use crate::component::test_utils;
+
+fn sample_state() -> LogViewerState {
+    let mut state = LogViewerState::new();
+    state.push_info("Server started");
+    state.push_success("Connected to database");
+    state.push_warning("Disk space low");
+    state.push_error("Connection timeout");
+    state
+}
+
+fn focused_state() -> LogViewerState {
+    let mut state = sample_state();
+    LogViewer::set_focused(&mut state, true);
+    state
+}
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+#[test]
+fn test_new() {
+    let state = LogViewerState::new();
+    assert!(state.is_empty());
+    assert_eq!(state.max_entries(), 1000);
+    assert!(!state.is_focused());
+    assert!(!state.is_disabled());
+}
+
+#[test]
+fn test_default() {
+    let state = LogViewerState::default();
+    assert!(state.is_empty());
+    assert!(state.show_info());
+    assert!(state.show_success());
+    assert!(state.show_warning());
+    assert!(state.show_error());
+    assert!(!state.show_timestamps());
+    assert_eq!(state.title(), None);
+}
+
+#[test]
+fn test_with_max_entries() {
+    let state = LogViewerState::new().with_max_entries(50);
+    assert_eq!(state.max_entries(), 50);
+}
+
+#[test]
+fn test_with_timestamps() {
+    let state = LogViewerState::new().with_timestamps(true);
+    assert!(state.show_timestamps());
+}
+
+#[test]
+fn test_with_title() {
+    let state = LogViewerState::new().with_title("Logs");
+    assert_eq!(state.title(), Some("Logs"));
+}
+
+#[test]
+fn test_with_disabled() {
+    let state = LogViewerState::new().with_disabled(true);
+    assert!(state.is_disabled());
+}
+
+// =============================================================================
+// Entry manipulation
+// =============================================================================
+
+#[test]
+fn test_push_info() {
+    let mut state = LogViewerState::new();
+    let id = state.push_info("hello");
+    assert_eq!(state.len(), 1);
+    assert_eq!(state.entries()[0].id(), id);
+    assert_eq!(state.entries()[0].message(), "hello");
+    assert_eq!(state.entries()[0].level(), StatusLogLevel::Info);
+}
+
+#[test]
+fn test_push_success() {
+    let mut state = LogViewerState::new();
+    state.push_success("done");
+    assert_eq!(state.entries()[0].level(), StatusLogLevel::Success);
+}
+
+#[test]
+fn test_push_warning() {
+    let mut state = LogViewerState::new();
+    state.push_warning("careful");
+    assert_eq!(state.entries()[0].level(), StatusLogLevel::Warning);
+}
+
+#[test]
+fn test_push_error() {
+    let mut state = LogViewerState::new();
+    state.push_error("oops");
+    assert_eq!(state.entries()[0].level(), StatusLogLevel::Error);
+}
+
+#[test]
+fn test_push_with_timestamp() {
+    let mut state = LogViewerState::new();
+    state.push_info_with_timestamp("msg", "12:00:00");
+    assert_eq!(state.entries()[0].timestamp(), Some("12:00:00"));
+}
+
+#[test]
+fn test_push_success_with_timestamp() {
+    let mut state = LogViewerState::new();
+    state.push_success_with_timestamp("msg", "12:00");
+    assert_eq!(state.entries()[0].timestamp(), Some("12:00"));
+}
+
+#[test]
+fn test_push_warning_with_timestamp() {
+    let mut state = LogViewerState::new();
+    state.push_warning_with_timestamp("msg", "12:00");
+    assert_eq!(state.entries()[0].timestamp(), Some("12:00"));
+}
+
+#[test]
+fn test_push_error_with_timestamp() {
+    let mut state = LogViewerState::new();
+    state.push_error_with_timestamp("msg", "12:00");
+    assert_eq!(state.entries()[0].timestamp(), Some("12:00"));
+}
+
+#[test]
+fn test_ids_increment() {
+    let mut state = LogViewerState::new();
+    let id1 = state.push_info("a");
+    let id2 = state.push_info("b");
+    let id3 = state.push_info("c");
+    assert_eq!(id1, 0);
+    assert_eq!(id2, 1);
+    assert_eq!(id3, 2);
+}
+
+#[test]
+fn test_remove() {
+    let mut state = LogViewerState::new();
+    let id = state.push_info("to remove");
+    assert!(state.remove(id));
+    assert!(state.is_empty());
+}
+
+#[test]
+fn test_remove_nonexistent() {
+    let mut state = LogViewerState::new();
+    assert!(!state.remove(999));
+}
+
+#[test]
+fn test_clear() {
+    let mut state = sample_state();
+    state.clear();
+    assert!(state.is_empty());
+    assert_eq!(state.scroll_offset(), 0);
+}
+
+#[test]
+fn test_eviction() {
+    let mut state = LogViewerState::new().with_max_entries(3);
+    state.push_info("a");
+    state.push_info("b");
+    state.push_info("c");
+    state.push_info("d");
+    assert_eq!(state.len(), 3);
+    // Oldest entry ("a") should have been evicted
+    assert_eq!(state.entries()[0].message(), "b");
+}
+
+#[test]
+fn test_set_max_entries_evicts() {
+    let mut state = LogViewerState::new();
+    state.push_info("a");
+    state.push_info("b");
+    state.push_info("c");
+    state.set_max_entries(2);
+    assert_eq!(state.len(), 2);
+    assert_eq!(state.entries()[0].message(), "b");
+}
+
+// =============================================================================
+// Filtering
+// =============================================================================
+
+#[test]
+fn test_visible_entries_all() {
+    let state = sample_state();
+    assert_eq!(state.visible_entries().len(), 4);
+}
+
+#[test]
+fn test_visible_entries_newest_first() {
+    let state = sample_state();
+    let visible = state.visible_entries();
+    assert_eq!(visible[0].message(), "Connection timeout");
+    assert_eq!(visible[3].message(), "Server started");
+}
+
+#[test]
+fn test_filter_info() {
+    let mut state = sample_state();
+    state.set_show_info(false);
+    assert_eq!(state.visible_entries().len(), 3);
+}
+
+#[test]
+fn test_filter_success() {
+    let mut state = sample_state();
+    state.set_show_success(false);
+    assert_eq!(state.visible_entries().len(), 3);
+}
+
+#[test]
+fn test_filter_warning() {
+    let mut state = sample_state();
+    state.set_show_warning(false);
+    assert_eq!(state.visible_entries().len(), 3);
+}
+
+#[test]
+fn test_filter_error() {
+    let mut state = sample_state();
+    state.set_show_error(false);
+    assert_eq!(state.visible_entries().len(), 3);
+}
+
+#[test]
+fn test_filter_multiple_levels() {
+    let mut state = sample_state();
+    state.set_show_info(false);
+    state.set_show_success(false);
+    assert_eq!(state.visible_entries().len(), 2);
+}
+
+#[test]
+fn test_filter_all_hidden() {
+    let mut state = sample_state();
+    state.set_show_info(false);
+    state.set_show_success(false);
+    state.set_show_warning(false);
+    state.set_show_error(false);
+    assert!(state.visible_entries().is_empty());
+}
+
+#[test]
+fn test_search_filter() {
+    let mut state = focused_state();
+    state.focus = Focus::Search;
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('c'));
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('o'));
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('n'));
+    // "Connected to database" and "Connection timeout" match "con"
+    assert_eq!(state.visible_entries().len(), 2);
+}
+
+#[test]
+fn test_search_case_insensitive() {
+    let mut state = focused_state();
+    state.focus = Focus::Search;
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('S'));
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('E'));
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('R'));
+    // "Server started" matches "SER" (case insensitive)
+    assert_eq!(state.visible_entries().len(), 1);
+}
+
+#[test]
+fn test_search_no_matches() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('z'));
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('z'));
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('z'));
+    assert!(state.visible_entries().is_empty());
+}
+
+#[test]
+fn test_search_combined_with_level_filter() {
+    let mut state = focused_state();
+    state.set_show_info(false);
+    state.focus = Focus::Search;
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('c'));
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('o'));
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('n'));
+    // "Connected to database" is success (visible), "Connection timeout" is error (visible)
+    // Info filter is off, so only these two match
+    assert_eq!(state.visible_entries().len(), 2);
+}
+
+// =============================================================================
+// Scrolling
+// =============================================================================
+
+#[test]
+fn test_scroll_down() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::ScrollDown);
+    assert_eq!(state.scroll_offset(), 1);
+}
+
+#[test]
+fn test_scroll_up() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::ScrollDown);
+    LogViewer::update(&mut state, LogViewerMessage::ScrollDown);
+    LogViewer::update(&mut state, LogViewerMessage::ScrollUp);
+    assert_eq!(state.scroll_offset(), 1);
+}
+
+#[test]
+fn test_scroll_up_at_top() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::ScrollUp);
+    assert_eq!(state.scroll_offset(), 0);
+}
+
+#[test]
+fn test_scroll_down_at_bottom() {
+    let mut state = focused_state();
+    // 4 entries, max offset = 3
+    LogViewer::update(&mut state, LogViewerMessage::ScrollDown);
+    LogViewer::update(&mut state, LogViewerMessage::ScrollDown);
+    LogViewer::update(&mut state, LogViewerMessage::ScrollDown);
+    LogViewer::update(&mut state, LogViewerMessage::ScrollDown);
+    assert_eq!(state.scroll_offset(), 3);
+}
+
+#[test]
+fn test_scroll_to_top() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::ScrollDown);
+    LogViewer::update(&mut state, LogViewerMessage::ScrollDown);
+    LogViewer::update(&mut state, LogViewerMessage::ScrollToTop);
+    assert_eq!(state.scroll_offset(), 0);
+}
+
+#[test]
+fn test_scroll_to_bottom() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::ScrollToBottom);
+    assert_eq!(state.scroll_offset(), 3);
+}
+
+#[test]
+fn test_set_scroll_offset() {
+    let mut state = sample_state();
+    state.set_scroll_offset(2);
+    assert_eq!(state.scroll_offset(), 2);
+}
+
+#[test]
+fn test_set_scroll_offset_clamped() {
+    let mut state = sample_state();
+    state.set_scroll_offset(100);
+    assert_eq!(state.scroll_offset(), 3);
+}
+
+// =============================================================================
+// Search bar focus
+// =============================================================================
+
+#[test]
+fn test_focus_search() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::FocusSearch);
+    assert!(state.is_search_focused());
+}
+
+#[test]
+fn test_focus_log() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::FocusSearch);
+    LogViewer::update(&mut state, LogViewerMessage::FocusLog);
+    assert!(!state.is_search_focused());
+}
+
+#[test]
+fn test_clear_search() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::FocusSearch);
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('x'));
+    assert_eq!(state.search_text(), "x");
+
+    LogViewer::update(&mut state, LogViewerMessage::ClearSearch);
+    assert_eq!(state.search_text(), "");
+    assert!(!state.is_search_focused());
+}
+
+#[test]
+fn test_search_backspace() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('a'));
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('b'));
+    LogViewer::update(&mut state, LogViewerMessage::SearchBackspace);
+    assert_eq!(state.search_text(), "a");
+}
+
+#[test]
+fn test_search_resets_scroll() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::ScrollDown);
+    LogViewer::update(&mut state, LogViewerMessage::ScrollDown);
+    assert_eq!(state.scroll_offset(), 2);
+
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('a'));
+    assert_eq!(state.scroll_offset(), 0);
+}
+
+// =============================================================================
+// Toggle filters via messages
+// =============================================================================
+
+#[test]
+fn test_toggle_info() {
+    let mut state = focused_state();
+    let output = LogViewer::update(&mut state, LogViewerMessage::ToggleInfo);
+    assert!(!state.show_info());
+    assert_eq!(output, Some(LogViewerOutput::FilterChanged));
+}
+
+#[test]
+fn test_toggle_success() {
+    let mut state = focused_state();
+    let output = LogViewer::update(&mut state, LogViewerMessage::ToggleSuccess);
+    assert!(!state.show_success());
+    assert_eq!(output, Some(LogViewerOutput::FilterChanged));
+}
+
+#[test]
+fn test_toggle_warning() {
+    let mut state = focused_state();
+    let output = LogViewer::update(&mut state, LogViewerMessage::ToggleWarning);
+    assert!(!state.show_warning());
+    assert_eq!(output, Some(LogViewerOutput::FilterChanged));
+}
+
+#[test]
+fn test_toggle_error() {
+    let mut state = focused_state();
+    let output = LogViewer::update(&mut state, LogViewerMessage::ToggleError);
+    assert!(!state.show_error());
+    assert_eq!(output, Some(LogViewerOutput::FilterChanged));
+}
+
+#[test]
+fn test_toggle_resets_scroll() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::ScrollDown);
+    LogViewer::update(&mut state, LogViewerMessage::ScrollDown);
+    LogViewer::update(&mut state, LogViewerMessage::ToggleInfo);
+    assert_eq!(state.scroll_offset(), 0);
+}
+
+// =============================================================================
+// Push/Clear/Remove via messages
+// =============================================================================
+
+#[test]
+fn test_push_via_message() {
+    let mut state = focused_state();
+    let output = LogViewer::update(
+        &mut state,
+        LogViewerMessage::Push {
+            message: "new entry".into(),
+            level: StatusLogLevel::Info,
+            timestamp: None,
+        },
+    );
+    assert_eq!(state.len(), 5);
+    assert!(matches!(output, Some(LogViewerOutput::Added(_))));
+}
+
+#[test]
+fn test_clear_via_message() {
+    let mut state = focused_state();
+    let output = LogViewer::update(&mut state, LogViewerMessage::Clear);
+    assert!(state.is_empty());
+    assert_eq!(output, Some(LogViewerOutput::Cleared));
+}
+
+#[test]
+fn test_remove_via_message() {
+    let mut state = focused_state();
+    let id = state.entries()[0].id();
+    let output = LogViewer::update(&mut state, LogViewerMessage::Remove(id));
+    assert_eq!(state.len(), 3);
+    assert_eq!(output, Some(LogViewerOutput::Removed(id)));
+}
+
+#[test]
+fn test_remove_nonexistent_via_message() {
+    let mut state = focused_state();
+    let output = LogViewer::update(&mut state, LogViewerMessage::Remove(999));
+    assert_eq!(output, None);
+}
+
+// =============================================================================
+// Disabled state
+// =============================================================================
+
+#[test]
+fn test_disabled_ignores_messages() {
+    let mut state = focused_state();
+    state.set_disabled(true);
+    let output = LogViewer::update(&mut state, LogViewerMessage::ScrollDown);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_disabled_ignores_events() {
+    let mut state = focused_state();
+    state.set_disabled(true);
+    let msg = LogViewer::handle_event(&state, &Event::key(KeyCode::Down));
+    assert_eq!(msg, None);
+}
+
+// =============================================================================
+// Unfocused state
+// =============================================================================
+
+#[test]
+fn test_unfocused_ignores_events() {
+    let state = sample_state();
+    let msg = LogViewer::handle_event(&state, &Event::key(KeyCode::Down));
+    assert_eq!(msg, None);
+}
+
+// =============================================================================
+// Event mapping — log mode
+// =============================================================================
+
+#[test]
+fn test_log_mode_up_key() {
+    let state = focused_state();
+    assert_eq!(
+        LogViewer::handle_event(&state, &Event::key(KeyCode::Up)),
+        Some(LogViewerMessage::ScrollUp)
+    );
+    assert_eq!(
+        LogViewer::handle_event(&state, &Event::char('k')),
+        Some(LogViewerMessage::ScrollUp)
+    );
+}
+
+#[test]
+fn test_log_mode_down_key() {
+    let state = focused_state();
+    assert_eq!(
+        LogViewer::handle_event(&state, &Event::key(KeyCode::Down)),
+        Some(LogViewerMessage::ScrollDown)
+    );
+    assert_eq!(
+        LogViewer::handle_event(&state, &Event::char('j')),
+        Some(LogViewerMessage::ScrollDown)
+    );
+}
+
+#[test]
+fn test_log_mode_home_end() {
+    let state = focused_state();
+    assert_eq!(
+        LogViewer::handle_event(&state, &Event::key(KeyCode::Home)),
+        Some(LogViewerMessage::ScrollToTop)
+    );
+    assert_eq!(
+        LogViewer::handle_event(&state, &Event::key(KeyCode::End)),
+        Some(LogViewerMessage::ScrollToBottom)
+    );
+}
+
+#[test]
+fn test_log_mode_slash() {
+    let state = focused_state();
+    assert_eq!(
+        LogViewer::handle_event(&state, &Event::char('/')),
+        Some(LogViewerMessage::FocusSearch)
+    );
+}
+
+#[test]
+fn test_log_mode_number_keys() {
+    let state = focused_state();
+    assert_eq!(
+        LogViewer::handle_event(&state, &Event::char('1')),
+        Some(LogViewerMessage::ToggleInfo)
+    );
+    assert_eq!(
+        LogViewer::handle_event(&state, &Event::char('2')),
+        Some(LogViewerMessage::ToggleSuccess)
+    );
+    assert_eq!(
+        LogViewer::handle_event(&state, &Event::char('3')),
+        Some(LogViewerMessage::ToggleWarning)
+    );
+    assert_eq!(
+        LogViewer::handle_event(&state, &Event::char('4')),
+        Some(LogViewerMessage::ToggleError)
+    );
+}
+
+// =============================================================================
+// Event mapping — search mode
+// =============================================================================
+
+#[test]
+fn test_search_mode_char_input() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::FocusSearch);
+    assert_eq!(
+        LogViewer::handle_event(&state, &Event::char('a')),
+        Some(LogViewerMessage::SearchInput('a'))
+    );
+}
+
+#[test]
+fn test_search_mode_esc() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::FocusSearch);
+    assert_eq!(
+        LogViewer::handle_event(&state, &Event::key(KeyCode::Esc)),
+        Some(LogViewerMessage::ClearSearch)
+    );
+}
+
+#[test]
+fn test_search_mode_enter() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::FocusSearch);
+    assert_eq!(
+        LogViewer::handle_event(&state, &Event::key(KeyCode::Enter)),
+        Some(LogViewerMessage::FocusLog)
+    );
+}
+
+#[test]
+fn test_search_mode_backspace() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::FocusSearch);
+    assert_eq!(
+        LogViewer::handle_event(&state, &Event::key(KeyCode::Backspace)),
+        Some(LogViewerMessage::SearchBackspace)
+    );
+}
+
+#[test]
+fn test_search_mode_delete() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::FocusSearch);
+    assert_eq!(
+        LogViewer::handle_event(&state, &Event::key(KeyCode::Delete)),
+        Some(LogViewerMessage::SearchDelete)
+    );
+}
+
+#[test]
+fn test_search_mode_left_right() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::FocusSearch);
+    assert_eq!(
+        LogViewer::handle_event(&state, &Event::key(KeyCode::Left)),
+        Some(LogViewerMessage::SearchLeft)
+    );
+    assert_eq!(
+        LogViewer::handle_event(&state, &Event::key(KeyCode::Right)),
+        Some(LogViewerMessage::SearchRight)
+    );
+}
+
+#[test]
+fn test_search_mode_home_end() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::FocusSearch);
+    assert_eq!(
+        LogViewer::handle_event(&state, &Event::key(KeyCode::Home)),
+        Some(LogViewerMessage::SearchHome)
+    );
+    assert_eq!(
+        LogViewer::handle_event(&state, &Event::key(KeyCode::End)),
+        Some(LogViewerMessage::SearchEnd)
+    );
+}
+
+// =============================================================================
+// Instance methods
+// =============================================================================
+
+#[test]
+fn test_instance_handle_event() {
+    let state = focused_state();
+    let msg = state.handle_event(&Event::key(KeyCode::Down));
+    assert_eq!(msg, Some(LogViewerMessage::ScrollDown));
+}
+
+#[test]
+fn test_instance_update() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::ScrollDown);
+    assert_eq!(state.scroll_offset(), 1);
+}
+
+#[test]
+fn test_instance_dispatch_event() {
+    let mut state = focused_state();
+    state.dispatch_event(&Event::key(KeyCode::Down));
+    assert_eq!(state.scroll_offset(), 1);
+}
+
+// =============================================================================
+// Rendering
+// =============================================================================
+
+#[test]
+fn test_render_empty() {
+    let state = LogViewerState::new();
+    let (mut terminal, theme) = test_utils::setup_render(60, 15);
+    terminal
+        .draw(|frame| {
+            LogViewer::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_with_entries() {
+    let state = sample_state();
+    let (mut terminal, theme) = test_utils::setup_render(60, 15);
+    terminal
+        .draw(|frame| {
+            LogViewer::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_focused() {
+    let state = focused_state();
+    let (mut terminal, theme) = test_utils::setup_render(60, 15);
+    terminal
+        .draw(|frame| {
+            LogViewer::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_search_focused() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::FocusSearch);
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('c'));
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('o'));
+    let (mut terminal, theme) = test_utils::setup_render(60, 15);
+    terminal
+        .draw(|frame| {
+            LogViewer::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_disabled() {
+    let state = LogViewerState::new().with_disabled(true);
+    let (mut terminal, theme) = test_utils::setup_render(60, 15);
+    terminal
+        .draw(|frame| {
+            LogViewer::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_with_title() {
+    let mut state = LogViewerState::new().with_title("Application Log");
+    state.push_info("entry 1");
+    state.push_error("entry 2");
+    let (mut terminal, theme) = test_utils::setup_render(60, 15);
+    terminal
+        .draw(|frame| {
+            LogViewer::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_with_timestamps() {
+    let mut state = LogViewerState::new().with_timestamps(true);
+    state.push_info_with_timestamp("entry 1", "12:00:00");
+    state.push_error_with_timestamp("entry 2", "12:00:01");
+    let (mut terminal, theme) = test_utils::setup_render(60, 15);
+    terminal
+        .draw(|frame| {
+            LogViewer::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_small_area() {
+    let state = sample_state();
+    let (mut terminal, theme) = test_utils::setup_render(60, 2);
+    terminal
+        .draw(|frame| {
+            LogViewer::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+// =============================================================================
+// Focusable trait
+// =============================================================================
+
+#[test]
+fn test_focusable_trait() {
+    let mut state = LogViewer::init();
+    assert!(!LogViewer::is_focused(&state));
+
+    LogViewer::focus(&mut state);
+    assert!(LogViewer::is_focused(&state));
+
+    LogViewer::blur(&mut state);
+    assert!(!LogViewer::is_focused(&state));
+}
+
+// =============================================================================
+// PartialEq
+// =============================================================================
+
+#[test]
+fn test_partial_eq() {
+    let state1 = sample_state();
+    let state2 = sample_state();
+    assert_eq!(state1, state2);
+}
+
+#[test]
+fn test_partial_eq_different_focus() {
+    let state1 = focused_state();
+    let state2 = sample_state();
+    assert_ne!(state1, state2);
+}
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
+#[test]
+fn test_scroll_empty_log() {
+    let mut state = LogViewerState::new();
+    LogViewer::set_focused(&mut state, true);
+    LogViewer::update(&mut state, LogViewerMessage::ScrollDown);
+    assert_eq!(state.scroll_offset(), 0);
+}
+
+#[test]
+fn test_search_cursor_navigation() {
+    let mut state = focused_state();
+    LogViewer::update(&mut state, LogViewerMessage::FocusSearch);
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('a'));
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('b'));
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('c'));
+    LogViewer::update(&mut state, LogViewerMessage::SearchHome);
+    LogViewer::update(&mut state, LogViewerMessage::SearchDelete);
+    assert_eq!(state.search_text(), "bc");
+    LogViewer::update(&mut state, LogViewerMessage::SearchEnd);
+    LogViewer::update(&mut state, LogViewerMessage::SearchBackspace);
+    assert_eq!(state.search_text(), "b");
+}
+
+#[test]
+fn test_filter_reapplied_after_search_clear() {
+    let mut state = focused_state();
+    // Filter to show only errors
+    state.set_show_info(false);
+    state.set_show_success(false);
+    state.set_show_warning(false);
+    assert_eq!(state.visible_entries().len(), 1);
+
+    // Search narrows further
+    LogViewer::update(&mut state, LogViewerMessage::SearchInput('x'));
+    assert_eq!(state.visible_entries().len(), 0);
+
+    // Clear search — should show errors again
+    LogViewer::update(&mut state, LogViewerMessage::ClearSearch);
+    assert_eq!(state.visible_entries().len(), 1);
+}
+
+#[test]
+fn test_title_with_filtered_count() {
+    let mut state = LogViewerState::new().with_title("Log");
+    state.push_info("a");
+    state.push_info("b");
+    state.push_error("c");
+    // Filter off info, so only 1 visible out of 3
+    state.set_show_info(false);
+    assert_eq!(state.visible_entries().len(), 1);
+    assert_eq!(state.len(), 3);
+}
+
+#[test]
+fn test_set_title() {
+    let mut state = LogViewerState::new();
+    state.set_title(Some("Test".to_string()));
+    assert_eq!(state.title(), Some("Test"));
+    state.set_title(None);
+    assert_eq!(state.title(), None);
+}
+
+#[test]
+fn test_set_show_timestamps() {
+    let mut state = LogViewerState::new();
+    state.set_show_timestamps(true);
+    assert!(state.show_timestamps());
+    state.set_show_timestamps(false);
+    assert!(!state.show_timestamps());
+}

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -125,6 +125,7 @@ mod form;
 mod searchable_list;
 mod split_panel;
 mod data_grid;
+mod log_viewer;
 
 // Data components
 #[cfg(feature = "data-components")]
@@ -226,6 +227,7 @@ pub use split_panel::{
     SplitOrientation, SplitPanel, SplitPanelMessage, SplitPanelOutput, SplitPanelState,
 };
 pub use data_grid::{DataGrid, DataGridMessage, DataGridOutput, DataGridState};
+pub use log_viewer::{LogViewer, LogViewerMessage, LogViewerOutput, LogViewerState};
 
 #[cfg(feature = "display-components")]
 pub use status_bar::{


### PR DESCRIPTION
## Summary
- Adds `LogViewer` compound component composing StatusLog entries with an InputField search bar and severity-level toggle filters
- Press `/` to focus search, `Escape` to clear search and return to log, `Enter` to keep search and return to log
- `1`-`4` toggle Info/Success/Warning/Error severity filters with visual indicators
- Case-insensitive search matches against entry messages, combined with level filters
- Convenience methods: `push_info()`, `push_success()`, `push_warning()`, `push_error()` (with timestamp variants)
- Newest-first display with scroll support, automatic eviction at configurable max_entries
- Implements `Focusable` trait with full disabled state support
- Instance methods on `LogViewerState` for ergonomic usage

## Test plan
- [x] 89 unit tests covering construction, entry manipulation, filtering, scrolling, search, event mapping, rendering, and edge cases
- [x] 4 doc tests on module, `new()`, `push_info()`, `visible_entries()`
- [x] Full test suite: 2,169 unit + 230 doc tests passing
- [x] Clippy clean with `-D warnings`
- [x] Examples build successfully
- [x] Both files under 1000 lines (980 + 919)

🤖 Generated with [Claude Code](https://claude.com/claude-code)