### PR TITLE
Split benchmarks into granular path-filtered jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,8 +202,52 @@ jobs:
         with:
           path: target/doc
 
-  bench:
-    name: Benchmarks
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      runtime: ${{ steps.filter.outputs.runtime }}
+      component-view: ${{ steps.filter.outputs.component-view }}
+      component-events: ${{ steps.filter.outputs.component-events }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'src/backend/**'
+              - 'benches/capture_backend.rs'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+            runtime:
+              - 'src/app/**'
+              - 'src/backend/**'
+              - 'src/overlay/**'
+              - 'benches/runtime.rs'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+            component-view:
+              - 'src/component/**'
+              - 'src/backend/**'
+              - 'src/theme/**'
+              - 'benches/component_view.rs'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+            component-events:
+              - 'src/component/**'
+              - 'src/input/**'
+              - 'benches/component_events.rs'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+
+  bench-backend:
+    name: Bench Backend
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -228,25 +272,175 @@ jobs:
         uses: actions/cache@v4
         with:
           path: target/criterion
-          key: criterion-baseline-${{ github.base_ref || 'main' }}
+          key: criterion-baseline-backend-${{ github.base_ref || 'main' }}
           restore-keys: |
-            criterion-baseline-main
+            criterion-baseline-backend-main
 
       - name: Run benchmarks
-        run: cargo bench --all-features
+        run: cargo bench --bench capture_backend --all-features
 
       - name: Save baseline
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: actions/cache/save@v4
         with:
           path: target/criterion
-          key: criterion-baseline-main
+          key: criterion-baseline-backend-main
 
       - name: Upload benchmark results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: criterion-report
+          name: criterion-report-backend
+          path: target/criterion
+          retention-days: 14
+
+  bench-runtime:
+    name: Bench Runtime
+    needs: changes
+    if: needs.changes.outputs.runtime == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-bench-
+
+      - name: Restore baseline
+        uses: actions/cache@v4
+        with:
+          path: target/criterion
+          key: criterion-baseline-runtime-${{ github.base_ref || 'main' }}
+          restore-keys: |
+            criterion-baseline-runtime-main
+
+      - name: Run benchmarks
+        run: cargo bench --bench runtime --all-features
+
+      - name: Save baseline
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/cache/save@v4
+        with:
+          path: target/criterion
+          key: criterion-baseline-runtime-main
+
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: criterion-report-runtime
+          path: target/criterion
+          retention-days: 14
+
+  bench-component-view:
+    name: Bench Component View
+    needs: changes
+    if: needs.changes.outputs.component-view == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-bench-
+
+      - name: Restore baseline
+        uses: actions/cache@v4
+        with:
+          path: target/criterion
+          key: criterion-baseline-component-view-${{ github.base_ref || 'main' }}
+          restore-keys: |
+            criterion-baseline-component-view-main
+
+      - name: Run benchmarks
+        run: cargo bench --bench component_view --all-features
+
+      - name: Save baseline
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/cache/save@v4
+        with:
+          path: target/criterion
+          key: criterion-baseline-component-view-main
+
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: criterion-report-component-view
+          path: target/criterion
+          retention-days: 14
+
+  bench-component-events:
+    name: Bench Component Events
+    needs: changes
+    if: needs.changes.outputs.component-events == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-bench-
+
+      - name: Restore baseline
+        uses: actions/cache@v4
+        with:
+          path: target/criterion
+          key: criterion-baseline-component-events-${{ github.base_ref || 'main' }}
+          restore-keys: |
+            criterion-baseline-component-events-main
+
+      - name: Run benchmarks
+        run: cargo bench --bench component_events --all-features
+
+      - name: Save baseline
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/cache/save@v4
+        with:
+          path: target/criterion
+          key: criterion-baseline-component-events-main
+
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: criterion-report-component-events
           path: target/criterion
           retention-days: 14
 


### PR DESCRIPTION
## Summary

- Replace the single `bench` CI job with a `changes` detection job + 4 independent benchmark jobs
- Uses `dorny/paths-filter@v3` to detect which source paths changed
- Each benchmark (backend, runtime, component-view, component-events) only runs when its dependencies are modified
- Per-benchmark criterion baselines and artifact uploads to avoid collisions

## Motivation

The single `bench` job runs all 4 benchmark suites (~25 min) on every PR regardless of what changed. A docs-only or single-component PR still waits for all benchmarks. This splits them so only relevant benchmarks run.

## Impact Examples

| Change | backend | runtime | component-view | component-events |
|--------|---------|---------|---------------|-----------------|
| `src/component/` only | SKIP | SKIP | RUN | RUN |
| `src/overlay/` only | SKIP | RUN | SKIP | SKIP |
| docs only | SKIP | SKIP | SKIP | SKIP |
| `Cargo.toml` | RUN | RUN | RUN | RUN |

## Test plan

- [ ] CI runs the `changes` detection job successfully
- [ ] Benchmark jobs are correctly skipped/triggered based on changed files
- [ ] Push to main still runs all 4 benchmark jobs
- [ ] All other CI jobs remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)