### PR TITLE
Add CI check requirement before merging PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,3 +6,4 @@
 - Do not commit directly to the main branch
 - Create a feature branch for each change, then open a PR
 - Each independent piece of work gets its own feature branch and PR. Do not bundle unrelated changes into a single branch. If there are 5 independent improvements to make, that means 5 branches and 5 PRs.
+- Before merging a PR, always check CI status with `gh pr checks <number>`. Do not attempt to merge until all required checks have passed. If checks are failing, investigate and resolve the failures first.


### PR DESCRIPTION
## Summary
- Adds instruction to CLAUDE.md requiring CI status checks (`gh pr checks`) before attempting to merge any PR
- Prevents premature merge attempts that fail due to branch protection rules

## Test plan
- [ ] Verify CLAUDE.md content is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)