### PR TITLE
Add cross-references between related types in documentation

### DIFF
--- a/src/component/accordion/mod.rs
+++ b/src/component/accordion/mod.rs
@@ -1,8 +1,12 @@
 //! An accordion component with collapsible panels.
 //!
-//! `Accordion` provides a vertically stacked list of panels that can be
+//! [`Accordion`] provides a vertically stacked list of panels that can be
 //! expanded or collapsed. Multiple panels can be open simultaneously,
-//! and keyboard navigation is supported.
+//! and keyboard navigation is supported. State is stored in
+//! [`AccordionState`], updated via [`AccordionMessage`], and produces
+//! [`AccordionOutput`]. Panels are defined with [`AccordionPanel`].
+//!
+//! Implements [`Focusable`] and [`Disableable`].
 //!
 //! # Example
 //!

--- a/src/component/breadcrumb/mod.rs
+++ b/src/component/breadcrumb/mod.rs
@@ -1,8 +1,12 @@
 //! A breadcrumb navigation component.
 //!
-//! `Breadcrumb` displays a hierarchical navigation path with clickable segments.
+//! [`Breadcrumb`] displays a hierarchical navigation path with clickable segments.
 //! Users can navigate through the path using keyboard navigation, and selecting
-//! a segment emits an output for navigation handling.
+//! a segment emits an output for navigation handling. State is stored in
+//! [`BreadcrumbState`], updated via [`BreadcrumbMessage`], and produces
+//! [`BreadcrumbOutput`].
+//!
+//! Implements [`Focusable`] and [`Disableable`].
 //!
 //! # Example
 //!

--- a/src/component/button/mod.rs
+++ b/src/component/button/mod.rs
@@ -1,7 +1,12 @@
 //! A clickable button component with keyboard activation.
 //!
-//! `Button` provides a simple button that can be activated via keyboard
-//! (Enter or Space) when focused.
+//! [`Button`] provides a simple button that can be activated via keyboard
+//! (Enter or Space) when focused. State is stored in [`ButtonState`],
+//! updated via [`ButtonMessage`], and produces [`ButtonOutput`] on activation.
+//!
+//! Implements [`Focusable`] and [`Disableable`].
+//!
+//! See also [`Checkbox`](super::Checkbox) for a boolean toggle input.
 //!
 //! # Example
 //!

--- a/src/component/chart/mod.rs
+++ b/src/component/chart/mod.rs
@@ -2,7 +2,8 @@
 //!
 //! Provides line charts (sparkline with labels) and bar charts
 //! (horizontal/vertical) with data series, labels, colors, and
-//! auto-scaling axes.
+//! auto-scaling axes. State is stored in [`ChartState`] and updated via
+//! [`ChartMessage`]. Chart data is configured with [`ChartConfig`].
 //!
 //! # Example
 //!

--- a/src/component/chat_view/mod.rs
+++ b/src/component/chat_view/mod.rs
@@ -1,8 +1,12 @@
 //! A chat interface with message history and multi-line input.
 //!
-//! `ChatView` provides a scrollable message history display and a
+//! [`ChatView`] provides a scrollable message history display and a
 //! [`TextArea`](super::TextArea) input field. Messages can be typed
 //! as user, system, or assistant and are styled differently per role.
+//! State is stored in [`ChatViewState`], updated via [`ChatViewMessage`],
+//! and produces [`ChatViewOutput`].
+//!
+//! Implements [`Focusable`] and [`Disableable`].
 //!
 //! # Example
 //!

--- a/src/component/checkbox/mod.rs
+++ b/src/component/checkbox/mod.rs
@@ -1,7 +1,12 @@
 //! A toggleable checkbox component with keyboard activation.
 //!
-//! `Checkbox` provides a boolean input that can be toggled via keyboard
-//! (Enter or Space) when focused.
+//! [`Checkbox`] provides a boolean input that can be toggled via keyboard
+//! (Enter or Space) when focused. State is stored in [`CheckboxState`],
+//! updated via [`CheckboxMessage`], and produces [`CheckboxOutput`].
+//!
+//! Implements [`Focusable`] and [`Disableable`].
+//!
+//! See also [`Button`](super::Button) for a press-only action.
 //!
 //! # Example
 //!

