### PR TITLE
Add doc tests to zero-coverage components

### DIFF
--- a/src/component/line_input/mod.rs
+++ b/src/component/line_input/mod.rs
@@ -104,11 +104,31 @@ impl Default for LineInputState {
 
 impl LineInputState {
     /// Creates a new empty LineInput state.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::LineInputState;
+    ///
+    /// let state = LineInputState::new();
+    /// assert!(state.is_empty());
+    /// assert_eq!(state.value(), "");
+    /// ```
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Creates a new LineInput state with the given initial value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::LineInputState;
+    ///
+    /// let state = LineInputState::with_value("hello");
+    /// assert_eq!(state.value(), "hello");
+    /// assert_eq!(state.len(), 5);
+    /// ```
     pub fn with_value(value: impl Into<String>) -> Self {
         let buffer: String = value.into();
         let cursor = buffer.len();
@@ -120,6 +140,15 @@ impl LineInputState {
     }
 
     /// Sets the placeholder text (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::LineInputState;
+    ///
+    /// let state = LineInputState::new().with_placeholder("Type here...");
+    /// assert_eq!(state.placeholder(), "Type here...");
+    /// ```
     pub fn with_placeholder(mut self, placeholder: impl Into<String>) -> Self {
         self.placeholder = placeholder.into();
         self
@@ -132,6 +161,15 @@ impl LineInputState {
     }
 
     /// Sets the disabled state (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::LineInputState;
+    ///
+    /// let state = LineInputState::new().with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn with_disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
         self
@@ -141,6 +179,15 @@ impl LineInputState {
     ///
     /// When set, insertions and pastes that would exceed this limit are
     /// rejected or truncated. `None` means unlimited.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::LineInputState;
+    ///
+    /// let state = LineInputState::new().with_max_length(100);
+    /// assert_eq!(state.max_length(), Some(100));
+    /// ```
     pub fn with_max_length(mut self, max: usize) -> Self {
         self.max_length = Some(max);
         self
@@ -149,11 +196,30 @@ impl LineInputState {
     // --- Accessors ---
 
     /// Returns the current buffer value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::LineInputState;
+    ///
+    /// let state = LineInputState::with_value("hello world");
+    /// assert_eq!(state.value(), "hello world");
+    /// ```
     pub fn value(&self) -> &str {
         &self.buffer
     }
 
     /// Sets the buffer value, moving the cursor to the end.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::LineInputState;
+    ///
+    /// let mut state = LineInputState::new();
+    /// state.set_value("new text");
+    /// assert_eq!(state.value(), "new text");
+    /// ```
     pub fn set_value(&mut self, value: impl Into<String>) {
         self.buffer = value.into();
         self.cursor = self.buffer.len();
@@ -161,11 +227,32 @@ impl LineInputState {
     }
 
     /// Returns true if the buffer is empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::LineInputState;
+    ///
+    /// let empty = LineInputState::new();
+    /// assert!(empty.is_empty());
+    ///
+    /// let non_empty = LineInputState::with_value("x");
+    /// assert!(!non_empty.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.buffer.is_empty()
     }
 
     /// Returns the number of characters in the buffer.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::LineInputState;
+    ///
+    /// let state = LineInputState::with_value("café");
+    /// assert_eq!(state.len(), 4); // chars, not bytes
+    /// ```
     pub fn len(&self) -> usize {
         self.buffer.chars().count()
     }
@@ -196,6 +283,18 @@ impl LineInputState {
     }
 
     /// Returns the maximum character length, or `None` if unlimited.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::LineInputState;
+    ///
+    /// let state = LineInputState::new();
+    /// assert_eq!(state.max_length(), None);
+    ///
+    /// let capped = LineInputState::new().with_max_length(50);
+    /// assert_eq!(capped.max_length(), Some(50));
+    /// ```
     pub fn max_length(&self) -> Option<usize> {
         self.max_length
     }
@@ -253,6 +352,15 @@ impl LineInputState {
     }
 
     /// Returns true if there is an active selection.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::LineInputState;
+    ///
+    /// let state = LineInputState::new();
+    /// assert!(!state.has_selection());
+    /// ```
     pub fn has_selection(&self) -> bool {
         self.selection_anchor.is_some()
     }
@@ -303,6 +411,20 @@ impl LineInputState {
     }
 
     /// Updates state with a message (instance method).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::{LineInputState, LineInputMessage, LineInputOutput};
+    ///
+    /// let mut state = LineInputState::new();
+    /// state.update(LineInputMessage::Insert('h'));
+    /// state.update(LineInputMessage::Insert('i'));
+    /// assert_eq!(state.value(), "hi");
+    ///
+    /// let output = state.update(LineInputMessage::Submit);
+    /// assert_eq!(output, Some(LineInputOutput::Submitted("hi".into())));
+    /// ```
     pub fn update(&mut self, msg: LineInputMessage) -> Option<LineInputOutput> {
         LineInput::update(self, msg)
     }

--- a/src/component/multi_progress/mod.rs
+++ b/src/component/multi_progress/mod.rs
@@ -93,6 +93,18 @@ pub struct ProgressItem {
 
 impl ProgressItem {
     /// Creates a new progress item.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::ProgressItem;
+    ///
+    /// let item = ProgressItem::new("dl-1", "Downloading");
+    /// assert_eq!(item.id(), "dl-1");
+    /// assert_eq!(item.label(), "Downloading");
+    /// assert_eq!(item.progress(), 0.0);
+    /// assert_eq!(item.percentage(), 0);
+    /// ```
     pub fn new(id: impl Into<String>, label: impl Into<String>) -> Self {
         Self {
             id: id.into(),
@@ -245,6 +257,15 @@ impl Default for MultiProgressState {
 
 impl MultiProgressState {
     /// Creates a new empty MultiProgress state.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let state = MultiProgressState::new();
+    /// assert!(state.is_empty());
+    /// ```
     pub fn new() -> Self {
         Self::default()
     }
@@ -262,6 +283,15 @@ impl MultiProgressState {
     }
 
     /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let state = MultiProgressState::new().with_title("Downloads");
+    /// assert_eq!(state.title(), Some("Downloads"));
+    /// ```
     pub fn with_title(mut self, title: impl Into<String>) -> Self {
         self.title = Some(title.into());
         self
@@ -276,6 +306,17 @@ impl MultiProgressState {
     /// Adds a new progress item.
     ///
     /// Returns true if the item was added (id was unique).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let mut state = MultiProgressState::new();
+    /// assert!(state.add("task1", "Download file"));
+    /// assert!(!state.add("task1", "Duplicate")); // duplicate ID rejected
+    /// assert_eq!(state.len(), 1);
+    /// ```
     pub fn add(&mut self, id: impl Into<String>, label: impl Into<String>) -> bool {
         let id = id.into();
         if self.items.iter().any(|i| i.id == id) {
@@ -325,6 +366,22 @@ impl MultiProgressState {
     }
 
     /// Returns the overall progress (average of all items).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::{MultiProgress, MultiProgressState, MultiProgressMessage, Component};
+    ///
+    /// let mut state = MultiProgressState::new();
+    /// state.add("a", "Task A");
+    /// state.add("b", "Task B");
+    ///
+    /// MultiProgress::update(&mut state, MultiProgressMessage::SetProgress {
+    ///     id: "a".to_string(),
+    ///     progress: 1.0,
+    /// });
+    /// assert!((state.overall_progress() - 0.5).abs() < f32::EPSILON);
+    /// ```
     pub fn overall_progress(&self) -> f32 {
         if self.items.is_empty() {
             return 0.0;
@@ -334,6 +391,17 @@ impl MultiProgressState {
     }
 
     /// Finds an item by ID.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let mut state = MultiProgressState::new();
+    /// state.add("dl", "Download");
+    /// assert_eq!(state.find("dl").unwrap().label(), "Download");
+    /// assert!(state.find("missing").is_none());
+    /// ```
     pub fn find(&self, id: &str) -> Option<&ProgressItem> {
         self.items.iter().find(|i| i.id == id)
     }
@@ -344,6 +412,17 @@ impl MultiProgressState {
     }
 
     /// Removes an item by ID.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let mut state = MultiProgressState::new();
+    /// state.add("task1", "Task");
+    /// assert!(state.remove("task1"));
+    /// assert!(state.is_empty());
+    /// ```
     pub fn remove(&mut self, id: &str) -> bool {
         let len_before = self.items.len();
         self.items.retain(|i| i.id != id);

--- a/src/component/router/mod.rs
+++ b/src/component/router/mod.rs
@@ -156,6 +156,19 @@ impl<S: Clone + PartialEq> PartialEq for RouterState<S> {
 
 impl<S: Clone + PartialEq> RouterState<S> {
     /// Creates a new router state starting at the given screen.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::RouterState;
+    ///
+    /// #[derive(Clone, Debug, PartialEq)]
+    /// enum Screen { Home, Settings }
+    ///
+    /// let state = RouterState::new(Screen::Home);
+    /// assert_eq!(state.current(), &Screen::Home);
+    /// assert!(!state.can_go_back());
+    /// ```
     pub fn new(initial: S) -> Self {
         Self {
             current: initial,
@@ -168,6 +181,18 @@ impl<S: Clone + PartialEq> RouterState<S> {
     ///
     /// When the history exceeds this limit, the oldest entries are removed.
     /// Set to 0 for unlimited history (default).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::RouterState;
+    ///
+    /// #[derive(Clone, Debug, PartialEq)]
+    /// enum Screen { Home }
+    ///
+    /// let state = RouterState::new(Screen::Home).with_max_history(5);
+    /// assert_eq!(state.max_history(), 5);
+    /// ```
     pub fn with_max_history(mut self, max: usize) -> Self {
         self.max_history = max;
         self
@@ -210,6 +235,19 @@ impl<S: Clone + PartialEq> RouterState<S> {
     }
 
     /// Checks if the current screen is the given screen.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::RouterState;
+    ///
+    /// #[derive(Clone, Debug, PartialEq)]
+    /// enum Screen { Home, Settings }
+    ///
+    /// let state = RouterState::new(Screen::Home);
+    /// assert!(state.is_at(&Screen::Home));
+    /// assert!(!state.is_at(&Screen::Settings));
+    /// ```
     pub fn is_at(&self, screen: &S) -> bool {
         &self.current == screen
     }


### PR DESCRIPTION
## Summary
- Add doc tests to the 3 components that had 0% doc test coverage
- **LineInput**: 10 doc tests covering constructors, builders, accessors, and update
- **MultiProgress**: 6 doc tests covering state management and item operations
- **Router**: 3 doc tests covering constructors and query methods
- Total doc test count increased from 414 to 436

## Test plan
- [x] `cargo test --doc --all-features` passes (436 doc tests)
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] Doc tests demonstrate meaningful behavior (not just `assert!(true)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)