### PR TITLE
Replace standalone trace events with span-based tracing hierarchies

### DIFF
--- a/src/app/runtime/mod.rs
+++ b/src/app/runtime/mod.rs
@@ -641,7 +641,7 @@ impl<A: App, B: Backend> Runtime<A, B> {
     /// Dispatches a message to update the state.
     pub fn dispatch(&mut self, msg: A::Message) {
         #[cfg(feature = "tracing")]
-        tracing::debug!("dispatch: updating state");
+        let _span = tracing::debug_span!("dispatch").entered();
 
         let cmd = A::update(&mut self.core.state, msg);
         self.commands.execute(cmd);
@@ -687,10 +687,10 @@ impl<A: App, B: Backend> Runtime<A, B> {
 
     /// Processes messages received from async tasks.
     fn process_async_messages(&mut self) {
-        while let Ok(msg) = self.message_rx.try_recv() {
-            #[cfg(feature = "tracing")]
-            tracing::debug!("processing async message");
+        #[cfg(feature = "tracing")]
+        let _span = tracing::debug_span!("process_async_messages").entered();
 
+        while let Ok(msg) = self.message_rx.try_recv() {
             self.dispatch(msg);
         }
     }
@@ -737,7 +737,7 @@ impl<A: App, B: Backend> Runtime<A, B> {
     /// - [`run_ticks`](Runtime::run_ticks) — Convenience: run N full tick cycles
     pub fn tick(&mut self) -> io::Result<()> {
         #[cfg(feature = "tracing")]
-        tracing::trace!("tick: start");
+        let _span = tracing::debug_span!("tick").entered();
 
         // Process pending commands
         self.process_commands();

--- a/src/app/runtime_core/mod.rs
+++ b/src/app/runtime_core/mod.rs
@@ -35,7 +35,7 @@ impl<A: App, B: Backend> RuntimeCore<A, B> {
     /// Renders the main app view first, then any active overlays on top.
     pub(crate) fn render(&mut self) -> io::Result<()> {
         #[cfg(feature = "tracing")]
-        tracing::trace!("render: drawing frame");
+        let _span = tracing::debug_span!("render").entered();
 
         let theme = &self.theme;
         let overlay_stack = &self.overlay_stack;

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -357,14 +357,15 @@ pub trait Component: Sized {
     /// identical to calling `view` directly.
     fn traced_view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
         #[cfg(feature = "tracing")]
-        tracing::trace!(
+        let _span = tracing::trace_span!(
+            "component_view",
             component = std::any::type_name::<Self>(),
             area.x = area.x,
             area.y = area.y,
             area.width = area.width,
             area.height = area.height,
-            "view: rendering component"
-        );
+        )
+        .entered();
         Self::view(state, frame, area, theme);
     }
 
@@ -392,17 +393,14 @@ pub trait Component: Sized {
     fn dispatch_event(state: &mut Self::State, event: &Event) -> Option<Self::Output> {
         if let Some(msg) = Self::handle_event(state, event) {
             #[cfg(feature = "tracing")]
-            tracing::debug!(
+            let _span = tracing::debug_span!(
+                "component_dispatch",
                 component = std::any::type_name::<Self>(),
-                "dispatch_event: updating state"
-            );
+            )
+            .entered();
             let output = Self::update(state, msg);
             #[cfg(feature = "tracing")]
-            tracing::trace!(
-                component = std::any::type_name::<Self>(),
-                has_output = output.is_some(),
-                "dispatch_event: update complete"
-            );
+            tracing::trace!(has_output = output.is_some(), "update complete");
             output
         } else {
             None


### PR DESCRIPTION
## Summary
- Replace standalone `tracing::trace!`/`tracing::debug!` calls with `tracing::debug_span!`/`tracing::trace_span!` in `tick()`, `dispatch()`, `process_async_messages()`, `render()`, `dispatch_event()`, and `traced_view()`
- Enables hierarchical grouping of related events within a tick cycle (e.g., render events nested under tick span)
- All behind `#[cfg(feature = "tracing")]` — zero cost when feature is disabled
- Net -2 lines changed

## Test plan
- [x] `cargo test` — all tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo check --features tracing` — compiles with tracing enabled
- [x] `cargo check --no-default-features` — compiles
- [x] `cargo test --doc` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)