--- a/src/component/confirm_dialog/mod.rs
+++ b/src/component/confirm_dialog/mod.rs
@@ -1,8 +1,15 @@
 //! A confirmation dialog component with preset button configurations.
 //!
-//! `ConfirmDialog` provides a centered modal overlay with a title, message,
+//! [`ConfirmDialog`] provides a centered modal overlay with a title, message,
 //! and button configurations such as Ok, Ok/Cancel, Yes/No, and Yes/No/Cancel.
-//! It supports keyboard shortcuts for quick responses.
+//! It supports keyboard shortcuts for quick responses. State is stored in
+//! [`ConfirmDialogState`], updated via [`ConfirmDialogMessage`], and produces
+//! [`ConfirmDialogOutput`] containing a [`ConfirmDialogResult`].
+//! Button layouts are configured with [`ButtonConfig`].
+//!
+//! Implements [`Focusable`], [`Disableable`](super::Disableable), and [`Toggleable`].
+//!
+//! See also [`Dialog`](super::Dialog) for a general-purpose modal dialog.
 //!
 //! # Example
 //!

--- a/src/component/data_grid/mod.rs
+++ b/src/component/data_grid/mod.rs
@@ -1,8 +1,11 @@
 //! A data grid with inline cell editing.
 //!
-//! `DataGrid` wraps [`Table`](super::Table) adding column navigation and
+//! [`DataGrid<T>`] wraps [`Table`](super::Table) adding column navigation and
 //! inline cell editing. Press Enter to edit a cell, Escape to cancel, and
-//! Enter again to confirm the edit.
+//! Enter again to confirm the edit. State is stored in [`DataGridState<T>`],
+//! updated via [`DataGridMessage`], and produces [`DataGridOutput`].
+//!
+//! Implements [`Focusable`] and [`Disableable`](super::Disableable).
 //!
 //! # Example
 //!

--- a/src/component/dialog/mod.rs
+++ b/src/component/dialog/mod.rs
@@ -1,8 +1,14 @@
 //! A modal dialog component with configurable buttons.
 //!
-//! `Dialog` provides a centered overlay dialog with title, message, and
-//! configurable buttons. This component implements both `Focusable` and
-//! `Toggleable` traits for focus management and visibility control.
+//! [`Dialog`] provides a centered overlay dialog with title, message, and
+//! configurable buttons. State is stored in [`DialogState`], updated via
+//! [`DialogMessage`], and produces [`DialogOutput`]. Buttons are configured
+//! with [`DialogButton`].
+//!
+//! Implements [`Focusable`], [`Disableable`], and [`Toggleable`].
+//!
+//! See also [`ConfirmDialog`](super::ConfirmDialog) for a purpose-built
+//! confirmation dialog with preset button configurations.
 //!
 //! # Example
 //!

--- a/src/component/dropdown/mod.rs
+++ b/src/component/dropdown/mod.rs
@@ -1,8 +1,13 @@
 //! A searchable dropdown selection component.
 //!
-//! `Dropdown` provides a filterable dropdown menu for selecting a single option
+//! [`Dropdown`] provides a filterable dropdown menu for selecting a single option
 //! from a list. Users can type to filter options, then navigate and select
-//! using keyboard controls.
+//! using keyboard controls. State is stored in [`DropdownState`], updated via
+//! [`DropdownMessage`], and produces [`DropdownOutput`].
+//!
+//! Implements [`Focusable`] and [`Disableable`].
+//!
+//! See also [`Select`](super::Select) for a simpler dropdown without filtering.
 //!
 //! # Example
 //!

--- a/src/component/file_browser/mod.rs
+++ b/src/component/file_browser/mod.rs
@@ -1,8 +1,13 @@
 //! A compound file browsing component with pluggable filesystem abstraction.
 //!
