### PR TITLE
Add envision-audit CLI tool for library auditing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 documentation = "https://docs.rs/envision"
 keywords = ["tui", "terminal", "ratatui", "testing", "headless"]
 categories = ["command-line-interface", "development-tools::testing"]
-exclude = [".claude/", "CLAUDE.md"]
+exclude = [".claude/", "CLAUDE.md", "tools/"]
 
 [features]
 default = ["serialization", "full"]

--- a/tools/audit/Cargo.toml
+++ b/tools/audit/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "envision-audit"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Audit tool for the envision library"
+
+[[bin]]
+name = "envision-audit"
+path = "src/main.rs"
+
+[dependencies]
+regex = "1"

--- a/tools/audit/src/cargo_checks.rs
+++ b/tools/audit/src/cargo_checks.rs
@@ -1,0 +1,114 @@
+use std::path::Path;
+use std::process::Command;
+
+pub fn run(root: &Path) {
+    println!("CARGO CHECKS");
+    println!("{}", "-".repeat(70));
+    println!();
+
+    let checks: &[(&str, &[&str])] = &[
+        (
+            "cargo test --all-features",
+            &["test", "--all-features"],
+        ),
+        (
+            "cargo clippy --all-features",
+            &["clippy", "--all-features", "--", "-D", "warnings"],
+        ),
+        (
+            "cargo doc --no-deps --all-features",
+            &["doc", "--no-deps", "--all-features"],
+        ),
+        (
+            "cargo build --examples --all-features",
+            &["build", "--examples", "--all-features"],
+        ),
+        (
+            "cargo test --doc --all-features",
+            &["test", "--doc", "--all-features"],
+        ),
+    ];
+
+    for (name, args) in checks {
+        run_check(name, args, root);
+    }
+}
+
+fn run_check(name: &str, args: &[&str], root: &Path) {
+    print!("  {} ... ", name);
+
+    let output = Command::new("cargo")
+        .args(args)
+        .current_dir(root)
+        .output();
+
+    match output {
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            let stdout = String::from_utf8_lossy(&o.stdout);
+
+            if o.status.success() {
+                let combined = format!("{}{}", stdout, stderr);
+                if name.contains("test") {
+                    let (passed, failed, ignored) = count_tests(&combined);
+                    println!(
+                        "PASS ({} passed, {} failed, {} ignored)",
+                        passed, failed, ignored
+                    );
+                } else if name.contains("clippy") {
+                    let warnings = count_clippy_warnings(&stderr);
+                    println!("PASS ({} warnings)", warnings);
+                } else {
+                    println!("PASS");
+                }
+            } else {
+                println!("FAIL");
+                let output_text = if stderr.is_empty() {
+                    stdout.to_string()
+                } else {
+                    stderr.to_string()
+                };
+                let lines: Vec<&str> = output_text.lines().collect();
+                let start = if lines.len() > 20 { lines.len() - 20 } else { 0 };
+                for line in &lines[start..] {
+                    println!("    {}", line);
+                }
+            }
+        }
+        Err(e) => println!("ERROR: {}", e),
+    }
+}
+
+fn count_tests(output: &str) -> (usize, usize, usize) {
+    let mut passed = 0;
+    let mut failed = 0;
+    let mut ignored = 0;
+
+    for line in output.lines() {
+        if line.contains("test result:") {
+            passed += extract_number(line, "passed").unwrap_or(0);
+            failed += extract_number(line, "failed").unwrap_or(0);
+            ignored += extract_number(line, "ignored").unwrap_or(0);
+        }
+    }
+
+    (passed, failed, ignored)
+}
+
+fn extract_number(line: &str, keyword: &str) -> Option<usize> {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    for (i, part) in parts.iter().enumerate() {
+        let clean = part.trim_end_matches([';', ',']);
+        if clean == keyword && i > 0 {
+            return parts[i - 1].parse().ok();
+        }
+    }
+    None
+}
+
+fn count_clippy_warnings(output: &str) -> usize {
+    output
+        .lines()
+        .filter(|line| line.starts_with("warning:") && !line.contains("generated"))
+        .count()
+}

