### PR TITLE
Exclude internal files from crates.io package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 documentation = "https://docs.rs/envision"
 keywords = ["tui", "terminal", "ratatui", "testing", "headless"]
 categories = ["command-line-interface", "development-tools::testing"]
+exclude = [".claude/", "CLAUDE.md"]
 
 [features]
 default = ["serialization", "full"]


### PR DESCRIPTION
## Summary
- Adds `exclude = [".claude/", "CLAUDE.md"]` to `[package]` section in Cargo.toml
- Prevents internal development files from being included in the published crate

## Test plan
- [x] `cargo package --list` no longer includes `.claude/` or `CLAUDE.md`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)