-//! `FileBrowser` provides a navigable directory listing with filtering, sorting,
+//! [`FileBrowser`] provides a navigable directory listing with filtering, sorting,
 //! and selection support. It uses a [`DirectoryProvider`] trait for filesystem
 //! access, enabling both real filesystem and in-memory/test implementations.
+//! State is stored in [`FileBrowserState`], updated via [`FileBrowserMessage`],
+//! and produces [`FileBrowserOutput`]. Entries are represented as
+//! [`FileEntry`].
+//!
+//! Implements [`Focusable`] and [`Disableable`].
 //!
 //! # Example
 //!

--- a/src/component/form/mod.rs
+++ b/src/component/form/mod.rs
@@ -1,8 +1,13 @@
 //! A dynamic form component with multiple field types.
 //!
-//! `Form` composes text inputs, checkboxes, and select fields into a
-//! navigable form. Tab/BackTab moves between fields, and submitting
-//! collects all field values.
+//! [`Form`] composes [`InputField`](super::InputField),
+//! [`Checkbox`](super::Checkbox), and [`Select`](super::Select) fields into
+//! a navigable form. Tab/BackTab moves between fields, and submitting
+//! collects all field values. State is stored in [`FormState`], updated via
+//! [`FormMessage`], and produces [`FormOutput`]. Fields are defined with
+//! [`FormField`] and [`FormFieldKind`].
+//!
+//! Implements [`Focusable`] and [`Disableable`](super::Disableable).
 //!
 //! # Example
 //!

--- a/src/component/input_field/mod.rs
+++ b/src/component/input_field/mod.rs
@@ -1,7 +1,14 @@
 //! A text input field component with cursor navigation and editing.
 //!
-//! `InputField` provides a single-line text input with cursor movement,
-//! text insertion, deletion, and selection.
+//! [`InputField`] provides a single-line text input with cursor movement,
+//! text insertion, deletion, and selection. State is stored in
+//! [`InputFieldState`], updated via [`InputFieldMessage`], and produces
+//! [`InputFieldOutput`].
+//!
+//! Implements [`Focusable`] and [`Disableable`].
+//!
+//! See also [`LineInput`](super::LineInput) for a multi-row wrapping input,
+//! and [`TextArea`](super::TextArea) for multi-line editing.
 //!
 //! # Example
 //!

--- a/src/component/key_hints/mod.rs
+++ b/src/component/key_hints/mod.rs
@@ -1,7 +1,8 @@
 //! A component for displaying keyboard shortcuts.
 //!
-//! `KeyHints` provides a bar displaying keyboard shortcuts with their actions,
+//! [`KeyHints`] provides a bar displaying keyboard shortcuts with their actions,
 //! commonly used at the bottom of TUI applications to show available commands.
+//! State is stored in [`KeyHintsState`] and updated via [`KeyHintsMessage`].
 //!
 //! # Example
 //!

--- a/src/component/line_input/mod.rs
+++ b/src/component/line_input/mod.rs
@@ -12,6 +12,14 @@
 //! - Undo/redo with edit grouping
 //! - Selection, copy, cut, paste
 //! - Word-level navigation and deletion
+//!
+//! State is stored in [`LineInputState`], updated via [`LineInputMessage`],
+//! and produces [`LineInputOutput`].
+//!
+//! Implements [`Focusable`](super::Focusable) and [`Disableable`](super::Disableable).
+//!
+//! See also [`InputField`](super::InputField) for a simpler single-line input,
+//! and [`TextArea`](super::TextArea) for multi-line editing.
 
 mod chunking;
 mod editing;

--- a/src/component/loading_list/mod.rs
+++ b/src/component/loading_list/mod.rs
@@ -1,8 +1,14 @@
 //! A list component with per-item loading and error states.
 //!
-//! `LoadingList` extends the basic list pattern with loading indicators and
+//! [`LoadingList<T>`] extends the basic list pattern with loading indicators and
 //! error states for each item. Useful for lists where items can be fetched
