### PR TITLE
Add with_disabled() builder to ProgressBar, Spinner, StatusBar, KeyHints

### DIFF
--- a/src/component/key_hints/mod.rs
+++ b/src/component/key_hints/mod.rs
@@ -220,6 +220,8 @@ pub struct KeyHintsState {
     key_style: Style,
     /// Action style.
     action_style: Style,
+    /// Whether the component is disabled.
+    disabled: bool,
 }
 
 impl Default for KeyHintsState {
@@ -231,6 +233,7 @@ impl Default for KeyHintsState {
             hint_separator: "  ".to_string(),
             key_style: Style::default().fg(Color::Green),
             action_style: Style::default(),
+            disabled: false,
         }
     }
 }
@@ -422,6 +425,32 @@ impl KeyHintsState {
     /// Sets the action style.
     pub fn set_action_style(&mut self, style: Style) {
         self.action_style = style;
+    }
+
+    /// Returns true if the key hints are disabled.
+    pub fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    /// Sets the disabled state.
+    pub fn set_disabled(&mut self, disabled: bool) {
+        self.disabled = disabled;
+    }
+
+    /// Sets the disabled state using builder pattern.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHintsState;
+    ///
+    /// let state = KeyHintsState::new()
+    ///     .with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
+    pub fn with_disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
     }
 }
 

--- a/src/component/key_hints/tests.rs
+++ b/src/component/key_hints/tests.rs
@@ -354,6 +354,40 @@ fn test_view_inline_layout() {
 }
 
 // ========================================
+// Disabled Tests
+// ========================================
+
+#[test]
+fn test_with_disabled() {
+    let state = KeyHintsState::new().with_disabled(true);
+    assert!(state.is_disabled());
+}
+
+#[test]
+fn test_with_disabled_false() {
+    let state = KeyHintsState::new().with_disabled(false);
+    assert!(!state.is_disabled());
+}
+
+#[test]
+fn test_disabled_default_is_false() {
+    let state = KeyHintsState::new();
+    assert!(!state.is_disabled());
+}
+
+#[test]
+fn test_set_disabled() {
+    let mut state = KeyHintsState::new();
+    assert!(!state.is_disabled());
+
+    state.set_disabled(true);
+    assert!(state.is_disabled());
+
+    state.set_disabled(false);
+    assert!(!state.is_disabled());
+}
+
+// ========================================
 // Style Tests
 // ========================================
 

--- a/src/component/progress_bar/mod.rs
+++ b/src/component/progress_bar/mod.rs
@@ -65,6 +65,8 @@ pub struct ProgressBarState {
     progress: f32,
     /// Optional label to display.
     label: Option<String>,
+    /// Whether the component is disabled.
+    disabled: bool,
 }
 
 impl ProgressBarState {
@@ -99,6 +101,7 @@ impl ProgressBarState {
         Self {
             progress: progress.clamp(0.0, 1.0),
             label: None,
+            disabled: false,
         }
     }
 
@@ -116,6 +119,7 @@ impl ProgressBarState {
         Self {
             progress: 0.0,
             label: Some(label.into()),
+            disabled: false,
         }
     }
 
@@ -150,6 +154,32 @@ impl ProgressBarState {
     /// Sets the label.
     pub fn set_label(&mut self, label: Option<String>) {
         self.label = label;
+    }
+
+    /// Returns true if the progress bar is disabled.
+    pub fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    /// Sets the disabled state.
+    pub fn set_disabled(&mut self, disabled: bool) {
+        self.disabled = disabled;
+    }
+
+    /// Sets the disabled state using builder pattern.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressBarState;
+    ///
+    /// let state = ProgressBarState::new()
+    ///     .with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
+    pub fn with_disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
     }
 }
 

--- a/src/component/progress_bar/tests.rs
+++ b/src/component/progress_bar/tests.rs
@@ -260,6 +260,36 @@ fn test_view_without_label() {
 }
 
 #[test]
+fn test_with_disabled() {
+    let state = ProgressBarState::new().with_disabled(true);
+    assert!(state.is_disabled());
+}
+
+#[test]
+fn test_with_disabled_false() {
+    let state = ProgressBarState::new().with_disabled(false);
+    assert!(!state.is_disabled());
+}
+
+#[test]
+fn test_disabled_default_is_false() {
+    let state = ProgressBarState::new();
+    assert!(!state.is_disabled());
+}
+
+#[test]
+fn test_set_disabled() {
+    let mut state = ProgressBarState::new();
+    assert!(!state.is_disabled());
+
+    state.set_disabled(true);
+    assert!(state.is_disabled());
+
+    state.set_disabled(false);
+    assert!(!state.is_disabled());
+}
+
+#[test]
 fn test_full_workflow() {
     let mut state = ProgressBarState::with_label("Downloading");
 

--- a/src/component/spinner/mod.rs
+++ b/src/component/spinner/mod.rs
@@ -150,6 +150,8 @@ pub struct SpinnerState {
     spinning: bool,
     /// Optional label displayed next to the spinner.
     label: Option<String>,
+    /// Whether the component is disabled.
+    disabled: bool,
 }
 
 impl Default for SpinnerState {
@@ -159,6 +161,7 @@ impl Default for SpinnerState {
             frame: 0,
             spinning: true,
             label: None,
+            disabled: false,
         }
     }
 }
