### PR TITLE
Expand WidgetType enum with new component variants

### DIFF
--- a/src/annotation/types/mod.rs
+++ b/src/annotation/types/mod.rs
@@ -79,6 +79,57 @@ pub enum WidgetType {
     /// A tree view
     Tree,
 
+    /// A spinner/loading indicator
+    Spinner,
+
+    /// A toast notification
+    Toast,
+
+    /// A tooltip overlay
+    Tooltip,
+
+    /// An accordion panel group
+    Accordion,
+
+    /// A breadcrumb navigation trail
+    Breadcrumb,
+
+    /// A loading list
+    LoadingList,
+
+    /// A key hints display
+    KeyHints,
+
+    /// A multi-progress display
+    MultiProgress,
+
+    /// A status log
+    StatusLog,
+
+    /// A title card display
+    TitleCard,
+
+    /// A line input
+    LineInput,
+
+    /// A dropdown select
+    Dropdown,
+
+    /// A scrollable text display
+    ScrollableText,
+
+    /// A form container
+    Form,
+
+    /// A split panel container
+    SplitPanel,
+
+    /// A searchable list container
+    SearchableList,
+
+    /// A radio group
+    RadioGroup,
+
     /// A custom widget type
     Custom(String),
 }
@@ -99,6 +150,12 @@ impl WidgetType {
                 | WidgetType::Tab
                 | WidgetType::MenuItem
                 | WidgetType::Tree
+                | WidgetType::LineInput
+                | WidgetType::Dropdown
+                | WidgetType::LoadingList
+                | WidgetType::Accordion
+                | WidgetType::RadioGroup
+                | WidgetType::SearchableList
         )
     }
 
@@ -106,7 +163,12 @@ impl WidgetType {
     pub fn is_container(&self) -> bool {
         matches!(
             self,
-            WidgetType::Container | WidgetType::Dialog | WidgetType::Scroll | WidgetType::Sidebar
+            WidgetType::Container
+                | WidgetType::Dialog
+                | WidgetType::Scroll
+                | WidgetType::Sidebar
+                | WidgetType::Form
+                | WidgetType::SplitPanel
         )
     }
 }