-//! or processed asynchronously.
+//! or processed asynchronously. State is stored in [`LoadingListState<T>`],
+//! updated via [`LoadingListMessage`], and produces [`LoadingListOutput`].
+//! Items are wrapped in [`LoadingItem<T>`].
+//!
+//! Implements [`Focusable`] and [`Disableable`].
+//!
+//! See also [`SelectableList`](super::SelectableList) for a simpler list.
 //!
 //! # Example
 //!

--- a/src/component/log_viewer/mod.rs
+++ b/src/component/log_viewer/mod.rs
@@ -1,9 +1,13 @@
 //! A searchable log viewer with severity filtering.
 //!
-//! `LogViewer` composes a [`StatusLog`](super::StatusLog) with an
+//! [`LogViewer`] composes a [`StatusLog`](super::StatusLog) with an
 //! [`InputField`](super::InputField) search bar and severity-level toggle
 //! filters. Press `/` to focus the search bar, `Escape` to clear and return
 //! to the log, and `1`-`4` to toggle Info/Success/Warning/Error filters.
+//! State is stored in [`LogViewerState`], updated via [`LogViewerMessage`],
+//! and produces [`LogViewerOutput`].
+//!
+//! Implements [`Focusable`] and [`Disableable`](super::Disableable).
 //!
 //! # Example
 //!

--- a/src/component/menu/mod.rs
+++ b/src/component/menu/mod.rs
@@ -1,7 +1,11 @@
 //! A horizontal menu bar component.
 //!
-//! `Menu` provides a horizontal menu bar for application commands and navigation.
-//! It supports keyboard navigation, item activation, and disabled states.
+//! [`Menu`] provides a horizontal menu bar for application commands and navigation.
+//! It supports keyboard navigation, item activation, and disabled states. State is
+//! stored in [`MenuState`], updated via [`MenuMessage`], and produces [`MenuOutput`].
+//! Items are configured with [`MenuItem`].
+//!
+//! Implements [`Focusable`] and [`Disableable`].
 //!
 //! # Example
 //!

--- a/src/component/metrics_dashboard/mod.rs
+++ b/src/component/metrics_dashboard/mod.rs
@@ -1,8 +1,12 @@
 //! A configurable dashboard of metric widgets.
 //!
-//! `MetricsDashboard` displays a grid of metric widgets, each showing a
+//! [`MetricsDashboard`] displays a grid of metric widgets, each showing a
 //! labeled value with an optional sparkline history. Supports keyboard
-//! navigation between widgets and tick-based value updates.
+//! navigation between widgets and tick-based value updates. State is stored in
+//! [`MetricsDashboardState`], updated via [`MetricsDashboardMessage`], and
+//! produces [`MetricsDashboardOutput`].
+//!
+//! Implements [`Focusable`] and [`Disableable`].
 //!
 //! # Example
 //!

--- a/src/component/multi_progress/mod.rs
+++ b/src/component/multi_progress/mod.rs
@@ -1,8 +1,11 @@
 //! A component for displaying multiple concurrent progress indicators.
 //!
-//! `MultiProgress` provides a scrollable list of progress bars for tracking
+//! [`MultiProgress`] provides a scrollable list of progress bars for tracking
 //! multiple concurrent operations, commonly used in file processing, downloads,
-//! or batch operations.
+//! or batch operations. State is stored in [`MultiProgressState`] and updated
+//! via [`MultiProgressMessage`].
+//!
+//! See also [`ProgressBar`](super::ProgressBar) for a single progress indicator.
 //!
 //! # Example
 //!

--- a/src/component/pane_layout/mod.rs
+++ b/src/component/pane_layout/mod.rs
@@ -1,9 +1,15 @@
 //! An N-pane layout manager with proportional sizing and focus cycling.
 //!
-//! `PaneLayout` divides a screen area into multiple panes with configurable
+//! [`PaneLayout`] divides a screen area into multiple panes with configurable
 //! proportions, min/max size constraints, and keyboard-driven focus management.
 //! The parent controls what to render in each pane — this component only manages
