### PR TITLE
Exclude clipboard feature from MSRV 1.81 CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,20 @@ jobs:
             ${{ runner.os }}-cargo-${{ matrix.rust }}-
 
       - name: Run tests
-        run: cargo test --all-features --verbose
+        run: |
+          if [ "${{ matrix.rust }}" = "stable" ]; then
+            cargo test --all-features --verbose
+          else
+            cargo test --features serialization,input-components,data-components,display-components,navigation-components,overlay-components,compound-components --verbose
+          fi
 
       - name: Build examples
-        run: cargo build --examples
+        run: |
+          if [ "${{ matrix.rust }}" = "stable" ]; then
+            cargo build --examples
+          else
+            cargo build --examples --features serialization,input-components,data-components,display-components,navigation-components,overlay-components,compound-components
+          fi
 
   no-default-features:
     name: No Default Features


### PR DESCRIPTION
## Summary
- Excludes the `clipboard` feature from MSRV 1.81 test and build steps in CI
- The `clipboard` feature pulls in `arboard → image → moxcms`, and `moxcms 0.7.11` uses `Cargo.toml` syntax that Rust 1.81's cargo cannot parse
- Stable toolchain continues to test with `--all-features` for full coverage
- All other features (serialization, all component groups) remain tested on MSRV

## Test plan
- [ ] MSRV 1.81 CI jobs pass (no `moxcms` in dependency graph without `clipboard`)
- [ ] Stable CI jobs still test with `--all-features`
- [ ] Examples build on both stable and MSRV

🤖 Generated with [Claude Code](https://claude.com/claude-code)