### PR TITLE
Add selected() getter alias for accessor symmetry

### DIFF
--- a/src/component/data_grid/mod.rs
+++ b/src/component/data_grid/mod.rs
@@ -206,6 +206,11 @@ impl<T: TableRow> DataGridState<T> {
         self.selected_row
     }
 
+    /// Alias for [`selected_index()`](Self::selected_index).
+    pub fn selected(&self) -> Option<usize> {
+        self.selected_index()
+    }
+
     /// Returns a reference to the currently selected row.
     pub fn selected_row(&self) -> Option<&T> {
         self.selected_row.and_then(|i| self.rows.get(i))

--- a/src/component/dropdown/mod.rs
+++ b/src/component/dropdown/mod.rs
@@ -225,6 +225,11 @@ impl DropdownState {
         self.selected_index
     }
 
+    /// Alias for [`selected_index()`](Self::selected_index).
+    pub fn selected(&self) -> Option<usize> {
+        self.selected_index()
+    }
+
     /// Returns the selected option value.
     ///
     /// # Examples

--- a/src/component/loading_list/mod.rs
+++ b/src/component/loading_list/mod.rs
@@ -396,6 +396,11 @@ impl<T: Clone> LoadingListState<T> {
         self.selected
     }
 
+    /// Alias for [`selected_index()`](Self::selected_index).
+    pub fn selected(&self) -> Option<usize> {
+        self.selected_index()
+    }
+
     /// Returns the selected item.
     ///
     /// Returns `None` if no item is selected.

--- a/src/component/menu/mod.rs
+++ b/src/component/menu/mod.rs
@@ -240,6 +240,11 @@ impl MenuState {
         self.selected_index
     }
 
+    /// Alias for [`selected_index()`](Self::selected_index).
+    pub fn selected(&self) -> Option<usize> {
+        self.selected_index()
+    }
+
     /// Sets the selected item index.
     ///
     /// Pass `Some(index)` to select an item (clamped to valid range), or

--- a/src/component/metrics_dashboard/mod.rs
+++ b/src/component/metrics_dashboard/mod.rs
@@ -385,6 +385,11 @@ impl MetricsDashboardState {
         self.selected
     }
 
+    /// Alias for [`selected_index()`](Self::selected_index).
+    pub fn selected(&self) -> Option<usize> {
+        self.selected_index()
+    }
+
     /// Sets the selected widget index.
     ///
     /// The index is clamped to the valid range. Has no effect on empty dashboards.

--- a/src/component/radio_group/mod.rs
+++ b/src/component/radio_group/mod.rs
@@ -191,6 +191,11 @@ impl<T: Clone> RadioGroupState<T> {
         self.selected
     }
 
+    /// Alias for [`selected_index()`](Self::selected_index).
+    pub fn selected(&self) -> Option<usize> {
+        self.selected_index()
+    }
+
     /// Returns a reference to the currently selected item.
     ///
     /// Returns `None` if the options are empty or no selection exists.

--- a/src/component/searchable_list/mod.rs
+++ b/src/component/searchable_list/mod.rs
@@ -261,6 +261,11 @@ impl<T: Clone> SearchableListState<T> {
         self.selected
     }
 
+    /// Alias for [`selected_index()`](Self::selected_index).
+    pub fn selected(&self) -> Option<usize> {
+        self.selected_index()
+    }
+
     /// Returns a reference to the currently selected item.
     pub fn selected_item(&self) -> Option<&T> {
         self.selected

--- a/src/component/select/mod.rs
+++ b/src/component/select/mod.rs
@@ -195,6 +195,11 @@ impl SelectState {
         self.selected_index
     }
 
+    /// Alias for [`selected_index()`](Self::selected_index).
+    pub fn selected(&self) -> Option<usize> {
+        self.selected_index()
+    }
+
     /// Returns the selected option value.
     ///
     /// # Examples

--- a/src/component/selectable_list/mod.rs
+++ b/src/component/selectable_list/mod.rs
@@ -226,6 +226,11 @@ impl<T: Clone> SelectableListState<T> {
             .and_then(|i| self.filtered_indices.get(i).copied())
     }
 
+    /// Alias for [`selected_index()`](Self::selected_index).
+    pub fn selected(&self) -> Option<usize> {
+        self.selected_index()
+    }
+
     /// Returns a reference to the currently selected item.
     ///
     /// # Examples

--- a/src/component/table/mod.rs
+++ b/src/component/table/mod.rs
@@ -446,6 +446,11 @@ impl<T: TableRow> TableState<T> {
         self.selected
     }
 
+    /// Alias for [`selected_index()`](Self::selected_index).
+    pub fn selected(&self) -> Option<usize> {
+        self.selected_index()
+    }
+
     /// Returns a reference to the currently selected row.
     ///
     /// Returns `None` if no row is selected or the table is empty.

--- a/src/component/tabs/mod.rs
+++ b/src/component/tabs/mod.rs
@@ -158,6 +158,11 @@ impl<T: Clone> TabsState<T> {
         self.selected
     }
 
+    /// Alias for [`selected_index()`](Self::selected_index).
+    pub fn selected(&self) -> Option<usize> {
+        self.selected_index()
+    }
+
     /// Returns the currently selected item.
     ///
     /// Returns `None` if there are no tabs or no selection.

--- a/src/component/tree/mod.rs
+++ b/src/component/tree/mod.rs
@@ -362,6 +362,11 @@ impl<T: Clone> TreeState<T> {
         self.selected_index
     }
 
+    /// Alias for [`selected_index()`](Self::selected_index).
+    pub fn selected(&self) -> Option<usize> {
+        self.selected_index()
+    }
+
     /// Sets the selected index in the flattened view.
     ///
     /// The index is clamped to the valid range of visible nodes.


### PR DESCRIPTION
## Summary
- Add `selected()` as an alias for `selected_index()` on all 12 selection-based components
- Restores setter/getter symmetry: `set_selected()` now has a matching `selected()` getter
- `selected_index()` remains the primary method; `selected()` is a convenience alias

**Components:** SelectableList, SearchableList, LoadingList, Tabs, RadioGroup, Menu, Tree, DataGrid, MetricsDashboard, Dropdown, Select, Table

## Test plan
- [x] All existing tests pass (no behavioral changes)
- [x] `cargo check --all-features` clean
- [x] Methods delegate directly to `selected_index()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)