-//! the layout and focus.
+//! the layout and focus. State is stored in [`PaneLayoutState`], updated via
+//! [`PaneLayoutMessage`], and produces [`PaneLayoutOutput`]. Panes are configured
+//! with [`PaneConfig`].
+//!
+//! Implements [`Focusable`] and [`Disableable`](super::Disableable).
+//!
+//! See also [`SplitPanel`](super::SplitPanel) for a simpler two-pane layout.
 //!
 //! # Example
 //!

--- a/src/component/progress_bar/mod.rs
+++ b/src/component/progress_bar/mod.rs
@@ -1,8 +1,12 @@
 //! A progress indicator component for displaying completion status.
 //!
-//! `ProgressBar` provides a visual progress indicator that shows completion
+//! [`ProgressBar`] provides a visual progress indicator that shows completion
 //! from 0% to 100%. This is a **display-only** component that does not
-//! receive keyboard focus.
+//! receive keyboard focus. State is stored in [`ProgressBarState`], updated
+//! via [`ProgressBarMessage`], and produces [`ProgressBarOutput`].
+//!
+//! See also [`Spinner`](super::Spinner) for indeterminate progress,
+//! and [`MultiProgress`](super::MultiProgress) for tracking multiple tasks.
 //!
 //! # Example
 //!

--- a/src/component/radio_group/mod.rs
+++ b/src/component/radio_group/mod.rs
@@ -1,8 +1,12 @@
 //! A mutually exclusive option selection component.
 //!
-//! `RadioGroup` provides a group of radio buttons where exactly one option
+//! [`RadioGroup<T>`] provides a group of radio buttons where exactly one option
 //! can be selected at a time. Unlike [`SelectableList`](super::SelectableList),
 //! navigation immediately changes the selection (traditional radio button behavior).
+//! State is stored in [`RadioGroupState<T>`], updated via [`RadioGroupMessage`],
+//! and produces [`RadioGroupOutput`].
+//!
+//! Implements [`Focusable`] and [`Disableable`].
 //!
 //! # Example
 //!

--- a/src/component/router/mod.rs
+++ b/src/component/router/mod.rs
@@ -1,8 +1,10 @@
 //! A component for multi-screen navigation with history.
 //!
-//! `Router` provides type-safe navigation between screens with back navigation
+//! [`Router<S>`] provides type-safe navigation between screens with back navigation
 //! support. Unlike most components, Router is state-only and doesn't implement
-//! a view - the parent application renders based on the current screen.
+//! a view — the parent application renders based on the current screen. State is
+//! stored in [`RouterState<S>`], updated via [`RouterMessage<S>`], and produces
+//! [`RouterOutput<S>`].
 //!
 //! # Example
 //!

--- a/src/component/scrollable_text/mod.rs
+++ b/src/component/scrollable_text/mod.rs
@@ -1,8 +1,14 @@
 //! A scrollable text display component.
 //!
-//! `ScrollableText` provides a read-only text buffer with scroll support.
+//! [`ScrollableText`] provides a read-only text buffer with scroll support.
 //! It wraps text within its display area and allows the user to scroll
-//! through content that exceeds the visible height.
+//! through content that exceeds the visible height. State is stored in
+//! [`ScrollableTextState`], updated via [`ScrollableTextMessage`], and
+//! produces [`ScrollableTextOutput`].
+//!
+//! Implements [`Focusable`] and [`Disableable`].
+//!
+//! See also [`StyledText`](super::StyledText) for rich text with semantic blocks.
 //!
 //! # Example
 //!

--- a/src/component/searchable_list/mod.rs
+++ b/src/component/searchable_list/mod.rs
@@ -1,9 +1,13 @@
 //! A searchable list component combining a text filter with a selectable list.
 //!
-//! `SearchableList` composes an [`InputField`](super::InputField) and a
+//! [`SearchableList<T>`] composes an [`InputField`](super::InputField) and a
 //! [`SelectableList`](super::SelectableList) into a single component. Typing
 //! in the filter field narrows the visible items, and keyboard navigation
