### PR TITLE
Rename OverlayAction::Message to OverlayAction::KeepAndMessage

### DIFF
--- a/src/app/runtime/mod.rs
+++ b/src/app/runtime/mod.rs
@@ -258,7 +258,7 @@ impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
                             if let Some(envision_event) = Self::convert_crossterm_event(&event) {
                                 match self.core.overlay_stack.handle_event(&envision_event) {
                                     OverlayAction::Consumed => {}
-                                    OverlayAction::Message(msg) => self.dispatch(msg),
+                                    OverlayAction::KeepAndMessage(msg) => self.dispatch(msg),
                                     OverlayAction::Dismiss => {
                                         self.core.overlay_stack.pop();
                                     }

--- a/src/app/runtime/tests/mod.rs
+++ b/src/app/runtime/tests/mod.rs
@@ -802,11 +802,11 @@ mod overlay_tests {
 
     #[test]
     fn test_runtime_overlay_message_from_event() {
-        // Test the OverlayAction::Message path in process_event
+        // Test the OverlayAction::KeepAndMessage path in process_event
         struct MsgOverlay;
         impl Overlay<EventMsg> for MsgOverlay {
             fn handle_event(&mut self, _event: &Event) -> OverlayAction<EventMsg> {
-                OverlayAction::Message(EventMsg::KeyPressed('z'))
+                OverlayAction::KeepAndMessage(EventMsg::KeyPressed('z'))
             }
             fn view(&self, _frame: &mut Frame, _area: Rect, _theme: &Theme) {}
         }

--- a/src/app/runtime_core/mod.rs
+++ b/src/app/runtime_core/mod.rs
@@ -61,7 +61,7 @@ impl<A: App, B: Backend> RuntimeCore<A, B> {
         if let Some(event) = self.events.pop() {
             match self.overlay_stack.handle_event(&event) {
                 OverlayAction::Consumed => ProcessEventResult::Consumed,
-                OverlayAction::Message(msg) => ProcessEventResult::Dispatch(msg),
+                OverlayAction::KeepAndMessage(msg) => ProcessEventResult::Dispatch(msg),
                 OverlayAction::Dismiss => {
                     self.overlay_stack.pop();
                     ProcessEventResult::Consumed

--- a/src/app/runtime_core/tests.rs
+++ b/src/app/runtime_core/tests.rs
@@ -80,7 +80,7 @@ struct MessageOverlay {
 
 impl Overlay<TestMsg> for MessageOverlay {
     fn handle_event(&mut self, _event: &Event) -> OverlayAction<TestMsg> {
-        OverlayAction::Message(TestMsg::FromOverlay(self.msg.clone()))
+        OverlayAction::KeepAndMessage(TestMsg::FromOverlay(self.msg.clone()))
     }
 
     fn view(&self, _frame: &mut ratatui::Frame, _area: Rect, _theme: &Theme) {}

--- a/src/overlay/action.rs
+++ b/src/overlay/action.rs
@@ -6,8 +6,8 @@
 pub enum OverlayAction<M> {
     /// Event was consumed by the overlay, stop propagation.
     Consumed,
-    /// Event produced a message to dispatch through `update()`.
-    Message(M),
+    /// Event produced a message; keep the overlay and dispatch it through `update()`.
+    KeepAndMessage(M),
     /// Dismiss (pop) this overlay, event is consumed.
     Dismiss,
     /// Dismiss this overlay and dispatch a message.
@@ -24,7 +24,7 @@ mod tests {
     fn test_overlay_action_variants() {
         // Verify all variants can be constructed
         let _consumed: OverlayAction<i32> = OverlayAction::Consumed;
-        let _message: OverlayAction<i32> = OverlayAction::Message(42);
+        let _message: OverlayAction<i32> = OverlayAction::KeepAndMessage(42);
         let _dismiss: OverlayAction<i32> = OverlayAction::Dismiss;
         let _dismiss_with: OverlayAction<i32> = OverlayAction::DismissWithMessage(42);
         let _propagate: OverlayAction<i32> = OverlayAction::Propagate;

--- a/src/overlay/stack/tests.rs
+++ b/src/overlay/stack/tests.rs
@@ -27,7 +27,7 @@ struct MessageOverlay {
 
 impl Overlay<i32> for MessageOverlay {
     fn handle_event(&mut self, _event: &Event) -> OverlayAction<i32> {
-        OverlayAction::Message(self.value)
+        OverlayAction::KeepAndMessage(self.value)
     }
 
     fn view(&self, _frame: &mut Frame, _area: Rect, _theme: &Theme) {}
@@ -111,7 +111,7 @@ fn test_stack_handle_event_propagate_to_bottom() {
     let event = Event::char('a');
     let action = stack.handle_event(&event);
     // Top propagates, bottom produces message
-    assert!(matches!(action, OverlayAction::Message(42)));
+    assert!(matches!(action, OverlayAction::KeepAndMessage(42)));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Renames `OverlayAction::Message(M)` to `OverlayAction::KeepAndMessage(M)` for clarity
- The new name makes explicit that the overlay is kept (not dismissed) while the message is dispatched
- Updated across all 6 files (definition, runtime core, terminal runtime, and all tests)

Closes #123

## Test plan
- [x] All existing tests pass with the renamed variant
- [x] Grep confirms zero remaining `OverlayAction::Message` occurrences
- [x] `cargo test --all-features` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)