### PR TITLE
Add doc tests to public methods on component State types

### DIFF
--- a/src/component/accordion/mod.rs
+++ b/src/component/accordion/mod.rs
@@ -222,6 +222,16 @@ impl AccordionState {
     }
 
     /// Returns the panels slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = AccordionState::from_pairs(vec![("A", "1"), ("B", "2")]);
+    /// assert_eq!(state.panels().len(), 2);
+    /// assert_eq!(state.panels()[0].title(), "A");
+    /// ```
     pub fn panels(&self) -> &[AccordionPanel] {
         &self.panels
     }
@@ -346,26 +356,84 @@ impl AccordionState {
     }
 
     /// Returns the count of expanded panels.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let panels = vec![
+    ///     AccordionPanel::new("A", "1").expanded(),
+    ///     AccordionPanel::new("B", "2"),
+    /// ];
+    /// let state = AccordionState::new(panels);
+    /// assert_eq!(state.expanded_count(), 1);
+    /// ```
     pub fn expanded_count(&self) -> usize {
         self.panels.iter().filter(|p| p.expanded).count()
     }
 
     /// Returns true if any panel is expanded.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let panels = vec![
+    ///     AccordionPanel::new("A", "1"),
+    ///     AccordionPanel::new("B", "2").expanded(),
+    /// ];
+    /// let state = AccordionState::new(panels);
+    /// assert!(state.is_any_expanded());
+    /// ```
     pub fn is_any_expanded(&self) -> bool {
         self.panels.iter().any(|p| p.expanded)
     }
 
     /// Returns true if all panels are expanded.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let panels = vec![
+    ///     AccordionPanel::new("A", "1").expanded(),
+    ///     AccordionPanel::new("B", "2").expanded(),
+    /// ];
+    /// let state = AccordionState::new(panels);
+    /// assert!(state.is_all_expanded());
+    /// ```
     pub fn is_all_expanded(&self) -> bool {
         !self.panels.is_empty() && self.panels.iter().all(|p| p.expanded)
     }
 
     /// Returns true if the accordion is focused.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = AccordionState::from_pairs(vec![("A", "1")]);
+    /// assert!(!state.is_focused());
+    /// ```
     pub fn is_focused(&self) -> bool {
         self.focused
     }
 
     /// Sets the focus state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = AccordionState::from_pairs(vec![("A", "1")]);
+    /// state.set_focused(true);
+    /// assert!(state.is_focused());
+    /// ```
     pub fn set_focused(&mut self, focused: bool) {
         self.focused = focused;
     }

--- a/src/component/dialog/mod.rs
+++ b/src/component/dialog/mod.rs
@@ -253,16 +253,45 @@ impl DialogState {
     }
 
     /// Returns the dialog title.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = DialogState::alert("Error", "Something went wrong.");
+    /// assert_eq!(state.title(), "Error");
+    /// ```
     pub fn title(&self) -> &str {
         &self.title
     }
 
     /// Returns the dialog message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = DialogState::alert("Error", "File not found.");
+    /// assert_eq!(state.message(), "File not found.");
+    /// ```
     pub fn message(&self) -> &str {
         &self.message
     }
 
     /// Returns the dialog buttons.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = DialogState::confirm("Delete?", "Are you sure?");
+    /// assert_eq!(state.buttons().len(), 2);
+    /// assert_eq!(state.buttons()[0].id(), "cancel");
+    /// assert_eq!(state.buttons()[1].id(), "ok");
+    /// ```
     pub fn buttons(&self) -> &[DialogButton] {
         &self.buttons
     }
@@ -383,11 +412,30 @@ impl DialogState {
     }
 
     /// Returns true if the dialog is focused.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = DialogState::alert("Info", "Done.");
+    /// assert!(!state.is_focused());
+    /// ```
     pub fn is_focused(&self) -> bool {
         self.focused
     }
 
     /// Sets the focus state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = DialogState::alert("Info", "Done.");
+    /// state.set_focused(true);
+    /// assert!(state.is_focused());
+    /// ```
     pub fn set_focused(&mut self, focused: bool) {
         self.focused = focused;
     }