@@ -257,6 +260,32 @@ impl SpinnerState {
     /// Returns the current frame index.
     pub fn frame_index(&self) -> usize {
         self.frame
+    }
+
+    /// Returns true if the spinner is disabled.
+    pub fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    /// Sets the disabled state.
+    pub fn set_disabled(&mut self, disabled: bool) {
+        self.disabled = disabled;
+    }
+
+    /// Sets the disabled state using builder pattern.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SpinnerState;
+    ///
+    /// let state = SpinnerState::new()
+    ///     .with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
+    pub fn with_disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
     }
 }
 

--- a/src/component/spinner/tests.rs
+++ b/src/component/spinner/tests.rs
@@ -233,6 +233,36 @@ fn test_full_animation_cycle() {
 }
 
 #[test]
+fn test_with_disabled() {
+    let state = SpinnerState::new().with_disabled(true);
+    assert!(state.is_disabled());
+}
+
+#[test]
+fn test_with_disabled_false() {
+    let state = SpinnerState::new().with_disabled(false);
+    assert!(!state.is_disabled());
+}
+
+#[test]
+fn test_disabled_default_is_false() {
+    let state = SpinnerState::new();
+    assert!(!state.is_disabled());
+}
+
+#[test]
+fn test_set_disabled() {
+    let mut state = SpinnerState::new();
+    assert!(!state.is_disabled());
+
+    state.set_disabled(true);
+    assert!(state.is_disabled());
+
+    state.set_disabled(false);
+    assert!(!state.is_disabled());
+}
+
+#[test]
 fn test_default_matches_init() {
     let default_state = SpinnerState::default();
     let init_state = Spinner::init();

--- a/src/component/status_bar/mod.rs
+++ b/src/component/status_bar/mod.rs
@@ -189,6 +189,8 @@ pub struct StatusBarState {
     separator: String,
     /// Background style for the entire bar.
     background: Color,
+    /// Whether the component is disabled.
+    disabled: bool,
 }
 
 impl StatusBarState {
@@ -211,6 +213,7 @@ impl StatusBarState {
             right: Vec::new(),
             separator: " | ".to_string(),
             background: Color::DarkGray,
+            disabled: false,
         }
     }
 
@@ -331,6 +334,32 @@ impl StatusBarState {
     /// Sets the background color.
     pub fn set_background(&mut self, color: Color) {
         self.background = color;
+    }
+
+    /// Returns true if the status bar is disabled.
+    pub fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    /// Sets the disabled state.
+    pub fn set_disabled(&mut self, disabled: bool) {
+        self.disabled = disabled;
+    }
+
+    /// Sets the disabled state using builder pattern.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarState;
+    ///
+    /// let state = StatusBarState::new()
+    ///     .with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
+    pub fn with_disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
     }
 
     /// Returns true if all sections are empty.

--- a/src/component/status_bar/tests/state.rs
+++ b/src/component/status_bar/tests/state.rs
@@ -62,6 +62,38 @@ fn test_state_clear() {
     assert_eq!(state.len(), 0);
 }
 
+// Disabled tests
+
+#[test]
+fn test_with_disabled() {
+    let state = StatusBarState::new().with_disabled(true);
+    assert!(state.is_disabled());
+}
+
+#[test]
+fn test_with_disabled_false() {
+    let state = StatusBarState::new().with_disabled(false);
+    assert!(!state.is_disabled());
+}
+
+#[test]
+fn test_disabled_default_is_false() {
+    let state = StatusBarState::new();
+    assert!(!state.is_disabled());
+}
+
+#[test]
+fn test_set_disabled() {
+    let mut state = StatusBarState::new();
+    assert!(!state.is_disabled());
+
+    state.set_disabled(true);
+    assert!(state.is_disabled());
+
+    state.set_disabled(false);
+    assert!(!state.is_disabled());
+}
+
 // Section tests
 
 #[test]


### PR DESCRIPTION
## Summary

- Add disabled field to ProgressBarState, SpinnerState, StatusBarState, and KeyHintsState
- Add is_disabled(), set_disabled(), and with_disabled() methods to each, matching the pattern used by all other components
- Add tests for each component covering with_disabled(true), with_disabled(false), default disabled state, and set_disabled() round-trip

## Test plan

- [x] cargo test --all-features passes
- [x] cargo clippy --all-targets --all-features -- -D warnings clean
- [x] cargo test --doc --all-features passes
- [x] Serialization round-trip tests pass for all 4 components
- [x] No file exceeds 1000 lines

Generated with Claude Code