-//! lets the user select from the filtered results.
+//! lets the user select from the filtered results. State is stored in
+//! [`SearchableListState<T>`], updated via [`SearchableListMessage`], and
+//! produces [`SearchableListOutput`].
+//!
+//! Implements [`Focusable`] and [`Disableable`].
 //!
 //! # Example
 //!

--- a/src/component/select/mod.rs
+++ b/src/component/select/mod.rs
@@ -1,8 +1,13 @@
 //! A dropdown selection component.
 //!
-//! `Select` provides a compact dropdown menu for selecting a single option
+//! [`Select`] provides a compact dropdown menu for selecting a single option
 //! from a list. It displays the selected value when closed and shows all
-//! options when opened.
+//! options when opened. State is stored in [`SelectState`], updated via
+//! [`SelectMessage`], and produces [`SelectOutput`].
+//!
+//! Implements [`Focusable`] and [`Disableable`].
+//!
+//! See also [`Dropdown`](super::Dropdown) for a variant with search filtering.
 //!
 //! # Example
 //!

--- a/src/component/selectable_list/mod.rs
+++ b/src/component/selectable_list/mod.rs
@@ -1,7 +1,14 @@
 //! A generic selectable list component with keyboard navigation.
 //!
-//! `SelectableList` provides a scrollable list of items with selection
-//! tracking and keyboard navigation (vim-style and arrow keys).
+//! [`SelectableList<T>`] provides a scrollable list of items with selection
+//! tracking and keyboard navigation (vim-style and arrow keys). State is
+//! stored in [`SelectableListState<T>`], updated via [`SelectableListMessage`],
+//! and produces [`SelectableListOutput`].
+//!
+//! Implements [`Focusable`] and [`Disableable`].
+//!
+//! See also [`SearchableList`](super::SearchableList) for a filterable variant,
+//! and [`LoadingList`](super::LoadingList) for lists with loading states.
 //!
 //! # Example
 //!

--- a/src/component/spinner/mod.rs
+++ b/src/component/spinner/mod.rs
@@ -1,8 +1,12 @@
 //! An indeterminate loading indicator component.
 //!
-//! `Spinner` provides a visual activity indicator that animates through frames
+//! [`Spinner`] provides a visual activity indicator that animates through frames
 //! to show ongoing activity. This is a **display-only** component that does not
-//! receive keyboard focus.
+//! receive keyboard focus. State is stored in [`SpinnerState`] and updated via
+//! [`SpinnerMessage`].
+//!
+//! See also [`ProgressBar`](super::ProgressBar) for determinate progress,
+//! and [`MultiProgress`](super::MultiProgress) for tracking multiple tasks.
 //!
 //! # Animation Model
 //!

--- a/src/component/split_panel/mod.rs
+++ b/src/component/split_panel/mod.rs
@@ -1,8 +1,14 @@
 //! A resizable split panel layout component.
 //!
-//! `SplitPanel` divides an area into two panes (horizontal or vertical)
+//! [`SplitPanel`] divides an area into two panes (horizontal or vertical)
 //! with a draggable split ratio. The parent controls what to render in
-//! each pane — this component only manages the layout and focus.
+//! each pane — this component only manages the layout and focus. State is
+//! stored in [`SplitPanelState`], updated via [`SplitPanelMessage`], and
+//! produces [`SplitPanelOutput`].
+//!
+//! Implements [`Focusable`] and [`Disableable`].
+//!
+//! See also [`PaneLayout`](super::PaneLayout) for N-pane layouts.
 //!
 //! # Example
 //!

--- a/src/component/status_bar/mod.rs
+++ b/src/component/status_bar/mod.rs
@@ -1,7 +1,8 @@
 //! A status bar component for displaying application state.
 //!
-//! `StatusBar` provides a horizontal bar typically displayed at the bottom of the
-//! screen showing application status, mode indicators, and other information.
+//! [`StatusBar`] provides a horizontal bar typically displayed at the bottom of the
+//! screen showing application status, mode indicators, and other information. State
+//! is stored in [`StatusBarState`] and updated via [`StatusBarMessage`].
 //!
 //! # Features
 //!

