### PR TITLE
Add with_placeholder() builder methods to Dropdown and Select

### DIFF
--- a/src/component/dropdown/mod.rs
+++ b/src/component/dropdown/mod.rs
@@ -251,6 +251,22 @@ impl DropdownState {
         self.placeholder = placeholder.into();
     }
 
+    /// Sets the placeholder text (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DropdownState;
+    ///
+    /// let state = DropdownState::new(vec!["Apple", "Banana", "Cherry"])
+    ///     .with_placeholder("Search fruits...");
+    /// assert_eq!(state.placeholder(), "Search fruits...");
+    /// ```
+    pub fn with_placeholder(mut self, placeholder: impl Into<String>) -> Self {
+        self.placeholder = placeholder.into();
+        self
+    }
+
     /// Returns true if the dropdown is disabled.
     pub fn is_disabled(&self) -> bool {
         self.disabled

--- a/src/component/dropdown/tests.rs
+++ b/src/component/dropdown/tests.rs
@@ -807,3 +807,18 @@ fn test_with_disabled_prevents_open() {
     assert_eq!(output, None);
     assert!(!state.is_open());
 }
+
+#[test]
+fn test_with_placeholder() {
+    let state = DropdownState::new(vec!["A", "B", "C"]).with_placeholder("Pick one...");
+    assert_eq!(state.placeholder(), "Pick one...");
+}
+
+#[test]
+fn test_with_placeholder_chained() {
+    let state = DropdownState::new(vec!["A", "B", "C"])
+        .with_placeholder("Pick one...")
+        .with_disabled(true);
+    assert_eq!(state.placeholder(), "Pick one...");
+    assert!(state.is_disabled());
+}

--- a/src/component/select/mod.rs
+++ b/src/component/select/mod.rs
@@ -204,6 +204,22 @@ impl SelectState {
         self.placeholder = placeholder.into();
     }
 
+    /// Sets the placeholder text (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SelectState;
+    ///
+    /// let state = SelectState::new(vec!["Red", "Green", "Blue"])
+    ///     .with_placeholder("Choose a color...");
+    /// assert_eq!(state.placeholder(), "Choose a color...");
+    /// ```
+    pub fn with_placeholder(mut self, placeholder: impl Into<String>) -> Self {
+        self.placeholder = placeholder.into();
+        self
+    }
+
     /// Returns true if the select is disabled.
     pub fn is_disabled(&self) -> bool {
         self.disabled

--- a/src/component/select/tests.rs
+++ b/src/component/select/tests.rs
@@ -442,3 +442,18 @@ fn test_with_disabled_prevents_open() {
     assert_eq!(output, None);
     assert!(!state.is_open());
 }
+
+#[test]
+fn test_with_placeholder() {
+    let state = SelectState::new(vec!["A", "B", "C"]).with_placeholder("Pick one...");
+    assert_eq!(state.placeholder(), "Pick one...");
+}
+
+#[test]
+fn test_with_placeholder_chained() {
+    let state = SelectState::new(vec!["A", "B", "C"])
+        .with_placeholder("Pick one...")
+        .with_disabled(true);
+    assert_eq!(state.placeholder(), "Pick one...");
+    assert!(state.is_disabled());
+}


### PR DESCRIPTION
## Summary
- Added with_placeholder(mut self, placeholder: impl Into<String>) -> Self builder methods to DropdownState and SelectState
- These components had set_placeholder()/placeholder() but lacked the builder variant that InputField, TextArea, SearchableList, and ChatView all provide
- Includes doc tests on both new methods and unit tests (test_with_placeholder, test_with_placeholder_chained) for each component

## Test plan
- [x] cargo test --lib -- dropdown -- all 73 tests pass
- [x] cargo test --lib -- select -- all 361 tests pass (includes related components)
- [x] cargo test --doc -- doc tests for both with_placeholder methods pass
- [x] cargo clippy --all-targets --all-features -- -D warnings -- clean
- [x] cargo fmt --all -- clean
- [x] All modified files under 1000 lines

Generated with [Claude Code](https://claude.com/claude-code)