### PR TITLE
Add set_options() to RadioGroup and set_tabs() to Tabs

### DIFF
--- a/src/component/radio_group/mod.rs
+++ b/src/component/radio_group/mod.rs
@@ -154,6 +154,36 @@ impl<T: Clone> RadioGroupState<T> {
         &self.options
     }
 
+    /// Sets the available options.
+    ///
+    /// If the current selected index would be out of bounds for the new options,
+    /// it is clamped to the last valid index. If the new options are empty,
+    /// the selection is set to `None`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::RadioGroupState;
+    ///
+    /// let mut state = RadioGroupState::new(vec!["A", "B", "C"]);
+    /// assert_eq!(state.selected_index(), Some(0));
+    ///
+    /// state.set_options(vec!["X", "Y"]);
+    /// assert_eq!(state.options(), &["X", "Y"]);
+    /// assert_eq!(state.selected_index(), Some(0));
+    /// ```
+    pub fn set_options(&mut self, options: Vec<T>) {
+        self.options = options;
+
+        if self.options.is_empty() {
+            self.selected = None;
+        } else if let Some(idx) = self.selected {
+            if idx >= self.options.len() {
+                self.selected = Some(self.options.len() - 1);
+            }
+        }
+    }
+
     /// Returns the currently selected index.
     ///
     /// Returns `None` if the options are empty.

--- a/src/component/radio_group/tests.rs
+++ b/src/component/radio_group/tests.rs
@@ -434,3 +434,63 @@ fn test_selected_item_empty() {
     let state: RadioGroupState<&str> = RadioGroupState::new(vec![]);
     assert_eq!(state.selected_item(), None);
 }
+
+// ========== set_options Tests ==========
+
+#[test]
+fn test_set_options_updates_options() {
+    let mut state = RadioGroupState::new(vec!["A", "B", "C"]);
+    state.set_options(vec!["X", "Y", "Z"]);
+    assert_eq!(state.options(), &["X", "Y", "Z"]);
+    assert_eq!(state.len(), 3);
+}
+
+#[test]
+fn test_set_options_preserves_valid_selection() {
+    let mut state = RadioGroupState::new(vec!["A", "B", "C"]);
+    state.set_selected(1);
+    state.set_options(vec!["X", "Y", "Z"]);
+    assert_eq!(state.selected_index(), Some(1));
+}
+
+#[test]
+fn test_set_options_clamps_selection() {
+    let mut state = RadioGroupState::with_selected(vec!["A", "B", "C", "D", "E"], 4);
+    assert_eq!(state.selected_index(), Some(4));
+
+    state.set_options(vec!["X", "Y"]);
+    assert_eq!(state.selected_index(), Some(1)); // Clamped to last valid index
+    assert_eq!(state.selected(), Some(&"Y"));
+}
+
+#[test]
+fn test_set_options_empty_clears_selection() {
+    let mut state = RadioGroupState::new(vec!["A", "B", "C"]);
+    assert_eq!(state.selected_index(), Some(0));
+
+    state.set_options(Vec::<&str>::new());
+    assert_eq!(state.selected_index(), None);
+    assert!(state.is_empty());
+}
+
+#[test]
+fn test_set_options_from_empty_to_non_empty() {
+    let mut state = RadioGroupState::<&str>::new(vec![]);
+    assert_eq!(state.selected_index(), None);
+
+    state.set_options(vec!["X", "Y"]);
+    assert_eq!(state.options(), &["X", "Y"]);
+    // Selection remains None since there was no prior selection
+    assert_eq!(state.selected_index(), None);
+}
+
+#[test]
+fn test_set_options_selection_at_boundary() {
+    let mut state = RadioGroupState::with_selected(vec!["A", "B", "C"], 2);
+    assert_eq!(state.selected_index(), Some(2));
+
+    // Set options to exactly 3 items - index 2 is still valid
+    state.set_options(vec!["X", "Y", "Z"]);
+    assert_eq!(state.selected_index(), Some(2));
+    assert_eq!(state.selected(), Some(&"Z"));
+}

--- a/src/component/tabs/mod.rs
+++ b/src/component/tabs/mod.rs
@@ -189,6 +189,36 @@ impl<T: Clone> TabsState<T> {
         &self.tabs
     }
 