--- a/tools/audit/src/code_analysis.rs
+++ b/tools/audit/src/code_analysis.rs
@@ -1,0 +1,706 @@
+use regex::Regex;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+struct ComponentInfo {
+    has_focusable: bool,
+    has_toggleable: bool,
+    has_disabled: bool,
+    has_visible: bool,
+    builder_methods: Vec<String>,
+    setter_methods: Vec<String>,
+    getter_methods: Vec<String>,
+    pub_fn_count: usize,
+    pub_fn_with_doctest: usize,
+    unit_test_count: usize,
+    snapshot_test_count: usize,
+    public_method_names: Vec<String>,
+}
+
+pub fn run(root: &Path) {
+    println!("CODE ANALYSIS");
+    println!("{}", "-".repeat(70));
+
+    let src = root.join("src");
+
+    let components = analyze_components(&src);
+    print_component_summary(&components);
+    print_trait_summary(&components);
+    print_builder_summary(&components);
+    print_accessor_symmetry(&components);
+    print_doctest_summary(&components);
+    print_test_summary(&components);
+    print_naming_patterns(&components);
+    print_quality_checks(&src, root);
+    print_reexports(&src);
+}
+
+fn analyze_components(src: &Path) -> BTreeMap<String, ComponentInfo> {
+    let component_dir = src.join("component");
+    let mut components = BTreeMap::new();
+
+    let Ok(entries) = fs::read_dir(&component_dir) else {
+        return components;
+    };
+
+    for entry in entries.flatten() {
+        if !entry.path().is_dir() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        let mod_file = entry.path().join("mod.rs");
+        if !mod_file.exists() {
+            continue;
+        }
+
+        let info = analyze_single_component(&entry.path());
+        components.insert(name, info);
+    }
+
+    components
+}
+
+fn analyze_single_component(dir: &Path) -> ComponentInfo {
+    let all_content = read_all_rs_in_dir(dir);
+    let mod_content = fs::read_to_string(dir.join("mod.rs")).unwrap_or_default();
+
+    let focusable_re = Regex::new(r"impl\b[^{{]*\bFocusable\b\s+for\b").unwrap();
+    let toggleable_re = Regex::new(r"impl\b[^{{]*\bToggleable\b\s+for\b").unwrap();
+
+    let has_focusable = focusable_re.is_match(&all_content);
+    let has_toggleable = toggleable_re.is_match(&all_content);
+    let has_disabled =
+        mod_content.contains("fn is_disabled") && mod_content.contains("fn set_disabled");
+    let has_visible =
+        mod_content.contains("fn is_visible") && mod_content.contains("fn set_visible");
+
+    let builder_methods = extract_method_names(&mod_content, "pub fn with_");
+    let setter_methods = extract_method_names(&mod_content, "pub fn set_");
+    let getter_methods = extract_getter_methods(&mod_content);
+    let public_method_names = extract_all_public_fn_names(&mod_content);
+    let (pub_fn_count, pub_fn_with_doctest) = count_doctest_coverage(&mod_content);
+
+    let test_content = read_test_files(dir);
+    let unit_test_count = test_content.matches("#[test]").count()
+        + test_content.matches("#[tokio::test]").count();
+
+    let snapshot_content =
+        fs::read_to_string(dir.join("snapshot_tests.rs")).unwrap_or_default();
+    let snapshot_test_count = snapshot_content.matches("#[test]").count();
+
+    ComponentInfo {
+        has_focusable,
+        has_toggleable,
+        has_disabled,
+        has_visible,
+        builder_methods,
+        setter_methods,
+        getter_methods,
+        pub_fn_count,
+        pub_fn_with_doctest,
+        unit_test_count,
+        snapshot_test_count,
+        public_method_names,
+    }
+}
+
+fn print_component_summary(components: &BTreeMap<String, ComponentInfo>) {
+    println!("\nComponents found: {}", components.len());
+    for name in components.keys() {
+        println!("  {}", name);
+    }
+}
+
+fn print_trait_summary(components: &BTreeMap<String, ComponentInfo>) {
+    println!("\nTrait Implementations:");
+
+    let focusable: Vec<_> = components
+        .iter()
+        .filter(|(_, i)| i.has_focusable)
+        .map(|(n, _)| n.as_str())
+        .collect();
+    println!("  Focusable ({}):", focusable.len());
+    for name in &focusable {
+        println!("    {}", name);
+    }
+
+    let toggleable: Vec<_> = components
+        .iter()
+        .filter(|(_, i)| i.has_toggleable)
+        .map(|(n, _)| n.as_str())
+        .collect();
+    println!("  Toggleable ({}):", toggleable.len());
+    for name in &toggleable {
+        println!("    {}", name);
+    }
+
+    let without_focusable: Vec<_> = components
+        .iter()
+        .filter(|(_, i)| !i.has_focusable)
+        .map(|(n, _)| n.as_str())
+        .collect();
+    if !without_focusable.is_empty() {
+        println!("  Without Focusable ({}):", without_focusable.len());
+        for name in &without_focusable {
+            println!("    {}", name);
+        }
+    }
+
+    let toggleable_without_visible: Vec<_> = components
+        .iter()
+        .filter(|(_, i)| i.has_toggleable && !i.has_visible)
+        .map(|(n, _)| n.as_str())
+        .collect();
+    if toggleable_without_visible.is_empty() {
+        println!("  Toggleable without is_visible: NONE (all consistent)");
+    } else {
+        println!(
+            "  Toggleable WITHOUT is_visible ({}):",
+            toggleable_without_visible.len()
+        );
+        for name in &toggleable_without_visible {
+            println!("    {}", name);
+        }
+    }
+
+    let focusable_without_disabled: Vec<_> = components
+        .iter()
+        .filter(|(_, i)| i.has_focusable && !i.has_disabled)
+        .map(|(n, _)| n.as_str())
+        .collect();
+    if focusable_without_disabled.is_empty() {
+        println!("  Focusable without is_disabled: NONE (all consistent)");
+    } else {
+        println!(
+            "  Focusable WITHOUT is_disabled ({}):",
+            focusable_without_disabled.len()
+        );
+        for name in &focusable_without_disabled {
+            println!("    {}", name);
+        }
+    }
+}
+
+fn print_builder_summary(components: &BTreeMap<String, ComponentInfo>) {
+    println!("\nBuilder Methods (with_*):");
+
+    let mut by_count: Vec<_> = components
+        .iter()
+        .map(|(n, i)| (n.as_str(), i.builder_methods.len()))
+        .filter(|(_, c)| *c > 0)
+        .collect();
+    by_count.sort_by(|a, b| b.1.cmp(&a.1));
+
+    for (name, count) in &by_count {
+        println!("  {} ({}):", name, count);
+        let info = &components[*name];
+        for method in &info.builder_methods {
+            println!("    with_{}", method);
+        }
+    }
+
+    let without_builders: Vec<_> = components
+        .iter()
+        .filter(|(_, i)| i.builder_methods.is_empty())
+        .map(|(n, _)| n.as_str())
+        .collect();
+    if !without_builders.is_empty() {
+        println!("  Without any builders ({}):", without_builders.len());
+        for name in &without_builders {
+            println!("    {}", name);
+        }
+    }
+}
+
+fn print_accessor_symmetry(components: &BTreeMap<String, ComponentInfo>) {
+    println!("\nAccessor Symmetry (set_X without matching getter):");
+
+    let mut any_mismatch = false;
+    for (name, info) in components {
+        let missing: Vec<_> = info
+            .setter_methods
+            .iter()
+            .filter(|setter| {
+                let getter_name = setter.strip_prefix("set_").unwrap_or(setter);
+                !info
+                    .getter_methods
+                    .iter()
+                    .any(|g| g == getter_name || g == &format!("is_{}", getter_name))
+            })
+            .collect();
+        if !missing.is_empty() {
+            any_mismatch = true;
+            println!("  {}:", name);
+            for m in &missing {
+                println!("    set_{} has no matching getter", m);
+            }
+        }
+    }
+    if !any_mismatch {
+        println!("  All setters have matching getters.");
+    }
+}
+
+fn print_doctest_summary(components: &BTreeMap<String, ComponentInfo>) {
+    println!("\nDoc Test Coverage (pub fn with doc test / total pub fn):");
+
+    let mut total_with = 0usize;
+    let mut total_pub = 0usize;
+    let mut entries: Vec<_> = components
+        .iter()
+        .filter(|(_, i)| i.pub_fn_count > 0)
+        .map(|(n, i)| {
+            let pct = if i.pub_fn_count > 0 {
+                i.pub_fn_with_doctest as f64 / i.pub_fn_count as f64 * 100.0
+            } else {
+                0.0
+            };
+            (n.as_str(), i.pub_fn_with_doctest, i.pub_fn_count, pct)
+        })
+        .collect();
+
+    entries.sort_by(|a, b| b.3.partial_cmp(&a.3).unwrap_or(std::cmp::Ordering::Equal));
+
+    for (name, with_dt, total, pct) in &entries {
+        println!("  {:>30}: {:>3}/{:<3} ({:>5.1}%)", name, with_dt, total, pct);
+        total_with += with_dt;
+        total_pub += total;
+    }
+
+    if total_pub > 0 {
+        let pct = total_with as f64 / total_pub as f64 * 100.0;
+        println!(
+            "  {:>30}: {:>3}/{:<3} ({:>5.1}%)",
+            "TOTAL", total_with, total_pub, pct
+        );
+    }
+}
+
+fn print_test_summary(components: &BTreeMap<String, ComponentInfo>) {
+    println!("\nTests Per Component:");
+
+    let mut total_unit = 0usize;
+    let mut total_snapshot = 0usize;
+
+    let mut entries: Vec<_> = components
+        .iter()
+        .filter(|(_, i)| i.unit_test_count > 0 || i.snapshot_test_count > 0)
+        .map(|(n, i)| (n.as_str(), i.unit_test_count, i.snapshot_test_count))
+        .collect();
+    entries.sort_by(|a, b| (b.1 + b.2).cmp(&(a.1 + a.2)));
+
+    println!(
+        "  {:>30}  {:>5}  {:>8}  {:>5}",
+        "Component", "Unit", "Snapshot", "Total"
+    );
+    println!("  {}", "-".repeat(55));
+    for (name, unit, snapshot) in &entries {
+        println!(
+            "  {:>30}  {:>5}  {:>8}  {:>5}",
+            name,
+            unit,
+            snapshot,
+            unit + snapshot
+        );
+        total_unit += unit;
+        total_snapshot += snapshot;
+    }
+    println!("  {}", "-".repeat(55));
+    println!(
+        "  {:>30}  {:>5}  {:>8}  {:>5}",
+        "TOTAL",
+        total_unit,
+        total_snapshot,
+        total_unit + total_snapshot
+    );
+}
+
+fn print_naming_patterns(components: &BTreeMap<String, ComponentInfo>) {
+    println!("\nNaming Patterns:");
+
+    let patterns = [
+        "selected",
+        "value",
+        "checked",
+        "expanded",
+        "items",
+        "label",
+        "title",
+        "placeholder",
+    ];
+
+    for pattern in &patterns {
+        let mut findings: Vec<(&str, &str)> = Vec::new();
+        for (name, info) in components {
+            for method in &info.public_method_names {
+                if method.contains(pattern) {
+                    findings.push((name.as_str(), method.as_str()));
+                }
+            }
+        }
+        if !findings.is_empty() {
+            println!("  \"{}\":", pattern);
+            for (comp, method) in &findings {
+                println!("    {}: {}()", comp, method);
+            }
+        }
+    }
+}
+
+fn print_quality_checks(src: &Path, root: &Path) {
+    println!("\nQuality Checks:");
+
+    let all_files = collect_all_rs_files(src);
+
+    // Unsafe blocks
+    let mut unsafe_locations: Vec<(PathBuf, usize, String)> = Vec::new();
+    for (path, content) in &all_files {
+        for (i, line) in content.lines().enumerate() {
+            let trimmed = line.trim();
+            if (trimmed.starts_with("unsafe ") || trimmed.contains(" unsafe "))
+                && !trimmed.starts_with("//")
+                && !trimmed.starts_with("///")
+            {
+                let display = path.strip_prefix(root).unwrap_or(path);
+                unsafe_locations.push((display.to_path_buf(), i + 1, trimmed.to_string()));
+            }
+        }
+    }
+    println!("  Unsafe blocks: {}", unsafe_locations.len());
+    for (path, line, code) in &unsafe_locations {
+        println!("    {}:{} - {}", path.display(), line, code);
+    }
+
+    // Clippy suppressions
+    let mut clippy_locations: Vec<(PathBuf, usize, String)> = Vec::new();
+    for (path, content) in &all_files {
+        for (i, line) in content.lines().enumerate() {
+            if line.contains("#[allow(clippy::") {
+                let display = path.strip_prefix(root).unwrap_or(path);
+                clippy_locations.push((display.to_path_buf(), i + 1, line.trim().to_string()));
+            }
+        }
+    }
+    println!("  Clippy suppressions: {}", clippy_locations.len());
+    for (path, line, code) in &clippy_locations {
+        println!("    {}:{} - {}", path.display(), line, code);
+    }
+
+    // #![warn(missing_docs)]
+    let lib_rs = fs::read_to_string(src.join("lib.rs")).unwrap_or_default();
+    let has_warn = lib_rs.contains("#![warn(missing_docs)]");
+    println!(
+        "  #![warn(missing_docs)]: {}",
+        if has_warn { "YES" } else { "NO" }
+    );
+
+    // Public items count
+    let mut pub_item_count = 0;
+    let pub_re = Regex::new(
+        r"(?m)^\s*pub\s+(?:fn|struct|enum|trait|type|const|static|mod|use)\b"
+    )
+    .unwrap();
+    let pub_crate_re = Regex::new(r"pub\s*\((?:crate|super|self)\)").unwrap();
+    for (_path, content) in &all_files {
+        for line in content.lines() {
+            if pub_re.is_match(line) && !pub_crate_re.is_match(line) {
+                pub_item_count += 1;
+            }
+        }
+    }
+    println!("  Total public items (across all src/): {}", pub_item_count);
+}
+
+fn print_reexports(src: &Path) {
+    println!("\nlib.rs Re-exports:");
+
+    let lib_rs = fs::read_to_string(src.join("lib.rs")).unwrap_or_default();
+    let mut total_items = 0;
+    let mut reexport_entries: Vec<(String, usize)> = Vec::new();
+
+    // Join multiline pub use statements, then count items
+    let mut current_use = String::new();
+    let mut in_use = false;
+
+    for line in lib_rs.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("pub use ") {
+            in_use = true;
+            current_use = trimmed.to_string();
+            if trimmed.contains(';') {
+                // Single-line use statement
+                in_use = false;
+                let count = count_use_items(&current_use);
+                total_items += count;
+                reexport_entries.push((current_use.clone(), count));
+                current_use.clear();
+            }
+        } else if in_use {
+            current_use.push(' ');
+            current_use.push_str(trimmed);
+            if trimmed.contains(';') {
+                in_use = false;
+                let count = count_use_items(&current_use);
+                total_items += count;
+                reexport_entries.push((current_use.clone(), count));
+                current_use.clear();
+            }
+        }
+    }
+
+    println!("  Total re-exported items: {}", total_items);
+    for (line, count) in &reexport_entries {
+        println!("  [{:>3}] {}", count, line);
+    }
+}
+
+fn count_use_items(use_stmt: &str) -> usize {
+    if use_stmt.contains('{') {
+        if let Some(brace_content) = use_stmt.split('{').nth(1) {
+            if let Some(items) = brace_content.split('}').next() {
+                return items.split(',').filter(|s| !s.trim().is_empty()).count();
+            }
+        }
+        0
+    } else if use_stmt.contains("::*") {
+        // Glob re-export like `pub use component::*`
+        1
+    } else {
+        1
+    }
+}
+
+// --- Helper functions ---
+
+/// Filters out inline test module content from source code.
+/// Handles both `#[cfg(test)] mod tests { ... }` (inline test blocks)
+/// and skips `#[cfg(test)] mod tests;` (external test file references)
+/// which should NOT terminate scanning of the rest of the file.
+fn non_test_content(content: &str) -> String {
+    non_test_lines(content).collect::<Vec<&str>>().join("\n")
+}
+
+fn non_test_lines(content: &str) -> impl Iterator<Item = &str> {
+    let lines: Vec<&str> = content.lines().collect();
+    let mut result = Vec::new();
+    let mut i = 0;
+    let mut brace_depth = 0;
+    let mut in_test_block = false;
+
+    while i < lines.len() {
+        let trimmed = lines[i].trim();
+
+        if in_test_block {
+            // Track brace depth to find the end of the test module block
+            for ch in trimmed.chars() {
+                match ch {
+                    '{' => brace_depth += 1,
+                    '}' => {
+                        brace_depth -= 1;
+                        if brace_depth == 0 {
+                            in_test_block = false;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            i += 1;
+            continue;
+        }
+
+        if trimmed == "#[cfg(test)]" {
+            // Look at next non-empty line to determine if this is an inline test block
+            let mut next = i + 1;
+            while next < lines.len() && lines[next].trim().is_empty() {
+                next += 1;
+            }
+            if next < lines.len() {
+                let next_trimmed = lines[next].trim();
+                if next_trimmed.starts_with("mod ") && next_trimmed.ends_with(';') {
+                    // External test module reference: `#[cfg(test)] mod tests;`
+                    // Skip the cfg line and the mod line, but keep scanning
+                    result.push(lines[i]); // keep it in output for line number consistency
+                    i += 1;
+                    continue;
+                }
+                // Inline test module block: skip everything until closing brace
+                in_test_block = true;
+                // Count opening braces on the next line
+                for ch in next_trimmed.chars() {
+                    match ch {
+                        '{' => brace_depth += 1,
+                        '}' => brace_depth -= 1,
+                        _ => {}
+                    }
+                }
+                if brace_depth == 0 {
+                    in_test_block = false;
+                }
+                i += 1;
+                continue;
+            }
+        }
+
+        result.push(lines[i]);
+        i += 1;
+    }
+
+    result.into_iter()
+}
+
+fn read_all_rs_in_dir(dir: &Path) -> String {
+    let mut content = String::new();
+    let Ok(entries) = fs::read_dir(dir) else {
+        return content;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_file() && path.extension().is_some_and(|e| e == "rs") {
+            if let Ok(c) = fs::read_to_string(&path) {
+                content.push_str(&c);
+                content.push('\n');
+            }
+        }
+    }
+    content
+}
+
+fn read_test_files(dir: &Path) -> String {
+    let mut content = String::new();
+    let test_files = ["tests.rs", "snapshot_tests.rs"];
+    for name in &test_files {
+        if let Ok(c) = fs::read_to_string(dir.join(name)) {
+            content.push_str(&c);
+            content.push('\n');
+        }
+    }
+    content
+}
+
+fn extract_method_names(content: &str, prefix: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    for line in non_test_lines(content) {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            if let Some(name_end) = rest.find(['(', '<', ' ']) {
+                let name = &rest[..name_end];
+                names.push(name.to_string());
+            }
+        }
+    }
+    names
+}
+
+fn extract_getter_methods(content: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    for line in non_test_lines(content) {
+        let trimmed = line.trim();
+        // Match pub fn name(&self) patterns (getters)
+        if (trimmed.starts_with("pub fn ") || trimmed.starts_with("pub const fn "))
+            && !trimmed.contains("pub(crate)")
+            && !trimmed.contains("pub(super)")
+            && trimmed.contains("&self")
+            && !trimmed.contains("&mut self")
+        {
+            if let Some(name) = extract_fn_name(trimmed) {
+                // Exclude with_ and set_ (those are builders/setters)
+                if !name.starts_with("with_") && !name.starts_with("set_") {
+                    names.push(name);
+                }
+            }
+        }
+    }
+    names
+}
+
+fn extract_all_public_fn_names(content: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    for line in non_test_lines(content) {
+        let trimmed = line.trim();
+        if is_public_fn(trimmed) {
+            if let Some(name) = extract_fn_name(trimmed) {
+                names.push(name);
+            }
+        }
+    }
+    names
+}
+
+fn extract_fn_name(line: &str) -> Option<String> {
+    let fn_pos = line.find("fn ")?;
+    let after_fn = &line[fn_pos + 3..];
+    let name_end = after_fn.find(|c: char| !c.is_alphanumeric() && c != '_')?;
+    Some(after_fn[..name_end].to_string())
+}
+
+fn is_public_fn(line: &str) -> bool {
+    (line.starts_with("pub fn ")
+        || line.starts_with("pub const fn ")
+        || line.starts_with("pub async fn "))
+        && !line.contains("pub(crate)")
+        && !line.contains("pub(super)")
+}
+
+fn count_doctest_coverage(content: &str) -> (usize, usize) {
+    let filtered = non_test_content(content);
+    let lines: Vec<&str> = filtered.lines().collect();
+    let mut pub_fn_count = 0;
+    let mut with_doctest = 0;
+
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if is_public_fn(trimmed) {
+            pub_fn_count += 1;
+            if has_doc_test_above(&lines, i) {
+                with_doctest += 1;
+            }
+        }
+    }
+
+    (pub_fn_count, with_doctest)
+}
+
+fn has_doc_test_above(lines: &[&str], fn_line: usize) -> bool {
+    let mut doc_lines = Vec::new();
+    let mut j = fn_line;
+
+    while j > 0 {
+        j -= 1;
+        let trimmed = lines[j].trim();
+        if trimmed.starts_with("///") {
+            doc_lines.push(trimmed);
+        } else if trimmed.starts_with("#[") {
+            // Attributes between doc comment and fn - skip
+            continue;
+        } else {
+            break;
+        }
+    }
+
+    doc_lines.iter().any(|line| line.contains("```"))
+}
+
+fn collect_all_rs_files(dir: &Path) -> Vec<(PathBuf, String)> {
+    let mut files = Vec::new();
+    walk_collect(dir, &mut files);
+    files
+}
+
+fn walk_collect(dir: &Path, files: &mut Vec<(PathBuf, String)>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries: Vec<_> = entries.flatten().collect();
+    entries.sort_by_key(|e| e.path());
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            walk_collect(&path, files);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            if let Ok(content) = fs::read_to_string(&path) {
+                files.push((path, content));
+            }
+        }
+    }
+}

