### PR TITLE
Increase doc test coverage for Dropdown, TextArea, Select

### DIFF
--- a/src/component/dropdown/mod.rs
+++ b/src/component/dropdown/mod.rs
@@ -166,6 +166,15 @@ impl DropdownState {
     }
 
     /// Returns the options list.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = DropdownState::new(vec!["Apple", "Banana"]);
+    /// assert_eq!(state.options(), &["Apple", "Banana"]);
+    /// ```
     pub fn options(&self) -> &[String] {
         &self.options
     }
@@ -174,6 +183,17 @@ impl DropdownState {
     ///
     /// Resets selection if the current selected index is out of bounds.
     /// Also updates the filtered indices.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = DropdownState::with_selection(vec!["A", "B"], 1);
+    /// state.set_options(vec!["X", "Y", "Z"]);
+    /// assert_eq!(state.options(), &["X", "Y", "Z"]);
+    /// assert_eq!(state.selected_index(), Some(1));
+    /// ```
     pub fn set_options<S: Into<String>>(&mut self, options: Vec<S>) {
         self.options = options.into_iter().map(|s| s.into()).collect();
 
@@ -189,11 +209,35 @@ impl DropdownState {
     }
 
     /// Returns the selected option index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = DropdownState::new(vec!["A", "B"]);
+    /// assert_eq!(state.selected_index(), None);
+    ///
+    /// let state = DropdownState::with_selection(vec!["A", "B"], 0);
+    /// assert_eq!(state.selected_index(), Some(0));
+    /// ```
     pub fn selected_index(&self) -> Option<usize> {
         self.selected_index
     }
 
     /// Returns the selected option value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = DropdownState::with_selection(vec!["Apple", "Banana"], 1);
+    /// assert_eq!(state.selected_value(), Some("Banana"));
+    ///
+    /// let state = DropdownState::new(vec!["Apple", "Banana"]);
+    /// assert_eq!(state.selected_value(), None);
+    /// ```
     pub fn selected_value(&self) -> Option<&str> {
         self.selected_index
             .and_then(|idx| self.options.get(idx).map(|s| s.as_str()))
@@ -203,11 +247,33 @@ impl DropdownState {
     ///
     /// This is an alias for [`selected_value()`](Self::selected_value) that provides a
     /// consistent accessor name across all selection-based components.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = DropdownState::with_selection(vec!["Apple", "Banana"], 0);
+    /// assert_eq!(state.selected_item(), Some("Apple"));
+    /// ```
     pub fn selected_item(&self) -> Option<&str> {
         self.selected_value()
     }
 
     /// Sets the selected option index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = DropdownState::new(vec!["A", "B", "C"]);
+    /// state.set_selected(Some(2));
+    /// assert_eq!(state.selected_value(), Some("C"));
+    ///
+    /// state.set_selected(None);
+    /// assert_eq!(state.selected_value(), None);
+    /// ```
     pub fn set_selected(&mut self, index: Option<usize>) {
         if let Some(idx) = index {
             if idx < self.options.len() {
@@ -219,11 +285,33 @@ impl DropdownState {
     }
 
     /// Returns the current filter text.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = DropdownState::new(vec!["Apple", "Banana"]);
+    /// assert_eq!(state.filter_text(), "");
+    ///
+    /// state.update(DropdownMessage::Insert('a'));
+    /// assert_eq!(state.filter_text(), "a");
+    /// ```
     pub fn filter_text(&self) -> &str {
         &self.filter_text
     }
 
     /// Returns the filtered options (values, not indices).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = DropdownState::new(vec!["Apple", "Banana", "Cherry"]);
+    /// state.update(DropdownMessage::Insert('a'));
+    /// assert_eq!(state.filtered_options(), vec!["Apple", "Banana"]);
+    /// ```
     pub fn filtered_options(&self) -> Vec<&str> {
         self.filtered_indices
             .iter()
@@ -232,21 +320,64 @@ impl DropdownState {
     }
 
     /// Returns the number of filtered options.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = DropdownState::new(vec!["Apple", "Banana", "Cherry"]);
+    /// assert_eq!(state.filtered_count(), 3);
+    ///
+    /// state.update(DropdownMessage::Insert('a'));
+    /// assert_eq!(state.filtered_count(), 2);
+    /// ```
     pub fn filtered_count(&self) -> usize {
         self.filtered_indices.len()
     }
 
     /// Returns true if the dropdown is open.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = DropdownState::new(vec!["A", "B"]);
+    /// assert!(!state.is_open());
+    ///
+    /// state.update(DropdownMessage::Open);
+    /// assert!(state.is_open());
+    /// ```
     pub fn is_open(&self) -> bool {
         self.is_open
     }
 
     /// Returns the placeholder text.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = DropdownState::new(vec!["A", "B"]);
+    /// assert_eq!(state.placeholder(), "Search...");
+    /// ```
     pub fn placeholder(&self) -> &str {
         &self.placeholder
     }
 
     /// Sets the placeholder text.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = DropdownState::new(vec!["A", "B"]);
+    /// state.set_placeholder("Pick one...");
+    /// assert_eq!(state.placeholder(), "Pick one...");
+    /// ```
     pub fn set_placeholder(&mut self, placeholder: impl Into<String>) {
         self.placeholder = placeholder.into();
     }
@@ -268,11 +399,34 @@ impl DropdownState {
     }
 
     /// Returns true if the dropdown is disabled.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = DropdownState::new(vec!["A", "B"]);
+    /// assert!(!state.is_disabled());
+    ///
+    /// let state = DropdownState::new(vec!["A", "B"]).with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn is_disabled(&self) -> bool {
         self.disabled
     }
 
     /// Sets the disabled state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = DropdownState::new(vec!["A", "B"]);
+    /// state.set_disabled(true);
+    /// assert!(state.is_disabled());
+    /// assert!(!state.is_open());
+    /// ```
     pub fn set_disabled(&mut self, disabled: bool) {
         self.disabled = disabled;
         if disabled {
@@ -281,32 +435,105 @@ impl DropdownState {
     }
 
     /// Sets the disabled state using builder pattern.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = DropdownState::new(vec!["A", "B"]).with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn with_disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
         self
     }
 
     /// Returns true if the dropdown is focused.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = DropdownState::new(vec!["A", "B"]);
+    /// assert!(!state.is_focused());
+    ///
+    /// state.set_focused(true);
+    /// assert!(state.is_focused());
+    /// ```
     pub fn is_focused(&self) -> bool {
         self.focused
     }
 
     /// Sets the focus state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = DropdownState::new(vec!["A", "B"]);
+    /// state.set_focused(true);
+    /// assert!(state.is_focused());
+    ///
+    /// state.set_focused(false);
+    /// assert!(!state.is_focused());
+    /// ```
     pub fn set_focused(&mut self, focused: bool) {
         self.focused = focused;
     }
 
     /// Maps an input event to a dropdown message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = DropdownState::new(vec!["A", "B"]);
+    /// state.set_focused(true);
+    /// state.update(DropdownMessage::Open);
+    ///
+    /// let event = Event::key(KeyCode::Down);
+    /// assert_eq!(state.handle_event(&event), Some(DropdownMessage::Down));
+    /// ```
     pub fn handle_event(&self, event: &Event) -> Option<DropdownMessage> {
         Dropdown::handle_event(self, event)
     }
 
     /// Dispatches an event, updating state and returning any output.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = DropdownState::new(vec!["A", "B"]);
+    /// state.set_focused(true);
+    /// state.update(DropdownMessage::Open);
+    ///
+    /// let event = Event::key(KeyCode::Down);
+    /// let output = state.dispatch_event(&event);
+    /// assert_eq!(output, Some(DropdownOutput::SelectionChanged(1)));
+    /// ```
     pub fn dispatch_event(&mut self, event: &Event) -> Option<DropdownOutput> {
         Dropdown::dispatch_event(self, event)
     }
 
     /// Updates the dropdown state with a message, returning any output.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = DropdownState::new(vec!["Apple", "Banana", "Cherry"]);
+    /// state.update(DropdownMessage::Open);
+    /// state.update(DropdownMessage::Down);
+    /// let output = state.update(DropdownMessage::Confirm);
+    /// assert_eq!(output, Some(DropdownOutput::Selected("Banana".to_string())));
+    /// ```
     pub fn update(&mut self, msg: DropdownMessage) -> Option<DropdownOutput> {
         Dropdown::update(self, msg)
     }

--- a/src/component/select/mod.rs
+++ b/src/component/select/mod.rs
@@ -135,6 +135,15 @@ impl SelectState {
     }
 
     /// Returns the options list.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = SelectState::new(vec!["Red", "Green", "Blue"]);
+    /// assert_eq!(state.options(), &["Red", "Green", "Blue"]);
+    /// ```
     pub fn options(&self) -> &[String] {
         &self.options
     }
@@ -142,6 +151,17 @@ impl SelectState {
     /// Sets the options list.
     ///
     /// Resets selection if the current selected index is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = SelectState::with_selection(vec!["A", "B"], 1);
+    /// state.set_options(vec!["X", "Y", "Z"]);
+    /// assert_eq!(state.options(), &["X", "Y", "Z"]);
+    /// assert_eq!(state.selected_index(), Some(1));
+    /// ```
     pub fn set_options<S: Into<String>>(&mut self, options: Vec<S>) {
         self.options = options.into_iter().map(|s| s.into()).collect();
 
@@ -159,11 +179,35 @@ impl SelectState {
     }
 
     /// Returns the selected option index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = SelectState::new(vec!["A", "B"]);
+    /// assert_eq!(state.selected_index(), None);
+    ///
+    /// let state = SelectState::with_selection(vec!["A", "B"], 0);
+    /// assert_eq!(state.selected_index(), Some(0));
+    /// ```
     pub fn selected_index(&self) -> Option<usize> {
         self.selected_index
     }
 
     /// Returns the selected option value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = SelectState::with_selection(vec!["Red", "Green", "Blue"], 2);
+    /// assert_eq!(state.selected_value(), Some("Blue"));
+    ///
+    /// let state = SelectState::new(vec!["Red", "Green", "Blue"]);
+    /// assert_eq!(state.selected_value(), None);
+    /// ```
     pub fn selected_value(&self) -> Option<&str> {
         self.selected_index
             .and_then(|idx| self.options.get(idx).map(|s| s.as_str()))
@@ -173,11 +217,33 @@ impl SelectState {
     ///
     /// This is an alias for [`selected_value()`](Self::selected_value) that provides a
     /// consistent accessor name across all selection-based components.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = SelectState::with_selection(vec!["Red", "Green"], 0);
+    /// assert_eq!(state.selected_item(), Some("Red"));
+    /// ```
     pub fn selected_item(&self) -> Option<&str> {
         self.selected_value()
     }
 
     /// Sets the selected option index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = SelectState::new(vec!["A", "B", "C"]);
+    /// state.set_selected(Some(2));
+    /// assert_eq!(state.selected_value(), Some("C"));
+    ///
+    /// state.set_selected(None);
+    /// assert_eq!(state.selected_value(), None);
+    /// ```
     pub fn set_selected(&mut self, index: Option<usize>) {
         if let Some(idx) = index {
             if idx < self.options.len() {
@@ -190,16 +256,47 @@ impl SelectState {
     }
 
     /// Returns true if the dropdown is open.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = SelectState::new(vec!["A", "B"]);
+    /// assert!(!state.is_open());
+    ///
+    /// state.update(SelectMessage::Open);
+    /// assert!(state.is_open());
+    /// ```
     pub fn is_open(&self) -> bool {
         self.is_open
     }
 
     /// Returns the placeholder text.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = SelectState::new(vec!["A", "B"]);
+    /// assert_eq!(state.placeholder(), "Select...");
+    /// ```
     pub fn placeholder(&self) -> &str {
         &self.placeholder
     }
 
     /// Sets the placeholder text.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = SelectState::new(vec!["A", "B"]);
+    /// state.set_placeholder("Pick one...");
+    /// assert_eq!(state.placeholder(), "Pick one...");
+    /// ```
     pub fn set_placeholder(&mut self, placeholder: impl Into<String>) {
         self.placeholder = placeholder.into();
     }
@@ -221,11 +318,34 @@ impl SelectState {
     }
 
     /// Returns true if the select is disabled.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = SelectState::new(vec!["A", "B"]);
+    /// assert!(!state.is_disabled());
+    ///
+    /// let state = SelectState::new(vec!["A", "B"]).with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn is_disabled(&self) -> bool {
         self.disabled
     }
 
     /// Sets the disabled state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = SelectState::new(vec!["A", "B"]);
+    /// state.set_disabled(true);
+    /// assert!(state.is_disabled());
+    /// assert!(!state.is_open());
+    /// ```
     pub fn set_disabled(&mut self, disabled: bool) {
         self.disabled = disabled;
         if disabled {
@@ -234,32 +354,104 @@ impl SelectState {
     }
 
     /// Sets the disabled state using builder pattern.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = SelectState::new(vec!["A", "B"]).with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn with_disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
         self
     }
 
     /// Returns true if the select is focused.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = SelectState::new(vec!["A", "B"]);
+    /// assert!(!state.is_focused());
+    ///
+    /// state.set_focused(true);
+    /// assert!(state.is_focused());
+    /// ```
     pub fn is_focused(&self) -> bool {
         self.focused
     }
 
     /// Sets the focus state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = SelectState::new(vec!["A", "B"]);
+    /// state.set_focused(true);
+    /// assert!(state.is_focused());
+    ///
+    /// state.set_focused(false);
+    /// assert!(!state.is_focused());
+    /// ```
     pub fn set_focused(&mut self, focused: bool) {
         self.focused = focused;
     }
 
     /// Maps an input event to a select message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = SelectState::new(vec!["A", "B"]);
+    /// state.set_focused(true);
+    ///
+    /// let event = Event::key(KeyCode::Enter);
+    /// assert_eq!(state.handle_event(&event), Some(SelectMessage::Toggle));
+    /// ```
     pub fn handle_event(&self, event: &Event) -> Option<SelectMessage> {
         Select::handle_event(self, event)
     }
 
     /// Dispatches an event, updating state and returning any output.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = SelectState::new(vec!["A", "B"]);
+    /// state.set_focused(true);
+    /// state.update(SelectMessage::Open);
+    ///
+    /// let event = Event::key(KeyCode::Down);
+    /// let output = state.dispatch_event(&event);
+    /// assert_eq!(output, Some(SelectOutput::SelectionChanged(1)));
+    /// ```
     pub fn dispatch_event(&mut self, event: &Event) -> Option<SelectOutput> {
         Select::dispatch_event(self, event)
     }
 
     /// Updates the select state with a message, returning any output.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = SelectState::new(vec!["Apple", "Banana", "Cherry"]);
+    /// state.update(SelectMessage::Open);
+    /// state.update(SelectMessage::Down);
+    /// let output = state.update(SelectMessage::Confirm);
+    /// assert_eq!(output, Some(SelectOutput::Selected("Banana".to_string())));
+    /// ```
     pub fn update(&mut self, msg: SelectMessage) -> Option<SelectOutput> {
         Select::update(self, msg)
     }

--- a/src/component/text_area/mod.rs
+++ b/src/component/text_area/mod.rs
@@ -224,6 +224,16 @@ impl TextAreaState {
 
     /// Creates a textarea with initial content, split on newlines.
     /// Cursor is placed at the end of the content.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = TextAreaState::with_value("Hello\nWorld");
+    /// assert_eq!(state.value(), "Hello\nWorld");
+    /// assert_eq!(state.line_count(), 2);
+    /// ```
     pub fn with_value(value: impl Into<String>) -> Self {
         let value = value.into();
         let lines: Vec<String> = if value.is_empty() {
@@ -251,6 +261,16 @@ impl TextAreaState {
     }
 
     /// Creates a textarea with placeholder text.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = TextAreaState::with_placeholder("Enter text...");
+    /// assert_eq!(state.placeholder(), "Enter text...");
+    /// assert!(state.is_empty());
+    /// ```
     pub fn with_placeholder(placeholder: impl Into<String>) -> Self {
         Self {
             placeholder: placeholder.into(),
@@ -259,11 +279,31 @@ impl TextAreaState {
     }
 
     /// Returns the full text content (lines joined with \n).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = TextAreaState::with_value("line1\nline2");
+    /// assert_eq!(state.value(), "line1\nline2");
+    /// ```
     pub fn value(&self) -> String {
         self.lines.join("\n")
     }
 
     /// Sets the content from a string (splits on \n). Cursor moves to end.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let mut state = TextAreaState::new();
+    /// state.set_value("Hello\nWorld");
+    /// assert_eq!(state.value(), "Hello\nWorld");
+    /// assert_eq!(state.cursor_position(), (1, 5));
+    /// ```
     pub fn set_value(&mut self, value: impl Into<String>) {
         let value = value.into();
         self.lines = if value.is_empty() {
@@ -339,6 +379,15 @@ impl TextAreaState {
     /// Returns true if the textarea is empty.
     ///
     /// A textarea is empty if it contains only a single empty line.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// assert!(TextAreaState::new().is_empty());
+    /// assert!(!TextAreaState::with_value("hi").is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.lines.len() == 1 && self.lines[0].is_empty()
     }


### PR DESCRIPTION
## Summary

- Add doc test examples to **20** public methods on `DropdownState` that were previously missing them (coverage: 13% -> 100%)
- Add doc test examples to **17** public methods on `SelectState` that were previously missing them (coverage: ~18% -> 100%)
- Add doc test examples to **5** public methods on `TextAreaState` (`with_value`, `with_placeholder`, `value`, `set_value`, `is_empty`) - file is at 999 lines so remaining methods require refactoring first (coverage: 7% -> 25%)

### Files not modified

- **`TableState`** (`src/component/table/mod.rs`): Already at 996 lines, leaving no room for doc tests without exceeding the 1000-line limit. This file needs refactoring (e.g., extracting the `view()` method or `Component` impl) before doc tests can be added.
- **`TextAreaState`** (`src/component/text_area/mod.rs`): Now at 999 lines after adding 5 doc tests. Remaining 21 public methods need the file refactored to make room.

## Test plan

- [x] All 411 doc tests pass (`cargo test --doc`)
- [x] `cargo fmt` produces no changes
- [x] `cargo clippy -- -D warnings` passes with no warnings
- [x] No file exceeds 1000 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)