### PR TITLE
Feature-gate undo module behind input-components

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,7 @@ pub mod layout;
 pub mod overlay;
 pub mod style;
 pub mod theme;
+#[cfg(feature = "input-components")]
 pub(crate) mod undo;
 
 // Re-export commonly used types


### PR DESCRIPTION
## Summary
- Gate `pub(crate) mod undo` with `#[cfg(feature = "input-components")]` in `src/lib.rs`
- The undo module is only used by InputField and TextArea (both behind `input-components`), but was always compiled, producing dead-code warnings under `--no-default-features`

## Verification
- `cargo check --no-default-features` produces zero warnings
- `cargo check --all-features` produces zero warnings
- All undo-related tests pass

## Test plan
- [x] `cargo check --no-default-features` — zero warnings
- [x] `cargo test --all-features -- undo` — all 67 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)