--- a/tools/audit/src/file_stats.rs
+++ b/tools/audit/src/file_stats.rs
@@ -1,0 +1,112 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+struct FileInfo {
+    path: PathBuf,
+    lines: usize,
+}
+
+pub fn run(root: &Path) {
+    println!("FILE STATISTICS");
+    println!("{}", "-".repeat(70));
+
+    let categories = [("src", 30usize), ("tests", 20), ("benches", 10), ("examples", 10)];
+
+    let mut grand_files = 0;
+    let mut grand_lines = 0;
+    let mut over_limit = Vec::new();
+
+    for (dir, top_n) in &categories {
+        let dir_path = root.join(dir);
+        if !dir_path.exists() {
+            continue;
+        }
+
+        let mut files = collect_rs_files(&dir_path);
+        files.sort_by(|a, b| b.lines.cmp(&a.lines));
+
+        let total_lines: usize = files.iter().map(|f| f.lines).sum();
+        let file_count = files.len();
+
+        println!(
+            "\n{} ({} files, {} lines):",
+            dir,
+            file_count,
+            format_number(total_lines)
+        );
+
+        for file in files.iter().take(*top_n) {
+            let display = file.path.strip_prefix(root).unwrap_or(&file.path);
+            let marker = if file.lines > 1000 { " !!" } else { "" };
+            println!("  {:>6}  {}{}", file.lines, display.display(), marker);
+        }
+
+        for file in &files {
+            if file.lines > 1000 {
+                let display = file.path.strip_prefix(root).unwrap_or(&file.path);
+                over_limit.push((display.to_path_buf(), file.lines));
+            }
+        }
+
+        if file_count > *top_n {
+            println!("  ... and {} more files", file_count - top_n);
+        }
+
+        grand_files += file_count;
+        grand_lines += total_lines;
+    }
+
+    println!(
+        "\nTotal: {} files, {} lines",
+        grand_files,
+        format_number(grand_lines)
+    );
+
+    println!("\nFiles exceeding 1000 lines:");
+    if over_limit.is_empty() {
+        println!("  NONE");
+    } else {
+        for (path, lines) in &over_limit {
+            println!("  {} ({} lines)", path.display(), lines);
+        }
+    }
+}
+
+fn collect_rs_files(dir: &Path) -> Vec<FileInfo> {
+    let mut results = Vec::new();
+    walk_dir(dir, &mut results);
+    results
+}
+
+fn walk_dir(dir: &Path, results: &mut Vec<FileInfo>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries: Vec<_> = entries.flatten().collect();
+    entries.sort_by_key(|e| e.path());
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            walk_dir(&path, results);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            if let Ok(content) = fs::read_to_string(&path) {
+                results.push(FileInfo {
+                    lines: content.lines().count(),
+                    path,
+                });
+            }
+        }
+    }
+}
+
+fn format_number(n: usize) -> String {
+    let s = n.to_string();
+    let mut result = String::new();
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result.chars().rev().collect()
+}

