### PR TITLE
Rename set_cursor to set_cursor_position for API consistency

### DIFF
--- a/benches/component_events.rs
+++ b/benches/component_events.rs
@@ -137,7 +137,7 @@ fn bench_handle_event(c: &mut Criterion) {
         let mut state = InputFieldState::with_value(&text);
         state.set_focused(true);
         // Place cursor in the middle for realistic benchmarking
-        state.set_cursor(size / 2);
+        state.set_cursor_position(size / 2);
 
         group.bench_with_input(
             BenchmarkId::new("input_field/focused/insert", size),
@@ -219,7 +219,7 @@ fn bench_dispatch_event(c: &mut Criterion) {
                 let mut state = TextAreaState::with_value(&content);
                 state.set_focused(true);
                 // Start at top so Down always moves
-                state.set_cursor(0, 0);
+                state.set_cursor_position(0, 0);
                 b.iter(|| TextArea::dispatch_event(black_box(&mut state), black_box(&event_down)))
             },
         );
@@ -237,7 +237,7 @@ fn bench_dispatch_event(c: &mut Criterion) {
             |b, _| {
                 let mut state = InputFieldState::with_value(&text);
                 state.set_focused(true);
-                state.set_cursor(size / 2);
+                state.set_cursor_position(size / 2);
                 b.iter(|| {
                     InputField::dispatch_event(black_box(&mut state), black_box(&event_insert))
                 })
@@ -252,7 +252,7 @@ fn bench_dispatch_event(c: &mut Criterion) {
             |b, _| {
                 let mut state = InputFieldState::with_value(&text);
                 state.set_focused(true);
-                state.set_cursor(size / 2);
+                state.set_cursor_position(size / 2);
                 b.iter(|| {
                     InputField::dispatch_event(black_box(&mut state), black_box(&event_backspace))
                 })

--- a/src/component/input_field/mod.rs
+++ b/src/component/input_field/mod.rs
@@ -316,7 +316,7 @@ impl InputFieldState {
     }
 
     /// Moves cursor to the given character position.
-    pub fn set_cursor(&mut self, char_pos: usize) {
+    pub fn set_cursor_position(&mut self, char_pos: usize) {
         let char_count = self.value.chars().count();
         let clamped = char_pos.min(char_count);
         self.cursor = self

--- a/src/component/input_field/selection_tests.rs
+++ b/src/component/input_field/selection_tests.rs
@@ -36,7 +36,7 @@ fn test_select_left_multiple() {
 #[test]
 fn test_select_right() {
     let mut state = InputFieldState::with_value("hello");
-    state.set_cursor(0);
+    state.set_cursor_position(0);
     InputField::update(&mut state, InputFieldMessage::SelectRight);
     assert!(state.has_selection());
     assert_eq!(state.selected_text(), Some("h"));
@@ -46,7 +46,7 @@ fn test_select_right() {
 #[test]
 fn test_select_right_multiple() {
     let mut state = InputFieldState::with_value("hello");
-    state.set_cursor(0);
+    state.set_cursor_position(0);
     InputField::update(&mut state, InputFieldMessage::SelectRight);
     InputField::update(&mut state, InputFieldMessage::SelectRight);
     InputField::update(&mut state, InputFieldMessage::SelectRight);
@@ -64,7 +64,7 @@ fn test_select_home() {
 #[test]
 fn test_select_end() {
     let mut state = InputFieldState::with_value("hello");
-    state.set_cursor(0);
+    state.set_cursor_position(0);
     InputField::update(&mut state, InputFieldMessage::SelectEnd);
     assert_eq!(state.selected_text(), Some("hello"));
     assert_eq!(state.cursor_position(), 5);
@@ -81,7 +81,7 @@ fn test_select_word_left() {
 #[test]
 fn test_select_word_right() {
     let mut state = InputFieldState::with_value("hello world");
-    state.set_cursor(0);
+    state.set_cursor_position(0);
     InputField::update(&mut state, InputFieldMessage::SelectWordRight);
     assert_eq!(state.selected_text(), Some("hello "));
 }
@@ -122,7 +122,7 @@ fn test_left_clears_selection() {
 #[test]
 fn test_right_clears_selection() {
     let mut state = InputFieldState::with_value("hello");
-    state.set_cursor(0);
+    state.set_cursor_position(0);
     InputField::update(&mut state, InputFieldMessage::SelectRight);
     InputField::update(&mut state, InputFieldMessage::SelectRight);
     assert!(state.has_selection());
@@ -146,7 +146,7 @@ fn test_home_clears_selection() {
 #[test]
 fn test_end_clears_selection() {
     let mut state = InputFieldState::with_value("hello");
-    state.set_cursor(0);
+    state.set_cursor_position(0);
     InputField::update(&mut state, InputFieldMessage::SelectRight);
     assert!(state.has_selection());
 
@@ -171,7 +171,7 @@ fn test_insert_replaces_selection() {
 #[test]
 fn test_insert_replaces_partial_selection() {
     let mut state = InputFieldState::with_value("hello world");
-    state.set_cursor(0);
+    state.set_cursor_position(0);
     // Select "hello"
     for _ in 0..5 {
         InputField::update(&mut state, InputFieldMessage::SelectRight);
@@ -238,7 +238,7 @@ fn test_delete_word_forward_deletes_selection() {
 fn test_copy_with_selection() {
     let mut state = InputFieldState::with_value("hello world");
     // Select "hello"
-    state.set_cursor(0);
+    state.set_cursor_position(0);
     for _ in 0..5 {
         InputField::update(&mut state, InputFieldMessage::SelectRight);
     }
@@ -263,7 +263,7 @@ fn test_copy_without_selection() {
 fn test_cut_with_selection() {
     let mut state = InputFieldState::with_value("hello world");
     // Select "hello"
-    state.set_cursor(0);
+    state.set_cursor_position(0);
     for _ in 0..5 {
         InputField::update(&mut state, InputFieldMessage::SelectRight);
     }
@@ -285,7 +285,7 @@ fn test_cut_without_selection() {
 #[test]
 fn test_paste() {
     let mut state = InputFieldState::with_value("hello");
-    state.set_cursor(5);
+    state.set_cursor_position(5);
     let output = InputField::update(&mut state, InputFieldMessage::Paste(" world".into()));
     assert_eq!(state.value(), "hello world");
     assert_eq!(
@@ -315,7 +315,7 @@ fn test_paste_empty_string() {
 #[test]
 fn test_paste_at_cursor() {
     let mut state = InputFieldState::with_value("helo");
-    state.set_cursor(3); // Between 'l' and 'o'
+    state.set_cursor_position(3); // Between 'l' and 'o'
     InputField::update(&mut state, InputFieldMessage::Paste("l".into()));
     assert_eq!(state.value(), "hello");
 }
@@ -337,7 +337,7 @@ fn test_copy_then_paste() {
 fn test_cut_then_paste() {
     let mut state = InputFieldState::with_value("hello world");
     // Select "hello"
-    state.set_cursor(0);
+    state.set_cursor_position(0);
     for _ in 0..5 {
         InputField::update(&mut state, InputFieldMessage::SelectRight);
     }
@@ -500,7 +500,7 @@ fn test_select_all_utf8() {
 #[test]
 fn test_cut_utf8() {
     let mut state = InputFieldState::with_value("héllo wörld");
-    state.set_cursor(0);
+    state.set_cursor_position(0);
     // Select "héllo"
     for _ in 0..5 {
         InputField::update(&mut state, InputFieldMessage::SelectRight);
@@ -524,7 +524,7 @@ fn test_paste_utf8() {
 #[test]
 fn test_select_left_at_start() {
     let mut state = InputFieldState::with_value("hello");
-    state.set_cursor(0);
+    state.set_cursor_position(0);
     InputField::update(&mut state, InputFieldMessage::SelectLeft);
     // Should set anchor but cursor can't move further
     assert!(!state.has_selection()); // anchor == cursor
@@ -541,7 +541,7 @@ fn test_select_right_at_end() {
 #[test]
 fn test_selection_preserved_across_multiple_shifts() {
     let mut state = InputFieldState::with_value("hello world");
-    state.set_cursor(0);
+    state.set_cursor_position(0);
     // Select "hello" then extend to "hello world"
     for _ in 0..5 {
         InputField::update(&mut state, InputFieldMessage::SelectRight);
@@ -557,8 +557,8 @@ fn test_selection_preserved_across_multiple_shifts() {
 #[test]
 fn test_select_then_reverse_direction() {
     let mut state = InputFieldState::with_value("hello");
-    state.set_cursor(2); // After "he"
-                         // Select right twice: anchor=2, cursor=4, selected "ll"
+    state.set_cursor_position(2); // After "he"
+                                  // Select right twice: anchor=2, cursor=4, selected "ll"
     InputField::update(&mut state, InputFieldMessage::SelectRight);
     InputField::update(&mut state, InputFieldMessage::SelectRight);
     assert_eq!(state.selected_text(), Some("ll"));

--- a/src/component/input_field/tests.rs
+++ b/src/component/input_field/tests.rs
@@ -80,7 +80,7 @@ fn test_backspace() {
 #[test]
 fn test_delete() {
     let mut state = InputFieldState::with_value("abc");
-    state.set_cursor(0);
+    state.set_cursor_position(0);
 
     let output = InputField::update(&mut state, InputFieldMessage::Delete);
     assert_eq!(state.value(), "bc");
@@ -117,12 +117,12 @@ fn test_cursor_bounds() {
     let mut state = InputFieldState::with_value("hi");
 
     // Can't go left past beginning
-    state.set_cursor(0);
+    state.set_cursor_position(0);
     InputField::update(&mut state, InputFieldMessage::Left);
     assert_eq!(state.cursor_position(), 0);
 
     // Can't go right past end
-    state.set_cursor(10); // Over the length
+    state.set_cursor_position(10); // Over the length
     assert_eq!(state.cursor_position(), 2); // Clamped
     InputField::update(&mut state, InputFieldMessage::Right);
     assert_eq!(state.cursor_position(), 2);
@@ -171,7 +171,7 @@ fn test_delete_word_back() {
 #[test]
 fn test_delete_word_forward() {
     let mut state = InputFieldState::with_value("hello world");
-    state.set_cursor(0);
+    state.set_cursor_position(0);
 
     let output = InputField::update(&mut state, InputFieldMessage::DeleteWordForward);
     assert_eq!(state.value(), "world");
@@ -236,7 +236,7 @@ fn test_submit() {
 #[test]
 fn test_insert_at_cursor() {
     let mut state = InputFieldState::with_value("helo");
-    state.set_cursor(3);
+    state.set_cursor_position(3);
 
     InputField::update(&mut state, InputFieldMessage::Insert('l'));
     assert_eq!(state.value(), "hello");

--- a/src/component/input_field/undo_tests.rs
+++ b/src/component/input_field/undo_tests.rs
@@ -106,7 +106,7 @@ fn test_grouped_deletes_undo_together() {
 #[test]
 fn test_delete_forward_grouped() {
     let mut state = InputFieldState::with_value("hello");
-    state.set_cursor(0);
+    state.set_cursor_position(0);
     InputField::update(&mut state, InputFieldMessage::Delete);
     InputField::update(&mut state, InputFieldMessage::Delete);
     assert_eq!(state.value(), "llo");
@@ -170,7 +170,7 @@ fn test_delete_word_back_is_own_undo_entry() {
 #[test]
 fn test_delete_word_forward_is_own_undo_entry() {
     let mut state = InputFieldState::with_value("hello world");
-    state.set_cursor(0);
+    state.set_cursor_position(0);
     InputField::update(&mut state, InputFieldMessage::DeleteWordForward);
     assert_eq!(state.value(), "world");
 

--- a/src/component/text_area/mod.rs
+++ b/src/component/text_area/mod.rs
@@ -361,7 +361,7 @@ impl TextAreaState {
     /// Sets the cursor position (row, char_column).
     ///
     /// Both row and column are clamped to valid ranges.
-    pub fn set_cursor(&mut self, row: usize, col: usize) {
+    pub fn set_cursor_position(&mut self, row: usize, col: usize) {
         self.cursor_row = row.min(self.lines.len().saturating_sub(1));
         // Convert char position to byte offset
         let line = &self.lines[self.cursor_row];

--- a/src/component/text_area/selection_tests.rs
+++ b/src/component/text_area/selection_tests.rs
@@ -28,7 +28,7 @@ fn test_select_left() {
 #[test]
 fn test_select_right() {
     let mut state = TextAreaState::with_value("hello");
-    state.set_cursor(0, 0);
+    state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::SelectRight);
     assert_eq!(state.selected_text(), Some("h".to_string()));
 }
@@ -43,7 +43,7 @@ fn test_select_home() {
 #[test]
 fn test_select_end() {
     let mut state = TextAreaState::with_value("hello");
-    state.set_cursor(0, 0);
+    state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::SelectEnd);
     assert_eq!(state.selected_text(), Some("hello".to_string()));
 }
@@ -61,7 +61,7 @@ fn test_select_up() {
 #[test]
 fn test_select_down() {
     let mut state = TextAreaState::with_value("line1\nline2");
-    state.set_cursor(0, 0);
+    state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::SelectDown);
     assert!(state.has_selection());
 }
@@ -76,7 +76,7 @@ fn test_select_word_left() {
 #[test]
 fn test_select_word_right() {
     let mut state = TextAreaState::with_value("hello world");
-    state.set_cursor(0, 0);
+    state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::SelectWordRight);
     assert_eq!(state.selected_text(), Some("hello ".to_string()));
 }
@@ -103,7 +103,7 @@ fn test_select_all_empty() {
 #[test]
 fn test_multiline_selection() {
     let mut state = TextAreaState::with_value("abc\ndef\nghi");
-    state.set_cursor(0, 0);
+    state.set_cursor_position(0, 0);
     // Select from start to end of line 1
     TextArea::update(&mut state, TextAreaMessage::SelectDown);
     TextArea::update(&mut state, TextAreaMessage::SelectEnd);
@@ -115,8 +115,8 @@ fn test_multiline_selection() {
 #[test]
 fn test_select_across_lines() {
     let mut state = TextAreaState::with_value("abc\ndef");
-    state.set_cursor(0, 1); // After 'a'
-                            // Select from (0,1) to (1,2) using SelectDown then SelectRight
+    state.set_cursor_position(0, 1); // After 'a'
+                                     // Select from (0,1) to (1,2) using SelectDown then SelectRight
     TextArea::update(&mut state, TextAreaMessage::SelectDown);
     TextArea::update(&mut state, TextAreaMessage::SelectRight);
     let text = state.selected_text().unwrap();
@@ -140,7 +140,7 @@ fn test_left_clears_selection() {
 #[test]
 fn test_right_clears_selection() {
     let mut state = TextAreaState::with_value("hello");
-    state.set_cursor(0, 0);
+    state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::SelectRight);
     assert!(state.has_selection());
 
@@ -387,7 +387,7 @@ fn test_set_value_clears_selection() {
 fn test_delete_partial_multiline_selection() {
     let mut state = TextAreaState::with_value("abc\ndef\nghi");
     // Select from middle of line 0 to middle of line 2
-    state.set_cursor(0, 1); // After 'a'
+    state.set_cursor_position(0, 1); // After 'a'
     state.selection_anchor = Some((0, 1));
     state.cursor_row = 2;
     state.cursor_col = 2; // After 'gh'

--- a/src/component/text_area/tests.rs
+++ b/src/component/text_area/tests.rs
@@ -76,9 +76,9 @@ fn test_line() {
 #[test]
 fn test_current_line() {
     let mut state = TextAreaState::with_value("Hello\nWorld");
-    state.set_cursor(0, 0);
+    state.set_cursor_position(0, 0);
     assert_eq!(state.current_line(), "Hello");
-    state.set_cursor(1, 0);
+    state.set_cursor_position(1, 0);
     assert_eq!(state.current_line(), "World");
 }
 
@@ -106,23 +106,23 @@ fn test_cursor_position() {
 }
 
 #[test]
-fn test_set_cursor() {
+fn test_set_cursor_position() {
     let mut state = TextAreaState::with_value("Hello\nWorld");
-    state.set_cursor(0, 2);
+    state.set_cursor_position(0, 2);
     assert_eq!(state.cursor_position(), (0, 2));
 }
 
 #[test]
 fn test_cursor_clamp_row() {
     let mut state = TextAreaState::with_value("Hello");
-    state.set_cursor(10, 0); // Row out of bounds
+    state.set_cursor_position(10, 0); // Row out of bounds
     assert_eq!(state.cursor_row(), 0);
 }
 
 #[test]
 fn test_cursor_clamp_col() {
     let mut state = TextAreaState::with_value("Hi");
-    state.set_cursor(0, 100); // Col out of bounds
+    state.set_cursor_position(0, 100); // Col out of bounds
     assert_eq!(state.cursor_position(), (0, 2));
 }
 
@@ -151,7 +151,7 @@ fn test_insert_unicode() {
 #[test]
 fn test_newline() {
     let mut state = TextAreaState::with_value("Hello");
-    state.set_cursor(0, 2);
+    state.set_cursor_position(0, 2);
     TextArea::update(&mut state, TextAreaMessage::NewLine);
     assert_eq!(state.line_count(), 2);
     assert_eq!(state.line(0), Some("He"));
@@ -162,7 +162,7 @@ fn test_newline() {
 #[test]
 fn test_newline_at_start() {
     let mut state = TextAreaState::with_value("Hello");
-    state.set_cursor(0, 0);
+    state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::NewLine);
     assert_eq!(state.line(0), Some(""));
     assert_eq!(state.line(1), Some("Hello"));
@@ -187,7 +187,7 @@ fn test_backspace() {
 #[test]
 fn test_backspace_join_lines() {
     let mut state = TextAreaState::with_value("Hello\nWorld");
-    state.set_cursor(1, 0); // Start of second line
+    state.set_cursor_position(1, 0); // Start of second line
     TextArea::update(&mut state, TextAreaMessage::Backspace);
     assert_eq!(state.value(), "HelloWorld");
     assert_eq!(state.cursor_position(), (0, 5));
@@ -196,7 +196,7 @@ fn test_backspace_join_lines() {
 #[test]
 fn test_backspace_first_line_start() {
     let mut state = TextAreaState::with_value("Hello");
-    state.set_cursor(0, 0);
+    state.set_cursor_position(0, 0);
     let output = TextArea::update(&mut state, TextAreaMessage::Backspace);
     assert_eq!(output, None);
     assert_eq!(state.value(), "Hello");
@@ -205,7 +205,7 @@ fn test_backspace_first_line_start() {
 #[test]
 fn test_delete() {
     let mut state = TextAreaState::with_value("Hello");
-    state.set_cursor(0, 0);
+    state.set_cursor_position(0, 0);
     let output = TextArea::update(&mut state, TextAreaMessage::Delete);
     assert_eq!(state.value(), "ello");
     assert!(matches!(output, Some(TextAreaOutput::Changed(_))));
@@ -214,7 +214,7 @@ fn test_delete() {
 #[test]
 fn test_delete_join_lines() {
     let mut state = TextAreaState::with_value("Hello\nWorld");
-    state.set_cursor(0, 5); // End of first line
+    state.set_cursor_position(0, 5); // End of first line
     TextArea::update(&mut state, TextAreaMessage::Delete);
     assert_eq!(state.value(), "HelloWorld");
 }
@@ -239,7 +239,7 @@ fn test_left() {
 #[test]
 fn test_left_wrap() {
     let mut state = TextAreaState::with_value("Hello\nWorld");
-    state.set_cursor(1, 0);
+    state.set_cursor_position(1, 0);
     TextArea::update(&mut state, TextAreaMessage::Left);
     assert_eq!(state.cursor_position(), (0, 5)); // End of first line
 }
@@ -247,7 +247,7 @@ fn test_left_wrap() {
 #[test]
 fn test_left_at_start() {
     let mut state = TextAreaState::with_value("Hello");
-    state.set_cursor(0, 0);
+    state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::Left);
     assert_eq!(state.cursor_position(), (0, 0)); // Stays at start
 }
@@ -255,7 +255,7 @@ fn test_left_at_start() {
 #[test]
 fn test_right() {
     let mut state = TextAreaState::with_value("Hello");
-    state.set_cursor(0, 0);
+    state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::Right);
     assert_eq!(state.cursor_position(), (0, 1));
 }
@@ -263,7 +263,7 @@ fn test_right() {
 #[test]
 fn test_right_wrap() {
     let mut state = TextAreaState::with_value("Hello\nWorld");
-    state.set_cursor(0, 5); // End of first line
+    state.set_cursor_position(0, 5); // End of first line
     TextArea::update(&mut state, TextAreaMessage::Right);
     assert_eq!(state.cursor_position(), (1, 0)); // Start of second line
 }
@@ -286,7 +286,7 @@ fn test_up() {
 #[test]
 fn test_up_clamps_column() {
     let mut state = TextAreaState::with_value("Hi\nHello");
-    state.set_cursor(1, 5); // End of "Hello"
+    state.set_cursor_position(1, 5); // End of "Hello"
     TextArea::update(&mut state, TextAreaMessage::Up);
     assert_eq!(state.cursor_position(), (0, 2)); // Clamped to "Hi" length
 }
@@ -294,7 +294,7 @@ fn test_up_clamps_column() {
 #[test]
 fn test_up_at_first_line() {
     let mut state = TextAreaState::with_value("Hello\nWorld");
-    state.set_cursor(0, 2);
+    state.set_cursor_position(0, 2);
     TextArea::update(&mut state, TextAreaMessage::Up);
     assert_eq!(state.cursor_position(), (0, 2)); // Stays on first line
 }
@@ -302,7 +302,7 @@ fn test_up_at_first_line() {
 #[test]
 fn test_down() {
     let mut state = TextAreaState::with_value("Hello\nWorld");
-    state.set_cursor(0, 2);
+    state.set_cursor_position(0, 2);
     TextArea::update(&mut state, TextAreaMessage::Down);
     assert_eq!(state.cursor_position(), (1, 2));
 }
@@ -310,7 +310,7 @@ fn test_down() {
 #[test]
 fn test_down_clamps_column() {
     let mut state = TextAreaState::with_value("Hello\nHi");
-    state.set_cursor(0, 5); // End of "Hello"
+    state.set_cursor_position(0, 5); // End of "Hello"
     TextArea::update(&mut state, TextAreaMessage::Down);
     assert_eq!(state.cursor_position(), (1, 2)); // Clamped to "Hi" length
 }
@@ -333,7 +333,7 @@ fn test_home() {
 #[test]
 fn test_end() {
     let mut state = TextAreaState::with_value("Hello");
-    state.set_cursor(0, 0);
+    state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::End);
     assert_eq!(state.cursor_position(), (0, 5));
 }
@@ -348,7 +348,7 @@ fn test_text_start() {
 #[test]
 fn test_text_end() {
     let mut state = TextAreaState::with_value("Hello\nWorld");
-    state.set_cursor(0, 0);
+    state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::TextEnd);
     assert_eq!(state.cursor_position(), (1, 5));
 }
@@ -363,7 +363,7 @@ fn test_word_left() {
 #[test]
 fn test_word_right() {
     let mut state = TextAreaState::with_value("hello world");
-    state.set_cursor(0, 0);
+    state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::WordRight);
     assert_eq!(state.cursor_position(), (0, 6)); // After "hello "
 }
@@ -373,7 +373,7 @@ fn test_word_right() {
 #[test]
 fn test_delete_line() {
     let mut state = TextAreaState::with_value("Line 1\nLine 2\nLine 3");
-    state.set_cursor(1, 0);
+    state.set_cursor_position(1, 0);
     TextArea::update(&mut state, TextAreaMessage::DeleteLine);
     assert_eq!(state.line_count(), 2);
     assert_eq!(state.value(), "Line 1\nLine 3");
@@ -390,7 +390,7 @@ fn test_delete_line_single() {
 #[test]
 fn test_delete_to_end() {
     let mut state = TextAreaState::with_value("Hello World");
-    state.set_cursor(0, 5);
+    state.set_cursor_position(0, 5);
     TextArea::update(&mut state, TextAreaMessage::DeleteToEnd);
     assert_eq!(state.value(), "Hello");
 }
@@ -398,7 +398,7 @@ fn test_delete_to_end() {
 #[test]
 fn test_delete_to_start() {
     let mut state = TextAreaState::with_value("Hello World");
-    state.set_cursor(0, 6);
+    state.set_cursor_position(0, 6);
     TextArea::update(&mut state, TextAreaMessage::DeleteToStart);
     assert_eq!(state.value(), "World");
     assert_eq!(state.cursor_position(), (0, 0));
@@ -460,7 +460,7 @@ fn test_scroll_offset() {
 #[test]
 fn test_ensure_cursor_visible_down() {
     let mut state = TextAreaState::with_value("1\n2\n3\n4\n5\n6\n7\n8\n9\n10");
-    state.set_cursor(9, 0); // Last line
+    state.set_cursor_position(9, 0); // Last line
     state.ensure_cursor_visible(5);
     assert!(state.scroll_offset > 0);
     assert!(state.cursor_row >= state.scroll_offset);
@@ -471,7 +471,7 @@ fn test_ensure_cursor_visible_down() {
 fn test_ensure_cursor_visible_up() {
     let mut state = TextAreaState::with_value("1\n2\n3\n4\n5\n6\n7\n8\n9\n10");
     state.scroll_offset = 5;
-    state.set_cursor(2, 0);
+    state.set_cursor_position(2, 0);
     state.ensure_cursor_visible(5);
     assert_eq!(state.scroll_offset, 2);
 }
@@ -609,7 +609,7 @@ fn test_cursor_col_accessor() {
 #[test]
 fn test_word_left_at_line_start() {
     let mut state = TextAreaState::with_value("Hello\nWorld");
-    state.set_cursor(1, 0); // Start of "World"
+    state.set_cursor_position(1, 0); // Start of "World"
     TextArea::update(&mut state, TextAreaMessage::WordLeft);
     // Should wrap to end of previous line
     assert_eq!(state.cursor_position(), (0, 5));
@@ -618,7 +618,7 @@ fn test_word_left_at_line_start() {
 #[test]
 fn test_word_left_skip_whitespace() {
     let mut state = TextAreaState::with_value("hello   world");
-    state.set_cursor(0, 8); // In the middle of spaces
+    state.set_cursor_position(0, 8); // In the middle of spaces
     TextArea::update(&mut state, TextAreaMessage::WordLeft);
     assert!(state.cursor_col() < 8);
 }
@@ -626,7 +626,7 @@ fn test_word_left_skip_whitespace() {
 #[test]
 fn test_word_right_at_line_end() {
     let mut state = TextAreaState::with_value("Hello\nWorld");
-    state.set_cursor(0, 5); // End of "Hello"
+    state.set_cursor_position(0, 5); // End of "Hello"
     TextArea::update(&mut state, TextAreaMessage::WordRight);
     // Should wrap to start of next line
     assert_eq!(state.cursor_position(), (1, 0));
@@ -635,7 +635,7 @@ fn test_word_right_at_line_end() {
 #[test]
 fn test_word_right_skip_word() {
     let mut state = TextAreaState::with_value("abc def");
-    state.set_cursor(0, 0);
+    state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::WordRight);
     // Should skip past "abc " to start of "def"
     assert_eq!(state.cursor_position(), (0, 4));
@@ -644,7 +644,7 @@ fn test_word_right_skip_word() {
 #[test]
 fn test_delete_line_last_line() {
     let mut state = TextAreaState::with_value("Line 1\nLine 2");
-    state.set_cursor(1, 3); // On last line
+    state.set_cursor_position(1, 3); // On last line
     TextArea::update(&mut state, TextAreaMessage::DeleteLine);
     // Should adjust cursor_row when deleting the last line
     assert_eq!(state.line_count(), 1);
@@ -670,7 +670,7 @@ fn test_delete_to_end_at_end() {
 #[test]
 fn test_delete_to_start_at_start() {
     let mut state = TextAreaState::with_value("Hello");
-    state.set_cursor(0, 0);
+    state.set_cursor_position(0, 0);
     let output = TextArea::update(&mut state, TextAreaMessage::DeleteToStart);
     assert_eq!(output, None);
 }
@@ -698,7 +698,7 @@ fn test_view_with_scroll() {
 fn test_view_cursor_above_scroll() {
     let mut state = TextAreaState::with_value("1\n2\n3\n4\n5\n6\n7\n8\n9\n10");
     state.scroll_offset = 5; // Scroll down
-    state.set_cursor(2, 0); // Cursor above scroll
+    state.set_cursor_position(2, 0); // Cursor above scroll
     state.focused = true;
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 5);
 
@@ -729,7 +729,7 @@ fn test_backspace_unicode() {
 #[test]
 fn test_delete_unicode() {
     let mut state = TextAreaState::with_value("日本");
-    state.set_cursor(0, 0);
+    state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::Delete);
     assert_eq!(state.value(), "本");
 }

--- a/src/component/text_area/undo_tests.rs
+++ b/src/component/text_area/undo_tests.rs
@@ -103,7 +103,7 @@ fn test_grouped_backspace_undo_together() {
 #[test]
 fn test_grouped_delete_undo_together() {
     let mut state = TextAreaState::with_value("hello");
-    state.set_cursor(0, 0);
+    state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::Delete);
     TextArea::update(&mut state, TextAreaMessage::Delete);
     assert_eq!(state.value(), "llo");
@@ -159,7 +159,7 @@ fn test_newline_breaks_insert_group() {
 #[test]
 fn test_delete_line_undo() {
     let mut state = TextAreaState::with_value("abc\ndef\nghi");
-    state.set_cursor(1, 0);
+    state.set_cursor_position(1, 0);
     TextArea::update(&mut state, TextAreaMessage::DeleteLine);
     assert_eq!(state.value(), "abc\nghi");
 
@@ -170,7 +170,7 @@ fn test_delete_line_undo() {
 #[test]
 fn test_delete_to_end_undo() {
     let mut state = TextAreaState::with_value("hello world");
-    state.set_cursor(0, 5);
+    state.set_cursor_position(0, 5);
     TextArea::update(&mut state, TextAreaMessage::DeleteToEnd);
     assert_eq!(state.value(), "hello");
 
@@ -181,7 +181,7 @@ fn test_delete_to_end_undo() {
 #[test]
 fn test_delete_to_start_undo() {
     let mut state = TextAreaState::with_value("hello world");
-    state.set_cursor(0, 6);
+    state.set_cursor_position(0, 6);
     TextArea::update(&mut state, TextAreaMessage::DeleteToStart);
     assert_eq!(state.value(), "world");
 
@@ -323,7 +323,7 @@ fn test_can_redo() {
 #[test]
 fn test_backspace_join_lines_undo() {
     let mut state = TextAreaState::with_value("abc\ndef");
-    state.set_cursor(1, 0);
+    state.set_cursor_position(1, 0);
     TextArea::update(&mut state, TextAreaMessage::Backspace);
     assert_eq!(state.value(), "abcdef");
     assert_eq!(state.line_count(), 1);


### PR DESCRIPTION
## Summary
- Renamed `set_cursor()` to `set_cursor_position()` on both `InputFieldState` and `TextAreaState` to match the existing `cursor_position()` getter convention
- Updated all call sites across source, tests, and benchmarks (9 files, 80 occurrences)
- This is a breaking API change appropriate for a pre-1.0 library; no deprecation needed

## Test plan
- [x] `cargo test --lib` -- 2964 tests pass
- [x] `cargo test --doc` -- 347 doc tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo fmt --all` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)