+    /// Sets the available tabs.
+    ///
+    /// If the current selected index would be out of bounds for the new tabs,
+    /// it is clamped to the last valid index. If the new tabs are empty,
+    /// the selection is set to `None`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TabsState;
+    ///
+    /// let mut state = TabsState::new(vec!["Home", "Settings", "Help"]);
+    /// assert_eq!(state.selected_index(), Some(0));
+    ///
+    /// state.set_tabs(vec!["Tab A", "Tab B"]);
+    /// assert_eq!(state.tabs(), &["Tab A", "Tab B"]);
+    /// assert_eq!(state.selected_index(), Some(0));
+    /// ```
+    pub fn set_tabs(&mut self, tabs: Vec<T>) {
+        self.tabs = tabs;
+
+        if self.tabs.is_empty() {
+            self.selected = None;
+        } else if let Some(idx) = self.selected {
+            if idx >= self.tabs.len() {
+                self.selected = Some(self.tabs.len() - 1);
+            }
+        }
+    }
+
     /// Returns the number of tabs.
     pub fn len(&self) -> usize {
         self.tabs.len()

--- a/src/component/tabs/tests.rs
+++ b/src/component/tabs/tests.rs
@@ -615,3 +615,63 @@ fn test_selected_item_empty() {
     let state: TabsState<&str> = TabsState::new(vec![]);
     assert_eq!(state.selected_item(), None);
 }
+
+// ========== set_tabs Tests ==========
+
+#[test]
+fn test_set_tabs_updates_tabs() {
+    let mut state = TabsState::new(vec!["A", "B", "C"]);
+    state.set_tabs(vec!["X", "Y", "Z"]);
+    assert_eq!(state.tabs(), &["X", "Y", "Z"]);
+    assert_eq!(state.len(), 3);
+}
+
+#[test]
+fn test_set_tabs_preserves_valid_selection() {
+    let mut state = TabsState::new(vec!["A", "B", "C"]);
+    state.set_selected(1);
+    state.set_tabs(vec!["X", "Y", "Z"]);
+    assert_eq!(state.selected_index(), Some(1));
+}
+
+#[test]
+fn test_set_tabs_clamps_selection() {
+    let mut state = TabsState::with_selected(vec!["A", "B", "C", "D", "E"], 4);
+    assert_eq!(state.selected_index(), Some(4));
+
+    state.set_tabs(vec!["X", "Y"]);
+    assert_eq!(state.selected_index(), Some(1)); // Clamped to last valid index
+    assert_eq!(state.selected(), Some(&"Y"));
+}
+
+#[test]
+fn test_set_tabs_empty_clears_selection() {
+    let mut state = TabsState::new(vec!["A", "B", "C"]);
+    assert_eq!(state.selected_index(), Some(0));
+
+    state.set_tabs(Vec::<&str>::new());
+    assert_eq!(state.selected_index(), None);
+    assert!(state.is_empty());
+}
+
+#[test]
+fn test_set_tabs_from_empty_to_non_empty() {
+    let mut state = TabsState::<&str>::new(vec![]);
+    assert_eq!(state.selected_index(), None);
+
+    state.set_tabs(vec!["X", "Y"]);
+    assert_eq!(state.tabs(), &["X", "Y"]);
+    // Selection remains None since there was no prior selection
+    assert_eq!(state.selected_index(), None);
+}
+
+#[test]
+fn test_set_tabs_selection_at_boundary() {
+    let mut state = TabsState::with_selected(vec!["A", "B", "C"], 2);
+    assert_eq!(state.selected_index(), Some(2));
+
+    // Set tabs to exactly 3 items - index 2 is still valid
+    state.set_tabs(vec!["X", "Y", "Z"]);
+    assert_eq!(state.selected_index(), Some(2));
+    assert_eq!(state.selected(), Some(&"Z"));
+}


### PR DESCRIPTION
## Summary
- Add `RadioGroupState::set_options()` method that updates the options list and clamps the selected index if out of bounds (or clears to `None` if the new list is empty)
- Add `TabsState::set_tabs()` method that updates the tabs list with the same index-clamping behavior
- Both methods follow the established pattern from `DropdownState::set_options()`

## Test plan
- [x] 6 new unit tests for `set_options()`: updates options, preserves valid selection, clamps out-of-bounds selection, clears selection on empty, handles empty-to-non-empty, boundary case
- [x] 6 new unit tests for `set_tabs()`: same test coverage as above
- [x] Doc tests on both new methods
- [x] Full test suite passes (`cargo test --all-features` -- 2930 unit + 283 doc tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] No file exceeds 1000 lines

Generated with [Claude Code](https://claude.com/claude-code)