### PR TITLE
Add serialization support for ScrollableText, TitleCard, and LineInput

### DIFF
--- a/src/component/line_input/history.rs
+++ b/src/component/line_input/history.rs
@@ -5,6 +5,10 @@
 
 /// A ring buffer for input history.
 #[derive(Clone, Debug)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct History {
     /// Previous entries (oldest first).
     entries: Vec<String>,

--- a/src/component/line_input/mod.rs
+++ b/src/component/line_input/mod.rs
@@ -50,6 +50,10 @@ pub struct LineInput;
 
 /// State for the [`LineInput`] component.
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct LineInputState {
     /// The text buffer (single line, no newlines).
     buffer: String,
@@ -66,10 +70,13 @@ pub struct LineInputState {
     /// Internal clipboard.
     clipboard: String,
     /// Command history.
+    #[cfg_attr(feature = "serialization", serde(skip))]
     history: History,
     /// Undo/redo stack.
+    #[cfg_attr(feature = "serialization", serde(skip))]
     undo_stack: UndoStack<LineInputSnapshot>,
     /// Last known display width from the parent layout.
+    #[cfg_attr(feature = "serialization", serde(skip))]
     last_display_width: usize,
 }
 

--- a/src/component/scrollable_text/mod.rs
+++ b/src/component/scrollable_text/mod.rs
@@ -58,6 +58,10 @@ pub enum ScrollableTextOutput {
 ///
 /// Contains the text content, scroll position, and display options.
 #[derive(Clone, Debug, Default, PartialEq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct ScrollableTextState {
     /// The text content.
     content: String,

--- a/src/component/title_card/mod.rs
+++ b/src/component/title_card/mod.rs
@@ -47,6 +47,10 @@ pub enum TitleCardMessage {
 ///
 /// Contains the title text, optional decorations, and styling configuration.
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct TitleCardState {
     /// The title text.
     title: String,

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -178,6 +178,34 @@ fn test_tooltip_state_round_trip() {
     assert_eq!(restored.content(), "Helpful tip");
 }
 
+#[test]
+fn test_scrollable_text_state_round_trip() {
+    let state = ScrollableTextState::new()
+        .with_content("Hello, world!")
+        .with_title("Preview");
+    let restored = round_trip(&state);
+    assert_eq!(restored.content(), "Hello, world!");
+    assert_eq!(restored.title(), Some("Preview"));
+}
+
+#[test]
+fn test_title_card_state_round_trip() {
+    let state = TitleCardState::new("My App")
+        .with_subtitle("v1.0")
+        .with_prefix("\u{1f680} ");
+    let restored = round_trip(&state);
+    assert_eq!(restored.title(), "My App");
+    assert_eq!(restored.subtitle(), Some("v1.0"));
+    assert_eq!(restored.prefix(), Some("\u{1f680} "));
+}
+
+#[test]
+fn test_line_input_state_round_trip() {
+    let state = LineInputState::with_value("hello world");
+    let restored = round_trip(&state);
+    assert_eq!(restored.value(), "hello world");
+}
+
 // =============================================================================
 // Generic State types
 // =============================================================================


### PR DESCRIPTION
## Summary
- Add `cfg_attr(feature = "serialization", derive(serde::Serialize, serde::Deserialize))` to `ScrollableTextState`, `TitleCardState`, `LineInputState`, and `History`
- Skip runtime-only fields (`history`, `undo_stack`, `last_display_width`) in `LineInputState` serialization
- Add 3 round-trip serialization tests

## Test plan
- [x] `cargo test --features serialization --test serialization` — all 30 tests pass
- [x] `cargo test --all-features` — all tests pass
- [x] `cargo clippy -- -D warnings` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)