### PR TITLE
Rename SelectState::set_selected_index() to set_selected()

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -332,6 +332,37 @@ if state.is_disabled() { /* ... */ }
 This is additive and not breaking unless you have custom components that
 implement the `Focusable` trait and also need to support disabled state.
 
+### Selection API Consistency
+
+The selection API has been standardized across all components. The canonical
+methods are now `selected_item()` for getting the selected value and
+`set_selected()` for setting the selection index.
+
+| Component | Old Method | New Method |
+|-----------|-----------|------------|
+| RadioGroup, Tabs, LoadingList | `selected()` | `selected_item()` |
+| Dropdown, Menu, Select | `set_selected_index()` | `set_selected()` |
+| DataGrid | `selected_row_index()` | `selected_index()` |
+| InputField, TextArea | `set_cursor()` | `set_cursor_position()` |
+
+**Before (0.4.x):**
+
+```rust
+let item = state.selected();        // RadioGroup, Tabs
+state.set_selected_index(Some(1));   // Select, Dropdown
+let idx = state.selected_row_index(); // DataGrid
+state.set_cursor(5);                 // InputField
+```
+
+**After (0.5.0):**
+
+```rust
+let item = state.selected_item();   // All selection components
+state.set_selected(Some(1));        // All selection components
+let idx = state.selected_index();   // All selection components
+state.set_cursor_position(5);       // InputField, TextArea
+```
+
 ### Quick Migration Checklist
 
 - [ ] Replace `AsyncRuntime` / sync `Runtime` with unified `Runtime`
@@ -348,5 +379,9 @@ implement the `Focusable` trait and also need to support disabled state.
 - [ ] Rename `OverlayAction::Message` to `OverlayAction::KeepAndMessage`
 - [ ] Update any component message/output type names to new `{Component}Message`/`{Component}Output` convention
 - [ ] Handle `selected_index()` returning `Option<usize>` instead of `usize`
+- [ ] Rename `selected()` → `selected_item()` on RadioGroup, Tabs, LoadingList
+- [ ] Rename `set_selected_index()` → `set_selected()` on Select, Dropdown, Menu
+- [ ] Rename `selected_row_index()` → `selected_index()` on DataGrid
+- [ ] Rename `set_cursor()` → `set_cursor_position()` on InputField, TextArea
 - [ ] If using serde: ensure `serialization` feature is enabled (it is by default)
 - [ ] If using specific component groups: add the appropriate feature flags

--- a/src/component/select/mod.rs
+++ b/src/component/select/mod.rs
@@ -178,7 +178,7 @@ impl SelectState {
     }
 
     /// Sets the selected option index.
-    pub fn set_selected_index(&mut self, index: Option<usize>) {
+    pub fn set_selected(&mut self, index: Option<usize>) {
         if let Some(idx) = index {
             if idx < self.options.len() {
                 self.selected_index = Some(idx);

--- a/src/component/select/tests.rs
+++ b/src/component/select/tests.rs
@@ -45,17 +45,17 @@ fn test_set_options_resets_invalid_selection() {
 }
 
 #[test]
-fn test_set_selected_index() {
+fn test_set_selected() {
     let mut state = SelectState::new(vec!["A", "B", "C"]);
-    state.set_selected_index(Some(1));
+    state.set_selected(Some(1));
     assert_eq!(state.selected_index(), Some(1));
     assert_eq!(state.selected_value(), Some("B"));
 }
 
 #[test]
-fn test_set_selected_index_out_of_bounds() {
+fn test_set_selected_out_of_bounds() {
     let mut state = SelectState::new(vec!["A", "B"]);
-    state.set_selected_index(Some(5));
+    state.set_selected(Some(5));
     assert_eq!(state.selected_index(), None);
 }
 


### PR DESCRIPTION
## Summary
- Renames `SelectState::set_selected_index()` to `set_selected()` to match all other selection-based components
- Updates all tests to use the new name
- Adds selection API rename table to MIGRATION.md with before/after examples

This was the last remaining selection API inconsistency across the 12 selection-based components.

## Test plan
- [x] `cargo test --all-features` passes
- [x] `cargo clippy --all-features -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)