--- a/src/component/status_log/mod.rs
+++ b/src/component/status_log/mod.rs
@@ -1,7 +1,11 @@
 //! A component for displaying scrolling status messages.
 //!
-//! `StatusLog` provides a scrolling list of status messages with severity levels,
+//! [`StatusLog`] provides a scrolling list of status messages with severity levels,
 //! commonly used to display application status, progress updates, or log entries.
+//! State is stored in [`StatusLogState`] and updated via [`StatusLogMessage`].
+//!
+//! See also [`LogViewer`](super::LogViewer) for a searchable log viewer with
+//! severity filtering.
 //!
 //! # Example
 //!

--- a/src/component/step_indicator/mod.rs
+++ b/src/component/step_indicator/mod.rs
@@ -1,8 +1,12 @@
 //! A pipeline/workflow visualization component showing step-by-step progress.
 //!
-//! `StepIndicator` displays a series of steps with their current status,
+//! [`StepIndicator`] displays a series of steps with their current status,
 //! connected by configurable connectors. Supports both horizontal and vertical
-//! orientations.
+//! orientations. State is stored in [`StepIndicatorState`], updated via
+//! [`StepIndicatorMessage`], and produces [`StepIndicatorOutput`]. Steps are
+//! defined with [`Step`] and have a [`StepStatus`].
+//!
+//! Implements [`Focusable`] and [`Disableable`](super::Disableable).
 //!
 //! # Example
 //!

--- a/src/component/styled_text/mod.rs
+++ b/src/component/styled_text/mod.rs
@@ -1,7 +1,14 @@
 //! A rich text display component with semantic block elements and inline styling.
 //!
-//! `StyledText` renders structured content composed of headings, paragraphs,
-//! lists, code blocks, and horizontal rules with scrolling support.
+//! [`StyledText`] renders structured content composed of headings, paragraphs,
+//! lists, code blocks, and horizontal rules with scrolling support. State is
+//! stored in [`StyledTextState`], updated via [`StyledTextMessage`], and
+//! produces [`StyledTextOutput`]. Content is built with [`StyledContent`],
+//! [`StyledBlock`], and [`StyledInline`].
+//!
+//! Implements [`Focusable`] and [`Disableable`](super::Disableable).
+//!
+//! See also [`ScrollableText`](super::ScrollableText) for plain text display.
 //!
 //! # Example
 //!

--- a/src/component/table/mod.rs
+++ b/src/component/table/mod.rs
@@ -1,7 +1,12 @@
 //! A data table component with row selection and column sorting.
 //!
-//! `Table` provides a tabular data display with keyboard navigation,
-//! row selection, and column sorting capabilities.
+//! [`Table<T>`] provides a tabular data display with keyboard navigation,
+//! row selection, and column sorting capabilities. State is stored in
+//! [`TableState<T>`], updated via [`TableMessage`], and produces [`TableOutput`].
+//!
+//! Implements [`Focusable`] and [`Disableable`].
+//!
+//! See also [`DataGrid`](super::DataGrid) for a table with inline cell editing.
 //!
 //! # Example
 //!

--- a/src/component/tabs/mod.rs
+++ b/src/component/tabs/mod.rs
@@ -1,7 +1,11 @@
 //! A horizontal tab navigation component.
 //!
-//! `Tabs` provides a horizontal tab bar for switching between views or panels.
+//! [`Tabs<T>`] provides a horizontal tab bar for switching between views or panels.
 //! It supports keyboard navigation with Left/Right keys and generic tab types.
+//! State is stored in [`TabsState<T>`], updated via [`TabsMessage`], and produces
+//! [`TabsOutput`].
+//!
+//! Implements [`Focusable`] and [`Disableable`].
 //!
 //! # Example
 //!

--- a/src/component/text_area/mod.rs
+++ b/src/component/text_area/mod.rs
@@ -1,7 +1,14 @@
 //! A multi-line text editing component with cursor navigation.
 //!