--- a/tools/audit/src/main.rs
+++ b/tools/audit/src/main.rs
@@ -1,0 +1,123 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process;
+
+mod cargo_checks;
+mod code_analysis;
+mod file_stats;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let (subcommand, project_root) = parse_args(&args);
+
+    if !project_root.join("Cargo.toml").exists() {
+        eprintln!("Error: No Cargo.toml found in {}", project_root.display());
+        process::exit(1);
+    }
+
+    let version = extract_version(&project_root);
+    let git_hash = extract_git_hash(&project_root);
+
+    println!("======================================================================");
+    println!("ENVISION AUDIT TOOL");
+    println!("Version: {}  Commit: {}", version, git_hash);
+    println!("======================================================================");
+    println!();
+
+    match subcommand.as_deref() {
+        Some("stats") => file_stats::run(&project_root),
+        Some("code") => code_analysis::run(&project_root),
+        Some("cargo") => cargo_checks::run(&project_root),
+        Some("all") | None => {
+            file_stats::run(&project_root);
+            println!();
+            code_analysis::run(&project_root);
+            println!();
+            cargo_checks::run(&project_root);
+        }
+        Some(cmd) => {
+            eprintln!("Unknown command: {cmd}");
+            print_usage();
+            process::exit(1);
+        }
+    }
+}
+
+fn parse_args(args: &[String]) -> (Option<String>, PathBuf) {
+    let mut subcommand = None;
+    let mut path = None;
+    let mut i = 1;
+
+    while i < args.len() {
+        match args[i].as_str() {
+            "--path" => {
+                i += 1;
+                if i < args.len() {
+                    path = Some(PathBuf::from(&args[i]));
+                } else {
+                    eprintln!("Error: --path requires a value");
+                    process::exit(1);
+                }
+            }
+            "--help" | "-h" => {
+                print_usage();
+                process::exit(0);
+            }
+            arg if !arg.starts_with('-') && subcommand.is_none() => {
+                subcommand = Some(arg.to_string());
+            }
+            other => {
+                eprintln!("Unknown option: {other}");
+                print_usage();
+                process::exit(1);
+            }
+        }
+        i += 1;
+    }
+
+    let root = path.unwrap_or_else(|| {
+        env::current_dir().unwrap_or_else(|e| {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        })
+    });
+
+    (subcommand, root)
+}
+
+fn extract_version(root: &Path) -> String {
+    let content = fs::read_to_string(root.join("Cargo.toml")).unwrap_or_default();
+    for line in content.lines() {
+        if let Some(rest) = line.strip_prefix("version = \"") {
+            if let Some(version) = rest.strip_suffix('"') {
+                return version.to_string();
+            }
+        }
+    }
+    "unknown".to_string()
+}
+
+fn extract_git_hash(root: &Path) -> String {
+    process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .current_dir(root)
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn print_usage() {
+    eprintln!("Usage: envision-audit [COMMAND] [OPTIONS]");
+    eprintln!();
+    eprintln!("Commands:");
+    eprintln!("  stats    File and line count statistics");
+    eprintln!("  code     Source code analysis");
+    eprintln!("  cargo    Run cargo checks (test, clippy, doc)");
+    eprintln!("  all      Run all analyses (default)");
+    eprintln!();
+    eprintln!("Options:");
+    eprintln!("  --path <dir>  Project root directory (default: current dir)");
+}


### PR DESCRIPTION
## Summary

- Adds a Rust CLI tool in `tools/audit/` that replaces the shell commands used during `/audit` runs
- Three subcommands: `stats` (file/line counts), `code` (source code analysis), `cargo` (test/clippy/doc checks)
- Excludes `tools/` from crate packaging via Cargo.toml `exclude` list

### `stats` subcommand
- File and line counts for src/, tests/, benches/, examples/
- Sorted by line count, flags files exceeding 1000 lines

### `code` subcommand
- Component inventory and trait implementations (Focusable, Toggleable)
- Builder method (`with_*`) analysis per component
- Accessor symmetry checks (set_X without matching getter)
- Doc test coverage per component
- Test counts (unit + snapshot) per component
- Naming pattern analysis across components
- Quality checks: unsafe blocks, clippy suppressions, `#![warn(missing_docs)]`
- lib.rs re-export inventory with item counts

### `cargo` subcommand
- Runs cargo test, clippy, doc, build --examples, test --doc
- Parses output to extract test counts and pass/fail status

## Test plan
- [x] `cargo build --manifest-path tools/audit/Cargo.toml` compiles cleanly
- [x] `cargo clippy --manifest-path tools/audit/Cargo.toml -- -D warnings` passes
- [x] `envision-audit stats` produces correct file statistics
- [x] `envision-audit code` detects all 37 components, traits, builders, doc tests
- [x] `envision-audit cargo` runs all 5 cargo checks successfully
- [x] Main project `cargo check` still passes with Cargo.toml changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)