### PR TITLE
Add run_terminal_blocking() convenience method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ tracing = { version = "0.1", optional = true }
 arboard = { version = "3", optional = true }
 unicode-width = "0.2"
 compact_str = "0.8"
-tokio = { version = "1", features = ["sync", "rt", "macros", "time", "fs"] }
+tokio = { version = "1", features = ["sync", "rt", "rt-multi-thread", "macros", "time", "fs"] }
 tokio-stream = "0.1"
 tokio-util = "0.7"
 async-stream = "0.3"

--- a/src/app/runtime/mod.rs
+++ b/src/app/runtime/mod.rs
@@ -341,6 +341,25 @@ impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
         result.and(cleanup_result)
     }
 
+    /// Runs the interactive terminal event loop, blocking the current thread.
+    ///
+    /// This is a convenience wrapper around [`run_terminal`](Runtime::run_terminal) for
+    /// applications that don't want to set up their own tokio runtime. It creates
+    /// a multi-threaded tokio runtime internally and blocks on the async event loop.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// // requires real terminal
+    /// fn main() -> std::io::Result<()> {
+    ///     Runtime::<MyApp>::new_terminal()?.run_terminal_blocking()
+    /// }
+    /// ```
+    pub fn run_terminal_blocking(self) -> io::Result<()> {
+        let rt = tokio::runtime::Runtime::new().map_err(io::Error::other)?;
+        rt.block_on(self.run_terminal())
+    }
+
     /// Converts a crossterm event to our Event type.
     fn convert_crossterm_event(event: &CrosstermEvent) -> Option<Event> {
         match event {

--- a/src/app/runtime/tests/mod.rs
+++ b/src/app/runtime/tests/mod.rs
@@ -1,7 +1,9 @@
 mod async_tests;
 
 use super::*;
+use ratatui::backend::CrosstermBackend;
 use ratatui::widgets::Paragraph;
+use std::io::{self, Stdout};
 
 struct CounterApp;
 
@@ -572,6 +574,15 @@ fn test_virtual_terminal_find_text() {
 
     let positions = vt.find_text("Not Here");
     assert!(positions.is_empty());
+}
+
+#[test]
+fn test_run_terminal_blocking_exists() {
+    // Verify that run_terminal_blocking is available on the terminal runtime type.
+    // We can't actually call it (requires a real terminal), but we can verify
+    // the method exists by taking a function pointer to it.
+    let _: fn(Runtime<CounterApp, CrosstermBackend<Stdout>>) -> io::Result<()> =
+        Runtime::<CounterApp, CrosstermBackend<Stdout>>::run_terminal_blocking;
 }
 
 // =========================================================================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,15 @@
 //! }
 //! ```
 //!
+//! Or without your own tokio runtime:
+//!
+//! ```rust,ignore
+//! // requires real terminal
+//! fn main() -> std::io::Result<()> {
+//!     Runtime::<MyApp>::new_terminal()?.run_terminal_blocking()
+//! }
+//! ```
+//!
 //! ### Virtual Terminal Mode - For Programmatic Control
 //!
 //! ```rust


### PR DESCRIPTION
## Summary
- Adds `run_terminal_blocking()` method on `Runtime<A, CrosstermBackend<Stdout>>` for sync entry points that don't want to set up their own tokio runtime
- Adds `rt-multi-thread` tokio feature to support multi-threaded runtime creation
- Updates lib.rs doc examples to show blocking usage pattern

Closes #121

## Test plan
- [x] Unit test verifying method exists and compiles (`test_run_terminal_blocking_exists`)
- [x] `cargo test --all-features` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)