-//! `TextArea` provides multi-line text input with cursor movement,
-//! text insertion, deletion, and line operations.
+//! [`TextArea`] provides multi-line text input with cursor movement,
+//! text insertion, deletion, and line operations. State is stored in
+//! [`TextAreaState`], updated via [`TextAreaMessage`], and produces
+//! [`TextAreaOutput`].
+//!
+//! Implements [`Focusable`] and [`Disableable`].
+//!
+//! See also [`InputField`](super::InputField) for single-line input,
+//! and [`LineInput`](super::LineInput) for a wrapping single-line input.
 //!
 //! # Example
 //!

--- a/src/component/title_card/mod.rs
+++ b/src/component/title_card/mod.rs
@@ -1,7 +1,8 @@
 //! A stylish display-only component for application titles.
 //!
-//! `TitleCard` provides a centered title display with optional emoji
-//! prefix/suffix, subtitle, configurable styles, and borders.
+//! [`TitleCard`] provides a centered title display with optional emoji
+//! prefix/suffix, subtitle, configurable styles, and borders. State is
+//! stored in [`TitleCardState`] and updated via [`TitleCardMessage`].
 //!
 //! # Example
 //!

--- a/src/component/toast/mod.rs
+++ b/src/component/toast/mod.rs
@@ -1,7 +1,8 @@
 //! A toast notification component for temporary messages.
 //!
-//! `Toast` provides non-modal notifications that appear as a vertical stack,
-//! with severity levels and auto-dismiss support.
+//! [`Toast`] provides non-modal notifications that appear as a vertical stack,
+//! with severity levels and auto-dismiss support. State is stored in
+//! [`ToastState`] and updated via [`ToastMessage`].
 //!
 //! # Example
 //!

--- a/src/component/tooltip/mod.rs
+++ b/src/component/tooltip/mod.rs
@@ -1,8 +1,12 @@
 //! A tooltip component for displaying contextual information.
 //!
-//! `Tooltip` provides a positioned overlay that displays helpful information
+//! [`Tooltip`] provides a positioned overlay that displays helpful information
 //! relative to a target area. Supports configurable positioning with automatic
-//! fallback, optional auto-hide, and basic styling.
+//! fallback, optional auto-hide, and basic styling. State is stored in
+//! [`TooltipState`], updated via [`TooltipMessage`], and produces
+//! [`TooltipOutput`].
+//!
+//! Implements [`Toggleable`].
 //!
 //! # Example
 //!

--- a/src/component/tree/mod.rs
+++ b/src/component/tree/mod.rs
@@ -1,7 +1,13 @@
 //! A hierarchical tree view component.
 //!
-//! `Tree` displays data in a hierarchical structure with expandable/collapsible
-//! nodes. It supports keyboard navigation and single selection.
+//! [`Tree<T>`] displays data in a hierarchical structure with expandable/collapsible
+//! nodes. It supports keyboard navigation and single selection. State is stored in
+//! [`TreeState<T>`], updated via [`TreeMessage`], and produces [`TreeOutput`].
+//! Tree data is provided via [`TreeNode<T>`].
+//!
+//! Implements [`Focusable`] and [`Disableable`].
+//!
+//! See also [`Accordion`](super::Accordion) for a simpler collapsible panel list.
 //!
 //! # Example
 //!


### PR DESCRIPTION
## Summary

- Add doc cross-references to all 41 component module-level docs
- Each component now links to its State, Message, and Output types
- Trait implementations (Focusable, Disableable, Toggleable) are linked
- Related components are cross-referenced (e.g., InputField ↔ LineInput ↔ TextArea)
- Fix unresolved doc link warnings for `Disableable` (7 components) and `FileEntry`

## Test plan

- [x] `cargo doc --no-deps --all-features` produces zero warnings
- [x] `cargo clippy --all-features -- -D warnings` passes
- [x] `cargo test --all-features` — all 511 tests pass
- [x] `cargo fmt` — no formatting changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)