### PR TITLE
Add benchmark CI job with regression detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,54 @@ jobs:
         with:
           path: target/doc
 
+  bench:
+    name: Benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-bench-
+
+      - name: Restore baseline
+        uses: actions/cache@v4
+        with:
+          path: target/criterion
+          key: criterion-baseline-${{ github.base_ref || 'main' }}
+          restore-keys: |
+            criterion-baseline-main
+
+      - name: Run benchmarks
+        run: cargo bench --all-features
+
+      - name: Save baseline
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/cache/save@v4
+        with:
+          path: target/criterion
+          key: criterion-baseline-main
+
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: criterion-report
+          path: target/criterion
+          retention-days: 14
+
   deploy-docs:
     name: Deploy Documentation
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'


### PR DESCRIPTION
## Summary
- Adds a `bench` job to CI that runs all Criterion benchmarks on every PR and push to main
- Caches baseline results from main so PRs automatically compare against the last known baseline
- Saves updated baselines when merging to main for continuous regression tracking
- Uploads Criterion HTML reports as artifacts (14-day retention) for detailed analysis

## Test plan
- [ ] Verify CI workflow YAML is valid (no syntax errors)
- [ ] Confirm benchmark job appears in GitHub Actions
- [ ] Verify baseline caching works on main push
- [ ] Verify PR runs compare against cached baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)