### PR TITLE
Add with_visible() builder to Dialog and Tooltip

### DIFF
--- a/src/component/dialog/mod.rs
+++ b/src/component/dialog/mod.rs
@@ -485,6 +485,21 @@ impl DialogState {
         Dialog::set_visible(self, visible);
     }
 
+    /// Sets the visibility state using builder pattern.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = DialogState::alert("Info", "Done.").with_visible(true);
+    /// assert!(state.is_visible());
+    /// ```
+    pub fn with_visible(mut self, visible: bool) -> Self {
+        Dialog::set_visible(&mut self, visible);
+        self
+    }
+
     /// Maps an input event to a dialog message.
     pub fn handle_event(&self, event: &Event) -> Option<DialogMessage> {
         Dialog::handle_event(self, event)

--- a/src/component/dialog/tests.rs
+++ b/src/component/dialog/tests.rs
@@ -595,6 +595,18 @@ fn test_instance_set_visible() {
 }
 
 #[test]
+fn test_with_visible() {
+    let state = DialogState::alert("T", "M").with_visible(true);
+    assert!(state.is_visible());
+}
+
+#[test]
+fn test_with_visible_false() {
+    let state = DialogState::alert("T", "M").with_visible(false);
+    assert!(!state.is_visible());
+}
+
+#[test]
 fn test_instance_is_focused() {
     let mut state = DialogState::alert("T", "M");
     assert!(!state.is_focused());

--- a/src/component/tooltip/mod.rs
+++ b/src/component/tooltip/mod.rs
@@ -335,6 +335,36 @@ impl TooltipState {
     pub fn set_border_color(&mut self, color: Color) {
         self.border_color = color;
     }
+
+    /// Sets the visibility state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = TooltipState::new("Help text");
+    /// state.set_visible(true);
+    /// assert!(state.is_visible());
+    /// ```
+    pub fn set_visible(&mut self, visible: bool) {
+        Tooltip::set_visible(self, visible);
+    }
+
+    /// Sets the visibility state using builder pattern.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = TooltipState::new("Help text").with_visible(true);
+    /// assert!(state.is_visible());
+    /// ```
+    pub fn with_visible(mut self, visible: bool) -> Self {
+        Tooltip::set_visible(&mut self, visible);
+        self
+    }
 }
 
 /// A tooltip component for displaying contextual information.

--- a/src/component/tooltip/tests.rs
+++ b/src/component/tooltip/tests.rs
@@ -657,3 +657,25 @@ fn test_annotation_emitted() {
     assert_eq!(regions.len(), 1);
     assert!(regions[0].annotation.has_id("tooltip"));
 }
+
+#[test]
+fn test_with_visible() {
+    let state = TooltipState::new("Help").with_visible(true);
+    assert!(state.is_visible());
+}
+
+#[test]
+fn test_with_visible_false() {
+    let state = TooltipState::new("Help").with_visible(false);
+    assert!(!state.is_visible());
+}
+
+#[test]
+fn test_instance_set_visible() {
+    let mut state = TooltipState::new("Help");
+    assert!(!state.is_visible());
+    state.set_visible(true);
+    assert!(state.is_visible());
+    state.set_visible(false);
+    assert!(!state.is_visible());
+}


### PR DESCRIPTION
## Summary

- Add `with_visible()` builder method to `DialogState` and `TooltipState`
- Add `set_visible()` instance method to `TooltipState` (was missing)
- Completes the Toggleable builder pattern (is_X / set_X / with_X trio)

## Test plan

- [x] Unit tests for `with_visible(true)` and `with_visible(false)` on both types
- [x] Unit test for `TooltipState::set_visible()` instance method
- [x] Doc tests on both new methods
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)