### PR TITLE
Standardize set_selected() to take Option<usize>

### DIFF
--- a/src/component/data_grid/mod.rs
+++ b/src/component/data_grid/mod.rs
@@ -237,15 +237,23 @@ impl<T: TableRow> DataGridState<T> {
     ///     vec![Item { name: "A".into() }, Item { name: "B".into() }],
     ///     vec![Column::new("Name", Constraint::Min(10))],
     /// );
-    /// state.set_selected(1);
+    /// state.set_selected(Some(1));
     /// assert_eq!(state.selected_index(), Some(1));
     /// ```
-    pub fn set_selected(&mut self, index: usize) {
-        if self.rows.is_empty() {
-            return;
+    pub fn set_selected(&mut self, index: Option<usize>) {
+        match index {
+            Some(i) => {
+                if self.rows.is_empty() {
+                    return;
+                }
+                self.editing = false;
+                self.selected_row = Some(i.min(self.rows.len() - 1));
+            }
+            None => {
+                self.editing = false;
+                self.selected_row = None;
+            }
         }
-        self.editing = false;
-        self.selected_row = Some(index.min(self.rows.len() - 1));
     }
 
     /// Returns the currently selected column index.

--- a/src/component/menu/mod.rs
+++ b/src/component/menu/mod.rs
@@ -242,11 +242,17 @@ impl MenuState {
 
     /// Sets the selected item index.
     ///
-    /// If the index is out of bounds, it will be clamped to the valid range.
-    /// Has no effect on an empty menu.
-    pub fn set_selected(&mut self, index: usize) {
-        if !self.items.is_empty() {
-            self.selected_index = Some(index.min(self.items.len() - 1));
+    /// Pass `Some(index)` to select an item (clamped to valid range), or
+    /// `None` to clear the selection. Has no effect on an empty menu when
+    /// selecting.
+    pub fn set_selected(&mut self, index: Option<usize>) {
+        match index {
+            Some(i) => {
+                if !self.items.is_empty() {
+                    self.selected_index = Some(i.min(self.items.len() - 1));
+                }
+            }
+            None => self.selected_index = None,
         }
     }
 
@@ -268,7 +274,7 @@ impl MenuState {
     /// assert_eq!(state.selected_index(), Some(1));
     /// ```
     pub fn with_selected(mut self, index: usize) -> Self {
-        self.set_selected(index);
+        self.set_selected(Some(index));
         self
     }
 

--- a/src/component/menu/tests.rs
+++ b/src/component/menu/tests.rs
@@ -62,7 +62,7 @@ fn test_set_items_resets_invalid_selection() {
         MenuItem::new("B"),
         MenuItem::new("C"),
     ]);
-    state.set_selected(2);
+    state.set_selected(Some(2));
 
     state.set_items(vec![MenuItem::new("X")]);
     assert_eq!(state.selected_index(), Some(0));
@@ -82,7 +82,7 @@ fn test_set_items_preserves_valid_selection() {
         MenuItem::new("B"),
         MenuItem::new("C"),
     ]);
-    state.set_selected(1);
+    state.set_selected(Some(1));
     state.set_items(vec![
         MenuItem::new("X"),
         MenuItem::new("Y"),
@@ -127,7 +127,7 @@ fn test_remove_item_adjusts_selection() {
         MenuItem::new("Edit"),
         MenuItem::new("View"),
     ]);
-    state.set_selected(2);
+    state.set_selected(Some(2));
 
     // Remove last item, selection should clamp
     state.remove_item(2);
@@ -157,10 +157,10 @@ fn test_selected_index() {
         MenuItem::new("C"),
     ]);
 
-    state.set_selected(1);
+    state.set_selected(Some(1));
     assert_eq!(state.selected_index(), Some(1));
 
-    state.set_selected(2);
+    state.set_selected(Some(2));
     assert_eq!(state.selected_index(), Some(2));
 }
 
@@ -168,7 +168,7 @@ fn test_selected_index() {
 fn test_selected_index_clamps() {
     let mut state = MenuState::new(vec![MenuItem::new("A"), MenuItem::new("B")]);
 
-    state.set_selected(10);
+    state.set_selected(Some(10));
     assert_eq!(state.selected_index(), Some(1));
 }
 
@@ -350,7 +350,7 @@ fn test_view_selected() {
         MenuItem::new("View"),
     ]);
     Menu::focus(&mut state);
-    state.set_selected(1);
+    state.set_selected(Some(1));
 
     let (mut terminal, theme) = crate::component::test_utils::setup_render(80, 24);
 

--- a/src/component/metrics_dashboard/mod.rs
+++ b/src/component/metrics_dashboard/mod.rs
@@ -399,14 +399,19 @@ impl MetricsDashboardState {
     ///     MetricWidget::counter("B", 0),
     ///     MetricWidget::counter("C", 0),
     /// ], 3);
-    /// state.set_selected(2);
+    /// state.set_selected(Some(2));
     /// assert_eq!(state.selected_index(), Some(2));
     /// ```
-    pub fn set_selected(&mut self, index: usize) {
-        if self.widgets.is_empty() {
-            return;
+    pub fn set_selected(&mut self, index: Option<usize>) {
+        match index {
+            Some(i) => {
+                if self.widgets.is_empty() {
+                    return;
+                }
+                self.selected = Some(i.min(self.widgets.len() - 1));
+            }
+            None => self.selected = None,
         }
-        self.selected = Some(index.min(self.widgets.len() - 1));
     }
 
     /// Returns a reference to the selected widget.

--- a/src/component/radio_group/mod.rs
+++ b/src/component/radio_group/mod.rs
@@ -200,10 +200,13 @@ impl<T: Clone> RadioGroupState<T> {
 
     /// Sets the selected index.
     ///
-    /// If the index is out of bounds, it will be ignored.
-    pub fn set_selected(&mut self, index: usize) {
-        if index < self.options.len() {
-            self.selected = Some(index);
+    /// Pass `Some(index)` to select an option (out-of-bounds indices are
+    /// ignored), or `None` to clear the selection.
+    pub fn set_selected(&mut self, index: Option<usize>) {
+        match index {
+            Some(i) if i < self.options.len() => self.selected = Some(i),
+            Some(_) => {} // Out of bounds, ignore
+            None => self.selected = None,
         }
     }
 

--- a/src/component/radio_group/tests.rs
+++ b/src/component/radio_group/tests.rs
@@ -55,12 +55,12 @@ fn test_selected_accessors() {
     assert_eq!(state.selected_index(), Some(0));
     assert_eq!(state.selected_item(), Some(&"A"));
 
-    state.set_selected(2);
+    state.set_selected(Some(2));
     assert_eq!(state.selected_index(), Some(2));
     assert_eq!(state.selected_item(), Some(&"C"));
 
     // Out of bounds is ignored
-    state.set_selected(100);
+    state.set_selected(Some(100));
     assert_eq!(state.selected_index(), Some(2));
 }
 
@@ -100,7 +100,7 @@ fn test_navigate_at_bounds() {
     assert_eq!(state.selected_index(), Some(0));
 
     // Go to last
-    state.set_selected(2);
+    state.set_selected(Some(2));
 
     // At last, Down returns None
     let output = RadioGroup::<&str>::update(&mut state, RadioGroupMessage::Down);
@@ -424,7 +424,7 @@ fn test_selected_item() {
     let mut state = RadioGroupState::new(vec!["A", "B", "C"]);
     assert_eq!(state.selected_item(), Some(&"A"));
 
-    state.set_selected(2);
+    state.set_selected(Some(2));
     assert_eq!(state.selected_item(), Some(&"C"));
     assert_eq!(state.selected_item(), Some(&"C"));
 }
@@ -448,7 +448,7 @@ fn test_set_options_updates_options() {
 #[test]
 fn test_set_options_preserves_valid_selection() {
     let mut state = RadioGroupState::new(vec!["A", "B", "C"]);
-    state.set_selected(1);
+    state.set_selected(Some(1));
     state.set_options(vec!["X", "Y", "Z"]);
     assert_eq!(state.selected_index(), Some(1));
 }

--- a/src/component/searchable_list/mod.rs
+++ b/src/component/searchable_list/mod.rs
@@ -283,15 +283,20 @@ impl<T: Clone> SearchableListState<T> {
     ///     "Banana".to_string(),
     ///     "Cherry".to_string(),
     /// ]);
-    /// state.set_selected(2);
+    /// state.set_selected(Some(2));
     /// assert_eq!(state.selected_index(), Some(2));
     /// assert_eq!(state.selected_item(), Some(&"Cherry".to_string()));
     /// ```
-    pub fn set_selected(&mut self, index: usize) {
-        if self.filtered_indices.is_empty() {
-            return;
+    pub fn set_selected(&mut self, index: Option<usize>) {
+        match index {
+            Some(i) => {
+                if self.filtered_indices.is_empty() {
+                    return;
+                }
+                self.selected = Some(i.min(self.filtered_indices.len() - 1));
+            }
+            None => self.selected = None,
         }
-        self.selected = Some(index.min(self.filtered_indices.len() - 1));
         self.sync_list_state();
     }
 

--- a/src/component/selectable_list/mod.rs
+++ b/src/component/selectable_list/mod.rs
@@ -268,8 +268,9 @@ impl<T: Clone> SelectableListState<T> {
 
     /// Sets the selected index.
     ///
-    /// The index is clamped to the valid range. Has no effect on empty lists.
-    /// If the item at the given index is filtered out, the selection is unchanged.
+    /// Pass `Some(index)` to select an item (clamped to valid range), or
+    /// `None` to clear the selection. Has no effect on empty lists when
+    /// selecting.
     ///
     /// # Examples
     ///
@@ -277,17 +278,27 @@ impl<T: Clone> SelectableListState<T> {
     /// use envision::prelude::*;
     ///
     /// let mut state = SelectableListState::new(vec!["a", "b", "c"]);
-    /// state.set_selected(2);
+    /// state.set_selected(Some(2));
     /// assert_eq!(state.selected_index(), Some(2));
     /// assert_eq!(state.selected_item(), Some(&"c"));
+    ///
+    /// state.set_selected(None);
+    /// assert_eq!(state.selected_index(), None);
     /// ```
-    pub fn set_selected(&mut self, index: usize) {
-        if self.items.is_empty() {
-            return;
-        }
-        let clamped = index.min(self.items.len() - 1);
-        if let Some(filtered_pos) = self.filtered_indices.iter().position(|&fi| fi == clamped) {
-            self.list_state.select(Some(filtered_pos));
+    pub fn set_selected(&mut self, index: Option<usize>) {
+        match index {
+            Some(i) => {
+                if self.items.is_empty() {
+                    return;
+                }
+                let clamped = i.min(self.items.len() - 1);
+                if let Some(filtered_pos) =
+                    self.filtered_indices.iter().position(|&fi| fi == clamped)
+                {
+                    self.list_state.select(Some(filtered_pos));
+                }
+            }
+            None => self.list_state.select(None),
         }
     }
 

--- a/src/component/tabs/mod.rs
+++ b/src/component/tabs/mod.rs
@@ -167,12 +167,18 @@ impl<T: Clone> TabsState<T> {
 
     /// Sets the selected tab by index.
     ///
-    /// The index is clamped to the valid range. Has no effect on empty tabs.
-    pub fn set_selected(&mut self, index: usize) {
-        if self.tabs.is_empty() {
-            self.selected = None;
-        } else {
-            self.selected = Some(index.min(self.tabs.len() - 1));
+    /// Pass `Some(index)` to select a tab (clamped to valid range), or
+    /// `None` to clear the selection.
+    pub fn set_selected(&mut self, index: Option<usize>) {
+        match index {
+            Some(i) => {
+                if self.tabs.is_empty() {
+                    self.selected = None;
+                } else {
+                    self.selected = Some(i.min(self.tabs.len() - 1));
+                }
+            }
+            None => self.selected = None,
         }
     }
 

--- a/src/component/tabs/tests.rs
+++ b/src/component/tabs/tests.rs
@@ -68,11 +68,11 @@ fn test_selected_empty() {
 #[test]
 fn test_set_selected() {
     let mut state = TabsState::new(vec!["A", "B", "C"]);
-    state.set_selected(2);
+    state.set_selected(Some(2));
     assert_eq!(state.selected_index(), Some(2));
 
     // Test clamping
-    state.set_selected(100);
+    state.set_selected(Some(100));
     assert_eq!(state.selected_index(), Some(2));
 }
 
@@ -629,7 +629,7 @@ fn test_set_tabs_updates_tabs() {
 #[test]
 fn test_set_tabs_preserves_valid_selection() {
     let mut state = TabsState::new(vec!["A", "B", "C"]);
-    state.set_selected(1);
+    state.set_selected(Some(1));
     state.set_tabs(vec!["X", "Y", "Z"]);
     assert_eq!(state.selected_index(), Some(1));
 }

--- a/src/component/tree/mod.rs
+++ b/src/component/tree/mod.rs
@@ -377,15 +377,20 @@ impl<T: Clone> TreeState<T> {
     /// root.add_child(TreeNode::new("Child 2", ()));
     ///
     /// let mut state = TreeState::new(vec![root]);
-    /// state.set_selected(2);
+    /// state.set_selected(Some(2));
     /// assert_eq!(state.selected_index(), Some(2));
     /// ```
-    pub fn set_selected(&mut self, index: usize) {
-        if self.roots.is_empty() {
-            return;
+    pub fn set_selected(&mut self, index: Option<usize>) {
+        match index {
+            Some(i) => {
+                if self.roots.is_empty() {
+                    return;
+                }
+                let visible = self.flatten().len();
+                self.selected_index = Some(i.min(visible.saturating_sub(1)));
+            }
+            None => self.selected_index = None,
         }
-        let visible = self.flatten().len();
-        self.selected_index = Some(index.min(visible.saturating_sub(1)));
     }
 
     /// Returns true if the tree is empty.


### PR DESCRIPTION
## Summary
- Standardize `set_selected()` to accept `Option<usize>` across all 12 components that have this method
- Previously 8 components took a bare `usize` while 4 took `Option<usize>`, creating an inconsistent API
- `None` clears the selection, `Some(index)` selects (with clamping/bounds checking per component)
- Matches the `Option<usize>` return type of `selected_index()`

**Affected components:** SelectableList, SearchableList, Tabs, RadioGroup, Menu, Tree, DataGrid, MetricsDashboard

**Already consistent (unchanged):** Table, Select, Dropdown, LoadingList

## Test plan
- [x] All existing tests updated and passing
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] Doc tests updated to reflect new signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)