### PR TITLE
Split 3 files exceeding 1000-line limit into submodules

### DIFF
--- a/src/component/file_browser/mod.rs
+++ b/src/component/file_browser/mod.rs
@@ -914,4 +914,6 @@ impl Focusable for FileBrowser {
 }
 
 #[cfg(test)]
+mod snapshot_tests;
+#[cfg(test)]
 mod tests;

--- a/src/component/file_browser/snapshot_tests.rs
+++ b/src/component/file_browser/snapshot_tests.rs
@@ -1,0 +1,121 @@
+use super::*;
+use crate::annotation::{with_annotations, WidgetType};
+use crate::component::test_utils;
+
+fn sample_entries() -> Vec<FileEntry> {
+    vec![
+        FileEntry::directory("src", "/src"),
+        FileEntry::directory("tests", "/tests"),
+        FileEntry::file("Cargo.toml", "/Cargo.toml").with_size(1024),
+        FileEntry::file("README.md", "/README.md").with_size(2048),
+        FileEntry::file("main.rs", "/main.rs").with_size(512),
+    ]
+}
+
+fn focused_state() -> FileBrowserState {
+    let mut state = FileBrowserState::new("/", sample_entries());
+    FileBrowser::set_focused(&mut state, true);
+    state
+}
+
+// =============================================================================
+// Rendering (snapshot)
+// =============================================================================
+
+#[test]
+fn test_render_basic() {
+    let state = focused_state();
+    let (mut terminal, theme) = test_utils::setup_render(60, 12);
+    terminal
+        .draw(|frame| {
+            FileBrowser::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+#[test]
+fn test_render_unfocused() {
+    let state = FileBrowserState::new("/", sample_entries());
+    let (mut terminal, theme) = test_utils::setup_render(60, 12);
+    terminal
+        .draw(|frame| {
+            FileBrowser::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+#[test]
+fn test_render_with_filter() {
+    let mut state = focused_state();
+    FileBrowser::update(&mut state, FileBrowserMessage::FilterChar('m'));
+    let (mut terminal, theme) = test_utils::setup_render(60, 12);
+    terminal
+        .draw(|frame| {
+            FileBrowser::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+#[test]
+fn test_render_disabled() {
+    let mut state = FileBrowserState::new("/", sample_entries()).with_disabled(true);
+    FileBrowser::set_focused(&mut state, true);
+    let (mut terminal, theme) = test_utils::setup_render(60, 12);
+    terminal
+        .draw(|frame| {
+            FileBrowser::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+#[test]
+fn test_render_with_selection_markers() {
+    let mut state = focused_state();
+    // Toggle first item
+    FileBrowser::update(&mut state, FileBrowserMessage::ToggleSelect);
+    let (mut terminal, theme) = test_utils::setup_render(60, 12);
+    terminal
+        .draw(|frame| {
+            FileBrowser::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+#[test]
+fn test_render_empty() {
+    let mut state = FileBrowserState::new("/empty", vec![]);
+    FileBrowser::set_focused(&mut state, true);
+    let (mut terminal, theme) = test_utils::setup_render(60, 8);
+    terminal
+        .draw(|frame| {
+            FileBrowser::view(&state, frame, frame.area(), &theme);
+        })
+        .unwrap();
+    insta::assert_snapshot!(terminal.backend().to_string());
+}
+
+// =============================================================================
+// Annotation
+// =============================================================================
+
+#[test]
+fn test_annotation_emitted() {
+    let state = FileBrowserState::new("/", sample_entries());
+    let (mut terminal, theme) = test_utils::setup_render(60, 12);
+    let registry = with_annotations(|| {
+        terminal
+            .draw(|frame| {
+                FileBrowser::view(&state, frame, frame.area(), &theme);
+            })
+            .unwrap();
+    });
+    assert_eq!(registry.len(), 1);
+    let regions = registry.find_by_type(&WidgetType::FileBrowser);
+    assert_eq!(regions.len(), 1);
+    assert!(regions[0].annotation.has_id("file_browser"));
+}

--- a/src/component/file_browser/snapshots/envision__component__file_browser__snapshot_tests__render_basic.snap
+++ b/src/component/file_browser/snapshots/envision__component__file_browser__snapshot_tests__render_basic.snap
@@ -1,10 +1,14 @@
 ---
-source: src/component/file_browser/tests.rs
+source: src/component/file_browser/snapshot_tests.rs
 expression: terminal.backend().to_string()
 ---
 ┌──────────────────────────────────────────────────────────┐
-│/ / empty                                                 │
-│                                                          │
+│/                                                         │
+│  📁  src                                                  │
+│  📁  tests                                                │
+│  📄  Cargo.toml  1.0K                                     │
+│  📄  main.rs  512B                                        │
+│  📄  README.md  2.0K                                      │
 │                                                          │
 │                                                          │
 │                                                          │

--- a/src/component/file_browser/snapshots/envision__component__file_browser__snapshot_tests__render_disabled.snap
+++ b/src/component/file_browser/snapshots/envision__component__file_browser__snapshot_tests__render_disabled.snap
@@ -1,10 +1,10 @@
 ---
-source: src/component/file_browser/tests.rs
+source: src/component/file_browser/snapshot_tests.rs
 expression: terminal.backend().to_string()
 ---
 ┌──────────────────────────────────────────────────────────┐
 │/                                                         │
-│✓ 📁  src                                                  │
+│  📁  src                                                  │
 │  📁  tests                                                │
 │  📄  Cargo.toml  1.0K                                     │
 │  📄  main.rs  512B                                        │

--- a/src/component/file_browser/snapshots/envision__component__file_browser__snapshot_tests__render_empty.snap
+++ b/src/component/file_browser/snapshots/envision__component__file_browser__snapshot_tests__render_empty.snap
@@ -1,14 +1,10 @@
 ---
-source: src/component/file_browser/tests.rs
+source: src/component/file_browser/snapshot_tests.rs
 expression: terminal.backend().to_string()
 ---
 ┌──────────────────────────────────────────────────────────┐
-│/                                                         │
-│  📁  src                                                  │
-│  📁  tests                                                │
-│  📄  Cargo.toml  1.0K                                     │
-│  📄  main.rs  512B                                        │
-│  📄  README.md  2.0K                                      │
+│/ / empty                                                 │
+│                                                          │
 │                                                          │
 │                                                          │
 │                                                          │

--- a/src/component/file_browser/snapshots/envision__component__file_browser__snapshot_tests__render_unfocused.snap
+++ b/src/component/file_browser/snapshots/envision__component__file_browser__snapshot_tests__render_unfocused.snap
@@ -1,14 +1,14 @@
 ---
-source: src/component/file_browser/tests.rs
+source: src/component/file_browser/snapshot_tests.rs
 expression: terminal.backend().to_string()
 ---
 ┌──────────────────────────────────────────────────────────┐
 │/                                                         │
-│Filter: m                                                 │
+│  📁  src                                                  │
+│  📁  tests                                                │
 │  📄  Cargo.toml  1.0K                                     │
 │  📄  main.rs  512B                                        │
 │  📄  README.md  2.0K                                      │
-│                                                          │
 │                                                          │
 │                                                          │
 │                                                          │

--- a/src/component/file_browser/snapshots/envision__component__file_browser__snapshot_tests__render_with_filter.snap
+++ b/src/component/file_browser/snapshots/envision__component__file_browser__snapshot_tests__render_with_filter.snap
@@ -1,14 +1,14 @@
 ---
-source: src/component/file_browser/tests.rs
+source: src/component/file_browser/snapshot_tests.rs
 expression: terminal.backend().to_string()
 ---
 ┌──────────────────────────────────────────────────────────┐
 │/                                                         │
-│  📁  src                                                  │
-│  📁  tests                                                │
+│Filter: m                                                 │
 │  📄  Cargo.toml  1.0K                                     │
 │  📄  main.rs  512B                                        │
 │  📄  README.md  2.0K                                      │
+│                                                          │
 │                                                          │
 │                                                          │
 │                                                          │

--- a/src/component/file_browser/snapshots/envision__component__file_browser__snapshot_tests__render_with_selection_markers.snap
+++ b/src/component/file_browser/snapshots/envision__component__file_browser__snapshot_tests__render_with_selection_markers.snap
@@ -1,10 +1,10 @@
 ---
-source: src/component/file_browser/tests.rs
+source: src/component/file_browser/snapshot_tests.rs
 expression: terminal.backend().to_string()
 ---
 ┌──────────────────────────────────────────────────────────┐
 │/                                                         │
-│  📁  src                                                  │
+│✓ 📁  src                                                  │
 │  📁  tests                                                │
 │  📄  Cargo.toml  1.0K                                     │
 │  📄  main.rs  512B                                        │

--- a/src/component/file_browser/tests.rs
+++ b/src/component/file_browser/tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::component::test_utils;
 use crate::input::{Event, KeyCode};
 
 fn sample_entries() -> Vec<FileEntry> {
@@ -866,109 +865,6 @@ fn test_debug_impl() {
     let debug = format!("{:?}", state);
     assert!(debug.contains("FileBrowserState"));
     assert!(debug.contains("current_path"));
-}
-
-// =============================================================================
-// Rendering (snapshot)
-// =============================================================================
-
-#[test]
-fn test_render_basic() {
-    let state = focused_state();
-    let (mut terminal, theme) = test_utils::setup_render(60, 12);
-    terminal
-        .draw(|frame| {
-            FileBrowser::view(&state, frame, frame.area(), &theme);
-        })
-        .unwrap();
-    insta::assert_snapshot!(terminal.backend().to_string());
-}
-
-#[test]
-fn test_render_unfocused() {
-    let state = FileBrowserState::new("/", sample_entries());
-    let (mut terminal, theme) = test_utils::setup_render(60, 12);
-    terminal
-        .draw(|frame| {
-            FileBrowser::view(&state, frame, frame.area(), &theme);
-        })
-        .unwrap();
-    insta::assert_snapshot!(terminal.backend().to_string());
-}
-
-#[test]
-fn test_render_with_filter() {
-    let mut state = focused_state();
-    FileBrowser::update(&mut state, FileBrowserMessage::FilterChar('m'));
-    let (mut terminal, theme) = test_utils::setup_render(60, 12);
-    terminal
-        .draw(|frame| {
-            FileBrowser::view(&state, frame, frame.area(), &theme);
-        })
-        .unwrap();
-    insta::assert_snapshot!(terminal.backend().to_string());
-}
-
-#[test]
-fn test_render_disabled() {
-    let mut state = FileBrowserState::new("/", sample_entries()).with_disabled(true);
-    FileBrowser::set_focused(&mut state, true);
-    let (mut terminal, theme) = test_utils::setup_render(60, 12);
-    terminal
-        .draw(|frame| {
-            FileBrowser::view(&state, frame, frame.area(), &theme);
-        })
-        .unwrap();
-    insta::assert_snapshot!(terminal.backend().to_string());
-}
-
-#[test]
-fn test_render_with_selection_markers() {
-    let mut state = focused_state();
-    // Toggle first item
-    FileBrowser::update(&mut state, FileBrowserMessage::ToggleSelect);
-    let (mut terminal, theme) = test_utils::setup_render(60, 12);
-    terminal
-        .draw(|frame| {
-            FileBrowser::view(&state, frame, frame.area(), &theme);
-        })
-        .unwrap();
-    insta::assert_snapshot!(terminal.backend().to_string());
-}
-
-#[test]
-fn test_render_empty() {
-    let mut state = FileBrowserState::new("/empty", vec![]);
-    FileBrowser::set_focused(&mut state, true);
-    let (mut terminal, theme) = test_utils::setup_render(60, 8);
-    terminal
-        .draw(|frame| {
-            FileBrowser::view(&state, frame, frame.area(), &theme);
-        })
-        .unwrap();
-    insta::assert_snapshot!(terminal.backend().to_string());
-}
-
-// =============================================================================
-// Annotation
-// =============================================================================
-
-#[test]
-fn test_annotation_emitted() {
-    use crate::annotation::{with_annotations, WidgetType};
-    let state = FileBrowserState::new("/", sample_entries());
-    let (mut terminal, theme) = test_utils::setup_render(60, 12);
-    let registry = with_annotations(|| {
-        terminal
-            .draw(|frame| {
-                FileBrowser::view(&state, frame, frame.area(), &theme);
-            })
-            .unwrap();
-    });
-    assert_eq!(registry.len(), 1);
-    let regions = registry.find_by_type(&WidgetType::FileBrowser);
-    assert_eq!(regions.len(), 1);
-    assert!(regions[0].annotation.has_id("file_browser"));
 }
 
 // =============================================================================

--- a/src/component/line_input/mod.rs
+++ b/src/component/line_input/mod.rs
@@ -16,7 +16,10 @@
 mod chunking;
 mod editing;
 mod history;
+mod types;
 mod view_helpers;
+
+pub use types::{LineInputMessage, LineInputOutput};
 
 #[cfg(test)]
 mod handle_event_tests;
@@ -474,94 +477,6 @@ impl LineInputState {
         self.clear_selection();
         Some(deleted)
     }
-}
-
-/// Messages for the [`LineInput`] component.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum LineInputMessage {
-    // Editing
-    /// Insert a character at the cursor.
-    Insert(char),
-    /// Delete the character before the cursor.
-    Backspace,
-    /// Delete the character at the cursor.
-    Delete,
-    /// Delete the word before the cursor.
-    DeleteWordBack,
-    /// Delete the word after the cursor.
-    DeleteWordForward,
-    /// Clear the buffer.
-    Clear,
-    /// Set the buffer to the given value.
-    SetValue(String),
-    /// Paste text at the cursor (newlines are stripped).
-    Paste(String),
-
-    // Movement
-    /// Move cursor one character left.
-    Left,
-    /// Move cursor one character right.
-    Right,
-    /// Move cursor to the start of the buffer.
-    Home,
-    /// Move cursor to the end of the buffer.
-    End,
-    /// Move cursor to the start of the previous word.
-    WordLeft,
-    /// Move cursor to the start of the next word.
-    WordRight,
-    /// Move cursor one visual row up.
-    VisualUp,
-    /// Move cursor one visual row down.
-    VisualDown,
-
-    // Selection
-    /// Extend selection one character left.
-    SelectLeft,
-    /// Extend selection one character right.
-    SelectRight,
-    /// Extend selection to the start of the buffer.
-    SelectHome,
-    /// Extend selection to the end of the buffer.
-    SelectEnd,
-    /// Extend selection to the start of the previous word.
-    SelectWordLeft,
-    /// Extend selection to the start of the next word.
-    SelectWordRight,
-    /// Select the entire buffer.
-    SelectAll,
-
-    // Clipboard
-    /// Copy selected text to internal clipboard.
-    Copy,
-    /// Cut selected text to internal clipboard.
-    Cut,
-
-    // History
-    /// Move to the previous (older) history entry.
-    HistoryPrev,
-    /// Move to the next (newer) history entry.
-    HistoryNext,
-
-    // Actions
-    /// Submit the current buffer contents.
-    Submit,
-    /// Undo the last edit.
-    Undo,
-    /// Redo the last undone edit.
-    Redo,
-}
-
-/// Output events from the [`LineInput`] component.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum LineInputOutput {
-    /// The buffer was submitted (Enter pressed). Contains the submitted text.
-    /// The buffer is cleared and the text is pushed to history.
-    Submitted(String),
-    /// The buffer value changed.
-    Changed(String),
-    /// Text was copied to the internal clipboard.
-    Copied(String),
 }
 
 impl Component for LineInput {

--- a/src/component/line_input/types.rs
+++ b/src/component/line_input/types.rs
@@ -1,0 +1,89 @@
+//! Types for the line input component.
+
+/// Messages for the [`super::LineInput`] component.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LineInputMessage {
+    // Editing
+    /// Insert a character at the cursor.
+    Insert(char),
+    /// Delete the character before the cursor.
+    Backspace,
+    /// Delete the character at the cursor.
+    Delete,
+    /// Delete the word before the cursor.
+    DeleteWordBack,
+    /// Delete the word after the cursor.
+    DeleteWordForward,
+    /// Clear the buffer.
+    Clear,
+    /// Set the buffer to the given value.
+    SetValue(String),
+    /// Paste text at the cursor (newlines are stripped).
+    Paste(String),
+
+    // Movement
+    /// Move cursor one character left.
+    Left,
+    /// Move cursor one character right.
+    Right,
+    /// Move cursor to the start of the buffer.
+    Home,
+    /// Move cursor to the end of the buffer.
+    End,
+    /// Move cursor to the start of the previous word.
+    WordLeft,
+    /// Move cursor to the start of the next word.
+    WordRight,
+    /// Move cursor one visual row up.
+    VisualUp,
+    /// Move cursor one visual row down.
+    VisualDown,
+
+    // Selection
+    /// Extend selection one character left.
+    SelectLeft,
+    /// Extend selection one character right.
+    SelectRight,
+    /// Extend selection to the start of the buffer.
+    SelectHome,
+    /// Extend selection to the end of the buffer.
+    SelectEnd,
+    /// Extend selection to the start of the previous word.
+    SelectWordLeft,
+    /// Extend selection to the start of the next word.
+    SelectWordRight,
+    /// Select the entire buffer.
+    SelectAll,
+
+    // Clipboard
+    /// Copy selected text to internal clipboard.
+    Copy,
+    /// Cut selected text to internal clipboard.
+    Cut,
+
+    // History
+    /// Move to the previous (older) history entry.
+    HistoryPrev,
+    /// Move to the next (newer) history entry.
+    HistoryNext,
+
+    // Actions
+    /// Submit the current buffer contents.
+    Submit,
+    /// Undo the last edit.
+    Undo,
+    /// Redo the last undone edit.
+    Redo,
+}
+
+/// Output events from the [`super::LineInput`] component.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LineInputOutput {
+    /// The buffer was submitted (Enter pressed). Contains the submitted text.
+    /// The buffer is cleared and the text is pushed to history.
+    Submitted(String),
+    /// The buffer value changed.
+    Changed(String),
+    /// Text was copied to the internal clipboard.
+    Copied(String),
+}

--- a/src/component/table/mod.rs
+++ b/src/component/table/mod.rs
@@ -51,234 +51,18 @@
 //! }));
 //! ```
 
+mod types;
+
+pub use types::{Column, SortDirection, TableMessage, TableOutput, TableRow};
+
 use std::marker::PhantomData;
 
-use ratatui::layout::Constraint;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Cell, Row};
 
 use super::{Component, Focusable};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
-
-/// Trait for types that can be displayed as table rows.
-///
-/// Implement this trait for your data types to use them with `Table`.
-///
-/// # Example
-///
-/// ```rust
-/// use envision::component::TableRow;
-///
-/// #[derive(Clone)]
-/// struct Product {
-///     name: String,
-///     price: f64,
-///     quantity: u32,
-/// }
-///
-/// impl TableRow for Product {
-///     fn cells(&self) -> Vec<String> {
-///         vec![
-///             self.name.clone(),
-///             format!("${:.2}", self.price),
-///             self.quantity.to_string(),
-///         ]
-///     }
-/// }
-/// ```
-pub trait TableRow: Clone {
-    /// Returns the cell values for this row.
-    ///
-    /// The order of values should match the order of columns
-    /// defined in the table.
-    fn cells(&self) -> Vec<String>;
-}
-
-/// Column definition for a table.
-///
-/// Columns define the header text, width, and whether the column
-/// is sortable.
-///
-/// # Example
-///
-/// ```rust
-/// use envision::component::Column;
-/// use ratatui::layout::Constraint;
-///
-/// let col = Column::new("Name", Constraint::Length(20)).sortable();
-/// assert_eq!(col.header(), "Name");
-/// assert!(col.is_sortable());
-/// ```
-#[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(
-    feature = "serialization",
-    derive(serde::Serialize, serde::Deserialize)
-)]
-pub struct Column {
-    header: String,
-    #[cfg_attr(feature = "serialization", serde(skip))]
-    width: Constraint,
-    sortable: bool,
-}
-
-impl Column {
-    /// Creates a new column with the given header and width.
-    ///
-    /// The column is not sortable by default.
-    pub fn new(header: impl Into<String>, width: Constraint) -> Self {
-        Self {
-            header: header.into(),
-            width,
-            sortable: false,
-        }
-    }
-
-    /// Makes this column sortable.
-    ///
-    /// Sortable columns can be sorted by clicking/selecting the header
-    /// or using `TableMessage::SortBy`.
-    pub fn sortable(mut self) -> Self {
-        self.sortable = true;
-        self
-    }
-
-    /// Returns the column header text.
-    pub fn header(&self) -> &str {
-        &self.header
-    }
-
-    /// Returns the column width constraint.
-    pub fn width(&self) -> Constraint {
-        self.width
-    }
-
-    /// Creates a column with a fixed width.
-    ///
-    /// This is a shorthand for `Column::new(header, Constraint::Length(width))`.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::Column;
-    ///
-    /// let col = Column::fixed("Name", 20);
-    /// assert_eq!(col.header(), "Name");
-    /// ```
-    pub fn fixed(header: impl Into<String>, width: u16) -> Self {
-        Self::new(header, Constraint::Length(width))
-    }
-
-    /// Creates a column with a minimum width.
-    ///
-    /// This is a shorthand for `Column::new(header, Constraint::Min(width))`.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::Column;
-    ///
-    /// let col = Column::min("Description", 10);
-    /// ```
-    pub fn min(header: impl Into<String>, width: u16) -> Self {
-        Self::new(header, Constraint::Min(width))
-    }
-
-    /// Creates a column that takes a percentage of available width.
-    ///
-    /// This is a shorthand for `Column::new(header, Constraint::Percentage(percent))`.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::Column;
-    ///
-    /// let col = Column::percent("Status", 25);
-    /// ```
-    pub fn percent(header: impl Into<String>, percent: u16) -> Self {
-        Self::new(header, Constraint::Percentage(percent))
-    }
-
-    /// Returns whether this column is sortable.
-    pub fn is_sortable(&self) -> bool {
-        self.sortable
-    }
-}
-
-/// Sort direction for table columns.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
-#[cfg_attr(
-    feature = "serialization",
-    derive(serde::Serialize, serde::Deserialize)
-)]
-pub enum SortDirection {
-    /// Sort in ascending order (A-Z, 0-9).
-    #[default]
-    Ascending,
-    /// Sort in descending order (Z-A, 9-0).
-    Descending,
-}
-
-impl SortDirection {
-    /// Returns the opposite sort direction.
-    pub fn toggle(self) -> Self {
-        match self {
-            SortDirection::Ascending => SortDirection::Descending,
-            SortDirection::Descending => SortDirection::Ascending,
-        }
-    }
-}
-
-/// Messages that can be sent to a Table component.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum TableMessage {
-    /// Move selection up by one row.
-    Up,
-    /// Move selection down by one row.
-    Down,
-    /// Move selection to the first row.
-    First,
-    /// Move selection to the last row.
-    Last,
-    /// Move selection up by a page.
-    PageUp(usize),
-    /// Move selection down by a page.
-    PageDown(usize),
-    /// Confirm the current selection.
-    Select,
-    /// Sort by the given column index.
-    ///
-    /// If already sorted by this column, toggles direction.
-    /// If sorted ascending, becomes descending.
-    /// If sorted descending, clears the sort.
-    SortBy(usize),
-    /// Clear the current sort, returning to original order.
-    ClearSort,
-    /// Set the filter text for searching rows.
-    SetFilter(String),
-    /// Clear the filter text.
-    ClearFilter,
-}
-
-/// Output messages from a Table component.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum TableOutput<T: Clone> {
-    /// A row was selected (e.g., Enter pressed).
-    Selected(T),
-    /// The selection changed to a new row index.
-    SelectionChanged(usize),
-    /// The sort changed.
-    Sorted {
-        /// The column being sorted by.
-        column: usize,
-        /// The sort direction.
-        direction: SortDirection,
-    },
-    /// Sort was cleared.
-    SortCleared,
-    /// The filter text changed.
-    FilterChanged(String),
-}
 
 /// State for a Table component.
 ///
@@ -917,7 +701,7 @@ impl<T: TableRow + 'static> Component for Table<T> {
             .iter()
             .enumerate()
             .map(|(i, col)| {
-                let mut text = col.header.clone();
+                let mut text = col.header().to_string();
                 if let Some((sort_col, dir)) = state.sort {
                     if sort_col == i {
                         text.push_str(match dir {
@@ -952,7 +736,7 @@ impl<T: TableRow + 'static> Component for Table<T> {
             })
             .collect();
 
-        let widths: Vec<Constraint> = state.columns.iter().map(|c| c.width).collect();
+        let widths: Vec<Constraint> = state.columns.iter().map(|c| c.width()).collect();
 
         let border_style = if state.focused && !state.disabled {
             theme.focused_border_style()

--- a/src/component/table/types.rs
+++ b/src/component/table/types.rs
@@ -1,0 +1,222 @@
+//! Types for the table component.
+
+use ratatui::layout::Constraint;
+
+/// Trait for types that can be displayed as table rows.
+///
+/// Implement this trait for your data types to use them with `Table`.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::component::TableRow;
+///
+/// #[derive(Clone)]
+/// struct Product {
+///     name: String,
+///     price: f64,
+///     quantity: u32,
+/// }
+///
+/// impl TableRow for Product {
+///     fn cells(&self) -> Vec<String> {
+///         vec![
+///             self.name.clone(),
+///             format!("${:.2}", self.price),
+///             self.quantity.to_string(),
+///         ]
+///     }
+/// }
+/// ```
+pub trait TableRow: Clone {
+    /// Returns the cell values for this row.
+    ///
+    /// The order of values should match the order of columns
+    /// defined in the table.
+    fn cells(&self) -> Vec<String>;
+}
+
+/// Column definition for a table.
+///
+/// Columns define the header text, width, and whether the column
+/// is sortable.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::component::Column;
+/// use ratatui::layout::Constraint;
+///
+/// let col = Column::new("Name", Constraint::Length(20)).sortable();
+/// assert_eq!(col.header(), "Name");
+/// assert!(col.is_sortable());
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct Column {
+    header: String,
+    #[cfg_attr(feature = "serialization", serde(skip))]
+    width: Constraint,
+    sortable: bool,
+}
+
+impl Column {
+    /// Creates a new column with the given header and width.
+    ///
+    /// The column is not sortable by default.
+    pub fn new(header: impl Into<String>, width: Constraint) -> Self {
+        Self {
+            header: header.into(),
+            width,
+            sortable: false,
+        }
+    }
+
+    /// Makes this column sortable.
+    ///
+    /// Sortable columns can be sorted by clicking/selecting the header
+    /// or using `TableMessage::SortBy`.
+    pub fn sortable(mut self) -> Self {
+        self.sortable = true;
+        self
+    }
+
+    /// Returns the column header text.
+    pub fn header(&self) -> &str {
+        &self.header
+    }
+
+    /// Returns the column width constraint.
+    pub fn width(&self) -> Constraint {
+        self.width
+    }
+
+    /// Creates a column with a fixed width.
+    ///
+    /// This is a shorthand for `Column::new(header, Constraint::Length(width))`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Column;
+    ///
+    /// let col = Column::fixed("Name", 20);
+    /// assert_eq!(col.header(), "Name");
+    /// ```
+    pub fn fixed(header: impl Into<String>, width: u16) -> Self {
+        Self::new(header, Constraint::Length(width))
+    }
+
+    /// Creates a column with a minimum width.
+    ///
+    /// This is a shorthand for `Column::new(header, Constraint::Min(width))`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Column;
+    ///
+    /// let col = Column::min("Description", 10);
+    /// ```
+    pub fn min(header: impl Into<String>, width: u16) -> Self {
+        Self::new(header, Constraint::Min(width))
+    }
+
+    /// Creates a column that takes a percentage of available width.
+    ///
+    /// This is a shorthand for `Column::new(header, Constraint::Percentage(percent))`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Column;
+    ///
+    /// let col = Column::percent("Status", 25);
+    /// ```
+    pub fn percent(header: impl Into<String>, percent: u16) -> Self {
+        Self::new(header, Constraint::Percentage(percent))
+    }
+
+    /// Returns whether this column is sortable.
+    pub fn is_sortable(&self) -> bool {
+        self.sortable
+    }
+}
+
+/// Sort direction for table columns.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub enum SortDirection {
+    /// Sort in ascending order (A-Z, 0-9).
+    #[default]
+    Ascending,
+    /// Sort in descending order (Z-A, 9-0).
+    Descending,
+}
+
+impl SortDirection {
+    /// Returns the opposite sort direction.
+    pub fn toggle(self) -> Self {
+        match self {
+            SortDirection::Ascending => SortDirection::Descending,
+            SortDirection::Descending => SortDirection::Ascending,
+        }
+    }
+}
+
+/// Messages that can be sent to a Table component.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TableMessage {
+    /// Move selection up by one row.
+    Up,
+    /// Move selection down by one row.
+    Down,
+    /// Move selection to the first row.
+    First,
+    /// Move selection to the last row.
+    Last,
+    /// Move selection up by a page.
+    PageUp(usize),
+    /// Move selection down by a page.
+    PageDown(usize),
+    /// Confirm the current selection.
+    Select,
+    /// Sort by the given column index.
+    ///
+    /// If already sorted by this column, toggles direction.
+    /// If sorted ascending, becomes descending.
+    /// If sorted descending, clears the sort.
+    SortBy(usize),
+    /// Clear the current sort, returning to original order.
+    ClearSort,
+    /// Set the filter text for searching rows.
+    SetFilter(String),
+    /// Clear the filter text.
+    ClearFilter,
+}
+
+/// Output messages from a Table component.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TableOutput<T: Clone> {
+    /// A row was selected (e.g., Enter pressed).
+    Selected(T),
+    /// The selection changed to a new row index.
+    SelectionChanged(usize),
+    /// The sort changed.
+    Sorted {
+        /// The column being sorted by.
+        column: usize,
+        /// The sort direction.
+        direction: SortDirection,
+    },
+    /// Sort was cleared.
+    SortCleared,
+    /// The filter text changed.
+    FilterChanged(String),
+}


### PR DESCRIPTION
## Summary
- **file_browser/tests.rs** (1085→981): Extracted snapshot and annotation tests into `snapshot_tests.rs`
- **line_input/mod.rs** (1035→950): Extracted `LineInputMessage` and `LineInputOutput` enums into `types.rs`
- **table/mod.rs** (1001→785): Extracted `TableRow` trait, `Column`, `SortDirection`, `TableMessage`, and `TableOutput` into `types.rs`

All files now under the 1000-line limit.

## Test plan
- [x] All 3763 unit tests pass
- [x] All 439 doc tests pass
- [x] Clippy clean
- [x] No behavior changes, only module extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)