### PR TITLE
Add Chart component with line, bar, and sparkline visualization

### DIFF
--- a/src/component/chart/mod.rs
+++ b/src/component/chart/mod.rs
@@ -1,0 +1,804 @@
+//! Chart components for data visualization.
+//!
+//! Provides line charts (sparkline with labels) and bar charts
+//! (horizontal/vertical) with data series, labels, colors, and
+//! auto-scaling axes.
+//!
+//! # Example
+//!
+//! ```rust
+//! use envision::component::{
+//!     Component, Chart, ChartState, ChartMessage, DataSeries, ChartKind,
+//! };
+//! use ratatui::style::Color;
+//!
+//! let series = DataSeries::new("Temperature", vec![20.0, 22.0, 25.0, 23.0])
+//!     .with_color(Color::Red);
+//! let mut state = ChartState::line(vec![series]);
+//! assert_eq!(state.series().len(), 1);
+//! assert_eq!(state.kind(), &ChartKind::Line);
+//! ```
+
+use std::marker::PhantomData;
+
+use ratatui::prelude::*;
+use ratatui::widgets::{Bar, BarChart, BarGroup, Block, Borders, Paragraph, Sparkline};
+
+use super::Component;
+use crate::input::{Event, KeyCode};
+use crate::theme::Theme;
+
+/// A named data series with values and styling.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DataSeries {
+    /// The series label.
+    label: String,
+    /// The data values.
+    values: Vec<f64>,
+    /// The display color.
+    color: Color,
+}
+
+impl DataSeries {
+    /// Creates a new data series.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    ///
+    /// let series = DataSeries::new("CPU", vec![10.0, 20.0, 30.0]);
+    /// assert_eq!(series.label(), "CPU");
+    /// assert_eq!(series.values(), &[10.0, 20.0, 30.0]);
+    /// ```
+    pub fn new(label: impl Into<String>, values: Vec<f64>) -> Self {
+        Self {
+            label: label.into(),
+            values,
+            color: Color::Cyan,
+        }
+    }
+
+    /// Sets the color (builder pattern).
+    pub fn with_color(mut self, color: Color) -> Self {
+        self.color = color;
+        self
+    }
+
+    /// Returns the label.
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// Returns the values.
+    pub fn values(&self) -> &[f64] {
+        &self.values
+    }
+
+    /// Returns the color.
+    pub fn color(&self) -> Color {
+        self.color
+    }
+
+    /// Appends a value.
+    pub fn push(&mut self, value: f64) {
+        self.values.push(value);
+    }
+
+    /// Appends a value, removing the oldest if over max length.
+    pub fn push_bounded(&mut self, value: f64, max_len: usize) {
+        self.values.push(value);
+        while self.values.len() > max_len {
+            self.values.remove(0);
+        }
+    }
+
+    /// Returns the minimum value, or 0.0 if empty.
+    pub fn min(&self) -> f64 {
+        self.values
+            .iter()
+            .copied()
+            .reduce(f64::min)
+            .unwrap_or(0.0)
+    }
+
+    /// Returns the maximum value, or 0.0 if empty.
+    pub fn max(&self) -> f64 {
+        self.values
+            .iter()
+            .copied()
+            .reduce(f64::max)
+            .unwrap_or(0.0)
+    }
+
+    /// Returns the most recent value.
+    pub fn last(&self) -> Option<f64> {
+        self.values.last().copied()
+    }
+
+    /// Returns the number of data points.
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Returns true if the series has no data points.
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    /// Clears all values.
+    pub fn clear(&mut self) {
+        self.values.clear();
+    }
+
+    /// Sets the label.
+    pub fn set_label(&mut self, label: impl Into<String>) {
+        self.label = label.into();
+    }
+
+    /// Sets the color.
+    pub fn set_color(&mut self, color: Color) {
+        self.color = color;
+    }
+}
+
+/// The kind of chart to display.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ChartKind {
+    /// A line chart (sparkline-style).
+    Line,
+    /// A vertical bar chart.
+    BarVertical,
+    /// A horizontal bar chart.
+    BarHorizontal,
+}
+
+/// Messages that can be sent to a Chart.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ChartMessage {
+    /// Cycle to the next series (for multi-series line charts).
+    NextSeries,
+    /// Cycle to the previous series.
+    PrevSeries,
+}
+
+/// Output messages from a Chart.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ChartOutput {
+    /// The active series changed.
+    ActiveSeriesChanged(usize),
+}
+
+/// State for a Chart component.
+///
+/// Contains the data series, chart kind, and display options.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ChartState {
+    /// The data series to display.
+    series: Vec<DataSeries>,
+    /// The chart kind.
+    kind: ChartKind,
+    /// Index of the active (highlighted) series.
+    active_series: usize,
+    /// Optional title.
+    title: Option<String>,
+    /// X-axis label.
+    x_label: Option<String>,
+    /// Y-axis label.
+    y_label: Option<String>,
+    /// Whether to show the legend.
+    show_legend: bool,
+    /// Maximum data points to display (for line charts).
+    max_display_points: usize,
+    /// Bar width for bar charts.
+    bar_width: u16,
+    /// Bar gap for bar charts.
+    bar_gap: u16,
+    /// Whether the component is focused.
+    focused: bool,
+    /// Whether the component is disabled.
+    disabled: bool,
+}
+
+impl Default for ChartState {
+    fn default() -> Self {
+        Self {
+            series: Vec::new(),
+            kind: ChartKind::Line,
+            active_series: 0,
+            title: None,
+            x_label: None,
+            y_label: None,
+            show_legend: true,
+            max_display_points: 50,
+            bar_width: 3,
+            bar_gap: 1,
+            focused: false,
+            disabled: false,
+        }
+    }
+}
+
+impl ChartState {
+    /// Creates a line chart state with the given series.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::line(vec![
+    ///     DataSeries::new("Series A", vec![1.0, 2.0, 3.0]),
+    /// ]);
+    /// assert_eq!(state.series().len(), 1);
+    /// ```
+    pub fn line(series: Vec<DataSeries>) -> Self {
+        Self {
+            series,
+            kind: ChartKind::Line,
+            ..Default::default()
+        }
+    }
+
+    /// Creates a vertical bar chart state.
+    pub fn bar_vertical(series: Vec<DataSeries>) -> Self {
+        Self {
+            series,
+            kind: ChartKind::BarVertical,
+            ..Default::default()
+        }
+    }
+
+    /// Creates a horizontal bar chart state.
+    pub fn bar_horizontal(series: Vec<DataSeries>) -> Self {
+        Self {
+            series,
+            kind: ChartKind::BarHorizontal,
+            ..Default::default()
+        }
+    }
+
+    /// Sets the title (builder pattern).
+    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Sets the X-axis label (builder pattern).
+    pub fn with_x_label(mut self, label: impl Into<String>) -> Self {
+        self.x_label = Some(label.into());
+        self
+    }
+
+    /// Sets the Y-axis label (builder pattern).
+    pub fn with_y_label(mut self, label: impl Into<String>) -> Self {
+        self.y_label = Some(label.into());
+        self
+    }
+
+    /// Sets whether to show the legend (builder pattern).
+    pub fn with_legend(mut self, show: bool) -> Self {
+        self.show_legend = show;
+        self
+    }
+
+    /// Sets the maximum display points for line charts (builder pattern).
+    pub fn with_max_display_points(mut self, max: usize) -> Self {
+        self.max_display_points = max;
+        self
+    }
+
+    /// Sets the bar width (builder pattern).
+    pub fn with_bar_width(mut self, width: u16) -> Self {
+        self.bar_width = width.max(1);
+        self
+    }
+
+    /// Sets the bar gap (builder pattern).
+    pub fn with_bar_gap(mut self, gap: u16) -> Self {
+        self.bar_gap = gap;
+        self
+    }
+
+    /// Sets the disabled state (builder pattern).
+    pub fn with_disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    // ---- Accessors ----
+
+    /// Returns the data series.
+    pub fn series(&self) -> &[DataSeries] {
+        &self.series
+    }
+
+    /// Returns a mutable reference to the series.
+    pub fn series_mut(&mut self) -> &mut [DataSeries] {
+        &mut self.series
+    }
+
+    /// Returns the series at the given index.
+    pub fn get_series(&self, index: usize) -> Option<&DataSeries> {
+        self.series.get(index)
+    }
+
+    /// Returns a mutable reference to the series at the given index.
+    pub fn get_series_mut(&mut self, index: usize) -> Option<&mut DataSeries> {
+        self.series.get_mut(index)
+    }
+
+    /// Returns the chart kind.
+    pub fn kind(&self) -> &ChartKind {
+        &self.kind
+    }
+
+    /// Sets the chart kind.
+    pub fn set_kind(&mut self, kind: ChartKind) {
+        self.kind = kind;
+    }
+
+    /// Returns the active series index.
+    pub fn active_series(&self) -> usize {
+        self.active_series
+    }
+
+    /// Returns the title.
+    pub fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    /// Sets the title.
+    pub fn set_title(&mut self, title: Option<String>) {
+        self.title = title;
+    }
+
+    /// Returns the X-axis label.
+    pub fn x_label(&self) -> Option<&str> {
+        self.x_label.as_deref()
+    }
+
+    /// Returns the Y-axis label.
+    pub fn y_label(&self) -> Option<&str> {
+        self.y_label.as_deref()
+    }
+
+    /// Returns whether the legend is shown.
+    pub fn show_legend(&self) -> bool {
+        self.show_legend
+    }
+
+    /// Returns the maximum display points.
+    pub fn max_display_points(&self) -> usize {
+        self.max_display_points
+    }
+
+    /// Returns the bar width.
+    pub fn bar_width(&self) -> u16 {
+        self.bar_width
+    }
+
+    /// Returns the bar gap.
+    pub fn bar_gap(&self) -> u16 {
+        self.bar_gap
+    }
+
+    /// Returns the number of series.
+    pub fn series_count(&self) -> usize {
+        self.series.len()
+    }
+
+    /// Returns true if there are no series.
+    pub fn is_empty(&self) -> bool {
+        self.series.is_empty()
+    }
+
+    /// Adds a series.
+    pub fn add_series(&mut self, series: DataSeries) {
+        self.series.push(series);
+    }
+
+    /// Clears all series.
+    pub fn clear_series(&mut self) {
+        self.series.clear();
+        self.active_series = 0;
+    }
+
+    /// Computes the global min value across all series.
+    pub fn global_min(&self) -> f64 {
+        self.series
+            .iter()
+            .map(|s| s.min())
+            .reduce(f64::min)
+            .unwrap_or(0.0)
+    }
+
+    /// Computes the global max value across all series.
+    pub fn global_max(&self) -> f64 {
+        self.series
+            .iter()
+            .map(|s| s.max())
+            .reduce(f64::max)
+            .unwrap_or(0.0)
+    }
+
+    // ---- Instance methods ----
+
+    /// Returns true if the component is focused.
+    pub fn is_focused(&self) -> bool {
+        self.focused
+    }
+
+    /// Sets the focus state.
+    pub fn set_focused(&mut self, focused: bool) {
+        self.focused = focused;
+    }
+
+    /// Returns true if the component is disabled.
+    pub fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    /// Sets the disabled state.
+    pub fn set_disabled(&mut self, disabled: bool) {
+        self.disabled = disabled;
+    }
+
+    /// Maps an input event to a chart message.
+    pub fn handle_event(&self, event: &Event) -> Option<ChartMessage> {
+        Chart::handle_event(self, event)
+    }
+
+    /// Dispatches an event, updating state and returning any output.
+    pub fn dispatch_event(&mut self, event: &Event) -> Option<ChartOutput> {
+        Chart::dispatch_event(self, event)
+    }
+
+    /// Updates the state with a message, returning any output.
+    pub fn update(&mut self, msg: ChartMessage) -> Option<ChartOutput> {
+        Chart::update(self, msg)
+    }
+}
+
+/// A chart component for data visualization.
+///
+/// Supports line charts (sparkline-style), vertical bar charts, and
+/// horizontal bar charts with multiple data series.
+///
+/// # Key Bindings
+///
+/// - `Tab` — Cycle to next series
+/// - `BackTab` — Cycle to previous series
+pub struct Chart(PhantomData<()>);
+
+impl Component for Chart {
+    type State = ChartState;
+    type Message = ChartMessage;
+    type Output = ChartOutput;
+
+    fn init() -> Self::State {
+        ChartState::default()
+    }
+
+    fn handle_event(state: &Self::State, event: &Event) -> Option<Self::Message> {
+        if !state.focused || state.disabled {
+            return None;
+        }
+
+        let key = event.as_key()?;
+
+        match key.code {
+            KeyCode::Tab => Some(ChartMessage::NextSeries),
+            KeyCode::BackTab => Some(ChartMessage::PrevSeries),
+            _ => None,
+        }
+    }
+
+    fn update(state: &mut Self::State, msg: Self::Message) -> Option<Self::Output> {
+        if state.disabled || state.series.is_empty() {
+            return None;
+        }
+
+        let len = state.series.len();
+
+        match msg {
+            ChartMessage::NextSeries => {
+                state.active_series = (state.active_series + 1) % len;
+                Some(ChartOutput::ActiveSeriesChanged(state.active_series))
+            }
+            ChartMessage::PrevSeries => {
+                state.active_series = if state.active_series == 0 {
+                    len - 1
+                } else {
+                    state.active_series - 1
+                };
+                Some(ChartOutput::ActiveSeriesChanged(state.active_series))
+            }
+        }
+    }
+
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+        if area.height < 3 || area.width < 3 {
+            return;
+        }
+
+        let border_style = if state.disabled {
+            theme.disabled_style()
+        } else if state.focused {
+            theme.focused_border_style()
+        } else {
+            theme.border_style()
+        };
+
+        let mut block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(border_style);
+
+        if let Some(ref title) = state.title {
+            block = block.title(title.as_str());
+        }
+
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        if inner.height == 0 || inner.width == 0 || state.series.is_empty() {
+            return;
+        }
+
+        // Reserve space for legend and axis labels
+        let legend_height = if state.show_legend && state.series.len() > 1 {
+            1u16
+        } else {
+            0
+        };
+
+        let x_label_height = if state.x_label.is_some() { 1u16 } else { 0 };
+
+        let chart_area = if legend_height + x_label_height > 0 {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Min(1),
+                    Constraint::Length(legend_height),
+                    Constraint::Length(x_label_height),
+                ])
+                .split(inner);
+
+            // Render legend
+            if legend_height > 0 {
+                render_legend(state, frame, chunks[1]);
+            }
+
+            // Render x-axis label
+            if x_label_height > 0 {
+                if let Some(ref label) = state.x_label {
+                    let p = Paragraph::new(label.as_str())
+                        .alignment(Alignment::Center)
+                        .style(Style::default().fg(Color::DarkGray));
+                    frame.render_widget(p, chunks[2]);
+                }
+            }
+
+            chunks[0]
+        } else {
+            inner
+        };
+
+        match state.kind {
+            ChartKind::Line => render_line_chart(state, frame, chart_area, theme),
+            ChartKind::BarVertical => render_bar_chart(state, frame, chart_area, theme, false),
+            ChartKind::BarHorizontal => render_bar_chart(state, frame, chart_area, theme, true),
+        }
+    }
+}
+
+/// Renders the legend showing series labels and colors.
+fn render_legend(state: &ChartState, frame: &mut Frame, area: Rect) {
+    let spans: Vec<Span> = state
+        .series
+        .iter()
+        .enumerate()
+        .flat_map(|(i, s)| {
+            let marker = if i == state.active_series {
+                "●"
+            } else {
+                "○"
+            };
+            let separator = if i < state.series.len() - 1 {
+                "  "
+            } else {
+                ""
+            };
+            vec![
+                Span::styled(
+                    format!("{} {}{}", marker, s.label(), separator),
+                    Style::default().fg(s.color()),
+                ),
+            ]
+        })
+        .collect();
+
+    let line = Line::from(spans);
+    let paragraph = Paragraph::new(line).alignment(Alignment::Center);
+    frame.render_widget(paragraph, area);
+}
+
+/// Renders a line chart using sparkline.
+fn render_line_chart(
+    state: &ChartState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+) {
+    if state.series.is_empty() {
+        return;
+    }
+
+    // Show y-axis labels on the left
+    let y_label_width = if state.y_label.is_some() { 8u16 } else { 0 };
+
+    let (y_area, chart_area) = if y_label_width > 0 {
+        let chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Length(y_label_width), Constraint::Min(1)])
+            .split(area);
+        (Some(chunks[0]), chunks[1])
+    } else {
+        (None, area)
+    };
+
+    // Render y-axis min/max labels
+    if let Some(y_area) = y_area {
+        let global_max = state.global_max();
+        let global_min = state.global_min();
+        let max_text = format!("{:.1}", global_max);
+        let min_text = format!("{:.1}", global_min);
+
+        if y_area.height >= 2 {
+            let p_max = Paragraph::new(max_text)
+                .style(Style::default().fg(Color::DarkGray))
+                .alignment(Alignment::Right);
+            frame.render_widget(
+                p_max,
+                Rect::new(y_area.x, y_area.y, y_area.width, 1),
+            );
+
+            let p_min = Paragraph::new(min_text)
+                .style(Style::default().fg(Color::DarkGray))
+                .alignment(Alignment::Right);
+            frame.render_widget(
+                p_min,
+                Rect::new(
+                    y_area.x,
+                    y_area.y + y_area.height - 1,
+                    y_area.width,
+                    1,
+                ),
+            );
+        }
+    }
+
+    // For multi-series, stack sparklines vertically
+    if state.series.len() == 1 || chart_area.height < 2 {
+        // Single series: full area sparkline
+        let series = &state.series[state.active_series];
+        let data = series_to_sparkline_data(series, state.max_display_points);
+        let style = if state.disabled {
+            theme.disabled_style()
+        } else {
+            Style::default().fg(series.color())
+        };
+        let sparkline = Sparkline::default().data(&data).style(style);
+        frame.render_widget(sparkline, chart_area);
+    } else {
+        // Multi-series: divide height
+        let count = state.series.len() as u16;
+        let constraints: Vec<Constraint> = (0..count)
+            .map(|_| Constraint::Ratio(1, count as u32))
+            .collect();
+
+        let areas = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(constraints)
+            .split(chart_area);
+
+        for (i, series) in state.series.iter().enumerate() {
+            if let Some(sparkline_area) = areas.get(i) {
+                let data = series_to_sparkline_data(series, state.max_display_points);
+                let style = if state.disabled {
+                    theme.disabled_style()
+                } else if i == state.active_series {
+                    Style::default()
+                        .fg(series.color())
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(series.color())
+                };
+                let sparkline = Sparkline::default().data(&data).style(style);
+                frame.render_widget(sparkline, *sparkline_area);
+            }
+        }
+    }
+}
+
+/// Converts a data series to sparkline-compatible u64 data.
+fn series_to_sparkline_data(series: &DataSeries, max_points: usize) -> Vec<u64> {
+    let values = if series.values.len() > max_points {
+        &series.values[series.values.len() - max_points..]
+    } else {
+        &series.values
+    };
+
+    if values.is_empty() {
+        return Vec::new();
+    }
+
+    let min = values.iter().copied().reduce(f64::min).unwrap_or(0.0);
+    let max = values.iter().copied().reduce(f64::max).unwrap_or(0.0);
+    let range = max - min;
+
+    if range == 0.0 {
+        return values.iter().map(|_| 50).collect();
+    }
+
+    values
+        .iter()
+        .map(|v| ((v - min) / range * 100.0) as u64)
+        .collect()
+}
+
+/// Renders a bar chart.
+fn render_bar_chart(
+    state: &ChartState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    horizontal: bool,
+) {
+    if state.series.is_empty() {
+        return;
+    }
+
+    // For bar charts, use the first series (or active series)
+    let series = &state.series[state.active_series];
+    if series.is_empty() {
+        return;
+    }
+
+    let style = if state.disabled {
+        theme.disabled_style()
+    } else {
+        Style::default().fg(series.color())
+    };
+
+    // Create bars from the series values
+    let bars: Vec<Bar> = series
+        .values
+        .iter()
+        .enumerate()
+        .map(|(i, &v)| {
+            let label = format!("{}", i + 1);
+            Bar::default()
+                .value(v.max(0.0) as u64)
+                .label(Line::from(label))
+                .style(style)
+        })
+        .collect();
+
+    let group = BarGroup::default().bars(&bars);
+
+    let mut bar_chart = BarChart::default()
+        .data(group)
+        .bar_width(state.bar_width)
+        .bar_gap(state.bar_gap)
+        .bar_style(style);
+
+    if horizontal {
+        bar_chart = bar_chart.direction(Direction::Horizontal);
+    }
+
+    frame.render_widget(bar_chart, area);
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/component/chart/tests.rs
+++ b/src/component/chart/tests.rs
@@ -1,0 +1,548 @@
+use super::*;
+use crate::component::test_utils;
+
+fn sample_series() -> Vec<DataSeries> {
+    vec![
+        DataSeries::new("Series A", vec![10.0, 20.0, 30.0, 25.0, 15.0]),
+        DataSeries::new("Series B", vec![5.0, 15.0, 10.0, 20.0, 25.0])
+            .with_color(Color::Red),
+    ]
+}
+
+fn focused_line_chart() -> ChartState {
+    let mut state = ChartState::line(sample_series());
+    state.set_focused(true);
+    state
+}
+
+// =============================================================================
+// DataSeries
+// =============================================================================
+
+#[test]
+fn test_data_series_new() {
+    let s = DataSeries::new("CPU", vec![1.0, 2.0, 3.0]);
+    assert_eq!(s.label(), "CPU");
+    assert_eq!(s.values(), &[1.0, 2.0, 3.0]);
+    assert_eq!(s.color(), Color::Cyan);
+}
+
+#[test]
+fn test_data_series_with_color() {
+    let s = DataSeries::new("Test", vec![]).with_color(Color::Red);
+    assert_eq!(s.color(), Color::Red);
+}
+
+#[test]
+fn test_data_series_push() {
+    let mut s = DataSeries::new("Test", vec![1.0]);
+    s.push(2.0);
+    assert_eq!(s.values(), &[1.0, 2.0]);
+}
+
+#[test]
+fn test_data_series_push_bounded() {
+    let mut s = DataSeries::new("Test", vec![1.0, 2.0, 3.0]);
+    s.push_bounded(4.0, 3);
+    assert_eq!(s.values(), &[2.0, 3.0, 4.0]);
+}
+
+#[test]
+fn test_data_series_min_max() {
+    let s = DataSeries::new("Test", vec![5.0, 1.0, 10.0, 3.0]);
+    assert_eq!(s.min(), 1.0);
+    assert_eq!(s.max(), 10.0);
+}
+
+#[test]
+fn test_data_series_min_max_empty() {
+    let s = DataSeries::new("Empty", vec![]);
+    assert_eq!(s.min(), 0.0);
+    assert_eq!(s.max(), 0.0);
+}
+
+#[test]
+fn test_data_series_last() {
+    let s = DataSeries::new("Test", vec![1.0, 2.0, 3.0]);
+    assert_eq!(s.last(), Some(3.0));
+}
+
+#[test]
+fn test_data_series_last_empty() {
+    let s = DataSeries::new("Empty", vec![]);
+    assert_eq!(s.last(), None);
+}
+
+#[test]
+fn test_data_series_len() {
+    let s = DataSeries::new("Test", vec![1.0, 2.0]);
+    assert_eq!(s.len(), 2);
+    assert!(!s.is_empty());
+}
+
+#[test]
+fn test_data_series_is_empty() {
+    let s = DataSeries::new("Empty", vec![]);
+    assert!(s.is_empty());
+}
+
+#[test]
+fn test_data_series_clear() {
+    let mut s = DataSeries::new("Test", vec![1.0, 2.0]);
+    s.clear();
+    assert!(s.is_empty());
+}
+
+#[test]
+fn test_data_series_set_label() {
+    let mut s = DataSeries::new("Old", vec![]);
+    s.set_label("New");
+    assert_eq!(s.label(), "New");
+}
+
+#[test]
+fn test_data_series_set_color() {
+    let mut s = DataSeries::new("Test", vec![]);
+    s.set_color(Color::Green);
+    assert_eq!(s.color(), Color::Green);
+}
+
+// =============================================================================
+// ChartState construction
+// =============================================================================
+
+#[test]
+fn test_line_chart() {
+    let state = ChartState::line(sample_series());
+    assert_eq!(state.kind(), &ChartKind::Line);
+    assert_eq!(state.series_count(), 2);
+    assert_eq!(state.active_series(), 0);
+}
+
+#[test]
+fn test_bar_vertical() {
+    let state = ChartState::bar_vertical(sample_series());
+    assert_eq!(state.kind(), &ChartKind::BarVertical);
+}
+
+#[test]
+fn test_bar_horizontal() {
+    let state = ChartState::bar_horizontal(sample_series());
+    assert_eq!(state.kind(), &ChartKind::BarHorizontal);
+}
+
+#[test]
+fn test_default() {
+    let state = ChartState::default();
+    assert!(state.is_empty());
+    assert_eq!(state.kind(), &ChartKind::Line);
+    assert_eq!(state.max_display_points(), 50);
+    assert_eq!(state.bar_width(), 3);
+    assert_eq!(state.bar_gap(), 1);
+    assert!(state.show_legend());
+}
+
+#[test]
+fn test_with_title() {
+    let state = ChartState::line(vec![]).with_title("Chart");
+    assert_eq!(state.title(), Some("Chart"));
+}
+
+#[test]
+fn test_with_x_label() {
+    let state = ChartState::line(vec![]).with_x_label("Time");
+    assert_eq!(state.x_label(), Some("Time"));
+}
+
+#[test]
+fn test_with_y_label() {
+    let state = ChartState::line(vec![]).with_y_label("Value");
+    assert_eq!(state.y_label(), Some("Value"));
+}
+
+#[test]
+fn test_with_legend() {
+    let state = ChartState::line(vec![]).with_legend(false);
+    assert!(!state.show_legend());
+}
+
+#[test]
+fn test_with_max_display_points() {
+    let state = ChartState::line(vec![]).with_max_display_points(100);
+    assert_eq!(state.max_display_points(), 100);
+}
+
+#[test]
+fn test_with_bar_width() {
+    let state = ChartState::bar_vertical(vec![]).with_bar_width(5);
+    assert_eq!(state.bar_width(), 5);
+}
+
+#[test]
+fn test_with_bar_width_minimum() {
+    let state = ChartState::bar_vertical(vec![]).with_bar_width(0);
+    assert_eq!(state.bar_width(), 1);
+}
+
+#[test]
+fn test_with_bar_gap() {
+    let state = ChartState::bar_vertical(vec![]).with_bar_gap(2);
+    assert_eq!(state.bar_gap(), 2);
+}
+
+#[test]
+fn test_with_disabled() {
+    let state = ChartState::line(vec![]).with_disabled(true);
+    assert!(state.is_disabled());
+}
+
+// =============================================================================
+// State manipulation
+// =============================================================================
+
+#[test]
+fn test_add_series() {
+    let mut state = ChartState::line(vec![]);
+    state.add_series(DataSeries::new("New", vec![1.0]));
+    assert_eq!(state.series_count(), 1);
+}
+
+#[test]
+fn test_clear_series() {
+    let mut state = ChartState::line(sample_series());
+    state.clear_series();
+    assert!(state.is_empty());
+    assert_eq!(state.active_series(), 0);
+}
+
+#[test]
+fn test_get_series() {
+    let state = ChartState::line(sample_series());
+    assert_eq!(state.get_series(0).unwrap().label(), "Series A");
+    assert_eq!(state.get_series(99), None);
+}
+
+#[test]
+fn test_get_series_mut() {
+    let mut state = ChartState::line(sample_series());
+    state.get_series_mut(0).unwrap().push(40.0);
+    assert_eq!(state.get_series(0).unwrap().len(), 6);
+}
+
+#[test]
+fn test_series_mut() {
+    let mut state = ChartState::line(sample_series());
+    state.series_mut()[0].set_label("Modified");
+    assert_eq!(state.series()[0].label(), "Modified");
+}
+
+#[test]
+fn test_set_kind() {
+    let mut state = ChartState::line(vec![]);
+    state.set_kind(ChartKind::BarVertical);
+    assert_eq!(state.kind(), &ChartKind::BarVertical);
+}
+
+#[test]
+fn test_set_title() {
+    let mut state = ChartState::line(vec![]);
+    state.set_title(Some("Test".into()));
+    assert_eq!(state.title(), Some("Test"));
+    state.set_title(None);
+    assert_eq!(state.title(), None);
+}
+
+#[test]
+fn test_global_min_max() {
+    let state = ChartState::line(sample_series());
+    assert_eq!(state.global_min(), 5.0);
+    assert_eq!(state.global_max(), 30.0);
+}
+
+#[test]
+fn test_global_min_max_empty() {
+    let state = ChartState::line(vec![]);
+    assert_eq!(state.global_min(), 0.0);
+    assert_eq!(state.global_max(), 0.0);
+}
+
+// =============================================================================
+// Series cycling
+// =============================================================================
+
+#[test]
+fn test_next_series() {
+    let mut state = focused_line_chart();
+    let output = Chart::update(&mut state, ChartMessage::NextSeries);
+    assert_eq!(state.active_series(), 1);
+    assert_eq!(output, Some(ChartOutput::ActiveSeriesChanged(1)));
+}
+
+#[test]
+fn test_next_series_wraps() {
+    let mut state = focused_line_chart();
+    Chart::update(&mut state, ChartMessage::NextSeries);
+    let output = Chart::update(&mut state, ChartMessage::NextSeries);
+    assert_eq!(state.active_series(), 0);
+    assert_eq!(output, Some(ChartOutput::ActiveSeriesChanged(0)));
+}
+
+#[test]
+fn test_prev_series() {
+    let mut state = focused_line_chart();
+    Chart::update(&mut state, ChartMessage::NextSeries);
+    let output = Chart::update(&mut state, ChartMessage::PrevSeries);
+    assert_eq!(state.active_series(), 0);
+    assert_eq!(output, Some(ChartOutput::ActiveSeriesChanged(0)));
+}
+
+#[test]
+fn test_prev_series_wraps() {
+    let mut state = focused_line_chart();
+    let output = Chart::update(&mut state, ChartMessage::PrevSeries);
+    assert_eq!(state.active_series(), 1);
+    assert_eq!(output, Some(ChartOutput::ActiveSeriesChanged(1)));
+}
+
+// =============================================================================
+// Disabled state
+// =============================================================================
+
+#[test]
+fn test_disabled_ignores_messages() {
+    let mut state = focused_line_chart();
+    state.set_disabled(true);
+    let output = Chart::update(&mut state, ChartMessage::NextSeries);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_disabled_ignores_events() {
+    let mut state = focused_line_chart();
+    state.set_disabled(true);
+    let msg = Chart::handle_event(&state, &Event::key(KeyCode::Tab));
+    assert_eq!(msg, None);
+}
+
+// =============================================================================
+// Unfocused state
+// =============================================================================
+
+#[test]
+fn test_unfocused_ignores_events() {
+    let state = ChartState::line(sample_series());
+    let msg = Chart::handle_event(&state, &Event::key(KeyCode::Tab));
+    assert_eq!(msg, None);
+}
+
+// =============================================================================
+// Event mapping
+// =============================================================================
+
+#[test]
+fn test_tab_maps_to_next() {
+    let state = focused_line_chart();
+    assert_eq!(
+        Chart::handle_event(&state, &Event::key(KeyCode::Tab)),
+        Some(ChartMessage::NextSeries)
+    );
+}
+
+#[test]
+fn test_backtab_maps_to_prev() {
+    let state = focused_line_chart();
+    assert_eq!(
+        Chart::handle_event(&state, &Event::key(KeyCode::BackTab)),
+        Some(ChartMessage::PrevSeries)
+    );
+}
+
+// =============================================================================
+// Sparkline data conversion
+// =============================================================================
+
+#[test]
+fn test_series_to_sparkline_data() {
+    let s = DataSeries::new("Test", vec![0.0, 50.0, 100.0]);
+    let data = series_to_sparkline_data(&s, 50);
+    assert_eq!(data, vec![0, 50, 100]);
+}
+
+#[test]
+fn test_series_to_sparkline_data_constant() {
+    let s = DataSeries::new("Test", vec![5.0, 5.0, 5.0]);
+    let data = series_to_sparkline_data(&s, 50);
+    assert_eq!(data, vec![50, 50, 50]);
+}
+
+#[test]
+fn test_series_to_sparkline_data_bounded() {
+    let s = DataSeries::new("Test", vec![1.0, 2.0, 3.0, 4.0, 5.0]);
+    let data = series_to_sparkline_data(&s, 3);
+    assert_eq!(data.len(), 3); // Only last 3 points
+}
+
+#[test]
+fn test_series_to_sparkline_data_empty() {
+    let s = DataSeries::new("Test", vec![]);
+    let data = series_to_sparkline_data(&s, 50);
+    assert!(data.is_empty());
+}
+
+// =============================================================================
+// Instance methods
+// =============================================================================
+
+#[test]
+fn test_instance_handle_event() {
+    let state = focused_line_chart();
+    let msg = state.handle_event(&Event::key(KeyCode::Tab));
+    assert_eq!(msg, Some(ChartMessage::NextSeries));
+}
+
+#[test]
+fn test_instance_update() {
+    let mut state = focused_line_chart();
+    let output = state.update(ChartMessage::NextSeries);
+    assert_eq!(output, Some(ChartOutput::ActiveSeriesChanged(1)));
+}
+
+#[test]
+fn test_instance_dispatch_event() {
+    let mut state = focused_line_chart();
+    let output = state.dispatch_event(&Event::key(KeyCode::Tab));
+    assert_eq!(output, Some(ChartOutput::ActiveSeriesChanged(1)));
+}
+
+// =============================================================================
+// Rendering
+// =============================================================================
+
+#[test]
+fn test_render_empty() {
+    let state = ChartState::default();
+    let (mut terminal, theme) = test_utils::setup_render(60, 20);
+    terminal
+        .draw(|frame| {
+            Chart::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_line_chart() {
+    let state = focused_line_chart();
+    let (mut terminal, theme) = test_utils::setup_render(60, 20);
+    terminal
+        .draw(|frame| {
+            Chart::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_line_chart_with_labels() {
+    let state = ChartState::line(sample_series())
+        .with_title("Temperature")
+        .with_x_label("Time")
+        .with_y_label("°C");
+    let (mut terminal, theme) = test_utils::setup_render(60, 20);
+    terminal
+        .draw(|frame| {
+            Chart::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_bar_vertical() {
+    let state = ChartState::bar_vertical(vec![DataSeries::new(
+        "Values",
+        vec![10.0, 20.0, 30.0, 15.0],
+    )]);
+    let (mut terminal, theme) = test_utils::setup_render(60, 20);
+    terminal
+        .draw(|frame| {
+            Chart::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_bar_horizontal() {
+    let state = ChartState::bar_horizontal(vec![DataSeries::new(
+        "Values",
+        vec![10.0, 20.0, 30.0],
+    )]);
+    let (mut terminal, theme) = test_utils::setup_render(60, 20);
+    terminal
+        .draw(|frame| {
+            Chart::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_disabled() {
+    let state = ChartState::line(sample_series()).with_disabled(true);
+    let (mut terminal, theme) = test_utils::setup_render(60, 20);
+    terminal
+        .draw(|frame| {
+            Chart::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_small_area() {
+    let state = focused_line_chart();
+    let (mut terminal, theme) = test_utils::setup_render(60, 2);
+    terminal
+        .draw(|frame| {
+            Chart::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_single_series_no_legend() {
+    let state = ChartState::line(vec![DataSeries::new("Solo", vec![1.0, 2.0, 3.0])]);
+    let (mut terminal, theme) = test_utils::setup_render(60, 20);
+    terminal
+        .draw(|frame| {
+            Chart::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+}
+
+// =============================================================================
+// PartialEq
+// =============================================================================
+
+#[test]
+fn test_partial_eq() {
+    let state1 = ChartState::line(sample_series());
+    let state2 = ChartState::line(sample_series());
+    assert_eq!(state1, state2);
+}
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
+#[test]
+fn test_empty_chart_ignores_messages() {
+    let mut state = ChartState::line(vec![]);
+    state.set_focused(true);
+    let output = Chart::update(&mut state, ChartMessage::NextSeries);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_single_series_cycling() {
+    let mut state = ChartState::line(vec![DataSeries::new("Solo", vec![1.0])]);
+    state.set_focused(true);
+    let output = Chart::update(&mut state, ChartMessage::NextSeries);
+    assert_eq!(state.active_series(), 0);
+    assert_eq!(output, Some(ChartOutput::ActiveSeriesChanged(0)));
+}

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -128,6 +128,7 @@ mod data_grid;
 mod log_viewer;
 mod chat_view;
 mod metrics_dashboard;
+mod chart;
 
 // Data components
 #[cfg(feature = "data-components")]
@@ -232,6 +233,7 @@ pub use data_grid::{DataGrid, DataGridMessage, DataGridOutput, DataGridState};
 pub use log_viewer::{LogViewer, LogViewerMessage, LogViewerOutput, LogViewerState};
 pub use chat_view::{ChatMessage, ChatRole, ChatView, ChatViewMessage, ChatViewOutput, ChatViewState};
 pub use metrics_dashboard::{MetricKind, MetricWidget, MetricsDashboard, MetricsDashboardMessage, MetricsDashboardOutput, MetricsDashboardState};
+pub use chart::{Chart, ChartKind, ChartMessage, ChartOutput, ChartState, DataSeries};
 
 #[cfg(feature = "display-components")]
 pub use status_bar::{


### PR DESCRIPTION
## Summary
- Adds `Chart` component supporting line charts (sparkline-style), vertical bar charts, and horizontal bar charts
- `DataSeries` type with label, color, values, and operations: `push()`, `push_bounded()`, `min()`, `max()`, `last()`
- Multiple series support with Tab/BackTab cycling and visual legend
- Auto-scaling axes with optional Y-axis min/max labels and X-axis label
- Configurable: title, axis labels, legend toggle, max display points, bar width/gap
- Line charts use sparkline rendering with automatic f64→u64 normalization
- Bar charts use ratatui's `BarChart` widget with horizontal/vertical support
- Types: `ChartState`, `ChartMessage`, `ChartOutput`, `DataSeries`, `ChartKind`

## Test plan
- [x] 62 unit tests covering DataSeries operations, construction, series manipulation, cycling, event mapping, sparkline conversion, rendering, and edge cases
- [x] 3 doc tests on module, `ChartState::line`, `DataSeries::new`
- [x] Full test suite: 2,142 unit + 229 doc tests passing
- [x] Clippy clean with `-D warnings`
- [x] Examples build successfully
- [x] Both files under 1000 lines (804 + 548)

🤖 Generated with [Claude Code](https://claude.com/claude-code)