### PR TITLE
Add PartialEq to FormState and FileBrowserState

### DIFF
--- a/src/component/file_browser/mod.rs
+++ b/src/component/file_browser/mod.rs
@@ -184,6 +184,27 @@ impl std::fmt::Debug for FileBrowserState {
     }
 }
 
+impl PartialEq for FileBrowserState {
+    fn eq(&self, other: &Self) -> bool {
+        self.current_path == other.current_path
+            && self.path_segments == other.path_segments
+            && self.entries == other.entries
+            && self.filtered_indices == other.filtered_indices
+            && self.selected_index == other.selected_index
+            && self.selected_paths == other.selected_paths
+            && self.filter_text == other.filter_text
+            && self.internal_focus == other.internal_focus
+            && self.focused == other.focused
+            && self.disabled == other.disabled
+            && self.selection_mode == other.selection_mode
+            && self.sort_field == other.sort_field
+            && self.sort_direction == other.sort_direction
+            && self.directories_first == other.directories_first
+            && self.show_hidden == other.show_hidden
+            && self.list_state.selected() == other.list_state.selected()
+    }
+}
+
 impl FileBrowserState {
     /// Creates a new file browser with initial path and entries.
     ///

--- a/src/component/form/mod.rs
+++ b/src/component/form/mod.rs
@@ -45,7 +45,7 @@ use crate::theme::Theme;
 ///
 /// Each field has an ID for retrieval, a label for display, and a kind
 /// that determines the widget type and behavior.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct FormField {
     /// Unique identifier for this field.
     id: String,
@@ -56,7 +56,7 @@ pub struct FormField {
 }
 
 /// The type of a form field.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum FormFieldKind {
     /// A text input field.
     Text,
@@ -160,7 +160,7 @@ impl FormField {
 }
 
 /// Internal representation of a field's widget state.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 enum FieldState {
     Text(InputFieldState),
     Checkbox(CheckboxState),
@@ -215,7 +215,7 @@ pub enum FormOutput {
 ///
 /// Contains the field descriptors, their widget states, focus tracking,
 /// and overall form state.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct FormState {
     /// Field descriptors (id, label, kind).
     fields: Vec<FormField>,


### PR DESCRIPTION
## Summary
- Derive `PartialEq` on `FormState`, `FormField`, `FormFieldKind`, and `FieldState`
- Add custom `PartialEq` impl for `FileBrowserState` (skips `list_state` and `provider`, matching existing pattern from `SelectableListState`)
- All 42 component state types now implement `PartialEq`

## Test plan
- [x] All 4070 unit tests pass
- [x] Follows existing custom PartialEq pattern for state types with non-comparable fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)