### PR TITLE
Add comprehensive test suite for Tree component

### DIFF
--- a/src/component/tree/tests/edge_cases.rs
+++ b/src/component/tree/tests/edge_cases.rs
@@ -1,0 +1,563 @@
+use super::*;
+
+// ========== Single Node Edge Cases ==========
+
+#[test]
+fn test_single_node_navigate_down_stays() {
+    let mut state = TreeState::new(vec![TreeNode::new("Only", ())]);
+    let output = Tree::update(&mut state, TreeMessage::Down);
+    assert_eq!(output, None);
+    assert_eq!(state.selected_index(), Some(0));
+}
+
+#[test]
+fn test_single_node_navigate_up_stays() {
+    let mut state = TreeState::new(vec![TreeNode::new("Only", ())]);
+    let output = Tree::update(&mut state, TreeMessage::Up);
+    assert_eq!(output, None);
+    assert_eq!(state.selected_index(), Some(0));
+}
+
+#[test]
+fn test_single_node_toggle_no_children() {
+    let mut state = TreeState::new(vec![TreeNode::new("Leaf", ())]);
+    let output = Tree::update(&mut state, TreeMessage::Toggle);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_single_node_select() {
+    let mut state = TreeState::new(vec![TreeNode::new("Only", "data")]);
+    let output = Tree::update(&mut state, TreeMessage::Select);
+    assert_eq!(output, Some(TreeOutput::Selected(vec![0])));
+}
+
+#[test]
+fn test_single_node_expand_all() {
+    let mut state = TreeState::new(vec![TreeNode::new("Leaf", ())]);
+    Tree::update(&mut state, TreeMessage::ExpandAll);
+    // Leaf node should not be expanded (no children)
+    assert!(!state.roots()[0].is_expanded());
+}
+
+#[test]
+fn test_single_node_collapse_all() {
+    let mut state = TreeState::new(vec![TreeNode::new("Leaf", ())]);
+    Tree::update(&mut state, TreeMessage::CollapseAll);
+    assert_eq!(state.selected_index(), Some(0));
+}
+
+// ========== Empty Tree Edge Cases ==========
+
+#[test]
+fn test_empty_tree_expand() {
+    let mut state: TreeState<()> = TreeState::new(Vec::new());
+    let output = Tree::update(&mut state, TreeMessage::Expand);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_empty_tree_collapse() {
+    let mut state: TreeState<()> = TreeState::new(Vec::new());
+    let output = Tree::update(&mut state, TreeMessage::Collapse);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_empty_tree_toggle() {
+    let mut state: TreeState<()> = TreeState::new(Vec::new());
+    let output = Tree::update(&mut state, TreeMessage::Toggle);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_empty_tree_up() {
+    let mut state: TreeState<()> = TreeState::new(Vec::new());
+    let output = Tree::update(&mut state, TreeMessage::Up);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_empty_tree_expand_all() {
+    let mut state: TreeState<()> = TreeState::new(Vec::new());
+    let output = Tree::update(&mut state, TreeMessage::ExpandAll);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_empty_tree_collapse_all() {
+    let mut state: TreeState<()> = TreeState::new(Vec::new());
+    let output = Tree::update(&mut state, TreeMessage::CollapseAll);
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_empty_tree_selected_path() {
+    let state: TreeState<()> = TreeState::new(Vec::new());
+    assert_eq!(state.selected_path(), None);
+}
+
+#[test]
+fn test_empty_tree_selected_node() {
+    let state: TreeState<()> = TreeState::new(Vec::new());
+    assert_eq!(state.selected_node(), None);
+}
+
+#[test]
+fn test_empty_tree_selected_item() {
+    let state: TreeState<()> = TreeState::new(Vec::new());
+    assert_eq!(state.selected_item(), None);
+}
+
+#[test]
+fn test_empty_tree_visible_count() {
+    let state: TreeState<()> = TreeState::new(Vec::new());
+    assert_eq!(state.visible_count(), 0);
+}
+
+// ========== Boundary Selection Tests ==========
+
+#[test]
+fn test_with_selected_zero_on_collapsed_with_children() {
+    let mut root = TreeNode::new("Root", ());
+    root.add_child(TreeNode::new("Child", ()));
+
+    let state = TreeState::new(vec![root]).with_selected(0);
+    assert_eq!(state.selected_index(), Some(0));
+    assert_eq!(state.selected_node().unwrap().label(), "Root");
+}
+
+#[test]
+fn test_navigate_boundary_down_then_up() {
+    let nodes = vec![TreeNode::new("A", ()), TreeNode::new("B", ())];
+    let mut state = TreeState::new(nodes);
+
+    // At start (0), go down to 1
+    Tree::<()>::update(&mut state, TreeMessage::Down);
+    assert_eq!(state.selected_index(), Some(1));
+
+    // At end (1), go down again - stay at 1
+    Tree::<()>::update(&mut state, TreeMessage::Down);
+    assert_eq!(state.selected_index(), Some(1));
+
+    // Go up to 0
+    Tree::<()>::update(&mut state, TreeMessage::Up);
+    assert_eq!(state.selected_index(), Some(0));
+
+    // At start (0), go up again - stay at 0
+    Tree::<()>::update(&mut state, TreeMessage::Up);
+    assert_eq!(state.selected_index(), Some(0));
+}
+
+// ========== Collapse Adjusts Selection Boundary Tests ==========
+
+#[test]
+fn test_collapse_when_selected_child_is_beyond_new_range() {
+    let mut root = TreeNode::new_expanded("Root", ());
+    root.add_child(TreeNode::new("Child 1", ()));
+    root.add_child(TreeNode::new("Child 2", ()));
+    root.add_child(TreeNode::new("Child 3", ()));
+
+    let second_root = TreeNode::new("Other", ());
+
+    let mut state = TreeState::new(vec![root, second_root]);
+    // Visible: Root(0), Child 1(1), Child 2(2), Child 3(3), Other(4)
+    assert_eq!(state.visible_count(), 5);
+
+    // Select Root and collapse
+    state.selected_index = Some(0);
+    Tree::update(&mut state, TreeMessage::Collapse);
+
+    // After collapse: Root(0), Other(1)
+    assert_eq!(state.visible_count(), 2);
+    assert!(state.selected_index().unwrap() < state.visible_count());
+}
+
+// ========== Expand/Collapse Sequences ==========
+
+#[test]
+fn test_expand_collapse_expand_cycle() {
+    let mut root = TreeNode::new("Root", ());
+    root.add_child(TreeNode::new("Child", ()));
+
+    let mut state = TreeState::new(vec![root]);
+    assert_eq!(state.visible_count(), 1);
+
+    // Expand
+    let output = Tree::update(&mut state, TreeMessage::Expand);
+    assert_eq!(output, Some(TreeOutput::Expanded(vec![0])));
+    assert_eq!(state.visible_count(), 2);
+
+    // Collapse
+    let output = Tree::update(&mut state, TreeMessage::Collapse);
+    assert_eq!(output, Some(TreeOutput::Collapsed(vec![0])));
+    assert_eq!(state.visible_count(), 1);
+
+    // Expand again
+    let output = Tree::update(&mut state, TreeMessage::Expand);
+    assert_eq!(output, Some(TreeOutput::Expanded(vec![0])));
+    assert_eq!(state.visible_count(), 2);
+}
+
+#[test]
+fn test_toggle_twice_returns_to_original_state() {
+    let mut root = TreeNode::new("Root", ());
+    root.add_child(TreeNode::new("Child", ()));
+
+    let mut state = TreeState::new(vec![root]);
+    let original_expanded = state.roots()[0].is_expanded();
+    let original_visible = state.visible_count();
+
+    Tree::update(&mut state, TreeMessage::Toggle);
+    Tree::update(&mut state, TreeMessage::Toggle);
+
+    assert_eq!(state.roots()[0].is_expanded(), original_expanded);
+    assert_eq!(state.visible_count(), original_visible);
+}
+
+// ========== SetFilter/ClearFilter Message Edge Cases ==========
+
+#[test]
+fn test_set_filter_empty_string_via_message() {
+    let mut state = TreeState::new(vec![TreeNode::new("Root", ())]);
+    state.set_filter_text("something");
+
+    let output = Tree::update(&mut state, TreeMessage::SetFilter(String::new()));
+    assert_eq!(state.filter_text(), "");
+    assert_eq!(output, Some(TreeOutput::FilterChanged(String::new())));
+}
+
+#[test]
+fn test_clear_filter_when_already_empty() {
+    let mut state = TreeState::new(vec![TreeNode::new("Root", ())]);
+    assert_eq!(state.filter_text(), "");
+
+    let output = Tree::update(&mut state, TreeMessage::ClearFilter);
+    assert_eq!(output, Some(TreeOutput::FilterChanged(String::new())));
+    assert_eq!(state.filter_text(), "");
+}
+
+#[test]
+fn test_set_filter_allowed_when_disabled() {
+    let mut state = TreeState::new(vec![TreeNode::new("Root", ())]);
+    state.set_disabled(true);
+
+    let output = Tree::update(&mut state, TreeMessage::SetFilter("test".into()));
+    assert_eq!(output, Some(TreeOutput::FilterChanged("test".into())));
+    assert_eq!(state.filter_text(), "test");
+}
+
+#[test]
+fn test_clear_filter_allowed_when_disabled() {
+    let mut state = TreeState::new(vec![TreeNode::new("Root", ())]);
+    state.set_disabled(true);
+    state.set_filter_text("test");
+
+    let output = Tree::update(&mut state, TreeMessage::ClearFilter);
+    assert_eq!(output, Some(TreeOutput::FilterChanged(String::new())));
+    assert_eq!(state.filter_text(), "");
+}
+
+// ========== Focusable Trait Tests ==========
+
+#[test]
+fn test_focus_sets_focused() {
+    let mut state = TreeState::new(vec![TreeNode::new("Root", ())]);
+    assert!(!Tree::<()>::is_focused(&state));
+
+    Tree::focus(&mut state);
+    assert!(Tree::<()>::is_focused(&state));
+    assert!(state.is_focused());
+}
+
+#[test]
+fn test_blur_unsets_focused() {
+    let mut state = TreeState::new(vec![TreeNode::new("Root", ())]);
+    Tree::focus(&mut state);
+    assert!(state.is_focused());
+
+    Tree::blur(&mut state);
+    assert!(!Tree::<()>::is_focused(&state));
+    assert!(!state.is_focused());
+}
+
+#[test]
+fn test_set_focused_via_trait() {
+    let mut state = TreeState::new(vec![TreeNode::new("Root", ())]);
+    Tree::<()>::set_focused(&mut state, true);
+    assert!(Tree::<()>::is_focused(&state));
+
+    Tree::<()>::set_focused(&mut state, false);
+    assert!(!Tree::<()>::is_focused(&state));
+}
+
+// ========== Node without Children Expand/Collapse Tests ==========
+
+#[test]
+fn test_expand_leaf_via_dispatch_event() {
+    let mut state = TreeState::new(vec![TreeNode::new("Leaf", ())]);
+    state.set_focused(true);
+
+    let output = Tree::<()>::dispatch_event(&mut state, &Event::key(KeyCode::Right));
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_collapse_leaf_via_dispatch_event() {
+    let mut state = TreeState::new(vec![TreeNode::new("Leaf", ())]);
+    state.set_focused(true);
+
+    let output = Tree::<()>::dispatch_event(&mut state, &Event::key(KeyCode::Left));
+    assert_eq!(output, None);
+}
+
+// ========== Unhandled Key Tests ==========
+
+#[test]
+fn test_handle_event_unrecognized_key() {
+    let mut state = TreeState::new(vec![TreeNode::new("Root", ())]);
+    state.set_focused(true);
+
+    let msg = Tree::<()>::handle_event(&state, &Event::char('z'));
+    assert_eq!(msg, None);
+}
+
+#[test]
+fn test_handle_event_tab_key() {
+    let mut state = TreeState::new(vec![TreeNode::new("Root", ())]);
+    state.set_focused(true);
+
+    let msg = Tree::<()>::handle_event(&state, &Event::key(KeyCode::Tab));
+    assert_eq!(msg, None);
+}
+
+#[test]
+fn test_handle_event_escape_key() {
+    let mut state = TreeState::new(vec![TreeNode::new("Root", ())]);
+    state.set_focused(true);
+
+    let msg = Tree::<()>::handle_event(&state, &Event::key(KeyCode::Esc));
+    assert_eq!(msg, None);
+}
+
+// ========== Multiple Roots Navigation ==========
+
+#[test]
+fn test_navigate_across_roots() {
+    let root1 = TreeNode::new("Root 1", "r1");
+    let root2 = TreeNode::new("Root 2", "r2");
+    let root3 = TreeNode::new("Root 3", "r3");
+
+    let mut state = TreeState::new(vec![root1, root2, root3]);
+    assert_eq!(state.selected_index(), Some(0));
+    assert_eq!(state.selected_node().unwrap().data(), &"r1");
+
+    Tree::<&str>::update(&mut state, TreeMessage::Down);
+    assert_eq!(state.selected_node().unwrap().data(), &"r2");
+
+    Tree::<&str>::update(&mut state, TreeMessage::Down);
+    assert_eq!(state.selected_node().unwrap().data(), &"r3");
+
+    // At end
+    Tree::<&str>::update(&mut state, TreeMessage::Down);
+    assert_eq!(state.selected_node().unwrap().data(), &"r3");
+}
+
+#[test]
+fn test_select_across_expanded_roots() {
+    let mut root1 = TreeNode::new_expanded("Root 1", "r1");
+    root1.add_child(TreeNode::new("R1 Child", "r1c"));
+
+    let mut root2 = TreeNode::new_expanded("Root 2", "r2");
+    root2.add_child(TreeNode::new("R2 Child", "r2c"));
+
+    let mut state = TreeState::new(vec![root1, root2]);
+    // Visible: Root 1(0), R1 Child(1), Root 2(2), R2 Child(3)
+    assert_eq!(state.visible_count(), 4);
+
+    // Navigate to R2 Child
+    Tree::<&str>::update(&mut state, TreeMessage::Down); // R1 Child
+    Tree::<&str>::update(&mut state, TreeMessage::Down); // Root 2
+    Tree::<&str>::update(&mut state, TreeMessage::Down); // R2 Child
+
+    let output = Tree::<&str>::update(&mut state, TreeMessage::Select);
+    assert_eq!(output, Some(TreeOutput::Selected(vec![1, 0])));
+    assert_eq!(state.selected_node().unwrap().data(), &"r2c");
+}
+
+// ========== Expand All / Collapse All with Deep Trees ==========
+
+#[test]
+fn test_expand_all_deep_tree() {
+    let mut level1 = TreeNode::new("L1", ());
+    let mut level2 = TreeNode::new("L2", ());
+    let mut level3 = TreeNode::new("L3", ());
+    level3.add_child(TreeNode::new("L4", ()));
+    level2.add_child(level3);
+    level1.add_child(level2);
+
+    let mut state = TreeState::new(vec![level1]);
+    assert_eq!(state.visible_count(), 1); // Only L1
+
+    state.expand_all();
+    assert_eq!(state.visible_count(), 4); // L1, L2, L3, L4
+    assert!(state.roots()[0].is_expanded());
+    assert!(state.roots()[0].children()[0].is_expanded());
+    assert!(state.roots()[0].children()[0].children()[0].is_expanded());
+}
+
+#[test]
+fn test_collapse_all_deep_tree() {
+    let mut level1 = TreeNode::new_expanded("L1", ());
+    let mut level2 = TreeNode::new_expanded("L2", ());
+    let mut level3 = TreeNode::new_expanded("L3", ());
+    level3.add_child(TreeNode::new("L4", ()));
+    level2.add_child(level3);
+    level1.add_child(level2);
+
+    let mut state = TreeState::new(vec![level1]);
+    assert_eq!(state.visible_count(), 4);
+
+    state.collapse_all();
+    assert_eq!(state.visible_count(), 1);
+    assert!(!state.roots()[0].is_expanded());
+    assert!(!state.roots()[0].children()[0].is_expanded());
+    assert!(!state.roots()[0].children()[0].children()[0].is_expanded());
+    assert_eq!(state.selected_index(), Some(0)); // Reset to first
+}
+
+// ========== set_roots Edge Cases ==========
+
+#[test]
+fn test_set_roots_replaces_tree() {
+    let mut state = TreeState::new(vec![TreeNode::new("Old", 1)]);
+    assert_eq!(state.roots()[0].label(), "Old");
+
+    state.set_roots(vec![TreeNode::new("New A", 2), TreeNode::new("New B", 3)]);
+    assert_eq!(state.roots().len(), 2);
+    assert_eq!(state.roots()[0].label(), "New A");
+    assert_eq!(state.roots()[1].label(), "New B");
+    assert_eq!(state.selected_index(), Some(0));
+}
+
+#[test]
+fn test_set_roots_clears_filter_text() {
+    let mut state = TreeState::new(vec![TreeNode::new("Root", ())]);
+    state.set_filter_text("filter");
+    assert_eq!(state.filter_text(), "filter");
+
+    state.set_roots(vec![TreeNode::new("New Root", ())]);
+    assert_eq!(state.filter_text(), "");
+}
+
+// ========== selected_item is alias of selected_node ==========
+
+#[test]
+fn test_selected_item_equals_selected_node() {
+    let mut root = TreeNode::new_expanded("Root", 10);
+    root.add_child(TreeNode::new("Child", 20));
+
+    let mut state = TreeState::new(vec![root]);
+
+    // At root
+    assert_eq!(
+        state.selected_item().map(|n| n.label()),
+        state.selected_node().map(|n| n.label())
+    );
+    assert_eq!(
+        state.selected_item().map(|n| n.data()),
+        state.selected_node().map(|n| n.data())
+    );
+
+    // At child
+    state.selected_index = Some(1);
+    assert_eq!(
+        state.selected_item().map(|n| n.label()),
+        state.selected_node().map(|n| n.label())
+    );
+}
+
+#[test]
+fn test_selected_item_empty_tree() {
+    let state: TreeState<()> = TreeState::new(Vec::new());
+    assert_eq!(state.selected_item(), None);
+    assert_eq!(state.selected_node(), None);
+}
+
+// ========== Default Trait ==========
+
+#[test]
+fn test_default_is_empty() {
+    let state: TreeState<String> = TreeState::default();
+    assert!(state.is_empty());
+    assert_eq!(state.selected_index(), None);
+    assert_eq!(state.visible_count(), 0);
+    assert!(!state.is_focused());
+    assert!(!state.is_disabled());
+    assert_eq!(state.filter_text(), "");
+}
+
+// ========== Node with Empty Label ==========
+
+#[test]
+fn test_node_empty_label() {
+    let node = TreeNode::new("", 42);
+    assert_eq!(node.label(), "");
+    assert_eq!(node.data(), &42);
+}
+
+#[test]
+fn test_tree_with_empty_labels() {
+    let mut state = TreeState::new(vec![TreeNode::new("", 1), TreeNode::new("", 2)]);
+    assert_eq!(state.visible_count(), 2);
+
+    Tree::<i32>::update(&mut state, TreeMessage::Down);
+    assert_eq!(state.selected_index(), Some(1));
+    assert_eq!(state.selected_node().unwrap().data(), &2);
+}
+
+// ========== Navigation After Expand/Collapse ==========
+
+#[test]
+fn test_navigate_after_expand() {
+    let mut root = TreeNode::new("Root", ());
+    root.add_child(TreeNode::new("Child 1", ()));
+    root.add_child(TreeNode::new("Child 2", ()));
+
+    let mut state = TreeState::new(vec![root]);
+    assert_eq!(state.visible_count(), 1);
+
+    // Expand root
+    Tree::update(&mut state, TreeMessage::Expand);
+    assert_eq!(state.visible_count(), 3);
+
+    // Navigate through newly visible children
+    Tree::update(&mut state, TreeMessage::Down);
+    assert_eq!(state.selected_node().unwrap().label(), "Child 1");
+
+    Tree::update(&mut state, TreeMessage::Down);
+    assert_eq!(state.selected_node().unwrap().label(), "Child 2");
+}
+
+#[test]
+fn test_navigate_after_collapse_resets_if_needed() {
+    let mut root = TreeNode::new_expanded("Root", ());
+    root.add_child(TreeNode::new("Child 1", ()));
+    root.add_child(TreeNode::new("Child 2", ()));
+
+    let second = TreeNode::new("Second", ());
+
+    let mut state = TreeState::new(vec![root, second]);
+    // Visible: Root(0), Child 1(1), Child 2(2), Second(3)
+
+    // Navigate to Second
+    state.selected_index = Some(3);
+    assert_eq!(state.selected_node().unwrap().label(), "Second");
+
+    // Go back to Root and collapse
+    state.selected_index = Some(0);
+    Tree::update(&mut state, TreeMessage::Collapse);
+    // Visible: Root(0), Second(1)
+    assert_eq!(state.visible_count(), 2);
+    assert!(state.selected_index().unwrap() < state.visible_count());
+}

--- a/src/component/tree/tests/equality.rs
+++ b/src/component/tree/tests/equality.rs
@@ -1,0 +1,163 @@
+use super::*;
+
+// ========== TreeNode PartialEq Tests ==========
+
+#[test]
+fn test_node_equal() {
+    let node1 = TreeNode::new("Label", 42);
+    let node2 = TreeNode::new("Label", 42);
+    assert_eq!(node1, node2);
+}
+
+#[test]
+fn test_node_not_equal_label() {
+    let node1 = TreeNode::new("Label A", 42);
+    let node2 = TreeNode::new("Label B", 42);
+    assert_ne!(node1, node2);
+}
+
+#[test]
+fn test_node_not_equal_data() {
+    let node1 = TreeNode::new("Label", 1);
+    let node2 = TreeNode::new("Label", 2);
+    assert_ne!(node1, node2);
+}
+
+#[test]
+fn test_node_not_equal_expanded() {
+    let node1 = TreeNode::new("Label", ());
+    let node2 = TreeNode::new_expanded("Label", ());
+    assert_ne!(node1, node2);
+}
+
+#[test]
+fn test_node_not_equal_children() {
+    let mut node1 = TreeNode::new("Parent", ());
+    node1.add_child(TreeNode::new("Child A", ()));
+
+    let mut node2 = TreeNode::new("Parent", ());
+    node2.add_child(TreeNode::new("Child B", ()));
+
+    assert_ne!(node1, node2);
+}
+
+#[test]
+fn test_node_equal_with_children() {
+    let mut node1 = TreeNode::new("Parent", ());
+    node1.add_child(TreeNode::new("Child", ()));
+
+    let mut node2 = TreeNode::new("Parent", ());
+    node2.add_child(TreeNode::new("Child", ()));
+
+    assert_eq!(node1, node2);
+}
+
+#[test]
+fn test_node_not_equal_different_child_count() {
+    let mut node1 = TreeNode::new("Parent", ());
+    node1.add_child(TreeNode::new("Child 1", ()));
+
+    let mut node2 = TreeNode::new("Parent", ());
+    node2.add_child(TreeNode::new("Child 1", ()));
+    node2.add_child(TreeNode::new("Child 2", ()));
+
+    assert_ne!(node1, node2);
+}
+
+#[test]
+fn test_node_equal_deep_nesting() {
+    let mut child1 = TreeNode::new("Child", ());
+    child1.add_child(TreeNode::new("Grandchild", ()));
+
+    let mut parent1 = TreeNode::new("Parent", ());
+    parent1.add_child(child1);
+
+    let mut child2 = TreeNode::new("Child", ());
+    child2.add_child(TreeNode::new("Grandchild", ()));
+
+    let mut parent2 = TreeNode::new("Parent", ());
+    parent2.add_child(child2);
+
+    assert_eq!(parent1, parent2);
+}
+
+// ========== TreeState PartialEq Tests ==========
+
+#[test]
+fn test_state_equal() {
+    let state1 = TreeState::new(vec![TreeNode::new("Root", 1)]);
+    let state2 = TreeState::new(vec![TreeNode::new("Root", 1)]);
+    assert_eq!(state1, state2);
+}
+
+#[test]
+fn test_state_not_equal_roots() {
+    let state1 = TreeState::new(vec![TreeNode::new("Root A", 1)]);
+    let state2 = TreeState::new(vec![TreeNode::new("Root B", 1)]);
+    assert_ne!(state1, state2);
+}
+
+#[test]
+fn test_state_not_equal_selected_index() {
+    let mut root1 = TreeNode::new_expanded("Root", ());
+    root1.add_child(TreeNode::new("Child", ()));
+    let mut root2 = TreeNode::new_expanded("Root", ());
+    root2.add_child(TreeNode::new("Child", ()));
+
+    let state1 = TreeState::new(vec![root1]).with_selected(0);
+    let state2 = TreeState::new(vec![root2]).with_selected(1);
+    assert_ne!(state1, state2);
+}
+
+#[test]
+fn test_state_not_equal_focused() {
+    let mut state1 = TreeState::new(vec![TreeNode::new("Root", ())]);
+    let mut state2 = TreeState::new(vec![TreeNode::new("Root", ())]);
+
+    state1.set_focused(true);
+    state2.set_focused(false);
+    assert_ne!(state1, state2);
+}
+
+#[test]
+fn test_state_not_equal_disabled() {
+    let mut state1 = TreeState::new(vec![TreeNode::new("Root", ())]);
+    let mut state2 = TreeState::new(vec![TreeNode::new("Root", ())]);
+
+    state1.set_disabled(true);
+    state2.set_disabled(false);
+    assert_ne!(state1, state2);
+}
+
+#[test]
+fn test_state_not_equal_filter_text() {
+    let mut state1 = TreeState::new(vec![TreeNode::new("Root", ())]);
+    let state2 = TreeState::new(vec![TreeNode::new("Root", ())]);
+
+    state1.set_filter_text("abc");
+    assert_ne!(state1, state2);
+}
+
+#[test]
+fn test_state_equal_empty() {
+    let state1: TreeState<()> = TreeState::new(Vec::new());
+    let state2: TreeState<()> = TreeState::new(Vec::new());
+    assert_eq!(state1, state2);
+}
+
+#[test]
+fn test_state_equal_complex() {
+    let mut root1 = TreeNode::new_expanded("Root", 1);
+    root1.add_child(TreeNode::new("Child", 2));
+
+    let mut root2 = TreeNode::new_expanded("Root", 1);
+    root2.add_child(TreeNode::new("Child", 2));
+
+    let mut state1 = TreeState::new(vec![root1]);
+    let mut state2 = TreeState::new(vec![root2]);
+
+    state1.set_focused(true);
+    state2.set_focused(true);
+
+    assert_eq!(state1, state2);
+}

--- a/src/component/tree/tests/mod.rs
+++ b/src/component/tree/tests/mod.rs
@@ -2,7 +2,10 @@ use super::*;
 use crate::input::{Event, KeyCode};
 
 mod component;
+mod edge_cases;
+mod equality;
 mod events;
 mod filter;
 mod node;
+mod snapshot;
 mod state;

--- a/src/component/tree/tests/snapshot.rs
+++ b/src/component/tree/tests/snapshot.rs
@@ -1,0 +1,340 @@
+use super::*;
+
+// ========== Multi-root View Tests ==========
+
+#[test]
+fn test_view_multiple_roots_collapsed() {
+    let mut root1 = TreeNode::new("Documents", ());
+    root1.add_child(TreeNode::new("readme.md", ()));
+    let mut root2 = TreeNode::new("Projects", ());
+    root2.add_child(TreeNode::new("envision", ()));
+    let root3 = TreeNode::new("Downloads", ());
+
+    let state = TreeState::new(vec![root1, root2, root3]);
+
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
+    terminal
+        .draw(|frame| {
+            Tree::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+#[test]
+fn test_view_multiple_roots_expanded() {
+    let mut root1 = TreeNode::new_expanded("Documents", ());
+    root1.add_child(TreeNode::new("readme.md", ()));
+    root1.add_child(TreeNode::new("guide.md", ()));
+    let mut root2 = TreeNode::new_expanded("Projects", ());
+    root2.add_child(TreeNode::new("envision", ()));
+    let root3 = TreeNode::new("Downloads", ());
+
+    let state = TreeState::new(vec![root1, root2, root3]);
+
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
+    terminal
+        .draw(|frame| {
+            Tree::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+#[test]
+fn test_view_multiple_roots_focused() {
+    let mut root1 = TreeNode::new_expanded("Documents", ());
+    root1.add_child(TreeNode::new("readme.md", ()));
+    let mut root2 = TreeNode::new_expanded("Projects", ());
+    root2.add_child(TreeNode::new("envision", ()));
+    let root3 = TreeNode::new("Downloads", ());
+
+    let mut state = TreeState::new(vec![root1, root2, root3]);
+    state.set_focused(true);
+
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
+    terminal
+        .draw(|frame| {
+            Tree::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+#[test]
+fn test_view_selection_on_child() {
+    let mut root = TreeNode::new_expanded("Root", ());
+    root.add_child(TreeNode::new("Child 1", ()));
+    root.add_child(TreeNode::new("Child 2", ()));
+    root.add_child(TreeNode::new("Child 3", ()));
+
+    let mut state = TreeState::new(vec![root]);
+    state.set_focused(true);
+    state.selected_index = Some(2); // Select "Child 2"
+
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
+    terminal
+        .draw(|frame| {
+            Tree::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+// ========== Deep Nesting View Tests ==========
+
+#[test]
+fn test_view_deep_nesting() {
+    let mut level1 = TreeNode::new_expanded("Level 1", ());
+    let mut level2 = TreeNode::new_expanded("Level 2", ());
+    let mut level3 = TreeNode::new_expanded("Level 3", ());
+    level3.add_child(TreeNode::new("Leaf", ()));
+    level2.add_child(level3);
+    level1.add_child(level2);
+
+    let state = TreeState::new(vec![level1]);
+
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
+    terminal
+        .draw(|frame| {
+            Tree::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+#[test]
+fn test_view_deep_nesting_selection_at_leaf() {
+    let mut level1 = TreeNode::new_expanded("Level 1", ());
+    let mut level2 = TreeNode::new_expanded("Level 2", ());
+    let mut level3 = TreeNode::new_expanded("Level 3", ());
+    level3.add_child(TreeNode::new("Leaf", ()));
+    level2.add_child(level3);
+    level1.add_child(level2);
+
+    let mut state = TreeState::new(vec![level1]);
+    state.set_focused(true);
+    state.selected_index = Some(3); // Select "Leaf"
+
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
+    terminal
+        .draw(|frame| {
+            Tree::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+// ========== Mixed Expand/Collapse View Tests ==========
+
+#[test]
+fn test_view_mixed_expanded_collapsed() {
+    let mut docs = TreeNode::new_expanded("Documents", ());
+    docs.add_child(TreeNode::new("readme.md", ()));
+
+    let mut projects = TreeNode::new("Projects", ()); // collapsed
+    projects.add_child(TreeNode::new("envision", ()));
+
+    let state = TreeState::new(vec![docs, projects]);
+
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
+    terminal
+        .draw(|frame| {
+            Tree::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+// ========== Unicode View Tests ==========
+
+#[test]
+fn test_view_unicode_labels() {
+    let mut folder = TreeNode::new_expanded("文件夹", ());
+    folder.add_child(TreeNode::new("文档.txt", ()));
+    folder.add_child(TreeNode::new("图片.png", ()));
+
+    let state = TreeState::new(vec![folder, TreeNode::new("설정", ())]);
+
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
+    terminal
+        .draw(|frame| {
+            Tree::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+// ========== Disabled View with Complex Tree ==========
+
+#[test]
+fn test_view_disabled_with_children() {
+    let mut root = TreeNode::new_expanded("Root", ());
+    root.add_child(TreeNode::new("Child 1", ()));
+    root.add_child(TreeNode::new("Child 2", ()));
+
+    let mut state = TreeState::new(vec![root]);
+    state.set_disabled(true);
+
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
+    terminal
+        .draw(|frame| {
+            Tree::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+// ========== Focused vs Unfocused with Expanded Tree ==========
+
+#[test]
+fn test_view_focused_expanded_tree() {
+    let mut root = TreeNode::new_expanded("Root", ());
+    root.add_child(TreeNode::new("Child 1", ()));
+    root.add_child(TreeNode::new("Child 2", ()));
+
+    let mut state = TreeState::new(vec![root]);
+    state.set_focused(true);
+
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
+    terminal
+        .draw(|frame| {
+            Tree::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+#[test]
+fn test_view_unfocused_expanded_tree() {
+    let mut root = TreeNode::new_expanded("Root", ());
+    root.add_child(TreeNode::new("Child 1", ()));
+    root.add_child(TreeNode::new("Child 2", ()));
+
+    let mut state = TreeState::new(vec![root]);
+    state.set_focused(false);
+
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
+    terminal
+        .draw(|frame| {
+            Tree::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+// ========== Filtered View Snapshots ==========
+
+#[test]
+fn test_view_filtered() {
+    let mut docs = TreeNode::new_expanded("Documents", ());
+    docs.add_child(TreeNode::new("readme.md", ()));
+    docs.add_child(TreeNode::new("guide.md", ()));
+
+    let mut projects = TreeNode::new_expanded("Projects", ());
+    projects.add_child(TreeNode::new("envision", ()));
+
+    let downloads = TreeNode::new("Downloads", ());
+
+    let mut state = TreeState::new(vec![docs, projects, downloads]);
+    state.set_filter_text("readme");
+
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
+    terminal
+        .draw(|frame| {
+            Tree::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+#[test]
+fn test_view_filtered_focused() {
+    let mut docs = TreeNode::new_expanded("Documents", ());
+    docs.add_child(TreeNode::new("readme.md", ()));
+    docs.add_child(TreeNode::new("guide.md", ()));
+
+    let mut state = TreeState::new(vec![docs]);
+    state.set_focused(true);
+    state.set_filter_text("readme");
+
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
+    terminal
+        .draw(|frame| {
+            Tree::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+#[test]
+fn test_view_filtered_no_matches() {
+    let root = TreeNode::new("Root", ());
+    let mut state = TreeState::new(vec![root]);
+    state.set_filter_text("xyz_nonexistent");
+
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
+    terminal
+        .draw(|frame| {
+            Tree::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+// ========== Sibling Tree View ==========
+
+#[test]
+fn test_view_many_siblings() {
+    let mut root = TreeNode::new_expanded("Root", ());
+    for i in 1..=5 {
+        root.add_child(TreeNode::new(format!("Item {}", i), ()));
+    }
+
+    let state = TreeState::new(vec![root]);
+
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
+    terminal
+        .draw(|frame| {
+            Tree::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+// ========== Focused selection on last item ==========
+
+#[test]
+fn test_view_selection_on_last_root() {
+    let root1 = TreeNode::new("Root 1", ());
+    let root2 = TreeNode::new("Root 2", ());
+    let root3 = TreeNode::new("Root 3", ());
+
+    let mut state = TreeState::new(vec![root1, root2, root3]);
+    state.set_focused(true);
+    state.selected_index = Some(2); // Select "Root 3"
+
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
+    terminal
+        .draw(|frame| {
+            Tree::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+
+    insta::assert_snapshot!(terminal.backend().to_string());
+}

--- a/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_deep_nesting.snap
+++ b/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_deep_nesting.snap
@@ -1,0 +1,8 @@
+---
+source: src/component/tree/tests/snapshot.rs
+expression: terminal.backend().to_string()
+---
+▼ Level 1                               
+  ▼ Level 2                             
+    ▼ Level 3                           
+        Leaf

--- a/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_deep_nesting_selection_at_leaf.snap
+++ b/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_deep_nesting_selection_at_leaf.snap
@@ -1,0 +1,8 @@
+---
+source: src/component/tree/tests/snapshot.rs
+expression: terminal.backend().to_string()
+---
+▼ Level 1                               
+  ▼ Level 2                             
+    ▼ Level 3                           
+        Leaf

--- a/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_disabled_with_children.snap
+++ b/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_disabled_with_children.snap
@@ -1,0 +1,7 @@
+---
+source: src/component/tree/tests/snapshot.rs
+expression: terminal.backend().to_string()
+---
+▼ Root                                  
+    Child 1                             
+    Child 2

--- a/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_filtered.snap
+++ b/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_filtered.snap
@@ -1,0 +1,6 @@
+---
+source: src/component/tree/tests/snapshot.rs
+expression: terminal.backend().to_string()
+---
+▼ Documents                             
+    readme.md

--- a/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_filtered_focused.snap
+++ b/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_filtered_focused.snap
@@ -1,0 +1,6 @@
+---
+source: src/component/tree/tests/snapshot.rs
+expression: terminal.backend().to_string()
+---
+▼ Documents                             
+    readme.md

--- a/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_filtered_no_matches.snap
+++ b/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_filtered_no_matches.snap
@@ -1,0 +1,5 @@
+---
+source: src/component/tree/tests/snapshot.rs
+expression: terminal.backend().to_string()
+---
+

--- a/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_focused_expanded_tree.snap
+++ b/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_focused_expanded_tree.snap
@@ -1,0 +1,7 @@
+---
+source: src/component/tree/tests/snapshot.rs
+expression: terminal.backend().to_string()
+---
+▼ Root                                  
+    Child 1                             
+    Child 2

--- a/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_many_siblings.snap
+++ b/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_many_siblings.snap
@@ -1,0 +1,10 @@
+---
+source: src/component/tree/tests/snapshot.rs
+expression: terminal.backend().to_string()
+---
+▼ Root                                  
+    Item 1                              
+    Item 2                              
+    Item 3                              
+    Item 4                              
+    Item 5

--- a/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_mixed_expanded_collapsed.snap
+++ b/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_mixed_expanded_collapsed.snap
@@ -1,0 +1,7 @@
+---
+source: src/component/tree/tests/snapshot.rs
+expression: terminal.backend().to_string()
+---
+▼ Documents                             
+    readme.md                           
+▶ Projects

--- a/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_multiple_roots_collapsed.snap
+++ b/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_multiple_roots_collapsed.snap
@@ -1,0 +1,7 @@
+---
+source: src/component/tree/tests/snapshot.rs
+expression: terminal.backend().to_string()
+---
+▶ Documents                             
+▶ Projects                              
+  Downloads

--- a/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_multiple_roots_expanded.snap
+++ b/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_multiple_roots_expanded.snap
@@ -1,0 +1,10 @@
+---
+source: src/component/tree/tests/snapshot.rs
+expression: terminal.backend().to_string()
+---
+▼ Documents                             
+    readme.md                           
+    guide.md                            
+▼ Projects                              
+    envision                            
+  Downloads

--- a/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_multiple_roots_focused.snap
+++ b/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_multiple_roots_focused.snap
@@ -1,0 +1,9 @@
+---
+source: src/component/tree/tests/snapshot.rs
+expression: terminal.backend().to_string()
+---
+▼ Documents                             
+    readme.md                           
+▼ Projects                              
+    envision                            
+  Downloads

--- a/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_selection_on_child.snap
+++ b/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_selection_on_child.snap
@@ -1,0 +1,8 @@
+---
+source: src/component/tree/tests/snapshot.rs
+expression: terminal.backend().to_string()
+---
+▼ Root                                  
+    Child 1                             
+    Child 2                             
+    Child 3

--- a/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_selection_on_last_root.snap
+++ b/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_selection_on_last_root.snap
@@ -1,0 +1,7 @@
+---
+source: src/component/tree/tests/snapshot.rs
+expression: terminal.backend().to_string()
+---
+  Root 1                                
+  Root 2                                
+  Root 3

--- a/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_unfocused_expanded_tree.snap
+++ b/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_unfocused_expanded_tree.snap
@@ -1,0 +1,7 @@
+---
+source: src/component/tree/tests/snapshot.rs
+expression: terminal.backend().to_string()
+---
+▼ Root                                  
+    Child 1                             
+    Child 2

--- a/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_unicode_labels.snap
+++ b/src/component/tree/tests/snapshots/envision__component__tree__tests__snapshot__view_unicode_labels.snap
@@ -1,0 +1,8 @@
+---
+source: src/component/tree/tests/snapshot.rs
+expression: terminal.backend().to_string()
+---
+▼ 文 件 夹                                 
+    文 档 .txt                            
+    图 片 .png                            
+  설 정


### PR DESCRIPTION
## Summary
- Add 78 new unit tests across three new test modules (`edge_cases`, `equality`, `snapshot`), bringing the Tree component from 119 to 197 tests
- Cover previously untested areas: `PartialEq` for `TreeNode`/`TreeState`, `Focusable` trait methods (`focus`/`blur`/`set_focused`), boundary navigation, empty/single-node edge cases, unhandled key events, expand/collapse cycles, and filter message handling when disabled
- Add 16 new insta snapshot tests for multi-root trees, deep nesting, unicode labels, filtered views, focused/unfocused states, disabled state with children, and selection at various positions

## Test plan
- [x] All 197 tree tests pass locally (`cargo test --lib -- tree`)
- [x] No compiler warnings
- [x] All test files under 1000 lines
- [x] Snapshot files accepted and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)