@@ -409,11 +457,30 @@ impl DialogState {
     }
 
     /// Returns true if the dialog is visible.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = DialogState::alert("Info", "Done.");
+    /// assert!(!state.is_visible());
+    /// ```
     pub fn is_visible(&self) -> bool {
         self.visible
     }
 
     /// Sets the visibility state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = DialogState::alert("Info", "Done.");
+    /// state.set_visible(true);
+    /// assert!(state.is_visible());
+    /// ```
     pub fn set_visible(&mut self, visible: bool) {
         Dialog::set_visible(self, visible);
     }

--- a/src/component/input_field/mod.rs
+++ b/src/component/input_field/mod.rs
@@ -154,11 +154,31 @@ pub struct InputFieldState {
 
 impl InputFieldState {
     /// Creates a new empty input field state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = InputFieldState::new();
+    /// assert_eq!(state.value(), "");
+    /// assert_eq!(state.cursor_position(), 0);
+    /// ```
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Creates a new state with the given initial value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = InputFieldState::with_value("hello");
+    /// assert_eq!(state.value(), "hello");
+    /// assert_eq!(state.cursor_position(), 5);
+    /// ```
     pub fn with_value(value: impl Into<String>) -> Self {
         let value = value.into();
         let cursor = value.len();
@@ -175,6 +195,16 @@ impl InputFieldState {
     }
 
     /// Creates a new state with placeholder text.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = InputFieldState::with_placeholder("Enter name...");
+    /// assert_eq!(state.placeholder(), "Enter name...");
+    /// assert_eq!(state.value(), "");
+    /// ```
     pub fn with_placeholder(placeholder: impl Into<String>) -> Self {
         Self {
             value: String::new(),
@@ -189,11 +219,31 @@ impl InputFieldState {
     }
 
     /// Returns the current value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = InputFieldState::with_value("hello");
+    /// assert_eq!(state.value(), "hello");
+    /// ```
     pub fn value(&self) -> &str {
         &self.value
     }
 
     /// Sets the value and moves cursor to the end.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = InputFieldState::new();
+    /// state.set_value("world");
+    /// assert_eq!(state.value(), "world");
+    /// assert_eq!(state.cursor_position(), 5);
+    /// ```
     pub fn set_value(&mut self, value: impl Into<String>) {
         self.value = value.into();
         self.cursor = self.value.len();
@@ -201,6 +251,15 @@ impl InputFieldState {
     }
 
     /// Returns the cursor position (character index).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = InputFieldState::with_value("abc");
+    /// assert_eq!(state.cursor_position(), 3);
+    /// ```
     pub fn cursor_position(&self) -> usize {
         self.value[..self.cursor].chars().count()
     }
@@ -480,11 +539,30 @@ impl InputFieldState {
     }
 
     /// Returns true if the input field is focused.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = InputFieldState::new();
+    /// assert!(!state.is_focused());
+    /// ```
     pub fn is_focused(&self) -> bool {
         self.focused
     }
 
     /// Sets the focus state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = InputFieldState::new();
+    /// state.set_focused(true);
+    /// assert!(state.is_focused());
+    /// ```
     pub fn set_focused(&mut self, focused: bool) {
         self.focused = focused;
     }

--- a/src/component/menu/mod.rs
+++ b/src/component/menu/mod.rs
@@ -160,6 +160,19 @@ impl MenuState {
     }
 
     /// Returns the menu items.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = MenuState::new(vec![
+    ///     MenuItem::new("File"),
+    ///     MenuItem::new("Edit"),
+    /// ]);
+    /// assert_eq!(state.items().len(), 2);
+    /// assert_eq!(state.items()[0].label(), "File");
+    /// ```
     pub fn items(&self) -> &[MenuItem] {
         &self.items
     }
@@ -211,6 +224,18 @@ impl MenuState {
     /// Returns the currently selected item index.
     ///
     /// Returns `None` if the menu is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = MenuState::new(vec![MenuItem::new("File"), MenuItem::new("Edit")]);
+    /// assert_eq!(state.selected_index(), Some(0));
+    ///
+    /// let empty = MenuState::new(vec![]);
+    /// assert_eq!(empty.selected_index(), None);
+    /// ```
     pub fn selected_index(&self) -> Option<usize> {
         self.selected_index
     }
@@ -248,26 +273,73 @@ impl MenuState {
     }
 
     /// Returns the currently selected item.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = MenuState::new(vec![MenuItem::new("File"), MenuItem::new("Edit")]);
+    /// assert_eq!(state.selected_item().unwrap().label(), "File");
+    /// ```
     pub fn selected_item(&self) -> Option<&MenuItem> {
         self.items.get(self.selected_index?)
     }
 
     /// Returns true if the menu is focused.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = MenuState::new(vec![MenuItem::new("File")]);
+    /// assert!(!state.is_focused());
+    /// ```
     pub fn is_focused(&self) -> bool {
         self.focused
     }
 
     /// Sets the focus state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = MenuState::new(vec![MenuItem::new("File")]);
+    /// state.set_focused(true);
+    /// assert!(state.is_focused());
+    /// ```
     pub fn set_focused(&mut self, focused: bool) {
         self.focused = focused;
     }
 
     /// Returns true if the menu is disabled.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = MenuState::new(vec![MenuItem::new("File")]);
+    /// assert!(!state.is_disabled());
+    /// ```
     pub fn is_disabled(&self) -> bool {
         self.disabled
     }
 
     /// Sets the disabled state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = MenuState::new(vec![MenuItem::new("File")]);
+    /// state.set_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn set_disabled(&mut self, disabled: bool) {
         self.disabled = disabled;
     }

--- a/src/component/selectable_list/mod.rs
+++ b/src/component/selectable_list/mod.rs
@@ -104,11 +104,30 @@ impl<T: Clone> SelectableListState<T> {
     /// Creates a new state with the given items.
     ///
     /// If the items list is non-empty, the first item is selected.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = SelectableListState::new(vec!["apple", "banana", "cherry"]);
+    /// assert_eq!(state.selected_index(), Some(0));
+    /// assert_eq!(state.len(), 3);
+    /// ```
     pub fn new(items: Vec<T>) -> Self {
         Self::with_items(items)
     }
 
     /// Creates a new state with the given items.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = SelectableListState::with_items(vec![1, 2, 3]);
+    /// assert_eq!(state.selected_item(), Some(&1));
+    /// ```
     pub fn with_items(items: Vec<T>) -> Self {
         let filtered_indices: Vec<usize> = (0..items.len()).collect();
         let mut state = Self {
@@ -126,11 +145,31 @@ impl<T: Clone> SelectableListState<T> {
     }
 
     /// Returns a reference to the items.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = SelectableListState::new(vec!["a", "b", "c"]);
+    /// assert_eq!(state.items(), &["a", "b", "c"]);
+    /// ```
     pub fn items(&self) -> &[T] {
         &self.items
     }
 
     /// Sets the items, clearing any active filter and resetting selection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = SelectableListState::new(vec!["old"]);
+    /// state.set_items(vec!["new1", "new2"]);
+    /// assert_eq!(state.items(), &["new1", "new2"]);
+    /// assert_eq!(state.selected_index(), Some(0));
+    /// ```
     pub fn set_items(&mut self, items: Vec<T>) {
         self.items = items;
         self.filter_text.clear();
@@ -145,6 +184,18 @@ impl<T: Clone> SelectableListState<T> {
     }
 
     /// Returns the currently selected index in the original items list.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = SelectableListState::new(vec!["a", "b", "c"]);
+    /// assert_eq!(state.selected_index(), Some(0));
+    ///
+    /// let empty: SelectableListState<String> = SelectableListState::new(vec![]);
+    /// assert_eq!(empty.selected_index(), None);
+    /// ```
     pub fn selected_index(&self) -> Option<usize> {
         self.list_state
             .selected()
@@ -152,6 +203,15 @@ impl<T: Clone> SelectableListState<T> {
     }
 
     /// Returns a reference to the currently selected item.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = SelectableListState::new(vec!["a", "b", "c"]);
+    /// assert_eq!(state.selected_item(), Some(&"a"));
+    /// ```
     pub fn selected_item(&self) -> Option<&T> {
         self.selected_index().and_then(|i| self.items.get(i))
     }
@@ -159,6 +219,17 @@ impl<T: Clone> SelectableListState<T> {
     /// Selects the item at the given index in the original items list.
     ///
     /// If the item is filtered out, the selection is unchanged.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = SelectableListState::new(vec!["a", "b", "c"]);
+    /// state.select(Some(2));
+    /// assert_eq!(state.selected_index(), Some(2));
+    /// assert_eq!(state.selected_item(), Some(&"c"));
+    /// ```
     pub fn select(&mut self, index: Option<usize>) {
         match index {
             Some(i) if i < self.items.len() => {
@@ -172,11 +243,32 @@ impl<T: Clone> SelectableListState<T> {
     }
 
     /// Returns true if the list is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let empty: SelectableListState<i32> = SelectableListState::new(vec![]);
+    /// assert!(empty.is_empty());
+    ///
+    /// let non_empty = SelectableListState::new(vec![1]);
+    /// assert!(!non_empty.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()
     }
 
     /// Returns the number of items in the list.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = SelectableListState::new(vec!["a", "b", "c"]);
+    /// assert_eq!(state.len(), 3);
+    /// ```
     pub fn len(&self) -> usize {
         self.items.len()
     }
@@ -194,21 +286,59 @@ impl<T: Clone> SelectableListState<T> {
 
 impl<T: Clone + std::fmt::Display + 'static> SelectableListState<T> {
     /// Returns true if the selectable list is focused.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = SelectableListState::new(vec!["a", "b"]);
+    /// assert!(!state.is_focused());
+    /// ```
     pub fn is_focused(&self) -> bool {
         self.focused
     }
 
     /// Sets the focus state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = SelectableListState::new(vec!["a", "b"]);
+    /// state.set_focused(true);
+    /// assert!(state.is_focused());
+    /// ```
     pub fn set_focused(&mut self, focused: bool) {
         self.focused = focused;
     }
 
     /// Returns true if the selectable list is disabled.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = SelectableListState::new(vec!["a"]);
+    /// assert!(!state.is_disabled());
+    /// ```
     pub fn is_disabled(&self) -> bool {
         self.disabled
     }
 
     /// Sets the disabled state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = SelectableListState::new(vec!["a"]);
+    /// state.set_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn set_disabled(&mut self, disabled: bool) {
         self.disabled = disabled;
     }

--- a/src/component/table/mod.rs
+++ b/src/component/table/mod.rs
@@ -392,11 +392,49 @@ impl<T: TableRow> TableState<T> {
     }
 
     /// Returns a reference to the rows.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// #[derive(Clone, Debug, PartialEq)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = TableState::new(
+    ///     vec![Item { name: "A".into() }],
+    ///     vec![Column::fixed("Name", 10)],
+    /// );
+    /// assert_eq!(state.rows().len(), 1);
+    /// assert_eq!(state.rows()[0].name, "A");
+    /// ```
     pub fn rows(&self) -> &[T] {
         &self.rows
     }
 
     /// Returns a reference to the columns.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = TableState::new(
+    ///     vec![Item { name: "A".into() }],
+    ///     vec![Column::fixed("Name", 10)],
+    /// );
+    /// assert_eq!(state.columns().len(), 1);
+    /// assert_eq!(state.columns()[0].header(), "Name");
+    /// ```
     pub fn columns(&self) -> &[Column] {
         &self.columns
     }
@@ -411,6 +449,24 @@ impl<T: TableRow> TableState<T> {
     /// Returns a reference to the currently selected row.
     ///
     /// Returns `None` if no row is selected or the table is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// #[derive(Clone, Debug, PartialEq)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = TableState::new(
+    ///     vec![Item { name: "first".into() }, Item { name: "second".into() }],
+    ///     vec![Column::fixed("Name", 10)],
+    /// );
+    /// assert_eq!(state.selected_row().unwrap().name, "first");
+    /// ```
     pub fn selected_row(&self) -> Option<&T> {
         self.selected
             .and_then(|i| self.display_order.get(i))
@@ -465,6 +521,25 @@ impl<T: TableRow> TableState<T> {
     ///
     /// Pass `None` to clear the selection.
     /// Out of bounds indices are ignored.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let mut state = TableState::new(
+    ///     vec![Item { name: "A".into() }, Item { name: "B".into() }],
+    ///     vec![Column::fixed("Name", 10)],
+    /// );
+    /// state.set_selected(Some(1));
+    /// assert_eq!(state.selected_index(), Some(1));
+    /// ```
     pub fn set_selected(&mut self, index: Option<usize>) {
         match index {
             Some(i) if i < self.display_order.len() => self.selected = Some(i),

--- a/src/component/tree/mod.rs
+++ b/src/component/tree/mod.rs
@@ -287,6 +287,19 @@ impl<T: Clone> TreeState<T> {
     }
 
     /// Returns the root nodes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = TreeState::new(vec![
+    ///     TreeNode::new("Root 1", 1),
+    ///     TreeNode::new("Root 2", 2),
+    /// ]);
+    /// assert_eq!(state.roots().len(), 2);
+    /// assert_eq!(state.roots()[0].label(), "Root 1");
+    /// ```
     pub fn roots(&self) -> &[TreeNode<T>] {
         &self.roots
     }
@@ -300,6 +313,17 @@ impl<T: Clone> TreeState<T> {
     ///
     /// Resets selection to the first node, or `None` if the new roots are empty.
     /// Clears any active filter.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = TreeState::new(vec![TreeNode::new("Old", 0)]);
+    /// state.set_roots(vec![TreeNode::new("New 1", 1), TreeNode::new("New 2", 2)]);
+    /// assert_eq!(state.roots().len(), 2);
+    /// assert_eq!(state.selected_index(), Some(0));
+    /// ```
     pub fn set_roots(&mut self, roots: Vec<TreeNode<T>>) {
         self.roots = roots;
         self.filter_text.clear();
@@ -309,6 +333,18 @@ impl<T: Clone> TreeState<T> {
     /// Returns the currently selected index in the flattened view.
     ///
     /// Returns `None` if the tree is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = TreeState::new(vec![TreeNode::new("Root", ())]);
+    /// assert_eq!(state.selected_index(), Some(0));
+    ///
+    /// let empty: TreeState<()> = TreeState::new(vec![]);
+    /// assert_eq!(empty.selected_index(), None);
+    /// ```
     pub fn selected_index(&self) -> Option<usize> {
         self.selected_index
     }
@@ -452,6 +488,17 @@ impl<T: Clone> TreeState<T> {
     }
 
     /// Returns a reference to the currently selected node.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = TreeState::new(vec![TreeNode::new("Root", 42)]);
+    /// let node = state.selected_node().unwrap();
+    /// assert_eq!(node.label(), "Root");
+    /// assert_eq!(node.data(), &42);
+    /// ```
     pub fn selected_node(&self) -> Option<&TreeNode<T>> {
         let path = self.selected_path()?;
         self.get_node(&path)
@@ -461,11 +508,32 @@ impl<T: Clone> TreeState<T> {
     ///
     /// This is an alias for [`selected_node()`](Self::selected_node) that provides a
     /// consistent accessor name across all selection-based components.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = TreeState::new(vec![TreeNode::new("Root", 1)]);
+    /// assert_eq!(state.selected_item(), state.selected_node());
+    /// ```
     pub fn selected_item(&self) -> Option<&TreeNode<T>> {
         self.selected_node()
     }
 
     /// Expands all nodes in the tree.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut root = TreeNode::new("Root", ());
+    /// root.add_child(TreeNode::new("Child", ()));
+    /// let mut state = TreeState::new(vec![root]);
+    /// state.expand_all();
+    /// assert!(state.roots()[0].is_expanded());
+    /// ```
     pub fn expand_all(&mut self) {
         for root in &mut self.roots {
             Self::expand_all_recursive(root);
@@ -483,6 +551,18 @@ impl<T: Clone> TreeState<T> {
     }
 
     /// Collapses all nodes in the tree.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut root = TreeNode::new_expanded("Root", ());
+    /// root.add_child(TreeNode::new("Child", ()));
+    /// let mut state = TreeState::new(vec![root]);
+    /// state.collapse_all();
+    /// assert!(!state.roots()[0].is_expanded());
+    /// ```
     pub fn collapse_all(&mut self) {
         for root in &mut self.roots {
             Self::collapse_all_recursive(root);
@@ -500,6 +580,19 @@ impl<T: Clone> TreeState<T> {
     }
 
     /// Returns the number of visible nodes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut root = TreeNode::new_expanded("Root", ());
+    /// root.add_child(TreeNode::new("Child 1", ()));
+    /// root.add_child(TreeNode::new("Child 2", ()));
+    /// let state = TreeState::new(vec![root]);
+    /// // Root + 2 children visible (root is expanded)
+    /// assert_eq!(state.visible_count(), 3);
+    /// ```
     pub fn visible_count(&self) -> usize {
         self.flatten().len()
     }
@@ -555,21 +648,59 @@ impl<T: Clone> TreeState<T> {
 
 impl<T: Clone + 'static> TreeState<T> {
     /// Returns true if the tree is focused.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state: TreeState<()> = TreeState::new(vec![]);
+    /// assert!(!state.is_focused());
+    /// ```
     pub fn is_focused(&self) -> bool {
         self.focused
     }
 
     /// Sets the focus state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = TreeState::new(vec![TreeNode::new("Root", ())]);
+    /// state.set_focused(true);
+    /// assert!(state.is_focused());
+    /// ```
     pub fn set_focused(&mut self, focused: bool) {
         self.focused = focused;
     }
 
     /// Returns true if the tree is disabled.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state: TreeState<()> = TreeState::new(vec![]);
+    /// assert!(!state.is_disabled());
+    /// ```
     pub fn is_disabled(&self) -> bool {
         self.disabled
     }
 
     /// Sets the disabled state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = TreeState::new(vec![TreeNode::new("Root", ())]);
+    /// state.set_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn set_disabled(&mut self, disabled: bool) {
         self.disabled = disabled;
     }


### PR DESCRIPTION
## Summary

- Adds 57 new doc tests across 7 component State types (SelectableList, Table, Tree, InputField, Dialog, Accordion, Menu), raising the total from 281 to 338
- Focuses on the most commonly-used public methods: constructors, key accessors (items, selected_item, selected_index), key mutators (set_items, set_focused, set_disabled), and visibility/state queries
- All doc tests use `use envision::prelude::*;` and demonstrate meaningful behavior with concise examples (3-6 lines)

### Components covered

| Component | Methods with new doc tests |
|---|---|
| SelectableListState | new, with_items, items, set_items, selected_index, selected_item, select, is_empty, len, is_focused, set_focused, is_disabled, set_disabled |
| TableState | rows, columns, selected_row, set_selected |
| TreeState | roots, set_roots, selected_index, selected_node, selected_item, expand_all, collapse_all, visible_count, is_focused, set_focused, is_disabled, set_disabled |
| InputFieldState | new, with_value, with_placeholder, value, set_value, cursor_position, is_focused, set_focused |
| DialogState | title, message, buttons, is_visible, set_visible, is_focused, set_focused |
| AccordionState | panels, expanded_count, is_any_expanded, is_all_expanded, is_focused, set_focused |
| MenuState | items, selected_index, selected_item, is_focused, set_focused, is_disabled, set_disabled |

### Skipped

- TextArea: already at 1011 lines, would exceed 1000-line limit

## Test plan

- [x] `cargo test --doc --all-features` passes with 338 doc tests (up from 281)
- [x] `cargo test --all-features` passes (2918 unit + 338 doc tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] No file exceeds 1000 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)