### PR TITLE
Add ChatView compound component with message history and input

### DIFF
--- a/src/component/chat_view/mod.rs
+++ b/src/component/chat_view/mod.rs
@@ -1,0 +1,933 @@
+//! A chat interface with message history and multi-line input.
+//!
+//! `ChatView` provides a scrollable message history display and a
+//! [`TextArea`](super::TextArea) input field. Messages can be typed
+//! as user, system, or assistant and are styled differently per role.
+//!
+//! # Example
+//!
+//! ```rust
+//! use envision::component::{
+//!     Component, Focusable, ChatView, ChatViewState,
+//!     ChatViewMessage, ChatViewOutput, ChatRole,
+//! };
+//!
+//! let mut state = ChatViewState::new();
+//! state.push_system("Welcome to the chat!");
+//! state.push_user("Hello");
+//! state.push_assistant("Hi! How can I help?");
+//!
+//! assert_eq!(state.message_count(), 3);
+//! assert_eq!(state.messages()[2].role(), ChatRole::Assistant);
+//! ```
+
+use std::marker::PhantomData;
+
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
+
+use super::{Component, Focusable, TextAreaMessage, TextAreaOutput, TextAreaState};
+use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::theme::Theme;
+
+/// The role of a chat message sender.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub enum ChatRole {
+    /// A message from the user.
+    User,
+    /// A system message (announcements, status, etc.).
+    System,
+    /// A message from an assistant or bot.
+    Assistant,
+}
+
+impl ChatRole {
+    /// Returns the display prefix for this role.
+    pub fn prefix(&self) -> &'static str {
+        match self {
+            Self::User => "You",
+            Self::System => "System",
+            Self::Assistant => "Assistant",
+        }
+    }
+
+    /// Returns the display color for this role.
+    pub fn color(&self) -> Color {
+        match self {
+            Self::User => Color::Cyan,
+            Self::System => Color::DarkGray,
+            Self::Assistant => Color::Green,
+        }
+    }
+}
+
+/// A single chat message.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChatMessage {
+    /// The role of the sender.
+    role: ChatRole,
+    /// The message content.
+    content: String,
+    /// Optional timestamp.
+    timestamp: Option<String>,
+    /// Optional username override.
+    username: Option<String>,
+}
+
+impl ChatMessage {
+    /// Creates a new chat message.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChatMessage, ChatRole};
+    ///
+    /// let msg = ChatMessage::new(ChatRole::User, "Hello!");
+    /// assert_eq!(msg.role(), ChatRole::User);
+    /// assert_eq!(msg.content(), "Hello!");
+    /// ```
+    pub fn new(role: ChatRole, content: impl Into<String>) -> Self {
+        Self {
+            role,
+            content: content.into(),
+            timestamp: None,
+            username: None,
+        }
+    }
+
+    /// Sets the timestamp (builder pattern).
+    pub fn with_timestamp(mut self, timestamp: impl Into<String>) -> Self {
+        self.timestamp = Some(timestamp.into());
+        self
+    }
+
+    /// Sets the username override (builder pattern).
+    pub fn with_username(mut self, username: impl Into<String>) -> Self {
+        self.username = Some(username.into());
+        self
+    }
+
+    /// Returns the role.
+    pub fn role(&self) -> ChatRole {
+        self.role
+    }
+
+    /// Returns the content.
+    pub fn content(&self) -> &str {
+        &self.content
+    }
+
+    /// Returns the timestamp.
+    pub fn timestamp(&self) -> Option<&str> {
+        self.timestamp.as_deref()
+    }
+
+    /// Returns the username (or the role's default prefix).
+    pub fn display_name(&self) -> &str {
+        self.username
+            .as_deref()
+            .unwrap_or_else(|| self.role.prefix())
+    }
+}
+
+/// Internal focus target for the chat view.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+enum Focus {
+    /// The message history is focused.
+    History,
+    /// The input field is focused.
+    #[default]
+    Input,
+}
+
+/// Messages that can be sent to a ChatView.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ChatViewMessage {
+    /// Type a character in the input field.
+    Input(char),
+    /// Insert a newline in the input field.
+    NewLine,
+    /// Delete the character before the cursor.
+    Backspace,
+    /// Delete the character at the cursor.
+    Delete,
+    /// Move cursor left in the input field.
+    Left,
+    /// Move cursor right in the input field.
+    Right,
+    /// Move cursor up in the input field or scroll history.
+    Up,
+    /// Move cursor down in the input field or scroll history.
+    Down,
+    /// Move cursor to start of line.
+    Home,
+    /// Move cursor to end of line.
+    End,
+    /// Submit the current input as a user message.
+    Submit,
+    /// Toggle focus between history and input.
+    ToggleFocus,
+    /// Focus the input field.
+    FocusInput,
+    /// Focus the message history.
+    FocusHistory,
+    /// Scroll history up by one line.
+    ScrollUp,
+    /// Scroll history down by one line.
+    ScrollDown,
+    /// Scroll to the top of history.
+    ScrollToTop,
+    /// Scroll to the bottom of history (newest).
+    ScrollToBottom,
+    /// Clear the input field.
+    ClearInput,
+    /// Move cursor to the start of the input.
+    InputStart,
+    /// Move cursor to the end of the input.
+    InputEnd,
+    /// Delete from cursor to end of line.
+    DeleteToEnd,
+    /// Delete from line start to cursor.
+    DeleteToStart,
+}
+
+/// Output messages from a ChatView.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ChatViewOutput {
+    /// The user submitted a message. Contains the message text.
+    Submitted(String),
+    /// The input text changed.
+    InputChanged(String),
+}
+
+/// State for a ChatView component.
+///
+/// Contains the message history, input field, and scroll state.
+#[derive(Clone, Debug)]
+pub struct ChatViewState {
+    /// Message history.
+    messages: Vec<ChatMessage>,
+    /// The text input area.
+    input: TextAreaState,
+    /// Scroll offset for the message history.
+    scroll_offset: usize,
+    /// Whether to auto-scroll to bottom on new messages.
+    auto_scroll: bool,
+    /// Maximum number of messages to keep.
+    max_messages: usize,
+    /// Internal focus target.
+    focus: Focus,
+    /// Whether the component is focused.
+    focused: bool,
+    /// Whether the component is disabled.
+    disabled: bool,
+    /// Whether to show timestamps.
+    show_timestamps: bool,
+    /// Input area height in lines.
+    input_height: u16,
+}
+
+impl Default for ChatViewState {
+    fn default() -> Self {
+        Self {
+            messages: Vec::new(),
+            input: TextAreaState::with_placeholder("Type a message..."),
+            scroll_offset: 0,
+            auto_scroll: true,
+            max_messages: 1000,
+            focus: Focus::Input,
+            focused: false,
+            disabled: false,
+            show_timestamps: false,
+            input_height: 3,
+        }
+    }
+}
+
+impl PartialEq for ChatViewState {
+    fn eq(&self, other: &Self) -> bool {
+        self.messages == other.messages
+            && self.scroll_offset == other.scroll_offset
+            && self.auto_scroll == other.auto_scroll
+            && self.max_messages == other.max_messages
+            && self.focus == other.focus
+            && self.focused == other.focused
+            && self.disabled == other.disabled
+            && self.show_timestamps == other.show_timestamps
+            && self.input_height == other.input_height
+    }
+}
+
+impl ChatViewState {
+    /// Creates a new empty chat view state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ChatViewState;
+    ///
+    /// let state = ChatViewState::new();
+    /// assert_eq!(state.message_count(), 0);
+    /// assert!(state.input_value().is_empty());
+    /// ```
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the maximum number of messages (builder pattern).
+    pub fn with_max_messages(mut self, max: usize) -> Self {
+        self.max_messages = max;
+        self
+    }
+
+    /// Sets whether to show timestamps (builder pattern).
+    pub fn with_timestamps(mut self, show: bool) -> Self {
+        self.show_timestamps = show;
+        self
+    }
+
+    /// Sets the input area height (builder pattern).
+    pub fn with_input_height(mut self, height: u16) -> Self {
+        self.input_height = height.max(1);
+        self
+    }
+
+    /// Sets the disabled state (builder pattern).
+    pub fn with_disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    /// Sets the input placeholder text (builder pattern).
+    pub fn with_placeholder(mut self, placeholder: impl Into<String>) -> Self {
+        self.input.set_placeholder(placeholder);
+        self
+    }
+
+    // ---- Message manipulation ----
+
+    /// Adds a message from any role.
+    pub fn push_message(&mut self, message: ChatMessage) {
+        self.messages.push(message);
+        while self.messages.len() > self.max_messages {
+            self.messages.remove(0);
+        }
+        if self.auto_scroll {
+            self.scroll_to_bottom();
+        }
+    }
+
+    /// Adds a user message.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChatViewState, ChatRole};
+    ///
+    /// let mut state = ChatViewState::new();
+    /// state.push_user("Hello!");
+    /// assert_eq!(state.messages()[0].role(), ChatRole::User);
+    /// ```
+    pub fn push_user(&mut self, content: impl Into<String>) {
+        self.push_message(ChatMessage::new(ChatRole::User, content));
+    }
+
+    /// Adds a system message.
+    pub fn push_system(&mut self, content: impl Into<String>) {
+        self.push_message(ChatMessage::new(ChatRole::System, content));
+    }
+
+    /// Adds an assistant message.
+    pub fn push_assistant(&mut self, content: impl Into<String>) {
+        self.push_message(ChatMessage::new(ChatRole::Assistant, content));
+    }
+
+    /// Adds a user message with a timestamp.
+    pub fn push_user_with_timestamp(
+        &mut self,
+        content: impl Into<String>,
+        timestamp: impl Into<String>,
+    ) {
+        self.push_message(
+            ChatMessage::new(ChatRole::User, content).with_timestamp(timestamp),
+        );
+    }
+
+    /// Adds a system message with a timestamp.
+    pub fn push_system_with_timestamp(
+        &mut self,
+        content: impl Into<String>,
+        timestamp: impl Into<String>,
+    ) {
+        self.push_message(
+            ChatMessage::new(ChatRole::System, content).with_timestamp(timestamp),
+        );
+    }
+
+    /// Adds an assistant message with a timestamp.
+    pub fn push_assistant_with_timestamp(
+        &mut self,
+        content: impl Into<String>,
+        timestamp: impl Into<String>,
+    ) {
+        self.push_message(
+            ChatMessage::new(ChatRole::Assistant, content).with_timestamp(timestamp),
+        );
+    }
+
+    /// Clears all messages.
+    pub fn clear_messages(&mut self) {
+        self.messages.clear();
+        self.scroll_offset = 0;
+    }
+
+    // ---- Accessors ----
+
+    /// Returns the messages.
+    pub fn messages(&self) -> &[ChatMessage] {
+        &self.messages
+    }
+
+    /// Returns the number of messages.
+    pub fn message_count(&self) -> usize {
+        self.messages.len()
+    }
+
+    /// Returns true if there are no messages.
+    pub fn is_empty(&self) -> bool {
+        self.messages.is_empty()
+    }
+
+    /// Returns the current input text.
+    pub fn input_value(&self) -> String {
+        self.input.value()
+    }
+
+    /// Sets the input text.
+    pub fn set_input_value(&mut self, value: impl Into<String>) {
+        self.input.set_value(value);
+    }
+
+    /// Returns the scroll offset.
+    pub fn scroll_offset(&self) -> usize {
+        self.scroll_offset
+    }
+
+    /// Returns the maximum number of messages.
+    pub fn max_messages(&self) -> usize {
+        self.max_messages
+    }
+
+    /// Sets the maximum number of messages.
+    pub fn set_max_messages(&mut self, max: usize) {
+        self.max_messages = max;
+        while self.messages.len() > self.max_messages {
+            self.messages.remove(0);
+        }
+    }
+
+    /// Returns whether timestamps are shown.
+    pub fn show_timestamps(&self) -> bool {
+        self.show_timestamps
+    }
+
+    /// Sets whether timestamps are shown.
+    pub fn set_show_timestamps(&mut self, show: bool) {
+        self.show_timestamps = show;
+    }
+
+    /// Returns whether auto-scroll is enabled.
+    pub fn auto_scroll(&self) -> bool {
+        self.auto_scroll
+    }
+
+    /// Sets whether auto-scroll is enabled.
+    pub fn set_auto_scroll(&mut self, auto_scroll: bool) {
+        self.auto_scroll = auto_scroll;
+    }
+
+    /// Returns the input area height.
+    pub fn input_height(&self) -> u16 {
+        self.input_height
+    }
+
+    /// Sets the input area height.
+    pub fn set_input_height(&mut self, height: u16) {
+        self.input_height = height.max(1);
+    }
+
+    /// Returns whether the input field is focused.
+    pub fn is_input_focused(&self) -> bool {
+        self.focus == Focus::Input
+    }
+
+    /// Returns whether the history is focused.
+    pub fn is_history_focused(&self) -> bool {
+        self.focus == Focus::History
+    }
+
+    /// Scrolls the message history to the bottom (newest).
+    fn scroll_to_bottom(&mut self) {
+        self.scroll_offset = self.messages.len().saturating_sub(1);
+    }
+
+    // ---- Instance methods ----
+
+    /// Returns true if the component is focused.
+    pub fn is_focused(&self) -> bool {
+        self.focused
+    }
+
+    /// Sets the focus state.
+    pub fn set_focused(&mut self, focused: bool) {
+        self.focused = focused;
+    }
+
+    /// Returns true if the component is disabled.
+    pub fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    /// Sets the disabled state.
+    pub fn set_disabled(&mut self, disabled: bool) {
+        self.disabled = disabled;
+    }
+
+    /// Maps an input event to a chat view message.
+    pub fn handle_event(&self, event: &Event) -> Option<ChatViewMessage> {
+        ChatView::handle_event(self, event)
+    }
+
+    /// Dispatches an event, updating state and returning any output.
+    pub fn dispatch_event(&mut self, event: &Event) -> Option<ChatViewOutput> {
+        ChatView::dispatch_event(self, event)
+    }
+
+    /// Updates the state with a message, returning any output.
+    pub fn update(&mut self, msg: ChatViewMessage) -> Option<ChatViewOutput> {
+        ChatView::update(self, msg)
+    }
+}
+
+/// A chat interface with message history and multi-line input.
+///
+/// The input area uses a [`TextArea`](super::TextArea) for multi-line
+/// editing. Press Ctrl+Enter to submit a message, Tab to toggle between
+/// history scrolling and input editing.
+///
+/// # Key Bindings (Input Mode)
+///
+/// - Characters — Type text
+/// - `Enter` — New line in input
+/// - `Ctrl+Enter` — Submit message
+/// - `Tab` — Switch to history mode
+/// - `Backspace` / `Delete` — Edit text
+/// - `Left` / `Right` / `Home` / `End` — Cursor movement
+///
+/// # Key Bindings (History Mode)
+///
+/// - `Up` / `k` — Scroll history up
+/// - `Down` / `j` — Scroll history down
+/// - `Home` — Scroll to top (oldest)
+/// - `End` — Scroll to bottom (newest)
+/// - `Tab` — Switch to input mode
+pub struct ChatView(PhantomData<()>);
+
+impl Component for ChatView {
+    type State = ChatViewState;
+    type Message = ChatViewMessage;
+    type Output = ChatViewOutput;
+
+    fn init() -> Self::State {
+        ChatViewState::default()
+    }
+
+    fn handle_event(state: &Self::State, event: &Event) -> Option<Self::Message> {
+        if !state.focused || state.disabled {
+            return None;
+        }
+
+        let key = event.as_key()?;
+
+        match state.focus {
+            Focus::Input => {
+                let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+                match key.code {
+                    KeyCode::Enter if ctrl => Some(ChatViewMessage::Submit),
+                    KeyCode::Enter => Some(ChatViewMessage::NewLine),
+                    KeyCode::Tab => Some(ChatViewMessage::ToggleFocus),
+                    KeyCode::Char(c) if !ctrl => Some(ChatViewMessage::Input(c)),
+                    KeyCode::Char('k') if ctrl => Some(ChatViewMessage::DeleteToEnd),
+                    KeyCode::Char('u') if ctrl => Some(ChatViewMessage::DeleteToStart),
+                    KeyCode::Backspace => Some(ChatViewMessage::Backspace),
+                    KeyCode::Delete => Some(ChatViewMessage::Delete),
+                    KeyCode::Left => Some(ChatViewMessage::Left),
+                    KeyCode::Right => Some(ChatViewMessage::Right),
+                    KeyCode::Up => Some(ChatViewMessage::Up),
+                    KeyCode::Down => Some(ChatViewMessage::Down),
+                    KeyCode::Home if ctrl => Some(ChatViewMessage::InputStart),
+                    KeyCode::Home => Some(ChatViewMessage::Home),
+                    KeyCode::End if ctrl => Some(ChatViewMessage::InputEnd),
+                    KeyCode::End => Some(ChatViewMessage::End),
+                    _ => None,
+                }
+            }
+            Focus::History => match key.code {
+                KeyCode::Up | KeyCode::Char('k') => Some(ChatViewMessage::ScrollUp),
+                KeyCode::Down | KeyCode::Char('j') => Some(ChatViewMessage::ScrollDown),
+                KeyCode::Home => Some(ChatViewMessage::ScrollToTop),
+                KeyCode::End => Some(ChatViewMessage::ScrollToBottom),
+                KeyCode::Tab => Some(ChatViewMessage::ToggleFocus),
+                _ => None,
+            },
+        }
+    }
+
+    fn update(state: &mut Self::State, msg: Self::Message) -> Option<Self::Output> {
+        if state.disabled {
+            return None;
+        }
+
+        match msg {
+            ChatViewMessage::Input(c) => {
+                state.input.update(TextAreaMessage::Insert(c));
+                Some(ChatViewOutput::InputChanged(state.input.value()))
+            }
+            ChatViewMessage::NewLine => {
+                state.input.update(TextAreaMessage::NewLine);
+                Some(ChatViewOutput::InputChanged(state.input.value()))
+            }
+            ChatViewMessage::Backspace => {
+                if let Some(TextAreaOutput::Changed(_)) =
+                    state.input.update(TextAreaMessage::Backspace)
+                {
+                    Some(ChatViewOutput::InputChanged(state.input.value()))
+                } else {
+                    None
+                }
+            }
+            ChatViewMessage::Delete => {
+                if let Some(TextAreaOutput::Changed(_)) =
+                    state.input.update(TextAreaMessage::Delete)
+                {
+                    Some(ChatViewOutput::InputChanged(state.input.value()))
+                } else {
+                    None
+                }
+            }
+            ChatViewMessage::Left => {
+                state.input.update(TextAreaMessage::Left);
+                None
+            }
+            ChatViewMessage::Right => {
+                state.input.update(TextAreaMessage::Right);
+                None
+            }
+            ChatViewMessage::Up => {
+                state.input.update(TextAreaMessage::Up);
+                None
+            }
+            ChatViewMessage::Down => {
+                state.input.update(TextAreaMessage::Down);
+                None
+            }
+            ChatViewMessage::Home => {
+                state.input.update(TextAreaMessage::Home);
+                None
+            }
+            ChatViewMessage::End => {
+                state.input.update(TextAreaMessage::End);
+                None
+            }
+            ChatViewMessage::InputStart => {
+                state.input.update(TextAreaMessage::TextStart);
+                None
+            }
+            ChatViewMessage::InputEnd => {
+                state.input.update(TextAreaMessage::TextEnd);
+                None
+            }
+            ChatViewMessage::DeleteToEnd => {
+                if let Some(TextAreaOutput::Changed(_)) =
+                    state.input.update(TextAreaMessage::DeleteToEnd)
+                {
+                    Some(ChatViewOutput::InputChanged(state.input.value()))
+                } else {
+                    None
+                }
+            }
+            ChatViewMessage::DeleteToStart => {
+                if let Some(TextAreaOutput::Changed(_)) =
+                    state.input.update(TextAreaMessage::DeleteToStart)
+                {
+                    Some(ChatViewOutput::InputChanged(state.input.value()))
+                } else {
+                    None
+                }
+            }
+            ChatViewMessage::Submit => {
+                let value = state.input.value();
+                if value.trim().is_empty() {
+                    return None;
+                }
+                state.push_user(&value);
+                state.input.update(TextAreaMessage::Clear);
+                Some(ChatViewOutput::Submitted(value))
+            }
+            ChatViewMessage::ToggleFocus => {
+                match state.focus {
+                    Focus::Input => {
+                        state.focus = Focus::History;
+                        state.input.set_focused(false);
+                    }
+                    Focus::History => {
+                        state.focus = Focus::Input;
+                        state.input.set_focused(true);
+                    }
+                }
+                None
+            }
+            ChatViewMessage::FocusInput => {
+                state.focus = Focus::Input;
+                state.input.set_focused(true);
+                None
+            }
+            ChatViewMessage::FocusHistory => {
+                state.focus = Focus::History;
+                state.input.set_focused(false);
+                None
+            }
+            ChatViewMessage::ScrollUp => {
+                if state.scroll_offset > 0 {
+                    state.scroll_offset -= 1;
+                    state.auto_scroll = false;
+                }
+                None
+            }
+            ChatViewMessage::ScrollDown => {
+                let max = state.messages.len().saturating_sub(1);
+                if state.scroll_offset < max {
+                    state.scroll_offset += 1;
+                    if state.scroll_offset >= max {
+                        state.auto_scroll = true;
+                    }
+                }
+                None
+            }
+            ChatViewMessage::ScrollToTop => {
+                state.scroll_offset = 0;
+                state.auto_scroll = false;
+                None
+            }
+            ChatViewMessage::ScrollToBottom => {
+                state.scroll_to_bottom();
+                state.auto_scroll = true;
+                None
+            }
+            ChatViewMessage::ClearInput => {
+                state.input.update(TextAreaMessage::Clear);
+                Some(ChatViewOutput::InputChanged(String::new()))
+            }
+        }
+    }
+
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+        if area.height < 4 {
+            return;
+        }
+
+        // Layout: history + input
+        let input_h = state.input_height + 2; // +2 for border
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(input_h)])
+            .split(area);
+
+        let history_area = chunks[0];
+        let input_area = chunks[1];
+
+        render_history(state, frame, history_area, theme);
+        render_input(state, frame, input_area, theme);
+    }
+}
+
+impl Focusable for ChatView {
+    fn is_focused(state: &Self::State) -> bool {
+        state.focused
+    }
+
+    fn set_focused(state: &mut Self::State, focused: bool) {
+        state.focused = focused;
+        if focused && state.focus == Focus::Input {
+            state.input.set_focused(true);
+        }
+    }
+}
+
+/// Renders the message history area.
+fn render_history(
+    state: &ChatViewState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+) {
+    let border_style = if state.disabled {
+        theme.disabled_style()
+    } else if state.focused && state.focus == Focus::History {
+        theme.focused_border_style()
+    } else {
+        theme.border_style()
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(border_style);
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if inner.height == 0 || inner.width == 0 {
+        return;
+    }
+
+    // Build display lines from messages
+    let display_lines: Vec<(Line, ChatRole)> = state
+        .messages
+        .iter()
+        .flat_map(|msg| format_message(msg, state.show_timestamps, inner.width as usize))
+        .collect();
+
+    let total_lines = display_lines.len();
+    let visible_lines = inner.height as usize;
+
+    // Calculate scroll offset based on message-level scroll
+    // We'll show from offset based on display lines
+    let line_offset = if state.auto_scroll {
+        total_lines.saturating_sub(visible_lines)
+    } else {
+        // Approximate: each message is roughly 2+ lines
+        let estimated_line = state.scroll_offset.saturating_mul(2);
+        estimated_line.min(total_lines.saturating_sub(visible_lines))
+    };
+
+    let items: Vec<ListItem> = display_lines
+        .into_iter()
+        .skip(line_offset)
+        .take(visible_lines)
+        .map(|(line, _)| ListItem::new(line))
+        .collect();
+
+    let list = List::new(items);
+    frame.render_widget(list, inner);
+}
+
+/// Formats a chat message into display lines.
+fn format_message(msg: &ChatMessage, show_timestamps: bool, _width: usize) -> Vec<(Line<'_>, ChatRole)> {
+    let mut result = Vec::new();
+    let role = msg.role();
+    let style = Style::default().fg(role.color());
+    let bold_style = style.add_modifier(Modifier::BOLD);
+
+    // Header line: [timestamp] Username:
+    let mut header_spans = Vec::new();
+
+    if show_timestamps {
+        if let Some(ts) = msg.timestamp() {
+            header_spans.push(Span::styled(
+                format!("[{}] ", ts),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+    }
+
+    header_spans.push(Span::styled(
+        format!("{}:", msg.display_name()),
+        bold_style,
+    ));
+
+    result.push((Line::from(header_spans), role));
+
+    // Content lines
+    for line in msg.content().lines() {
+        result.push((
+            Line::from(Span::styled(format!("  {}", line), style)),
+            role,
+        ));
+    }
+
+    // Handle empty content
+    if msg.content().is_empty() {
+        result.push((Line::from(Span::styled("  ", style)), role));
+    }
+
+    result
+}
+
+/// Renders the input area.
+fn render_input(
+    state: &ChatViewState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+) {
+    let border_style = if state.disabled {
+        theme.disabled_style()
+    } else if state.focused && state.focus == Focus::Input {
+        theme.focused_border_style()
+    } else {
+        theme.border_style()
+    };
+
+    let text_style = if state.disabled {
+        theme.disabled_style()
+    } else if state.focused && state.focus == Focus::Input {
+        theme.focused_style()
+    } else {
+        theme.normal_style()
+    };
+
+    let value = state.input.value();
+    let display_text = if value.is_empty() && !state.input.placeholder().is_empty() {
+        state.input.placeholder().to_string()
+    } else {
+        value
+    };
+
+    let text_style_final = if state.input.is_empty() && !state.input.placeholder().is_empty() {
+        theme.placeholder_style()
+    } else {
+        text_style
+    };
+
+    let paragraph = Paragraph::new(display_text)
+        .style(text_style_final)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(border_style),
+        )
+        .wrap(Wrap { trim: false });
+
+    frame.render_widget(paragraph, area);
+
+    // Show cursor when input is focused
+    if state.focused && state.focus == Focus::Input && !state.disabled {
+        let (cursor_row, cursor_col) = state.input.cursor_position();
+        let cursor_x = area.x + 1 + cursor_col as u16;
+        let cursor_y = area.y + 1 + cursor_row as u16;
+        if cursor_x < area.right() - 1 && cursor_y < area.bottom() - 1 {
+            frame.set_cursor_position(Position::new(cursor_x, cursor_y));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/component/chat_view/tests.rs
+++ b/src/component/chat_view/tests.rs
@@ -1,0 +1,862 @@
+use super::*;
+use crate::component::test_utils;
+
+fn focused_state() -> ChatViewState {
+    let mut state = ChatViewState::new();
+    ChatView::set_focused(&mut state, true);
+    state
+}
+
+fn state_with_messages() -> ChatViewState {
+    let mut state = focused_state();
+    state.push_system("Welcome!");
+    state.push_user("Hello");
+    state.push_assistant("Hi there!");
+    state
+}
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+#[test]
+fn test_new() {
+    let state = ChatViewState::new();
+    assert_eq!(state.message_count(), 0);
+    assert!(state.input_value().is_empty());
+    assert!(!state.is_focused());
+    assert!(!state.is_disabled());
+    assert!(state.is_input_focused());
+}
+
+#[test]
+fn test_default() {
+    let state = ChatViewState::default();
+    assert_eq!(state.max_messages(), 1000);
+    assert!(!state.show_timestamps());
+    assert!(state.auto_scroll());
+    assert_eq!(state.input_height(), 3);
+}
+
+#[test]
+fn test_with_max_messages() {
+    let state = ChatViewState::new().with_max_messages(50);
+    assert_eq!(state.max_messages(), 50);
+}
+
+#[test]
+fn test_with_timestamps() {
+    let state = ChatViewState::new().with_timestamps(true);
+    assert!(state.show_timestamps());
+}
+
+#[test]
+fn test_with_input_height() {
+    let state = ChatViewState::new().with_input_height(5);
+    assert_eq!(state.input_height(), 5);
+}
+
+#[test]
+fn test_with_input_height_minimum() {
+    let state = ChatViewState::new().with_input_height(0);
+    assert_eq!(state.input_height(), 1);
+}
+
+#[test]
+fn test_with_disabled() {
+    let state = ChatViewState::new().with_disabled(true);
+    assert!(state.is_disabled());
+}
+
+#[test]
+fn test_with_placeholder() {
+    let state = ChatViewState::new().with_placeholder("Enter text...");
+    assert_eq!(state.input.placeholder(), "Enter text...");
+}
+
+// =============================================================================
+// ChatRole
+// =============================================================================
+
+#[test]
+fn test_role_prefix() {
+    assert_eq!(ChatRole::User.prefix(), "You");
+    assert_eq!(ChatRole::System.prefix(), "System");
+    assert_eq!(ChatRole::Assistant.prefix(), "Assistant");
+}
+
+#[test]
+fn test_role_color() {
+    assert_eq!(ChatRole::User.color(), Color::Cyan);
+    assert_eq!(ChatRole::System.color(), Color::DarkGray);
+    assert_eq!(ChatRole::Assistant.color(), Color::Green);
+}
+
+// =============================================================================
+// ChatMessage
+// =============================================================================
+
+#[test]
+fn test_chat_message_new() {
+    let msg = ChatMessage::new(ChatRole::User, "Hello");
+    assert_eq!(msg.role(), ChatRole::User);
+    assert_eq!(msg.content(), "Hello");
+    assert_eq!(msg.timestamp(), None);
+    assert_eq!(msg.display_name(), "You");
+}
+
+#[test]
+fn test_chat_message_with_timestamp() {
+    let msg = ChatMessage::new(ChatRole::User, "Hello").with_timestamp("12:00");
+    assert_eq!(msg.timestamp(), Some("12:00"));
+}
+
+#[test]
+fn test_chat_message_with_username() {
+    let msg = ChatMessage::new(ChatRole::User, "Hello").with_username("Alice");
+    assert_eq!(msg.display_name(), "Alice");
+}
+
+#[test]
+fn test_chat_message_display_name_default() {
+    let msg = ChatMessage::new(ChatRole::Assistant, "Hi");
+    assert_eq!(msg.display_name(), "Assistant");
+}
+
+// =============================================================================
+// Message manipulation
+// =============================================================================
+
+#[test]
+fn test_push_user() {
+    let mut state = ChatViewState::new();
+    state.push_user("Hello");
+    assert_eq!(state.message_count(), 1);
+    assert_eq!(state.messages()[0].role(), ChatRole::User);
+    assert_eq!(state.messages()[0].content(), "Hello");
+}
+
+#[test]
+fn test_push_system() {
+    let mut state = ChatViewState::new();
+    state.push_system("Welcome");
+    assert_eq!(state.messages()[0].role(), ChatRole::System);
+}
+
+#[test]
+fn test_push_assistant() {
+    let mut state = ChatViewState::new();
+    state.push_assistant("How can I help?");
+    assert_eq!(state.messages()[0].role(), ChatRole::Assistant);
+}
+
+#[test]
+fn test_push_with_timestamps() {
+    let mut state = ChatViewState::new();
+    state.push_user_with_timestamp("Hi", "12:00");
+    state.push_system_with_timestamp("Info", "12:01");
+    state.push_assistant_with_timestamp("Hello", "12:02");
+    assert_eq!(state.messages()[0].timestamp(), Some("12:00"));
+    assert_eq!(state.messages()[1].timestamp(), Some("12:01"));
+    assert_eq!(state.messages()[2].timestamp(), Some("12:02"));
+}
+
+#[test]
+fn test_push_message_custom() {
+    let mut state = ChatViewState::new();
+    let msg = ChatMessage::new(ChatRole::User, "Custom")
+        .with_username("Bob")
+        .with_timestamp("09:00");
+    state.push_message(msg);
+    assert_eq!(state.messages()[0].display_name(), "Bob");
+}
+
+#[test]
+fn test_clear_messages() {
+    let mut state = state_with_messages();
+    state.clear_messages();
+    assert!(state.is_empty());
+    assert_eq!(state.scroll_offset(), 0);
+}
+
+#[test]
+fn test_eviction() {
+    let mut state = ChatViewState::new().with_max_messages(3);
+    state.push_user("a");
+    state.push_user("b");
+    state.push_user("c");
+    state.push_user("d");
+    assert_eq!(state.message_count(), 3);
+    assert_eq!(state.messages()[0].content(), "b");
+}
+
+#[test]
+fn test_set_max_messages() {
+    let mut state = ChatViewState::new();
+    state.push_user("a");
+    state.push_user("b");
+    state.push_user("c");
+    state.set_max_messages(2);
+    assert_eq!(state.message_count(), 2);
+    assert_eq!(state.messages()[0].content(), "b");
+}
+
+// =============================================================================
+// Input editing
+// =============================================================================
+
+#[test]
+fn test_type_input() {
+    let mut state = focused_state();
+    let output = ChatView::update(&mut state, ChatViewMessage::Input('H'));
+    ChatView::update(&mut state, ChatViewMessage::Input('i'));
+    assert_eq!(state.input_value(), "Hi");
+    assert!(matches!(output, Some(ChatViewOutput::InputChanged(_))));
+}
+
+#[test]
+fn test_newline() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::Input('a'));
+    ChatView::update(&mut state, ChatViewMessage::NewLine);
+    ChatView::update(&mut state, ChatViewMessage::Input('b'));
+    assert_eq!(state.input_value(), "a\nb");
+}
+
+#[test]
+fn test_backspace() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::Input('a'));
+    ChatView::update(&mut state, ChatViewMessage::Input('b'));
+    let output = ChatView::update(&mut state, ChatViewMessage::Backspace);
+    assert_eq!(state.input_value(), "a");
+    assert!(matches!(output, Some(ChatViewOutput::InputChanged(_))));
+}
+
+#[test]
+fn test_backspace_at_start() {
+    let mut state = focused_state();
+    let output = ChatView::update(&mut state, ChatViewMessage::Backspace);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_delete() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::Input('a'));
+    ChatView::update(&mut state, ChatViewMessage::Input('b'));
+    ChatView::update(&mut state, ChatViewMessage::Home);
+    let output = ChatView::update(&mut state, ChatViewMessage::Delete);
+    assert_eq!(state.input_value(), "b");
+    assert!(matches!(output, Some(ChatViewOutput::InputChanged(_))));
+}
+
+#[test]
+fn test_delete_at_end() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::Input('a'));
+    let output = ChatView::update(&mut state, ChatViewMessage::Delete);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_set_input_value() {
+    let mut state = ChatViewState::new();
+    state.set_input_value("preset text");
+    assert_eq!(state.input_value(), "preset text");
+}
+
+#[test]
+fn test_clear_input() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::Input('a'));
+    let output = ChatView::update(&mut state, ChatViewMessage::ClearInput);
+    assert!(state.input_value().is_empty());
+    assert_eq!(output, Some(ChatViewOutput::InputChanged(String::new())));
+}
+
+#[test]
+fn test_delete_to_end() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::Input('a'));
+    ChatView::update(&mut state, ChatViewMessage::Input('b'));
+    ChatView::update(&mut state, ChatViewMessage::Home);
+    let output = ChatView::update(&mut state, ChatViewMessage::DeleteToEnd);
+    assert!(state.input_value().is_empty());
+    assert!(matches!(output, Some(ChatViewOutput::InputChanged(_))));
+}
+
+#[test]
+fn test_delete_to_start() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::Input('a'));
+    ChatView::update(&mut state, ChatViewMessage::Input('b'));
+    let output = ChatView::update(&mut state, ChatViewMessage::DeleteToStart);
+    assert!(state.input_value().is_empty());
+    assert!(matches!(output, Some(ChatViewOutput::InputChanged(_))));
+}
+
+// =============================================================================
+// Submit
+// =============================================================================
+
+#[test]
+fn test_submit() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::Input('H'));
+    ChatView::update(&mut state, ChatViewMessage::Input('i'));
+    let output = ChatView::update(&mut state, ChatViewMessage::Submit);
+    assert_eq!(output, Some(ChatViewOutput::Submitted("Hi".into())));
+    assert!(state.input_value().is_empty());
+    assert_eq!(state.message_count(), 1);
+    assert_eq!(state.messages()[0].content(), "Hi");
+}
+
+#[test]
+fn test_submit_empty() {
+    let mut state = focused_state();
+    let output = ChatView::update(&mut state, ChatViewMessage::Submit);
+    assert_eq!(output, None);
+    assert_eq!(state.message_count(), 0);
+}
+
+#[test]
+fn test_submit_whitespace_only() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::Input(' '));
+    ChatView::update(&mut state, ChatViewMessage::Input(' '));
+    let output = ChatView::update(&mut state, ChatViewMessage::Submit);
+    assert_eq!(output, None);
+}
+
+// =============================================================================
+// Focus management
+// =============================================================================
+
+#[test]
+fn test_toggle_focus() {
+    let mut state = focused_state();
+    assert!(state.is_input_focused());
+
+    ChatView::update(&mut state, ChatViewMessage::ToggleFocus);
+    assert!(state.is_history_focused());
+
+    ChatView::update(&mut state, ChatViewMessage::ToggleFocus);
+    assert!(state.is_input_focused());
+}
+
+#[test]
+fn test_focus_input() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::FocusHistory);
+    ChatView::update(&mut state, ChatViewMessage::FocusInput);
+    assert!(state.is_input_focused());
+}
+
+#[test]
+fn test_focus_history() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::FocusHistory);
+    assert!(state.is_history_focused());
+}
+
+// =============================================================================
+// Scrolling
+// =============================================================================
+
+#[test]
+fn test_scroll_down() {
+    let mut state = state_with_messages();
+    state.auto_scroll = false;
+    state.scroll_offset = 0;
+    ChatView::update(&mut state, ChatViewMessage::ScrollDown);
+    assert_eq!(state.scroll_offset(), 1);
+}
+
+#[test]
+fn test_scroll_up() {
+    let mut state = state_with_messages();
+    state.auto_scroll = false;
+    state.scroll_offset = 2;
+    ChatView::update(&mut state, ChatViewMessage::ScrollUp);
+    assert_eq!(state.scroll_offset(), 1);
+}
+
+#[test]
+fn test_scroll_up_at_top() {
+    let mut state = state_with_messages();
+    state.scroll_offset = 0;
+    ChatView::update(&mut state, ChatViewMessage::ScrollUp);
+    assert_eq!(state.scroll_offset(), 0);
+}
+
+#[test]
+fn test_scroll_to_top() {
+    let mut state = state_with_messages();
+    state.scroll_offset = 2;
+    ChatView::update(&mut state, ChatViewMessage::ScrollToTop);
+    assert_eq!(state.scroll_offset(), 0);
+    assert!(!state.auto_scroll());
+}
+
+#[test]
+fn test_scroll_to_bottom() {
+    let mut state = state_with_messages();
+    state.auto_scroll = false;
+    state.scroll_offset = 0;
+    ChatView::update(&mut state, ChatViewMessage::ScrollToBottom);
+    assert_eq!(state.scroll_offset(), 2);
+    assert!(state.auto_scroll());
+}
+
+#[test]
+fn test_auto_scroll_on_new_message() {
+    let mut state = focused_state();
+    state.push_user("a");
+    state.push_user("b");
+    // auto_scroll should keep us at the bottom
+    assert!(state.auto_scroll());
+}
+
+#[test]
+fn test_scroll_up_disables_auto_scroll() {
+    let mut state = state_with_messages();
+    ChatView::update(&mut state, ChatViewMessage::ScrollUp);
+    assert!(!state.auto_scroll());
+}
+
+#[test]
+fn test_set_auto_scroll() {
+    let mut state = ChatViewState::new();
+    state.set_auto_scroll(false);
+    assert!(!state.auto_scroll());
+    state.set_auto_scroll(true);
+    assert!(state.auto_scroll());
+}
+
+// =============================================================================
+// Disabled state
+// =============================================================================
+
+#[test]
+fn test_disabled_ignores_messages() {
+    let mut state = focused_state();
+    state.set_disabled(true);
+    let output = ChatView::update(&mut state, ChatViewMessage::Input('a'));
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_disabled_ignores_events() {
+    let mut state = focused_state();
+    state.set_disabled(true);
+    let msg = ChatView::handle_event(&state, &Event::char('a'));
+    assert_eq!(msg, None);
+}
+
+// =============================================================================
+// Unfocused state
+// =============================================================================
+
+#[test]
+fn test_unfocused_ignores_events() {
+    let state = ChatViewState::new();
+    let msg = ChatView::handle_event(&state, &Event::char('a'));
+    assert_eq!(msg, None);
+}
+
+// =============================================================================
+// Event mapping — input mode
+// =============================================================================
+
+#[test]
+fn test_input_mode_char() {
+    let state = focused_state();
+    assert_eq!(
+        ChatView::handle_event(&state, &Event::char('a')),
+        Some(ChatViewMessage::Input('a'))
+    );
+}
+
+#[test]
+fn test_input_mode_enter() {
+    let state = focused_state();
+    assert_eq!(
+        ChatView::handle_event(&state, &Event::key(KeyCode::Enter)),
+        Some(ChatViewMessage::NewLine)
+    );
+}
+
+#[test]
+fn test_input_mode_ctrl_enter() {
+    let state = focused_state();
+    assert_eq!(
+        ChatView::handle_event(
+            &state,
+            &Event::key_with(KeyCode::Enter, KeyModifiers::CONTROL)
+        ),
+        Some(ChatViewMessage::Submit)
+    );
+}
+
+#[test]
+fn test_input_mode_tab() {
+    let state = focused_state();
+    assert_eq!(
+        ChatView::handle_event(&state, &Event::key(KeyCode::Tab)),
+        Some(ChatViewMessage::ToggleFocus)
+    );
+}
+
+#[test]
+fn test_input_mode_backspace() {
+    let state = focused_state();
+    assert_eq!(
+        ChatView::handle_event(&state, &Event::key(KeyCode::Backspace)),
+        Some(ChatViewMessage::Backspace)
+    );
+}
+
+#[test]
+fn test_input_mode_delete() {
+    let state = focused_state();
+    assert_eq!(
+        ChatView::handle_event(&state, &Event::key(KeyCode::Delete)),
+        Some(ChatViewMessage::Delete)
+    );
+}
+
+#[test]
+fn test_input_mode_arrows() {
+    let state = focused_state();
+    assert_eq!(
+        ChatView::handle_event(&state, &Event::key(KeyCode::Left)),
+        Some(ChatViewMessage::Left)
+    );
+    assert_eq!(
+        ChatView::handle_event(&state, &Event::key(KeyCode::Right)),
+        Some(ChatViewMessage::Right)
+    );
+    assert_eq!(
+        ChatView::handle_event(&state, &Event::key(KeyCode::Up)),
+        Some(ChatViewMessage::Up)
+    );
+    assert_eq!(
+        ChatView::handle_event(&state, &Event::key(KeyCode::Down)),
+        Some(ChatViewMessage::Down)
+    );
+}
+
+#[test]
+fn test_input_mode_home_end() {
+    let state = focused_state();
+    assert_eq!(
+        ChatView::handle_event(&state, &Event::key(KeyCode::Home)),
+        Some(ChatViewMessage::Home)
+    );
+    assert_eq!(
+        ChatView::handle_event(&state, &Event::key(KeyCode::End)),
+        Some(ChatViewMessage::End)
+    );
+}
+
+#[test]
+fn test_input_mode_ctrl_home_end() {
+    let state = focused_state();
+    assert_eq!(
+        ChatView::handle_event(
+            &state,
+            &Event::key_with(KeyCode::Home, KeyModifiers::CONTROL)
+        ),
+        Some(ChatViewMessage::InputStart)
+    );
+    assert_eq!(
+        ChatView::handle_event(
+            &state,
+            &Event::key_with(KeyCode::End, KeyModifiers::CONTROL)
+        ),
+        Some(ChatViewMessage::InputEnd)
+    );
+}
+
+// =============================================================================
+// Event mapping — history mode
+// =============================================================================
+
+#[test]
+fn test_history_mode_up_down() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::FocusHistory);
+    assert_eq!(
+        ChatView::handle_event(&state, &Event::key(KeyCode::Up)),
+        Some(ChatViewMessage::ScrollUp)
+    );
+    assert_eq!(
+        ChatView::handle_event(&state, &Event::key(KeyCode::Down)),
+        Some(ChatViewMessage::ScrollDown)
+    );
+    assert_eq!(
+        ChatView::handle_event(&state, &Event::char('k')),
+        Some(ChatViewMessage::ScrollUp)
+    );
+    assert_eq!(
+        ChatView::handle_event(&state, &Event::char('j')),
+        Some(ChatViewMessage::ScrollDown)
+    );
+}
+
+#[test]
+fn test_history_mode_home_end() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::FocusHistory);
+    assert_eq!(
+        ChatView::handle_event(&state, &Event::key(KeyCode::Home)),
+        Some(ChatViewMessage::ScrollToTop)
+    );
+    assert_eq!(
+        ChatView::handle_event(&state, &Event::key(KeyCode::End)),
+        Some(ChatViewMessage::ScrollToBottom)
+    );
+}
+
+#[test]
+fn test_history_mode_tab() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::FocusHistory);
+    assert_eq!(
+        ChatView::handle_event(&state, &Event::key(KeyCode::Tab)),
+        Some(ChatViewMessage::ToggleFocus)
+    );
+}
+
+// =============================================================================
+// Instance methods
+// =============================================================================
+
+#[test]
+fn test_instance_handle_event() {
+    let state = focused_state();
+    let msg = state.handle_event(&Event::char('a'));
+    assert_eq!(msg, Some(ChatViewMessage::Input('a')));
+}
+
+#[test]
+fn test_instance_update() {
+    let mut state = focused_state();
+    state.update(ChatViewMessage::Input('a'));
+    assert_eq!(state.input_value(), "a");
+}
+
+#[test]
+fn test_instance_dispatch_event() {
+    let mut state = focused_state();
+    state.dispatch_event(&Event::char('a'));
+    assert_eq!(state.input_value(), "a");
+}
+
+// =============================================================================
+// Accessors
+// =============================================================================
+
+#[test]
+fn test_set_show_timestamps() {
+    let mut state = ChatViewState::new();
+    state.set_show_timestamps(true);
+    assert!(state.show_timestamps());
+}
+
+#[test]
+fn test_set_input_height() {
+    let mut state = ChatViewState::new();
+    state.set_input_height(5);
+    assert_eq!(state.input_height(), 5);
+}
+
+#[test]
+fn test_set_input_height_minimum() {
+    let mut state = ChatViewState::new();
+    state.set_input_height(0);
+    assert_eq!(state.input_height(), 1);
+}
+
+// =============================================================================
+// Rendering
+// =============================================================================
+
+#[test]
+fn test_render_empty() {
+    let state = ChatViewState::new();
+    let (mut terminal, theme) = test_utils::setup_render(60, 20);
+    terminal
+        .draw(|frame| {
+            ChatView::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_with_messages() {
+    let state = state_with_messages();
+    let (mut terminal, theme) = test_utils::setup_render(60, 20);
+    terminal
+        .draw(|frame| {
+            ChatView::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_focused_input() {
+    let state = focused_state();
+    let (mut terminal, theme) = test_utils::setup_render(60, 20);
+    terminal
+        .draw(|frame| {
+            ChatView::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_focused_history() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::FocusHistory);
+    let (mut terminal, theme) = test_utils::setup_render(60, 20);
+    terminal
+        .draw(|frame| {
+            ChatView::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_disabled() {
+    let state = ChatViewState::new().with_disabled(true);
+    let (mut terminal, theme) = test_utils::setup_render(60, 20);
+    terminal
+        .draw(|frame| {
+            ChatView::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_with_timestamps() {
+    let mut state = ChatViewState::new().with_timestamps(true);
+    state.push_user_with_timestamp("Hello", "12:00");
+    state.push_assistant_with_timestamp("Hi!", "12:01");
+    let (mut terminal, theme) = test_utils::setup_render(60, 20);
+    terminal
+        .draw(|frame| {
+            ChatView::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_small_area() {
+    let state = state_with_messages();
+    let (mut terminal, theme) = test_utils::setup_render(60, 3);
+    terminal
+        .draw(|frame| {
+            ChatView::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_with_input_text() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::Input('H'));
+    ChatView::update(&mut state, ChatViewMessage::Input('e'));
+    ChatView::update(&mut state, ChatViewMessage::Input('l'));
+    ChatView::update(&mut state, ChatViewMessage::Input('l'));
+    ChatView::update(&mut state, ChatViewMessage::Input('o'));
+    let (mut terminal, theme) = test_utils::setup_render(60, 20);
+    terminal
+        .draw(|frame| {
+            ChatView::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+// =============================================================================
+// Focusable trait
+// =============================================================================
+
+#[test]
+fn test_focusable_trait() {
+    let mut state = ChatView::init();
+    assert!(!ChatView::is_focused(&state));
+
+    ChatView::focus(&mut state);
+    assert!(ChatView::is_focused(&state));
+
+    ChatView::blur(&mut state);
+    assert!(!ChatView::is_focused(&state));
+}
+
+// =============================================================================
+// PartialEq
+// =============================================================================
+
+#[test]
+fn test_partial_eq() {
+    let state1 = state_with_messages();
+    let state2 = state_with_messages();
+    assert_eq!(state1, state2);
+}
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
+#[test]
+fn test_submit_clears_input() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::Input('x'));
+    ChatView::update(&mut state, ChatViewMessage::Submit);
+    assert!(state.input_value().is_empty());
+}
+
+#[test]
+fn test_scroll_empty_history() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::ScrollDown);
+    assert_eq!(state.scroll_offset(), 0);
+}
+
+#[test]
+fn test_input_cursor_movement() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::Input('a'));
+    ChatView::update(&mut state, ChatViewMessage::Input('b'));
+    ChatView::update(&mut state, ChatViewMessage::Input('c'));
+    ChatView::update(&mut state, ChatViewMessage::Home);
+    ChatView::update(&mut state, ChatViewMessage::Right);
+    ChatView::update(&mut state, ChatViewMessage::Delete);
+    assert_eq!(state.input_value(), "ac");
+}
+
+#[test]
+fn test_multiline_submit() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::Input('l'));
+    ChatView::update(&mut state, ChatViewMessage::Input('1'));
+    ChatView::update(&mut state, ChatViewMessage::NewLine);
+    ChatView::update(&mut state, ChatViewMessage::Input('l'));
+    ChatView::update(&mut state, ChatViewMessage::Input('2'));
+    let output = ChatView::update(&mut state, ChatViewMessage::Submit);
+    assert_eq!(output, Some(ChatViewOutput::Submitted("l1\nl2".into())));
+}
+
+#[test]
+fn test_input_start_end() {
+    let mut state = focused_state();
+    ChatView::update(&mut state, ChatViewMessage::Input('a'));
+    ChatView::update(&mut state, ChatViewMessage::NewLine);
+    ChatView::update(&mut state, ChatViewMessage::Input('b'));
+    ChatView::update(&mut state, ChatViewMessage::InputStart);
+    // Cursor should be at (0,0) now
+    ChatView::update(&mut state, ChatViewMessage::Input('!'));
+    assert_eq!(state.input_value(), "!a\nb");
+}

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -126,6 +126,7 @@ mod searchable_list;
 mod split_panel;
 mod data_grid;
 mod log_viewer;
+mod chat_view;
 
 // Data components
 #[cfg(feature = "data-components")]
@@ -228,6 +229,7 @@ pub use split_panel::{
 };
 pub use data_grid::{DataGrid, DataGridMessage, DataGridOutput, DataGridState};
 pub use log_viewer::{LogViewer, LogViewerMessage, LogViewerOutput, LogViewerState};
+pub use chat_view::{ChatMessage, ChatRole, ChatView, ChatViewMessage, ChatViewOutput, ChatViewState};
 
 #[cfg(feature = "display-components")]
 pub use status_bar::{


### PR DESCRIPTION
## Summary
- Adds `ChatView` compound component with scrollable message history and multi-line `TextArea` input
- Three message roles (`ChatRole::User`, `System`, `Assistant`) with distinct color styling
- `Ctrl+Enter` submits, `Tab` toggles between history scrolling and input editing
- Auto-scroll to newest messages (disabled when user scrolls up, re-enabled at bottom)
- Supports timestamps, custom usernames, configurable input height, placeholder text
- Convenience methods: `push_user()`, `push_system()`, `push_assistant()` (with timestamp variants)
- Types: `ChatViewState`, `ChatViewMessage`, `ChatViewOutput`, `ChatMessage`, `ChatRole`

## Test plan
- [x] 82 unit tests covering construction, message manipulation, input editing, submit, focus management, scrolling, event mapping, rendering, and edge cases
- [x] 4 doc tests on module, `ChatViewState::new`, `ChatViewState::push_user`, `ChatMessage::new`
- [x] Full test suite: 2,162 unit + 230 doc tests passing
- [x] Clippy clean with `-D warnings`
- [x] Examples build successfully
- [x] Both files under 1000 lines (933 + 862)

🤖 Generated with [Claude Code](https://claude.com/claude-code)