@@ -238,6 +300,91 @@ impl Annotation {
     /// Creates a header annotation.
     pub fn header(text: impl Into<String>) -> Self {
         Self::new(WidgetType::Header).with_label(text)
+    }
+
+    /// Creates a spinner annotation.
+    pub fn spinner(id: impl Into<String>) -> Self {
+        Self::new(WidgetType::Spinner).with_id(id)
+    }
+
+    /// Creates a toast annotation.
+    pub fn toast(id: impl Into<String>) -> Self {
+        Self::new(WidgetType::Toast).with_id(id)
+    }
+
+    /// Creates a tooltip annotation.
+    pub fn tooltip(id: impl Into<String>) -> Self {
+        Self::new(WidgetType::Tooltip).with_id(id)
+    }
+
+    /// Creates an accordion annotation.
+    pub fn accordion(id: impl Into<String>) -> Self {
+        Self::new(WidgetType::Accordion).with_id(id)
+    }
+
+    /// Creates a breadcrumb annotation.
+    pub fn breadcrumb(id: impl Into<String>) -> Self {
+        Self::new(WidgetType::Breadcrumb).with_id(id)
+    }
+
+    /// Creates a loading list annotation.
+    pub fn loading_list(id: impl Into<String>) -> Self {
+        Self::new(WidgetType::LoadingList).with_id(id)
+    }
+
+    /// Creates a key hints annotation.
+    pub fn key_hints(id: impl Into<String>) -> Self {
+        Self::new(WidgetType::KeyHints).with_id(id)
+    }
+
+    /// Creates a multi-progress annotation.
+    pub fn multi_progress(id: impl Into<String>) -> Self {
+        Self::new(WidgetType::MultiProgress).with_id(id)
+    }
+
+    /// Creates a status log annotation.
+    pub fn status_log(id: impl Into<String>) -> Self {
+        Self::new(WidgetType::StatusLog).with_id(id)
+    }
+
+    /// Creates a title card annotation.
+    pub fn title_card(id: impl Into<String>) -> Self {
+        Self::new(WidgetType::TitleCard).with_id(id)
+    }
+
+    /// Creates a line input annotation.
+    pub fn line_input(id: impl Into<String>) -> Self {
+        Self::new(WidgetType::LineInput).with_id(id)
+    }
+
+    /// Creates a dropdown annotation.
+    pub fn dropdown(id: impl Into<String>) -> Self {
+        Self::new(WidgetType::Dropdown).with_id(id)
+    }
+
+    /// Creates a scrollable text annotation.
+    pub fn scrollable_text(id: impl Into<String>) -> Self {
+        Self::new(WidgetType::ScrollableText).with_id(id)
+    }
+
+    /// Creates a form annotation.
+    pub fn form(id: impl Into<String>) -> Self {
+        Self::new(WidgetType::Form).with_id(id)
+    }
+
+    /// Creates a split panel annotation.
+    pub fn split_panel(id: impl Into<String>) -> Self {
+        Self::new(WidgetType::SplitPanel).with_id(id)
+    }
+
+    /// Creates a searchable list annotation.
+    pub fn searchable_list(id: impl Into<String>) -> Self {
+        Self::new(WidgetType::SearchableList).with_id(id)
+    }
+
+    /// Creates a radio group annotation.
+    pub fn radio_group(id: impl Into<String>) -> Self {
+        Self::new(WidgetType::RadioGroup).with_id(id)
     }
 
     /// Creates a custom widget annotation.

--- a/src/annotation/types/tests.rs
+++ b/src/annotation/types/tests.rs
@@ -230,6 +230,12 @@ fn test_widget_type_interactive_all() {
     assert!(WidgetType::Tab.is_interactive());
     assert!(WidgetType::MenuItem.is_interactive());
     assert!(WidgetType::Tree.is_interactive());
+    assert!(WidgetType::LineInput.is_interactive());
+    assert!(WidgetType::Dropdown.is_interactive());
+    assert!(WidgetType::LoadingList.is_interactive());
+    assert!(WidgetType::Accordion.is_interactive());
+    assert!(WidgetType::RadioGroup.is_interactive());
+    assert!(WidgetType::SearchableList.is_interactive());
 
     // Non-interactive types
     assert!(!WidgetType::Header.is_interactive());
@@ -242,6 +248,17 @@ fn test_widget_type_interactive_all() {
     assert!(!WidgetType::TabBar.is_interactive());
     assert!(!WidgetType::Menu.is_interactive());
     assert!(!WidgetType::Custom("test".to_string()).is_interactive());
+    assert!(!WidgetType::Spinner.is_interactive());
+    assert!(!WidgetType::Toast.is_interactive());
+    assert!(!WidgetType::Tooltip.is_interactive());
+    assert!(!WidgetType::Breadcrumb.is_interactive());
+    assert!(!WidgetType::KeyHints.is_interactive());
+    assert!(!WidgetType::MultiProgress.is_interactive());
+    assert!(!WidgetType::StatusLog.is_interactive());
+    assert!(!WidgetType::TitleCard.is_interactive());
+    assert!(!WidgetType::ScrollableText.is_interactive());
+    assert!(!WidgetType::Form.is_interactive());
+    assert!(!WidgetType::SplitPanel.is_interactive());
 }
 
 #[test]
@@ -254,4 +271,135 @@ fn test_widget_type_hash() {
     set.insert(WidgetType::Button); // Duplicate
 
     assert_eq!(set.len(), 2);
+}
+
+// =============================================================================
+// New WidgetType variants
+// =============================================================================
+
+#[test]
+fn test_widget_type_is_container_expanded() {
+    assert!(WidgetType::Form.is_container());
+    assert!(WidgetType::SplitPanel.is_container());
+    assert!(!WidgetType::Spinner.is_container());
+    assert!(!WidgetType::LineInput.is_container());
+}
+
+#[test]
+fn test_annotation_spinner() {
+    let ann = Annotation::spinner("loading");
+    assert_eq!(ann.widget_type, WidgetType::Spinner);
+    assert!(ann.has_id("loading"));
+}
+
+#[test]
+fn test_annotation_toast_constructor() {
+    let ann = Annotation::toast("notification");
+    assert_eq!(ann.widget_type, WidgetType::Toast);
+    assert!(ann.has_id("notification"));
+}
+
+#[test]
+fn test_annotation_tooltip_constructor() {
+    let ann = Annotation::tooltip("help_tip");
+    assert_eq!(ann.widget_type, WidgetType::Tooltip);
+    assert!(ann.has_id("help_tip"));
+}
+
+#[test]
+fn test_annotation_accordion_constructor() {
+    let ann = Annotation::accordion("settings");
+    assert_eq!(ann.widget_type, WidgetType::Accordion);
+    assert!(ann.has_id("settings"));
+}
+
+#[test]
+fn test_annotation_breadcrumb_constructor() {
+    let ann = Annotation::breadcrumb("nav");
+    assert_eq!(ann.widget_type, WidgetType::Breadcrumb);
+    assert!(ann.has_id("nav"));
+}
+
+#[test]
+fn test_annotation_loading_list_constructor() {
+    let ann = Annotation::loading_list("tasks");
+    assert_eq!(ann.widget_type, WidgetType::LoadingList);
+    assert!(ann.has_id("tasks"));
+}
+
+#[test]
+fn test_annotation_key_hints_constructor() {
+    let ann = Annotation::key_hints("hints");
+    assert_eq!(ann.widget_type, WidgetType::KeyHints);
+    assert!(ann.has_id("hints"));
+}
+
+#[test]
+fn test_annotation_multi_progress_constructor() {
+    let ann = Annotation::multi_progress("downloads");
+    assert_eq!(ann.widget_type, WidgetType::MultiProgress);
+    assert!(ann.has_id("downloads"));
+}
+
+#[test]
+fn test_annotation_status_log_constructor() {
+    let ann = Annotation::status_log("log");
+    assert_eq!(ann.widget_type, WidgetType::StatusLog);
+    assert!(ann.has_id("log"));
+}
+
+#[test]
+fn test_annotation_title_card_constructor() {
+    let ann = Annotation::title_card("app_title");
+    assert_eq!(ann.widget_type, WidgetType::TitleCard);
+    assert!(ann.has_id("app_title"));
+}
+
+#[test]
+fn test_annotation_line_input_constructor() {
+    let ann = Annotation::line_input("chat_input");
+    assert_eq!(ann.widget_type, WidgetType::LineInput);
+    assert!(ann.has_id("chat_input"));
+}
+
+#[test]
+fn test_annotation_dropdown_constructor() {
+    let ann = Annotation::dropdown("color_picker");
+    assert_eq!(ann.widget_type, WidgetType::Dropdown);
+    assert!(ann.has_id("color_picker"));
+}
+
+#[test]
+fn test_annotation_scrollable_text_constructor() {
+    let ann = Annotation::scrollable_text("preview");
+    assert_eq!(ann.widget_type, WidgetType::ScrollableText);
+    assert!(ann.has_id("preview"));
+}
+
+#[test]
+fn test_annotation_form_constructor() {
+    let ann = Annotation::form("login_form");
+    assert_eq!(ann.widget_type, WidgetType::Form);
+    assert!(ann.has_id("login_form"));
+}
+
+#[test]
+fn test_annotation_split_panel_constructor() {
+    let ann = Annotation::split_panel("editor");
+    assert_eq!(ann.widget_type, WidgetType::SplitPanel);
+    assert!(ann.has_id("editor"));
+}
+
+#[test]
+fn test_annotation_searchable_list_constructor() {
+    let ann = Annotation::searchable_list("file_list");
+    assert_eq!(ann.widget_type, WidgetType::SearchableList);
+    assert!(ann.has_id("file_list"));
+}
+
+#[test]
+fn test_annotation_radio_group_constructor() {
+    let ann = Annotation::radio_group("options");
+    assert_eq!(ann.widget_type, WidgetType::RadioGroup);
+    assert!(ann.has_id("options"));
 }


### PR DESCRIPTION
## Summary
- Add 17 new `WidgetType` variants: Spinner, Toast, Tooltip, Accordion, Breadcrumb, LoadingList, KeyHints, MultiProgress, StatusLog, TitleCard, LineInput, Dropdown, ScrollableText, Form, SplitPanel, SearchableList, RadioGroup
- Update `is_interactive()` to include LineInput, Dropdown, LoadingList, Accordion, RadioGroup, SearchableList
- Update `is_container()` to include Form and SplitPanel
- Add convenience constructors for all new variants on `Annotation`

## Test plan
- [x] 45 annotation tests pass (27 existing + 18 new)
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)