### PR TITLE
Refactor: extract selection methods from text_area/mod.rs

### DIFF
--- a/src/component/text_area/mod.rs
+++ b/src/component/text_area/mod.rs
@@ -53,6 +53,7 @@ fn system_clipboard_get() -> Option<String> {
 }
 
 mod cursor;
+mod selection;
 
 /// A snapshot of TextArea state for undo/redo.
 #[derive(Debug, Clone)]
@@ -386,79 +387,6 @@ impl TextAreaState {
         if self.cursor_row >= self.scroll_offset + visible_lines {
             self.scroll_offset = self.cursor_row - visible_lines + 1;
         }
-    }
-
-    /// Returns true if there is an active text selection.
-    pub fn has_selection(&self) -> bool {
-        match self.selection_anchor {
-            Some((r, c)) => r != self.cursor_row || c != self.cursor_col,
-            None => false,
-        }
-    }
-
-    /// Returns the ordered selection positions as `((start_row, start_col), (end_row, end_col))`.
-    pub fn selection_positions(&self) -> Option<((usize, usize), (usize, usize))> {
-        let (ar, ac) = self.selection_anchor?;
-        if ar == self.cursor_row && ac == self.cursor_col {
-            return None;
-        }
-        let a = (ar, ac);
-        let b = (self.cursor_row, self.cursor_col);
-        if a < b {
-            Some((a, b))
-        } else {
-            Some((b, a))
-        }
-    }
-
-    /// Returns the selected text, or None if no selection.
-    pub fn selected_text(&self) -> Option<String> {
-        let ((sr, sc), (er, ec)) = self.selection_positions()?;
-        if sr == er {
-            Some(self.lines[sr][sc..ec].to_string())
-        } else {
-            let mut result = self.lines[sr][sc..].to_string();
-            for row in (sr + 1)..er {
-                result.push('\n');
-                result.push_str(&self.lines[row]);
-            }
-            result.push('\n');
-            result.push_str(&self.lines[er][..ec]);
-            Some(result)
-        }
-    }
-
-    /// Returns the internal clipboard contents.
-    pub fn clipboard(&self) -> &str {
-        &self.clipboard
-    }
-
-    fn clear_selection(&mut self) {
-        self.selection_anchor = None;
-    }
-
-    fn ensure_selection_anchor(&mut self) {
-        if self.selection_anchor.is_none() {
-            self.selection_anchor = Some((self.cursor_row, self.cursor_col));
-        }
-    }
-
-    /// Deletes selected text. Returns deleted text or None.
-    fn delete_selection(&mut self) -> Option<String> {
-        let ((sr, sc), (er, ec)) = self.selection_positions()?;
-        let deleted = self.selected_text()?;
-        if sr == er {
-            self.lines[sr].drain(sc..ec);
-        } else {
-            let after = self.lines[er][ec..].to_string();
-            self.lines[sr].truncate(sc);
-            self.lines[sr].push_str(&after);
-            self.lines.drain((sr + 1)..=er);
-        }
-        self.cursor_row = sr;
-        self.cursor_col = sc;
-        self.selection_anchor = None;
-        Some(deleted)
     }
 
     /// Returns true if there are edits that can be undone.

--- a/src/component/text_area/selection.rs
+++ b/src/component/text_area/selection.rs
@@ -1,0 +1,80 @@
+/// Selection helpers for TextAreaState.
+///
+/// These are implementation details extracted to keep
+/// the main module under the 1000-line limit.
+use super::TextAreaState;
+
+impl TextAreaState {
+    /// Returns true if there is an active text selection.
+    pub fn has_selection(&self) -> bool {
+        match self.selection_anchor {
+            Some((r, c)) => r != self.cursor_row || c != self.cursor_col,
+            None => false,
+        }
+    }
+
+    /// Returns the ordered selection positions as `((start_row, start_col), (end_row, end_col))`.
+    pub fn selection_positions(&self) -> Option<((usize, usize), (usize, usize))> {
+        let (ar, ac) = self.selection_anchor?;
+        if ar == self.cursor_row && ac == self.cursor_col {
+            return None;
+        }
+        let a = (ar, ac);
+        let b = (self.cursor_row, self.cursor_col);
+        if a < b {
+            Some((a, b))
+        } else {
+            Some((b, a))
+        }
+    }
+
+    /// Returns the selected text, or None if no selection.
+    pub fn selected_text(&self) -> Option<String> {
+        let ((sr, sc), (er, ec)) = self.selection_positions()?;
+        if sr == er {
+            Some(self.lines[sr][sc..ec].to_string())
+        } else {
+            let mut result = self.lines[sr][sc..].to_string();
+            for row in (sr + 1)..er {
+                result.push('\n');
+                result.push_str(&self.lines[row]);
+            }
+            result.push('\n');
+            result.push_str(&self.lines[er][..ec]);
+            Some(result)
+        }
+    }
+
+    /// Returns the internal clipboard contents.
+    pub fn clipboard(&self) -> &str {
+        &self.clipboard
+    }
+
+    pub(super) fn clear_selection(&mut self) {
+        self.selection_anchor = None;
+    }
+
+    pub(super) fn ensure_selection_anchor(&mut self) {
+        if self.selection_anchor.is_none() {
+            self.selection_anchor = Some((self.cursor_row, self.cursor_col));
+        }
+    }
+
+    /// Deletes selected text. Returns deleted text or None.
+    pub(super) fn delete_selection(&mut self) -> Option<String> {
+        let ((sr, sc), (er, ec)) = self.selection_positions()?;
+        let deleted = self.selected_text()?;
+        if sr == er {
+            self.lines[sr].drain(sc..ec);
+        } else {
+            let after = self.lines[er][ec..].to_string();
+            self.lines[sr].truncate(sc);
+            self.lines[sr].push_str(&after);
+            self.lines.drain((sr + 1)..=er);
+        }
+        self.cursor_row = sr;
+        self.cursor_col = sc;
+        self.selection_anchor = None;
+        Some(deleted)
+    }
+}


### PR DESCRIPTION
## Summary
- Extract 7 selection-related methods (`has_selection`, `selection_positions`, `selected_text`, `clipboard`, `clear_selection`, `ensure_selection_anchor`, `delete_selection`) from `text_area/mod.rs` into a new `text_area/selection.rs` submodule
- Follows the same pattern already used by `text_area/cursor.rs` for cursor/editing helpers
- Brings `mod.rs` from 1012 lines down to 939 lines, satisfying the project's 1000-line file limit

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes with zero warnings
- [x] `cargo test --all-features` passes (281 tests, 0 failures)
- [x] `cargo test --doc --all-features` passes (281 doc tests, 0 failures)
- [x] `wc -l` confirms mod.rs is 939 lines (under 1000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)