### PR TITLE
Add doc examples to ~50 most-used public methods

### DIFF
--- a/src/app/command/mod.rs
+++ b/src/app/command/mod.rs
@@ -54,6 +54,15 @@ pub(crate) enum CommandAction<M> {
 
 impl<M> Command<M> {
     /// Creates an empty command (no-op).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::app::Command;
+    ///
+    /// let cmd: Command<String> = Command::none();
+    /// assert!(cmd.is_none());
+    /// ```
     pub fn none() -> Self {
         Self {
             actions: Vec::new(),
@@ -61,11 +70,29 @@ impl<M> Command<M> {
     }
 
     /// Returns true if this command has no actions.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::app::Command;
+    ///
+    /// assert!(Command::<String>::none().is_none());
+    /// assert!(!Command::message("hello".to_string()).is_none());
+    /// ```
     pub fn is_none(&self) -> bool {
         self.actions.is_empty()
     }
 
     /// Creates a command that dispatches a single message.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::app::Command;
+    ///
+    /// let cmd = Command::message("data_loaded".to_string());
+    /// assert!(!cmd.is_none());
+    /// ```
     pub fn message(msg: M) -> Self {
         Self {
             actions: vec![CommandAction::Message(msg)],
@@ -73,6 +100,19 @@ impl<M> Command<M> {
     }
 
     /// Creates a command that dispatches multiple messages.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::app::Command;
+    ///
+    /// let cmd = Command::batch(vec!["first".to_string(), "second".to_string()]);
+    /// assert!(!cmd.is_none());
+    ///
+    /// // An empty batch produces a no-op command
+    /// let empty: Command<String> = Command::batch(vec![]);
+    /// assert!(empty.is_none());
+    /// ```
     pub fn batch(messages: impl IntoIterator<Item = M>) -> Self {
         let msgs: Vec<M> = messages.into_iter().collect();
         if msgs.is_empty() {
@@ -85,6 +125,15 @@ impl<M> Command<M> {
     }
 
     /// Creates a command that quits the application.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::app::Command;
+    ///
+    /// let cmd: Command<String> = Command::quit();
+    /// assert!(!cmd.is_none());
+    /// ```
     pub fn quit() -> Self {
         Self {
             actions: vec![CommandAction::Quit],
@@ -94,6 +143,16 @@ impl<M> Command<M> {
     /// Creates a command from a synchronous callback.
     ///
     /// The callback will be executed and may optionally return a message.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::app::Command;
+    ///
+    /// let cmd: Command<String> = Command::perform(|| {
+    ///     Some("done".to_string())
+    /// });
+    /// ```
     pub fn perform<F>(f: F) -> Self
     where
         F: FnOnce() -> Option<M> + Send + 'static,
@@ -254,6 +313,18 @@ impl<M> Command<M> {
     }
 
     /// Combines multiple commands into one.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::app::Command;
+    ///
+    /// let combined: Command<String> = Command::combine(vec![
+    ///     Command::message("first".to_string()),
+    ///     Command::message("second".to_string()),
+    /// ]);
+    /// assert!(!combined.is_none());
+    /// ```
     pub fn combine(commands: impl IntoIterator<Item = Command<M>>) -> Self {
         let mut actions = Vec::new();
         for cmd in commands {
@@ -263,6 +334,16 @@ impl<M> Command<M> {
     }
 
     /// Appends another command to this one.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::app::Command;
+    ///
+    /// let cmd = Command::message("first".to_string())
+    ///     .and(Command::message("second".to_string()));
+    /// assert!(!cmd.is_none());
+    /// ```
     pub fn and(mut self, other: Command<M>) -> Self {
         self.actions.extend(other.actions);
         self
@@ -276,6 +357,15 @@ impl<M> Command<M> {
     }
 
     /// Maps the message type to a different type.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::app::Command;
+    ///
+    /// let cmd: Command<i32> = Command::message(42);
+    /// let mapped: Command<String> = cmd.map(|n| n.to_string());
+    /// ```
     pub fn map<N, F>(self, f: F) -> Command<N>
     where
         F: Fn(M) -> N + Clone + Send + 'static,

--- a/src/app/runtime/config.rs
+++ b/src/app/runtime/config.rs
@@ -1,0 +1,127 @@
+//! Runtime configuration.
+
+use std::time::Duration;
+
+/// Configuration for the runtime.
+#[derive(Clone, Debug)]
+pub struct RuntimeConfig {
+    /// How often to poll for events (default: 50ms)
+    pub tick_rate: Duration,
+
+    /// How often to render (default: 16ms for ~60fps)
+    pub frame_rate: Duration,
+
+    /// Maximum number of messages to process per tick (prevents infinite loops)
+    pub max_messages_per_tick: usize,
+
+    /// Whether to capture frame history
+    pub capture_history: bool,
+
+    /// Number of frames to keep in history
+    pub history_capacity: usize,
+
+    /// Capacity of the async message channel
+    pub message_channel_capacity: usize,
+}
+
+impl Default for RuntimeConfig {
+    fn default() -> Self {
+        Self {
+            tick_rate: Duration::from_millis(50),
+            frame_rate: Duration::from_millis(16),
+            max_messages_per_tick: 100,
+            capture_history: false,
+            history_capacity: 10,
+            message_channel_capacity: 256,
+        }
+    }
+}
+
+impl RuntimeConfig {
+    /// Creates a new runtime config with default settings.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::app::RuntimeConfig;
+    ///
+    /// let config = RuntimeConfig::new();
+    /// ```
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the tick rate.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::app::RuntimeConfig;
+    /// use std::time::Duration;
+    ///
+    /// let config = RuntimeConfig::new().tick_rate(Duration::from_millis(100));
+    /// ```
+    pub fn tick_rate(mut self, rate: Duration) -> Self {
+        self.tick_rate = rate;
+        self
+    }
+
+    /// Sets the frame rate.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::app::RuntimeConfig;
+    /// use std::time::Duration;
+    ///
+    /// // ~30fps
+    /// let config = RuntimeConfig::new().frame_rate(Duration::from_millis(33));
+    /// ```
+    pub fn frame_rate(mut self, rate: Duration) -> Self {
+        self.frame_rate = rate;
+        self
+    }
+
+    /// Enables frame history capture.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::app::RuntimeConfig;
+    ///
+    /// let config = RuntimeConfig::new().with_history(5);
+    /// ```
+    pub fn with_history(mut self, capacity: usize) -> Self {
+        self.capture_history = true;
+        self.history_capacity = capacity;
+        self
+    }
+
+    /// Sets the maximum messages per tick.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::app::RuntimeConfig;
+    ///
+    /// let config = RuntimeConfig::new().max_messages(50);
+    /// ```
+    pub fn max_messages(mut self, max: usize) -> Self {
+        self.max_messages_per_tick = max;
+        self
+    }
+
+    /// Sets the message channel capacity.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::app::RuntimeConfig;
+    ///
+    /// let config = RuntimeConfig::new().channel_capacity(512);
+    /// ```
+    pub fn channel_capacity(mut self, capacity: usize) -> Self {
+        self.message_channel_capacity = capacity;
+        self
+    }
+}

--- a/src/app/runtime/mod.rs
+++ b/src/app/runtime/mod.rs
@@ -51,17 +51,13 @@
 //!
 //! Events are injected programmatically and the display can be inspected.
 
-use std::io::{self, Stdout};
-use std::time::Duration;
+mod config;
+mod terminal;
+pub use config::RuntimeConfig;
 
-use crossterm::event::{
-    DisableMouseCapture, EnableMouseCapture, Event as CrosstermEvent, KeyEventKind,
-};
-use crossterm::terminal::{
-    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
-};
-use crossterm::ExecutableCommand;
-use ratatui::backend::{Backend, CrosstermBackend};
+use std::io;
+
+use ratatui::backend::Backend;
 use ratatui::Terminal;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -72,81 +68,8 @@ use super::runtime_core::{ProcessEventResult, RuntimeCore};
 use super::subscription::{BoxedSubscription, Subscription};
 use crate::backend::CaptureBackend;
 use crate::input::{Event, EventQueue};
-use crate::overlay::{Overlay, OverlayAction, OverlayStack};
+use crate::overlay::{Overlay, OverlayStack};
 use crate::theme::Theme;
-
-/// Configuration for the runtime.
-#[derive(Clone, Debug)]
-pub struct RuntimeConfig {
-    /// How often to poll for events (default: 50ms)
-    pub tick_rate: Duration,
-
-    /// How often to render (default: 16ms for ~60fps)
-    pub frame_rate: Duration,
-
-    /// Maximum number of messages to process per tick (prevents infinite loops)
-    pub max_messages_per_tick: usize,
-
-    /// Whether to capture frame history
-    pub capture_history: bool,
-
-    /// Number of frames to keep in history
-    pub history_capacity: usize,
-
-    /// Capacity of the async message channel
-    pub message_channel_capacity: usize,
-}
-
-impl Default for RuntimeConfig {
-    fn default() -> Self {
-        Self {
-            tick_rate: Duration::from_millis(50),
-            frame_rate: Duration::from_millis(16),
-            max_messages_per_tick: 100,
-            capture_history: false,
-            history_capacity: 10,
-            message_channel_capacity: 256,
-        }
-    }
-}
-
-impl RuntimeConfig {
-    /// Creates a new runtime config with default settings.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Sets the tick rate.
-    pub fn tick_rate(mut self, rate: Duration) -> Self {
-        self.tick_rate = rate;
-        self
-    }
-
-    /// Sets the frame rate.
-    pub fn frame_rate(mut self, rate: Duration) -> Self {
-        self.frame_rate = rate;
-        self
-    }
-
-    /// Enables frame history capture.
-    pub fn with_history(mut self, capacity: usize) -> Self {
-        self.capture_history = true;
-        self.history_capacity = capacity;
-        self
-    }
-
-    /// Sets the maximum messages per tick.
-    pub fn max_messages(mut self, max: usize) -> Self {
-        self.max_messages_per_tick = max;
-        self
-    }
-
-    /// Sets the message channel capacity.
-    pub fn channel_capacity(mut self, capacity: usize) -> Self {
-        self.message_channel_capacity = capacity;
-        self
-    }
-}
 
 /// The runtime that executes a TEA application.
 ///
@@ -179,220 +102,6 @@ pub struct Runtime<A: App, B: Backend> {
 
     /// Active subscriptions as streams
     subscriptions: Vec<std::pin::Pin<Box<dyn tokio_stream::Stream<Item = A::Message> + Send>>>,
-}
-
-// =============================================================================
-// Terminal Mode - for real terminal applications
-// =============================================================================
-
-impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
-    /// Creates a new runtime connected to a real terminal.
-    ///
-    /// This sets up the terminal for TUI operation:
-    /// - Enables raw mode (input is not line-buffered)
-    /// - Enters alternate screen (preserves the original terminal content)
-    /// - Enables mouse capture
-    ///
-    /// Call `run_terminal()` to start the interactive event loop.
-    ///
-    /// # Example
-    ///
-    /// ```rust,ignore
-    /// // requires real terminal
-    /// #[tokio::main]
-    /// async fn main() -> std::io::Result<()> {
-    ///     Runtime::<MyApp>::new_terminal()?.run_terminal().await
-    /// }
-    /// ```
-    pub fn new_terminal() -> io::Result<Self> {
-        Self::terminal_with_config(RuntimeConfig::default())
-    }
-
-    /// Creates a terminal runtime with custom configuration.
-    pub fn terminal_with_config(config: RuntimeConfig) -> io::Result<Self> {
-        // Set up terminal
-        enable_raw_mode()?;
-        let mut stdout = io::stdout();
-        stdout.execute(EnterAlternateScreen)?;
-        stdout.execute(EnableMouseCapture)?;
-
-        let backend = CrosstermBackend::new(stdout);
-        Self::with_backend_and_config(backend, config)
-    }
-
-    /// Runs the interactive event loop until the application quits.
-    ///
-    /// This is the main entry point for terminal applications. It uses
-    /// `crossterm::event::EventStream` for non-blocking event reading,
-    /// and `tokio::select!` to multiplex between terminal events,
-    /// async messages, tick intervals, and render intervals.
-    ///
-    /// # Example
-    ///
-    /// ```rust,ignore
-    /// // requires real terminal
-    /// #[tokio::main]
-    /// async fn main() -> std::io::Result<()> {
-    ///     Runtime::<MyApp>::new_terminal()?.run_terminal().await
-    /// }
-    /// ```
-    pub async fn run_terminal(mut self) -> io::Result<()> {
-        use futures_util::StreamExt;
-
-        #[cfg(feature = "tracing")]
-        tracing::info!("starting terminal runtime loop");
-
-        let mut tick_interval = tokio::time::interval(self.config.tick_rate);
-        let mut render_interval = tokio::time::interval(self.config.frame_rate);
-        let mut event_stream = crossterm::event::EventStream::new();
-
-        // Initial render
-        self.render()?;
-
-        let result = loop {
-            tokio::select! {
-                // Handle terminal events from crossterm
-                maybe_event = event_stream.next() => {
-                    match maybe_event {
-                        Some(Ok(event)) => {
-                            if let Some(envision_event) = Self::convert_crossterm_event(&event) {
-                                match self.core.overlay_stack.handle_event(&envision_event) {
-                                    OverlayAction::Consumed => {}
-                                    OverlayAction::KeepAndMessage(msg) => self.dispatch(msg),
-                                    OverlayAction::Dismiss => {
-                                        self.core.overlay_stack.pop();
-                                    }
-                                    OverlayAction::DismissWithMessage(msg) => {
-                                        self.core.overlay_stack.pop();
-                                        self.dispatch(msg);
-                                    }
-                                    OverlayAction::Propagate => {
-                                        if let Some(msg) =
-                                            A::handle_event_with_state(&self.core.state, &envision_event)
-                                        {
-                                            self.dispatch(msg);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        Some(Err(e)) => {
-                            break Err(e);
-                        }
-                        None => {
-                            // Event stream ended
-                            break Ok(());
-                        }
-                    }
-                }
-
-                // Handle async messages from spawned tasks
-                Some(msg) = self.message_rx.recv() => {
-                    self.dispatch(msg);
-                }
-
-                // Handle tick interval
-                _ = tick_interval.tick() => {
-                    // Process sync commands
-                    self.process_commands();
-
-                    // Process events from the queue
-                    let mut messages_processed = 0;
-                    while self.process_event() && messages_processed < self.core.max_messages_per_tick {
-                        messages_processed += 1;
-                    }
-
-                    // Handle tick
-                    if let Some(msg) = A::on_tick(&self.core.state) {
-                        self.dispatch(msg);
-                    }
-
-                    // Check if we should quit
-                    if A::should_quit(&self.core.state) {
-                        self.core.should_quit = true;
-                    }
-                }
-
-                // Handle render interval
-                _ = render_interval.tick() => {
-                    if let Err(e) = self.render() {
-                        break Err(e);
-                    }
-                }
-
-                // Handle cancellation
-                _ = self.cancel_token.cancelled() => {
-                    self.core.should_quit = true;
-                }
-            }
-
-            if self.core.should_quit {
-                break Ok(());
-            }
-        };
-
-        // Cleanup terminal - always attempt cleanup even on error
-        let cleanup_result = self.cleanup_terminal();
-
-        // Call on_exit
-        A::on_exit(&self.core.state);
-
-        // Return the first error if any
-        result.and(cleanup_result)
-    }
-
-    /// Runs the interactive terminal event loop, blocking the current thread.
-    ///
-    /// This is a convenience wrapper around [`run_terminal`](Runtime::run_terminal) for
-    /// applications that don't want to set up their own tokio runtime. It creates
-    /// a multi-threaded tokio runtime internally and blocks on the async event loop.
-    ///
-    /// # Example
-    ///
-    /// ```rust,ignore
-    /// // requires real terminal
-    /// fn main() -> std::io::Result<()> {
-    ///     Runtime::<MyApp>::new_terminal()?.run_terminal_blocking()
-    /// }
-    /// ```
-    pub fn run_terminal_blocking(self) -> io::Result<()> {
-        let rt = tokio::runtime::Runtime::new().map_err(io::Error::other)?;
-        rt.block_on(self.run_terminal())
-    }
-
-    /// Converts a crossterm event to our Event type.
-    fn convert_crossterm_event(event: &CrosstermEvent) -> Option<Event> {
-        match event {
-            CrosstermEvent::Key(key_event) => {
-                // Only handle key press events, not release or repeat
-                if key_event.kind == KeyEventKind::Press {
-                    Some(Event::Key(*key_event))
-                } else {
-                    None
-                }
-            }
-            CrosstermEvent::Mouse(mouse_event) => Some(Event::Mouse(*mouse_event)),
-            CrosstermEvent::Resize(width, height) => Some(Event::Resize(*width, *height)),
-            CrosstermEvent::FocusGained => Some(Event::FocusGained),
-            CrosstermEvent::FocusLost => Some(Event::FocusLost),
-            CrosstermEvent::Paste(text) => Some(Event::Paste(text.clone())),
-        }
-    }
-
-    /// Cleans up terminal state.
-    fn cleanup_terminal(&mut self) -> io::Result<()> {
-        disable_raw_mode()?;
-        self.core
-            .terminal
-            .backend_mut()
-            .execute(LeaveAlternateScreen)?;
-        self.core
-            .terminal
-            .backend_mut()
-            .execute(DisableMouseCapture)?;
-        self.core.terminal.show_cursor()?;
-        Ok(())
-    }
 }
 
 // =============================================================================
@@ -455,6 +164,28 @@ impl<A: App> Runtime<A, CaptureBackend> {
     /// Sends an event to the virtual terminal.
     ///
     /// The event is queued and will be processed on the next `tick()`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use envision::prelude::*;
+    /// # struct MyApp;
+    /// # #[derive(Default, Clone)]
+    /// # struct MyState;
+    /// # #[derive(Clone)]
+    /// # enum MyMsg {}
+    /// # impl App for MyApp {
+    /// #     type State = MyState;
+    /// #     type Message = MyMsg;
+    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState, Command::none()) }
+    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+    /// #     fn view(state: &MyState, frame: &mut Frame) {}
+    /// # }
+    /// let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+    /// vt.send(Event::key(KeyCode::Enter));
+    /// vt.tick()?;
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
     pub fn send(&mut self, event: Event) {
         self.core.events.push(event);
     }
@@ -462,6 +193,28 @@ impl<A: App> Runtime<A, CaptureBackend> {
     /// Returns the current display content as plain text.
     ///
     /// This is what would be shown on a terminal screen.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use envision::prelude::*;
+    /// # struct MyApp;
+    /// # #[derive(Default, Clone)]
+    /// # struct MyState;
+    /// # #[derive(Clone)]
+    /// # enum MyMsg {}
+    /// # impl App for MyApp {
+    /// #     type State = MyState;
+    /// #     type Message = MyMsg;
+    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState, Command::none()) }
+    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+    /// #     fn view(state: &MyState, frame: &mut Frame) {}
+    /// # }
+    /// let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+    /// vt.tick()?;
+    /// let screen = vt.display();
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
     pub fn display(&self) -> String {
         self.core.terminal.backend().to_string()
     }
@@ -521,11 +274,54 @@ impl<A: App, B: Backend> Runtime<A, B> {
     }
 
     /// Returns a reference to the current state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use envision::prelude::*;
+    /// # struct MyApp;
+    /// # #[derive(Default, Clone)]
+    /// # struct MyState { count: i32 }
+    /// # #[derive(Clone)]
+    /// # enum MyMsg {}
+    /// # impl App for MyApp {
+    /// #     type State = MyState;
+    /// #     type Message = MyMsg;
+    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState::default(), Command::none()) }
+    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+    /// #     fn view(state: &MyState, frame: &mut Frame) {}
+    /// # }
+    /// let vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+    /// assert_eq!(vt.state().count, 0);
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
     pub fn state(&self) -> &A::State {
         &self.core.state
     }
 
     /// Returns a mutable reference to the state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use envision::prelude::*;
+    /// # struct MyApp;
+    /// # #[derive(Default, Clone)]
+    /// # struct MyState { count: i32 }
+    /// # #[derive(Clone)]
+    /// # enum MyMsg {}
+    /// # impl App for MyApp {
+    /// #     type State = MyState;
+    /// #     type Message = MyMsg;
+    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState::default(), Command::none()) }
+    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+    /// #     fn view(state: &MyState, frame: &mut Frame) {}
+    /// # }
+    /// let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+    /// vt.state_mut().count = 42;
+    /// assert_eq!(vt.state().count, 42);
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
     pub fn state_mut(&mut self) -> &mut A::State {
         &mut self.core.state
     }
@@ -658,6 +454,31 @@ impl<A: App, B: Backend> Runtime<A, B> {
     }
 
     /// Dispatches a message to update the state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use envision::prelude::*;
+    /// # struct MyApp;
+    /// # #[derive(Default, Clone)]
+    /// # struct MyState { count: i32 }
+    /// # #[derive(Clone)]
+    /// # enum MyMsg { Increment }
+    /// # impl App for MyApp {
+    /// #     type State = MyState;
+    /// #     type Message = MyMsg;
+    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState::default(), Command::none()) }
+    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> {
+    /// #         match msg { MyMsg::Increment => state.count += 1 }
+    /// #         Command::none()
+    /// #     }
+    /// #     fn view(state: &MyState, frame: &mut Frame) {}
+    /// # }
+    /// let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+    /// vt.dispatch(MyMsg::Increment);
+    /// assert_eq!(vt.state().count, 1);
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
     pub fn dispatch(&mut self, msg: A::Message) {
         #[cfg(feature = "tracing")]
         let _span = tracing::debug_span!("dispatch").entered();
@@ -754,6 +575,28 @@ impl<A: App, B: Backend> Runtime<A, B> {
     /// - [`process_all_events`](Runtime::process_all_events) — Drain the event queue only
     /// - [`process_event`](Runtime::process_event) — Process exactly one event
     /// - [`run_ticks`](Runtime::run_ticks) — Convenience: run N full tick cycles
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use envision::prelude::*;
+    /// # struct MyApp;
+    /// # #[derive(Default, Clone)]
+    /// # struct MyState;
+    /// # #[derive(Clone)]
+    /// # enum MyMsg {}
+    /// # impl App for MyApp {
+    /// #     type State = MyState;
+    /// #     type Message = MyMsg;
+    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState, Command::none()) }
+    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+    /// #     fn view(state: &MyState, frame: &mut Frame) {}
+    /// # }
+    /// let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+    /// vt.send(Event::key(KeyCode::Char('j')));
+    /// vt.tick()?; // processes the 'j' event and re-renders
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
     pub fn tick(&mut self) -> io::Result<()> {
         #[cfg(feature = "tracing")]
         let _span = tracing::debug_span!("tick").entered();
@@ -866,6 +709,27 @@ impl<A: App, B: Backend> Runtime<A, B> {
     }
 
     /// Runs for a specified number of ticks.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use envision::prelude::*;
+    /// # struct MyApp;
+    /// # #[derive(Default, Clone)]
+    /// # struct MyState;
+    /// # #[derive(Clone)]
+    /// # enum MyMsg {}
+    /// # impl App for MyApp {
+    /// #     type State = MyState;
+    /// #     type Message = MyMsg;
+    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState, Command::none()) }
+    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+    /// #     fn view(state: &MyState, frame: &mut Frame) {}
+    /// # }
+    /// let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+    /// vt.run_ticks(5)?;
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
     pub fn run_ticks(&mut self, ticks: usize) -> io::Result<()> {
         for _ in 0..ticks {
             if self.core.should_quit {
@@ -952,6 +816,30 @@ impl<A: App> Runtime<A, CaptureBackend> {
     }
 
     /// Returns true if the display contains the given text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use envision::prelude::*;
+    /// # struct MyApp;
+    /// # #[derive(Default, Clone)]
+    /// # struct MyState;
+    /// # #[derive(Clone)]
+    /// # enum MyMsg {}
+    /// # impl App for MyApp {
+    /// #     type State = MyState;
+    /// #     type Message = MyMsg;
+    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState, Command::none()) }
+    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+    /// #     fn view(state: &MyState, frame: &mut Frame) {
+    /// #         frame.render_widget(ratatui::widgets::Paragraph::new("Hello"), frame.area());
+    /// #     }
+    /// # }
+    /// let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+    /// vt.tick()?;
+    /// assert!(vt.contains_text("Hello"));
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
     pub fn contains_text(&self, needle: &str) -> bool {
         self.core.terminal.backend().contains_text(needle)
     }

--- a/src/app/runtime/terminal.rs
+++ b/src/app/runtime/terminal.rs
@@ -1,0 +1,235 @@
+//! Terminal mode runtime implementation.
+//!
+//! Provides the `Runtime` methods for running applications in a real terminal
+//! using crossterm for input and alternate screen management.
+
+use std::io::{self, Stdout};
+
+use crossterm::event::{
+    DisableMouseCapture, EnableMouseCapture, Event as CrosstermEvent, KeyEventKind,
+};
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use crossterm::ExecutableCommand;
+use ratatui::backend::CrosstermBackend;
+
+use super::config::RuntimeConfig;
+use super::Runtime;
+use crate::app::model::App;
+use crate::input::Event;
+use crate::overlay::OverlayAction;
+
+// =============================================================================
+// Terminal Mode - for real terminal applications
+// =============================================================================
+
+impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
+    /// Creates a new runtime connected to a real terminal.
+    ///
+    /// This sets up the terminal for TUI operation:
+    /// - Enables raw mode (input is not line-buffered)
+    /// - Enters alternate screen (preserves the original terminal content)
+    /// - Enables mouse capture
+    ///
+    /// Call `run_terminal()` to start the interactive event loop.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// // requires real terminal
+    /// #[tokio::main]
+    /// async fn main() -> std::io::Result<()> {
+    ///     Runtime::<MyApp>::new_terminal()?.run_terminal().await
+    /// }
+    /// ```
+    pub fn new_terminal() -> io::Result<Self> {
+        Self::terminal_with_config(RuntimeConfig::default())
+    }
+
+    /// Creates a terminal runtime with custom configuration.
+    pub fn terminal_with_config(config: RuntimeConfig) -> io::Result<Self> {
+        // Set up terminal
+        enable_raw_mode()?;
+        let mut stdout = io::stdout();
+        stdout.execute(EnterAlternateScreen)?;
+        stdout.execute(EnableMouseCapture)?;
+
+        let backend = CrosstermBackend::new(stdout);
+        Self::with_backend_and_config(backend, config)
+    }
+
+    /// Runs the interactive event loop until the application quits.
+    ///
+    /// This is the main entry point for terminal applications. It uses
+    /// `crossterm::event::EventStream` for non-blocking event reading,
+    /// and `tokio::select!` to multiplex between terminal events,
+    /// async messages, tick intervals, and render intervals.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// // requires real terminal
+    /// #[tokio::main]
+    /// async fn main() -> std::io::Result<()> {
+    ///     Runtime::<MyApp>::new_terminal()?.run_terminal().await
+    /// }
+    /// ```
+    pub async fn run_terminal(mut self) -> io::Result<()> {
+        use futures_util::StreamExt;
+
+        #[cfg(feature = "tracing")]
+        tracing::info!("starting terminal runtime loop");
+
+        let mut tick_interval = tokio::time::interval(self.config.tick_rate);
+        let mut render_interval = tokio::time::interval(self.config.frame_rate);
+        let mut event_stream = crossterm::event::EventStream::new();
+
+        // Initial render
+        self.render()?;
+
+        let result = loop {
+            tokio::select! {
+                // Handle terminal events from crossterm
+                maybe_event = event_stream.next() => {
+                    match maybe_event {
+                        Some(Ok(event)) => {
+                            if let Some(envision_event) = Self::convert_crossterm_event(&event) {
+                                match self.core.overlay_stack.handle_event(&envision_event) {
+                                    OverlayAction::Consumed => {}
+                                    OverlayAction::KeepAndMessage(msg) => self.dispatch(msg),
+                                    OverlayAction::Dismiss => {
+                                        self.core.overlay_stack.pop();
+                                    }
+                                    OverlayAction::DismissWithMessage(msg) => {
+                                        self.core.overlay_stack.pop();
+                                        self.dispatch(msg);
+                                    }
+                                    OverlayAction::Propagate => {
+                                        if let Some(msg) =
+                                            A::handle_event_with_state(&self.core.state, &envision_event)
+                                        {
+                                            self.dispatch(msg);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        Some(Err(e)) => {
+                            break Err(e);
+                        }
+                        None => {
+                            // Event stream ended
+                            break Ok(());
+                        }
+                    }
+                }
+
+                // Handle async messages from spawned tasks
+                Some(msg) = self.message_rx.recv() => {
+                    self.dispatch(msg);
+                }
+
+                // Handle tick interval
+                _ = tick_interval.tick() => {
+                    // Process sync commands
+                    self.process_commands();
+
+                    // Process events from the queue
+                    let mut messages_processed = 0;
+                    while self.process_event() && messages_processed < self.core.max_messages_per_tick {
+                        messages_processed += 1;
+                    }
+
+                    // Handle tick
+                    if let Some(msg) = A::on_tick(&self.core.state) {
+                        self.dispatch(msg);
+                    }
+
+                    // Check if we should quit
+                    if A::should_quit(&self.core.state) {
+                        self.core.should_quit = true;
+                    }
+                }
+
+                // Handle render interval
+                _ = render_interval.tick() => {
+                    if let Err(e) = self.render() {
+                        break Err(e);
+                    }
+                }
+
+                // Handle cancellation
+                _ = self.cancel_token.cancelled() => {
+                    self.core.should_quit = true;
+                }
+            }
+
+            if self.core.should_quit {
+                break Ok(());
+            }
+        };
+
+        // Cleanup terminal - always attempt cleanup even on error
+        let cleanup_result = self.cleanup_terminal();
+
+        // Call on_exit
+        A::on_exit(&self.core.state);
+
+        // Return the first error if any
+        result.and(cleanup_result)
+    }
+
+    /// Runs the interactive terminal event loop, blocking the current thread.
+    ///
+    /// This is a convenience wrapper around [`run_terminal`](Runtime::run_terminal) for
+    /// applications that don't want to set up their own tokio runtime. It creates
+    /// a multi-threaded tokio runtime internally and blocks on the async event loop.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// // requires real terminal
+    /// fn main() -> std::io::Result<()> {
+    ///     Runtime::<MyApp>::new_terminal()?.run_terminal_blocking()
+    /// }
+    /// ```
+    pub fn run_terminal_blocking(self) -> io::Result<()> {
+        let rt = tokio::runtime::Runtime::new().map_err(io::Error::other)?;
+        rt.block_on(self.run_terminal())
+    }
+
+    /// Converts a crossterm event to our Event type.
+    fn convert_crossterm_event(event: &CrosstermEvent) -> Option<Event> {
+        match event {
+            CrosstermEvent::Key(key_event) => {
+                // Only handle key press events, not release or repeat
+                if key_event.kind == KeyEventKind::Press {
+                    Some(Event::Key(*key_event))
+                } else {
+                    None
+                }
+            }
+            CrosstermEvent::Mouse(mouse_event) => Some(Event::Mouse(*mouse_event)),
+            CrosstermEvent::Resize(width, height) => Some(Event::Resize(*width, *height)),
+            CrosstermEvent::FocusGained => Some(Event::FocusGained),
+            CrosstermEvent::FocusLost => Some(Event::FocusLost),
+            CrosstermEvent::Paste(text) => Some(Event::Paste(text.clone())),
+        }
+    }
+
+    /// Cleans up terminal state.
+    fn cleanup_terminal(&mut self) -> io::Result<()> {
+        disable_raw_mode()?;
+        self.core
+            .terminal
+            .backend_mut()
+            .execute(LeaveAlternateScreen)?;
+        self.core
+            .terminal
+            .backend_mut()
+            .execute(DisableMouseCapture)?;
+        self.core.terminal.show_cursor()?;
+        Ok(())
+    }
+}

--- a/src/app/runtime/tests/mod.rs
+++ b/src/app/runtime/tests/mod.rs
@@ -4,6 +4,7 @@ use super::*;
 use ratatui::backend::CrosstermBackend;
 use ratatui::widgets::Paragraph;
 use std::io::{self, Stdout};
+use std::time::Duration;
 
 struct CounterApp;
 

--- a/src/harness/app_harness/mod.rs
+++ b/src/harness/app_harness/mod.rs
@@ -55,6 +55,28 @@ impl<A: App> AppHarness<A> {
     /// Creates a new async test harness with the given dimensions.
     ///
     /// Note: For time control, use `#[tokio::test(start_paused = true)]`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use envision::prelude::*;
+    /// # struct MyApp;
+    /// # #[derive(Default, Clone)]
+    /// # struct MyState;
+    /// # #[derive(Clone)]
+    /// # enum MyMsg {}
+    /// # impl App for MyApp {
+    /// #     type State = MyState;
+    /// #     type Message = MyMsg;
+    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState, Command::none()) }
+    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+    /// #     fn view(state: &MyState, frame: &mut Frame) {}
+    /// # }
+    /// use envision::harness::AppHarness;
+    ///
+    /// let harness = AppHarness::<MyApp>::new(80, 24)?;
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
     pub fn new(width: u16, height: u16) -> io::Result<Self> {
         let runtime = Runtime::virtual_terminal(width, height)?;
         Ok(Self { runtime })
@@ -144,6 +166,33 @@ impl<A: App> AppHarness<A> {
     ///
     /// This dispatches the message, spawns any async commands, and processes
     /// any immediately available async results.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use envision::prelude::*;
+    /// # struct MyApp;
+    /// # #[derive(Default, Clone)]
+    /// # struct MyState { count: i32 }
+    /// # #[derive(Clone)]
+    /// # enum MyMsg { Increment }
+    /// # impl App for MyApp {
+    /// #     type State = MyState;
+    /// #     type Message = MyMsg;
+    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState::default(), Command::none()) }
+    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> {
+    /// #         match msg { MyMsg::Increment => state.count += 1 }
+    /// #         Command::none()
+    /// #     }
+    /// #     fn view(state: &MyState, frame: &mut Frame) {}
+    /// # }
+    /// use envision::harness::AppHarness;
+    ///
+    /// let mut harness = AppHarness::<MyApp>::new(80, 24)?;
+    /// harness.dispatch(MyMsg::Increment);
+    /// assert_eq!(harness.state().count, 1);
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
     pub fn dispatch(&mut self, msg: A::Message) {
         self.runtime.dispatch(msg);
         self.runtime.process_pending();
@@ -229,6 +278,30 @@ impl<A: App> AppHarness<A> {
     }
 
     /// Runs a single tick of the application.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use envision::prelude::*;
+    /// # struct MyApp;
+    /// # #[derive(Default, Clone)]
+    /// # struct MyState;
+    /// # #[derive(Clone)]
+    /// # enum MyMsg {}
+    /// # impl App for MyApp {
+    /// #     type State = MyState;
+    /// #     type Message = MyMsg;
+    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState, Command::none()) }
+    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+    /// #     fn view(state: &MyState, frame: &mut Frame) {}
+    /// # }
+    /// use envision::harness::AppHarness;
+    ///
+    /// let mut harness = AppHarness::<MyApp>::new(80, 24)?;
+    /// harness.push_event(Event::key(KeyCode::Enter));
+    /// harness.tick()?;
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
     pub fn tick(&mut self) -> io::Result<()> {
         self.runtime.tick()
     }
@@ -286,6 +359,32 @@ impl<A: App> AppHarness<A> {
     /// # Panics
     ///
     /// Panics if the text is not found.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use envision::prelude::*;
+    /// # struct MyApp;
+    /// # #[derive(Default, Clone)]
+    /// # struct MyState;
+    /// # #[derive(Clone)]
+    /// # enum MyMsg {}
+    /// # impl App for MyApp {
+    /// #     type State = MyState;
+    /// #     type Message = MyMsg;
+    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState, Command::none()) }
+    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+    /// #     fn view(state: &MyState, frame: &mut Frame) {
+    /// #         frame.render_widget(ratatui::widgets::Paragraph::new("Welcome"), frame.area());
+    /// #     }
+    /// # }
+    /// use envision::harness::AppHarness;
+    ///
+    /// let mut harness = AppHarness::<MyApp>::new(80, 24)?;
+    /// harness.tick()?;
+    /// harness.assert_contains("Welcome");
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
     pub fn assert_contains(&self, needle: &str) {
         if !self.contains_text(needle) {
             panic!(

--- a/src/harness/test_harness/mod.rs
+++ b/src/harness/test_harness/mod.rs
@@ -42,6 +42,16 @@ pub struct TestHarness {
 
 impl TestHarness {
     /// Creates a new test harness with the given dimensions.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::harness::TestHarness;
+    ///
+    /// let harness = TestHarness::new(80, 24);
+    /// assert_eq!(harness.width(), 80);
+    /// assert_eq!(harness.height(), 24);
+    /// ```
     pub fn new(width: u16, height: u16) -> Self {
         let backend = CaptureBackend::new(width, height);
         let terminal = Terminal::new(backend).expect("Failed to create terminal");
@@ -76,6 +86,20 @@ impl TestHarness {
     /// Renders a frame using the provided closure.
     ///
     /// This collects annotations during rendering and increments the frame count.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::harness::TestHarness;
+    /// use ratatui::widgets::Paragraph;
+    ///
+    /// let mut harness = TestHarness::new(80, 24);
+    /// harness.render(|frame| {
+    ///     frame.render_widget(Paragraph::new("Hello!"), frame.area());
+    /// })?;
+    /// assert!(harness.contains("Hello!"));
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
     pub fn render<F>(&mut self, f: F) -> io::Result<()>
     where
         F: FnOnce(&mut ratatui::Frame),
@@ -141,6 +165,18 @@ impl TestHarness {
     }
 
     /// Queues a single event.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::harness::TestHarness;
+    /// use envision::input::{Event, KeyCode};
+    ///
+    /// let mut harness = TestHarness::new(80, 24);
+    /// harness.push_event(Event::key(KeyCode::Enter));
+    /// let event = harness.pop_event();
+    /// assert!(event.is_some());
+    /// ```
     pub fn push_event(&mut self, event: Event) {
         self.events.push(event);
     }
@@ -151,6 +187,18 @@ impl TestHarness {
     }
 
     /// Types a string as keyboard input.
+    ///
+    /// Each character is enqueued as a separate key event.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::harness::TestHarness;
+    ///
+    /// let mut harness = TestHarness::new(80, 24);
+    /// harness.type_str("hello");
+    /// // 5 key events are now queued
+    /// ```
     pub fn type_str(&mut self, s: &str) {
         self.events.type_str(s);
     }
@@ -243,6 +291,20 @@ impl TestHarness {
     // -------------------------------------------------------------------------
 
     /// Returns true if the screen contains the given text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::harness::TestHarness;
+    /// use ratatui::widgets::Paragraph;
+    ///
+    /// let mut harness = TestHarness::new(80, 24);
+    /// harness.render(|frame| {
+    ///     frame.render_widget(Paragraph::new("Search"), frame.area());
+    /// }).unwrap();
+    /// assert!(harness.contains("Search"));
+    /// assert!(!harness.contains("Missing"));
+    /// ```
     pub fn contains(&self, needle: &str) -> bool {
         self.terminal.backend().contains_text(needle)
     }

--- a/src/input/events/mod.rs
+++ b/src/input/events/mod.rs
@@ -33,6 +33,15 @@ pub enum Event {
 
 impl Event {
     /// Creates a key press event for a character.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::Event;
+    ///
+    /// let event = Event::char('a');
+    /// assert!(event.is_key());
+    /// ```
     pub fn char(c: char) -> Self {
         Self::Key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE))
     }
@@ -43,26 +52,71 @@ impl Event {
     }
 
     /// Creates a key press event for a special key.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::{Event, KeyCode};
+    ///
+    /// let event = Event::key(KeyCode::Enter);
+    /// assert!(event.is_key());
+    /// ```
     pub fn key(code: KeyCode) -> Self {
         Self::Key(KeyEvent::new(code, KeyModifiers::NONE))
     }
 
     /// Creates a key press event with modifiers.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::{Event, KeyCode, KeyModifiers};
+    ///
+    /// let event = Event::key_with(KeyCode::Char('s'), KeyModifiers::CONTROL);
+    /// assert!(event.is_key());
+    /// ```
     pub fn key_with(code: KeyCode, modifiers: KeyModifiers) -> Self {
         Self::Key(KeyEvent::new(code, modifiers))
     }
 
     /// Creates a Ctrl+key event.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::Event;
+    ///
+    /// let event = Event::ctrl('c');
+    /// assert!(event.is_key());
+    /// ```
     pub fn ctrl(c: char) -> Self {
         Self::Key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL))
     }
 
     /// Creates an Alt+key event.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::Event;
+    ///
+    /// let event = Event::alt('x');
+    /// assert!(event.is_key());
+    /// ```
     pub fn alt(c: char) -> Self {
         Self::Key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::ALT))
     }
 
     /// Creates a mouse click event at the specified position.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::Event;
+    ///
+    /// let event = Event::click(10, 5);
+    /// assert!(event.is_mouse());
+    /// ```
     pub fn click(x: u16, y: u16) -> Self {
         Self::Mouse(MouseEvent {
             kind: MouseEventKind::Down(MouseButton::Left),
@@ -133,16 +187,44 @@ impl Event {
     }
 
     /// Returns true if this is a key event.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::Event;
+    ///
+    /// assert!(Event::char('a').is_key());
+    /// assert!(!Event::click(0, 0).is_key());
+    /// ```
     pub fn is_key(&self) -> bool {
         matches!(self, Event::Key(_))
     }
 
     /// Returns true if this is a mouse event.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::Event;
+    ///
+    /// assert!(Event::click(0, 0).is_mouse());
+    /// assert!(!Event::char('a').is_mouse());
+    /// ```
     pub fn is_mouse(&self) -> bool {
         matches!(self, Event::Mouse(_))
     }
 
     /// Returns the key event if this is one.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::{Event, KeyCode};
+    ///
+    /// let event = Event::key(KeyCode::Enter);
+    /// assert!(event.as_key().is_some());
+    /// assert!(Event::click(0, 0).as_key().is_none());
+    /// ```
     pub fn as_key(&self) -> Option<&KeyEvent> {
         match self {
             Event::Key(e) => Some(e),
@@ -151,6 +233,16 @@ impl Event {
     }
 
     /// Returns the mouse event if this is one.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::Event;
+    ///
+    /// let event = Event::click(5, 10);
+    /// assert!(event.as_mouse().is_some());
+    /// assert!(Event::char('a').as_mouse().is_none());
+    /// ```
     pub fn as_mouse(&self) -> Option<&MouseEvent> {
         match self {
             Event::Mouse(e) => Some(e),

--- a/src/input/queue/mod.rs
+++ b/src/input/queue/mod.rs
@@ -33,11 +33,32 @@ pub struct EventQueue {
 
 impl EventQueue {
     /// Creates a new empty event queue.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::EventQueue;
+    ///
+    /// let queue = EventQueue::new();
+    /// assert!(queue.is_empty());
+    /// ```
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Creates a queue with pre-loaded events.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::{Event, EventQueue, KeyCode};
+    ///
+    /// let queue = EventQueue::with_events(vec![
+    ///     Event::char('a'),
+    ///     Event::key(KeyCode::Enter),
+    /// ]);
+    /// assert_eq!(queue.len(), 2);
+    /// ```
     pub fn with_events(events: impl IntoIterator<Item = Event>) -> Self {
         Self {
             events: events.into_iter().collect(),
@@ -60,6 +81,16 @@ impl EventQueue {
     }
 
     /// Adds an event to the end of the queue.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::{Event, EventQueue};
+    ///
+    /// let mut queue = EventQueue::new();
+    /// queue.push(Event::char('x'));
+    /// assert_eq!(queue.len(), 1);
+    /// ```
     pub fn push(&mut self, event: Event) {
         self.events.push_back(event);
     }
@@ -90,6 +121,16 @@ impl EventQueue {
     }
 
     /// Adds key events for each character in a string.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::EventQueue;
+    ///
+    /// let mut queue = EventQueue::new();
+    /// queue.type_str("hello");
+    /// assert_eq!(queue.len(), 5);
+    /// ```
     pub fn type_str(&mut self, s: &str) {
         for c in s.chars() {
             self.push(Event::char(c));

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -489,6 +489,15 @@ impl Theme {
     /// Returns a style for focused elements.
     ///
     /// Uses the theme's focused color for foreground.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::theme::Theme;
+    ///
+    /// let theme = Theme::nord();
+    /// let style = theme.focused_style();
+    /// ```
     pub fn focused_style(&self) -> Style {
         Style::default().fg(self.focused)
     }
@@ -539,6 +548,15 @@ impl Theme {
     }
 
     /// Returns a style for disabled elements.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::theme::Theme;
+    ///
+    /// let theme = Theme::default();
+    /// let style = theme.disabled_style();
+    /// ```
     pub fn disabled_style(&self) -> Style {
         Style::default().fg(self.disabled)
     }
@@ -552,6 +570,17 @@ impl Theme {
     ///
     /// Uses the theme's foreground and background colors so components
     /// render correctly with non-default themes (e.g., Nord).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::theme::Theme;
+    /// use ratatui::widgets::Paragraph;
+    /// use ratatui::prelude::Stylize;
+    ///
+    /// let theme = Theme::default();
+    /// let paragraph = Paragraph::new("text").style(theme.normal_style());
+    /// ```
     pub fn normal_style(&self) -> Style {
         Style::default().fg(self.foreground).bg(self.background)
     }


### PR DESCRIPTION
## Summary
- Add `# Examples` doc sections with runnable doc tests to 49 public methods across the most important framework APIs:
  - **Command**: `none`, `is_none`, `message`, `batch`, `quit`, `perform`, `combine`, `and`, `map`
  - **Event**: `char`, `key`, `key_with`, `ctrl`, `alt`, `click`, `is_key`, `is_mouse`, `as_key`, `as_mouse`
  - **RuntimeConfig**: `new`, `tick_rate`, `frame_rate`, `with_history`, `max_messages`, `channel_capacity`
  - **Runtime**: `state`, `state_mut`, `send`, `display`, `dispatch`, `tick`, `run_ticks`, `contains_text`
  - **TestHarness**: `new`, `render`, `push_event`, `type_str`, `contains`
  - **AppHarness**: `new`, `dispatch`, `tick`, `assert_contains`
  - **EventQueue**: `new`, `with_events`, `push`, `type_str`
  - **Theme**: `focused_style`, `normal_style`, `disabled_style`
- Extract `RuntimeConfig` to `config.rs` and terminal mode to `terminal.rs` to keep `runtime/mod.rs` under the 1000-line limit (854 lines)
- Doc test count increased from 440 to 488 (+48 runnable examples)

## Test plan
- [x] All 488 doc tests pass (`cargo test --doc --all-features`)
- [x] All unit tests pass (`cargo test --all-features`)
- [x] Clippy clean (`cargo clippy --all-features -- -D warnings`)
- [x] No files over 1000 lines
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)