### PR TITLE
Add compound-components feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ full = [
     "display-components",
     "navigation-components",
     "overlay-components",
+    "compound-components",
 ]
 
 # Component groups
@@ -29,6 +30,7 @@ data-components = []
 display-components = []
 navigation-components = []
 overlay-components = []
+compound-components = ["input-components", "data-components", "display-components"]
 
 serialization = ["dep:serde", "dep:serde_json", "compact_str/serde", "ratatui/serde"]
 tracing = ["dep:tracing"]

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -121,13 +121,21 @@ mod select;
 mod text_area;
 
 // Compound components
+#[cfg(feature = "compound-components")]
 mod form;
+#[cfg(feature = "compound-components")]
 mod searchable_list;
+#[cfg(feature = "compound-components")]
 mod split_panel;
+#[cfg(feature = "compound-components")]
 mod data_grid;
+#[cfg(feature = "compound-components")]
 mod log_viewer;
+#[cfg(feature = "compound-components")]
 mod chat_view;
+#[cfg(feature = "compound-components")]
 mod metrics_dashboard;
+#[cfg(feature = "compound-components")]
 mod chart;
 
 // Data components
@@ -222,17 +230,25 @@ pub use progress_bar::{ProgressBar, ProgressBarMessage, ProgressBarOutput, Progr
 pub use spinner::{Spinner, SpinnerMessage, SpinnerState, SpinnerStyle};
 
 // Compound components
+#[cfg(feature = "compound-components")]
 pub use form::{Form, FormField, FormFieldKind, FormMessage, FormOutput, FormState, FormValue};
+#[cfg(feature = "compound-components")]
 pub use searchable_list::{
     SearchableList, SearchableListMessage, SearchableListOutput, SearchableListState,
 };
+#[cfg(feature = "compound-components")]
 pub use split_panel::{
     SplitOrientation, SplitPanel, SplitPanelMessage, SplitPanelOutput, SplitPanelState,
 };
+#[cfg(feature = "compound-components")]
 pub use data_grid::{DataGrid, DataGridMessage, DataGridOutput, DataGridState};
+#[cfg(feature = "compound-components")]
 pub use log_viewer::{LogViewer, LogViewerMessage, LogViewerOutput, LogViewerState};
+#[cfg(feature = "compound-components")]
 pub use chat_view::{ChatMessage, ChatRole, ChatView, ChatViewMessage, ChatViewOutput, ChatViewState};
+#[cfg(feature = "compound-components")]
 pub use metrics_dashboard::{MetricKind, MetricWidget, MetricsDashboard, MetricsDashboardMessage, MetricsDashboardOutput, MetricsDashboardState};
+#[cfg(feature = "compound-components")]
 pub use chart::{Chart, ChartKind, ChartMessage, ChartOutput, ChartState, DataSeries};
 
 #[cfg(feature = "display-components")]


### PR DESCRIPTION
## Summary
- Adds a new `compound-components` feature flag that gates all 8 compound components: Form, SearchableList, SplitPanel, DataGrid, LogViewer, ChatView, MetricsDashboard, Chart
- The feature transitively enables `input-components`, `data-components`, and `display-components` (the dependencies compound components need)
- Added to the `full` feature, so default behavior is unchanged
- Users who only need basic component groups can now skip compiling compound components

## Test plan
- [x] `cargo check --all-features` passes
- [x] `cargo check --no-default-features` compiles (compound components excluded)
- [x] `cargo check --no-default-features --features input-components` compiles clean
- [x] `cargo test --all-features` passes (2882 unit + 267 doc)
- [x] `cargo clippy --all-features -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)