### PR TITLE
Add examples for tree, dropdown, text_area, and data_grid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,22 @@ required-features = ["input-components"]
 name = "chat_app"
 required-features = ["compound-components"]
 
+[[example]]
+name = "tree"
+required-features = ["data-components"]
+
+[[example]]
+name = "dropdown"
+required-features = ["input-components"]
+
+[[example]]
+name = "text_area"
+required-features = ["input-components"]
+
+[[example]]
+name = "data_grid"
+required-features = ["compound-components"]
+
 [[bench]]
 name = "capture_backend"
 harness = false

--- a/examples/data_grid.rs
+++ b/examples/data_grid.rs
@@ -100,8 +100,7 @@ impl App for DataGridApp {
             .unwrap_or_else(|| "None".into());
         let status = format!(" Selected: {}", selected);
         frame.render_widget(
-            ratatui::widgets::Paragraph::new(status)
-                .style(Style::default().fg(Color::DarkGray)),
+            ratatui::widgets::Paragraph::new(status).style(Style::default().fg(Color::DarkGray)),
             chunks[1],
         );
     }

--- a/examples/dropdown.rs
+++ b/examples/dropdown.rs
@@ -29,7 +29,15 @@ impl App for DropdownApp {
 
     fn init() -> (State, Command<Msg>) {
         let languages = vec![
-            "Rust", "Python", "TypeScript", "Go", "Java", "C++", "Haskell", "Elixir", "Zig",
+            "Rust",
+            "Python",
+            "TypeScript",
+            "Go",
+            "Java",
+            "C++",
+            "Haskell",
+            "Elixir",
+            "Zig",
         ];
 
         let mut language = DropdownState::new(languages).with_placeholder("Select language...");
@@ -58,8 +66,7 @@ impl App for DropdownApp {
         let selected = state.language.selected_value().unwrap_or("None");
         let status = format!(" Selected: {}", selected);
         frame.render_widget(
-            ratatui::widgets::Paragraph::new(status)
-                .style(Style::default().fg(Color::DarkGray)),
+            ratatui::widgets::Paragraph::new(status).style(Style::default().fg(Color::DarkGray)),
             chunks[1],
         );
     }

--- a/examples/text_area.rs
+++ b/examples/text_area.rs
@@ -56,8 +56,7 @@ impl App for TextAreaApp {
         let lines = state.editor.line_count();
         let status = format!(" Ln {}, Col {} | {} lines", row + 1, col + 1, lines);
         frame.render_widget(
-            ratatui::widgets::Paragraph::new(status)
-                .style(Style::default().fg(Color::DarkGray)),
+            ratatui::widgets::Paragraph::new(status).style(Style::default().fg(Color::DarkGray)),
             chunks[1],
         );
     }

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -78,8 +78,7 @@ impl App for TreeApp {
             .unwrap_or_else(|| "None".into());
         let status = format!(" Selected: {}", selected);
         frame.render_widget(
-            ratatui::widgets::Paragraph::new(status)
-                .style(Style::default().fg(Color::DarkGray)),
+            ratatui::widgets::Paragraph::new(status).style(Style::default().fg(Color::DarkGray)),
             chunks[1],
         );
     }


### PR DESCRIPTION
## Summary
- Adds 4 new runnable examples covering previously uncovered components
- `examples/tree.rs` — hierarchical tree view with expand/collapse
- `examples/dropdown.rs` — searchable dropdown with type-to-filter
- `examples/text_area.rs` — multi-line text editor with cursor navigation
- `examples/data_grid.rs` — editable data table with row selection

All examples follow the virtual_terminal pattern used by existing examples.

## Test plan
- [x] `cargo build --examples --all-features` compiles successfully
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)