### PR TITLE
Add doc tests to 10 components with lowest coverage

### DIFF
--- a/src/component/button/mod.rs
+++ b/src/component/button/mod.rs
@@ -80,16 +80,44 @@ impl ButtonState {
     }
 
     /// Returns the button label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ButtonState;
+    ///
+    /// let state = ButtonState::new("Submit");
+    /// assert_eq!(state.label(), "Submit");
+    /// ```
     pub fn label(&self) -> &str {
         &self.label
     }
 
     /// Sets the button label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ButtonState;
+    ///
+    /// let mut state = ButtonState::new("Save");
+    /// state.set_label("Save All");
+    /// assert_eq!(state.label(), "Save All");
+    /// ```
     pub fn set_label(&mut self, label: impl Into<String>) {
         self.label = label.into();
     }
 
     /// Returns true if the button is disabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ButtonState;
+    ///
+    /// let state = ButtonState::new("OK");
+    /// assert!(!state.is_disabled());
+    /// ```
     pub fn is_disabled(&self) -> bool {
         self.disabled
     }
@@ -97,37 +125,109 @@ impl ButtonState {
     /// Sets the disabled state.
     ///
     /// Disabled buttons do not respond to press events.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ButtonState;
+    ///
+    /// let mut state = ButtonState::new("OK");
+    /// state.set_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn set_disabled(&mut self, disabled: bool) {
         self.disabled = disabled;
     }
 
     /// Sets the disabled state using builder pattern.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ButtonState;
+    ///
+    /// let state = ButtonState::new("OK").with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn with_disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
         self
     }
 
     /// Returns true if the button is focused.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ButtonState;
+    ///
+    /// let state = ButtonState::new("OK");
+    /// assert!(!state.is_focused());
+    /// ```
     pub fn is_focused(&self) -> bool {
         self.focused
     }
 
     /// Sets the focus state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ButtonState;
+    ///
+    /// let mut state = ButtonState::new("OK");
+    /// state.set_focused(true);
+    /// assert!(state.is_focused());
+    /// ```
     pub fn set_focused(&mut self, focused: bool) {
         self.focused = focused;
     }
 
     /// Maps an input event to a button message.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ButtonMessage, ButtonState};
+    /// use envision::input::Event;
+    ///
+    /// let mut state = ButtonState::new("OK");
+    /// state.set_focused(true);
+    /// let event = Event::key(envision::input::KeyCode::Enter);
+    /// assert_eq!(state.handle_event(&event), Some(ButtonMessage::Press));
+    /// ```
     pub fn handle_event(&self, event: &Event) -> Option<ButtonMessage> {
         Button::handle_event(self, event)
     }
 
     /// Dispatches an event, updating state and returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ButtonOutput, ButtonState};
+    /// use envision::input::Event;
+    ///
+    /// let mut state = ButtonState::new("OK");
+    /// state.set_focused(true);
+    /// let event = Event::key(envision::input::KeyCode::Enter);
+    /// assert_eq!(state.dispatch_event(&event), Some(ButtonOutput::Pressed));
+    /// ```
     pub fn dispatch_event(&mut self, event: &Event) -> Option<ButtonOutput> {
         Button::dispatch_event(self, event)
     }
 
     /// Updates the button state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ButtonMessage, ButtonOutput, ButtonState};
+    ///
+    /// let mut state = ButtonState::new("OK");
+    /// let output = state.update(ButtonMessage::Press);
+    /// assert_eq!(output, Some(ButtonOutput::Pressed));
+    /// ```
     pub fn update(&mut self, msg: ButtonMessage) -> Option<ButtonOutput> {
         Button::update(self, msg)
     }

--- a/src/component/chart/mod.rs
+++ b/src/component/chart/mod.rs
@@ -60,6 +60,17 @@ impl DataSeries {
     }
 
     /// Sets the color (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    /// use ratatui::style::Color;
+    ///
+    /// let series = DataSeries::new("CPU", vec![1.0, 2.0])
+    ///     .with_color(Color::Red);
+    /// assert_eq!(series.color(), Color::Red);
+    /// ```
     pub fn with_color(mut self, color: Color) -> Self {
         self.color = color;
         self
@@ -81,11 +92,32 @@ impl DataSeries {
     }
 
     /// Appends a value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    ///
+    /// let mut series = DataSeries::new("Temp", vec![20.0]);
+    /// series.push(25.0);
+    /// assert_eq!(series.len(), 2);
+    /// assert_eq!(series.values(), &[20.0, 25.0]);
+    /// ```
     pub fn push(&mut self, value: f64) {
         self.values.push(value);
     }
 
     /// Appends a value, removing the oldest if over max length.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    ///
+    /// let mut series = DataSeries::new("Temp", vec![1.0, 2.0, 3.0]);
+    /// series.push_bounded(4.0, 3);
+    /// assert_eq!(series.values(), &[2.0, 3.0, 4.0]);
+    /// ```
     pub fn push_bounded(&mut self, value: f64, max_len: usize) {
         self.values.push(value);
         while self.values.len() > max_len {
@@ -94,11 +126,29 @@ impl DataSeries {
     }
 
     /// Returns the minimum value, or 0.0 if empty.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    ///
+    /// let series = DataSeries::new("Temp", vec![15.0, 22.0, 8.0]);
+    /// assert_eq!(series.min(), 8.0);
+    /// ```
     pub fn min(&self) -> f64 {
         self.values.iter().copied().reduce(f64::min).unwrap_or(0.0)
     }
 
     /// Returns the maximum value, or 0.0 if empty.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    ///
+    /// let series = DataSeries::new("Temp", vec![15.0, 22.0, 8.0]);
+    /// assert_eq!(series.max(), 22.0);
+    /// ```
     pub fn max(&self) -> f64 {
         self.values.iter().copied().reduce(f64::max).unwrap_or(0.0)
     }
@@ -233,6 +283,17 @@ impl ChartState {
     }
 
     /// Creates a vertical bar chart state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartKind, ChartState, DataSeries};
+    ///
+    /// let state = ChartState::bar_vertical(vec![
+    ///     DataSeries::new("Sales", vec![10.0, 20.0, 30.0]),
+    /// ]);
+    /// assert_eq!(state.kind(), &ChartKind::BarVertical);
+    /// ```
     pub fn bar_vertical(series: Vec<DataSeries>) -> Self {
         Self {
             series,
@@ -251,12 +312,32 @@ impl ChartState {
     }
 
     /// Sets the title (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::line(vec![DataSeries::new("CPU", vec![50.0])])
+    ///     .with_title("CPU Usage");
+    /// assert_eq!(state.title(), Some("CPU Usage"));
+    /// ```
     pub fn with_title(mut self, title: impl Into<String>) -> Self {
         self.title = Some(title.into());
         self
     }
 
     /// Sets the X-axis label (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::line(vec![DataSeries::new("CPU", vec![50.0])])
+    ///     .with_x_label("Time");
+    /// assert_eq!(state.x_label(), Some("Time"));
+    /// ```
     pub fn with_x_label(mut self, label: impl Into<String>) -> Self {
         self.x_label = Some(label.into());
         self
@@ -386,11 +467,33 @@ impl ChartState {
     }
 
     /// Adds a series.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let mut state = ChartState::line(vec![]);
+    /// state.add_series(DataSeries::new("CPU", vec![50.0]));
+    /// assert_eq!(state.series_count(), 1);
+    /// ```
     pub fn add_series(&mut self, series: DataSeries) {
         self.series.push(series);
     }
 
     /// Clears all series.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let mut state = ChartState::line(vec![
+    ///     DataSeries::new("A", vec![1.0]),
+    /// ]);
+    /// state.clear_series();
+    /// assert!(state.is_empty());
+    /// ```
     pub fn clear_series(&mut self) {
         self.series.clear();
         self.active_series = 0;

--- a/src/component/checkbox/mod.rs
+++ b/src/component/checkbox/mod.rs
@@ -106,11 +106,30 @@ impl CheckboxState {
     }
 
     /// Returns the checkbox label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CheckboxState;
+    ///
+    /// let state = CheckboxState::new("Accept terms");
+    /// assert_eq!(state.label(), "Accept terms");
+    /// ```
     pub fn label(&self) -> &str {
         &self.label
     }
 
     /// Sets the checkbox label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CheckboxState;
+    ///
+    /// let mut state = CheckboxState::new("Accept");
+    /// state.set_label("I agree to terms");
+    /// assert_eq!(state.label(), "I agree to terms");
+    /// ```
     pub fn set_label(&mut self, label: impl Into<String>) {
         self.label = label.into();
     }
@@ -121,6 +140,16 @@ impl CheckboxState {
     }
 
     /// Sets the checked state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CheckboxState;
+    ///
+    /// let mut state = CheckboxState::new("Opt in");
+    /// state.set_checked(true);
+    /// assert!(state.is_checked());
+    /// ```
     pub fn set_checked(&mut self, checked: bool) {
         self.checked = checked;
     }
@@ -138,6 +167,15 @@ impl CheckboxState {
     }
 
     /// Sets the disabled state using builder pattern.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CheckboxState;
+    ///
+    /// let state = CheckboxState::new("Option").with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn with_disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
         self
@@ -154,6 +192,18 @@ impl CheckboxState {
     }
 
     /// Maps an input event to a checkbox message.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{CheckboxMessage, CheckboxState};
+    /// use envision::input::Event;
+    ///
+    /// let mut state = CheckboxState::new("Opt in");
+    /// state.set_focused(true);
+    /// let event = Event::key(envision::input::KeyCode::Enter);
+    /// assert_eq!(state.handle_event(&event), Some(CheckboxMessage::Toggle));
+    /// ```
     pub fn handle_event(&self, event: &Event) -> Option<CheckboxMessage> {
         Checkbox::handle_event(self, event)
     }
@@ -164,6 +214,17 @@ impl CheckboxState {
     }
 
     /// Updates the checkbox state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{CheckboxMessage, CheckboxOutput, CheckboxState};
+    ///
+    /// let mut state = CheckboxState::new("Dark mode");
+    /// let output = state.update(CheckboxMessage::Toggle);
+    /// assert_eq!(output, Some(CheckboxOutput::Toggled(true)));
+    /// assert!(state.is_checked());
+    /// ```
     pub fn update(&mut self, msg: CheckboxMessage) -> Option<CheckboxOutput> {
         Checkbox::update(self, msg)
     }

--- a/src/component/data_grid/mod.rs
+++ b/src/component/data_grid/mod.rs
@@ -194,11 +194,50 @@ impl<T: TableRow> DataGridState<T> {
     }
 
     /// Returns the rows.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{DataGridState, TableRow, Column};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = DataGridState::new(
+    ///     vec![Item { name: "A".into() }],
+    ///     vec![Column::new("Name", Constraint::Min(10))],
+    /// );
+    /// assert_eq!(state.rows().len(), 1);
+    /// ```
     pub fn rows(&self) -> &[T] {
         &self.rows
     }
 
     /// Returns the columns.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{DataGridState, TableRow, Column};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = DataGridState::new(
+    ///     vec![Item { name: "A".into() }],
+    ///     vec![Column::new("Name", Constraint::Min(10))],
+    /// );
+    /// assert_eq!(state.columns().len(), 1);
+    /// assert_eq!(state.columns()[0].header(), "Name");
+    /// ```
     pub fn columns(&self) -> &[Column] {
         &self.columns
     }
@@ -269,6 +308,25 @@ impl<T: TableRow> DataGridState<T> {
     }
 
     /// Returns true if a cell is currently being edited.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{DataGridState, TableRow, Column};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = DataGridState::new(
+    ///     vec![Item { name: "A".into() }],
+    ///     vec![Column::new("Name", Constraint::Min(10))],
+    /// );
+    /// assert!(!state.is_editing());
+    /// ```
     pub fn is_editing(&self) -> bool {
         self.editing
     }
@@ -289,16 +347,72 @@ impl<T: TableRow> DataGridState<T> {
     }
 
     /// Returns the number of rows.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{DataGridState, TableRow, Column};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = DataGridState::new(
+    ///     vec![Item { name: "A".into() }, Item { name: "B".into() }],
+    ///     vec![Column::new("Name", Constraint::Min(10))],
+    /// );
+    /// assert_eq!(state.row_count(), 2);
+    /// ```
     pub fn row_count(&self) -> usize {
         self.rows.len()
     }
 
     /// Returns the number of columns.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{DataGridState, TableRow, Column};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = DataGridState::new(
+    ///     vec![Item { name: "A".into() }],
+    ///     vec![
+    ///         Column::new("Name", Constraint::Min(10)),
+    ///         Column::new("Value", Constraint::Min(5)),
+    ///     ],
+    /// );
+    /// assert_eq!(state.column_count(), 2);
+    /// ```
     pub fn column_count(&self) -> usize {
         self.columns.len()
     }
 
     /// Returns true if the grid has no rows.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{DataGridState, TableRow, Column};
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state: DataGridState<Item> = DataGridState::default();
+    /// assert!(state.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.rows.is_empty()
     }

--- a/src/component/file_browser/mod.rs
+++ b/src/component/file_browser/mod.rs
@@ -259,6 +259,17 @@ impl FileBrowserState {
     }
 
     /// Sets the selection mode (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState, SelectionMode};
+    ///
+    /// let state = FileBrowserState::new("/", vec![
+    ///     FileEntry::file("a.txt", "/a.txt"),
+    /// ]).with_selection_mode(SelectionMode::Multiple);
+    /// assert_eq!(state.selection_mode(), &SelectionMode::Multiple);
+    /// ```
     pub fn with_selection_mode(mut self, mode: SelectionMode) -> Self {
         self.selection_mode = mode;
         self
@@ -301,6 +312,15 @@ impl FileBrowserState {
     // ---- Accessors ----
 
     /// Returns the current directory path.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState};
+    ///
+    /// let state = FileBrowserState::new("/home/user", vec![]);
+    /// assert_eq!(state.current_path(), "/home/user");
+    /// ```
     pub fn current_path(&self) -> &str {
         &self.current_path
     }
@@ -329,6 +349,18 @@ impl FileBrowserState {
     }
 
     /// Returns the currently selected entry.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState};
+    ///
+    /// let state = FileBrowserState::new("/", vec![
+    ///     FileEntry::file("readme.md", "/readme.md"),
+    /// ]);
+    /// let entry = state.selected_entry().unwrap();
+    /// assert_eq!(entry.name(), "readme.md");
+    /// ```
     pub fn selected_entry(&self) -> Option<&FileEntry> {
         self.selected_index
             .and_then(|sel| self.filtered_indices.get(sel))
@@ -362,6 +394,15 @@ impl FileBrowserState {
     }
 
     /// Returns the current filter text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState};
+    ///
+    /// let state = FileBrowserState::new("/", vec![]);
+    /// assert_eq!(state.filter_text(), "");
+    /// ```
     pub fn filter_text(&self) -> &str {
         &self.filter_text
     }
@@ -382,6 +423,18 @@ impl FileBrowserState {
     }
 
     /// Returns whether hidden files are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState};
+    ///
+    /// let state = FileBrowserState::new("/", vec![]);
+    /// assert!(!state.show_hidden());
+    ///
+    /// let state = FileBrowserState::new("/", vec![]).with_show_hidden(true);
+    /// assert!(state.show_hidden());
+    /// ```
     pub fn show_hidden(&self) -> bool {
         self.show_hidden
     }

--- a/src/component/file_browser/types.rs
+++ b/src/component/file_browser/types.rs
@@ -18,6 +18,17 @@ pub struct FileEntry {
 
 impl FileEntry {
     /// Creates a new file entry.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::FileEntry;
+    ///
+    /// let entry = FileEntry::file("main.rs", "/src/main.rs");
+    /// assert_eq!(entry.name(), "main.rs");
+    /// assert_eq!(entry.path(), "/src/main.rs");
+    /// assert!(!entry.is_dir());
+    /// ```
     pub fn file(name: impl Into<String>, path: impl Into<String>) -> Self {
         let name_str = name.into();
         let ext = name_str
@@ -37,6 +48,16 @@ impl FileEntry {
     }
 
     /// Creates a new directory entry.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::FileEntry;
+    ///
+    /// let entry = FileEntry::directory("src", "/src");
+    /// assert_eq!(entry.name(), "src");
+    /// assert!(entry.is_dir());
+    /// ```
     pub fn directory(name: impl Into<String>, path: impl Into<String>) -> Self {
         let name_str = name.into();
         Self {

--- a/src/component/loading_list/mod.rs
+++ b/src/component/loading_list/mod.rs
@@ -55,11 +55,29 @@ pub enum ItemState {
 
 impl ItemState {
     /// Returns true if the item is loading.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ItemState;
+    ///
+    /// assert!(!ItemState::Ready.is_loading());
+    /// assert!(ItemState::Loading.is_loading());
+    /// ```
     pub fn is_loading(&self) -> bool {
         matches!(self, Self::Loading)
     }
 
     /// Returns true if the item has an error.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ItemState;
+    ///
+    /// assert!(!ItemState::Ready.is_error());
+    /// assert!(ItemState::Error("failed".into()).is_error());
+    /// ```
     pub fn is_error(&self) -> bool {
         matches!(self, Self::Error(_))
     }
@@ -70,6 +88,17 @@ impl ItemState {
     }
 
     /// Returns the error message if in error state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ItemState;
+    ///
+    /// let state = ItemState::Error("connection lost".into());
+    /// assert_eq!(state.error_message(), Some("connection lost"));
+    ///
+    /// assert_eq!(ItemState::Ready.error_message(), None);
+    /// ```
     pub fn error_message(&self) -> Option<&str> {
         if let Self::Error(msg) = self {
             Some(msg)
@@ -354,12 +383,32 @@ impl<T: Clone> LoadingListState<T> {
     }
 
     /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let state = LoadingListState::<String>::new()
+    ///     .with_title("Tasks");
+    /// assert_eq!(state.title(), Some("Tasks"));
+    /// ```
     pub fn with_title(mut self, title: impl Into<String>) -> Self {
         self.title = Some(title.into());
         self
     }
 
     /// Sets whether to show loading indicators.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let state = LoadingListState::<String>::new()
+    ///     .with_indicators(false);
+    /// assert!(!state.show_indicators());
+    /// ```
     pub fn with_indicators(mut self, show: bool) -> Self {
         self.show_indicators = show;
         self
@@ -447,6 +496,22 @@ impl<T: Clone> LoadingListState<T> {
     }
 
     /// Sets the loading state for an item.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// #[derive(Clone)]
+    /// struct Task { name: String }
+    ///
+    /// let mut state = LoadingListState::with_items(
+    ///     vec![Task { name: "Build".to_string() }],
+    ///     |t| t.name.clone(),
+    /// );
+    /// state.set_loading(0);
+    /// assert!(state.has_loading());
+    /// ```
     pub fn set_loading(&mut self, index: usize) {
         if let Some(item) = self.items.get_mut(index) {
             item.state = ItemState::Loading;
@@ -468,6 +533,26 @@ impl<T: Clone> LoadingListState<T> {
     }
 
     /// Returns the number of items currently loading.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// #[derive(Clone)]
+    /// struct Task { name: String }
+    ///
+    /// let mut state = LoadingListState::with_items(
+    ///     vec![
+    ///         Task { name: "A".to_string() },
+    ///         Task { name: "B".to_string() },
+    ///     ],
+    ///     |t| t.name.clone(),
+    /// );
+    /// state.set_loading(0);
+    /// state.set_loading(1);
+    /// assert_eq!(state.loading_count(), 2);
+    /// ```
     pub fn loading_count(&self) -> usize {
         self.items.iter().filter(|i| i.is_loading()).count()
     }

--- a/src/component/log_viewer/mod.rs
+++ b/src/component/log_viewer/mod.rs
@@ -27,10 +27,11 @@
 //! assert_eq!(state.visible_entries().len(), 1);
 //! ```
 
+mod view;
+
 use std::marker::PhantomData;
 
 use ratatui::prelude::*;
-use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
 
 use super::{
     Component, Disableable, Focusable, InputFieldMessage, InputFieldState, StatusLogEntry,
@@ -219,18 +220,45 @@ impl LogViewerState {
     }
 
     /// Sets the maximum number of entries (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let state = LogViewerState::new().with_max_entries(500);
+    /// assert_eq!(state.max_entries(), 500);
+    /// ```
     pub fn with_max_entries(mut self, max: usize) -> Self {
         self.max_entries = max;
         self
     }
 
     /// Sets whether to show timestamps (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let state = LogViewerState::new().with_timestamps(true);
+    /// assert!(state.show_timestamps());
+    /// ```
     pub fn with_timestamps(mut self, show: bool) -> Self {
         self.show_timestamps = show;
         self
     }
 
     /// Sets the title (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let state = LogViewerState::new().with_title("Application Log");
+    /// assert_eq!(state.title(), Some("Application Log"));
+    /// ```
     pub fn with_title(mut self, title: impl Into<String>) -> Self {
         self.title = Some(title.into());
         self
@@ -260,6 +288,16 @@ impl LogViewerState {
     }
 
     /// Adds a success-level entry, returning its ID.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new();
+    /// let id = state.push_success("Build completed");
+    /// assert_eq!(state.len(), 1);
+    /// ```
     pub fn push_success(&mut self, message: impl Into<String>) -> u64 {
         self.push_entry(message.into(), StatusLogLevel::Success, None)
     }
@@ -344,6 +382,18 @@ impl LogViewerState {
     }
 
     /// Removes an entry by ID. Returns true if the entry was found.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new();
+    /// let id = state.push_info("test");
+    /// assert_eq!(state.len(), 1);
+    /// assert!(state.remove(id));
+    /// assert!(state.is_empty());
+    /// ```
     pub fn remove(&mut self, id: u64) -> bool {
         if let Some(pos) = self.entries.iter().position(|e| e.id() == id) {
             self.entries.remove(pos);
@@ -354,6 +404,18 @@ impl LogViewerState {
     }
 
     /// Clears all entries.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new();
+    /// state.push_info("entry 1");
+    /// state.push_info("entry 2");
+    /// state.clear();
+    /// assert!(state.is_empty());
+    /// ```
     pub fn clear(&mut self) {
         self.entries.clear();
         self.scroll_offset = 0;
@@ -468,6 +530,16 @@ impl LogViewerState {
     /// Returns whether the search bar is focused.
     pub fn is_search_focused(&self) -> bool {
         self.focus == Focus::Search
+    }
+
+    /// Returns the current value of the search input field.
+    pub fn search_value(&self) -> &str {
+        self.search.value()
+    }
+
+    /// Returns the cursor display position in the search field.
+    pub fn search_cursor_position(&self) -> usize {
+        self.search.cursor_display_position()
     }
 
     // ---- Filtering ----
@@ -787,13 +859,13 @@ impl Component for LogViewer {
         let log_area = chunks[2];
 
         // Render search bar
-        render_search_bar(state, frame, search_area, theme);
+        view::render_search_bar(state, frame, search_area, theme);
 
         // Render filter bar
-        render_filter_bar(state, frame, filter_area, theme);
+        view::render_filter_bar(state, frame, filter_area, theme);
 
         // Render log entries
-        render_log(state, frame, log_area, theme);
+        view::render_log(state, frame, log_area, theme);
     }
 }
 
@@ -815,170 +887,6 @@ impl Disableable for LogViewer {
     fn set_disabled(state: &mut Self::State, disabled: bool) {
         state.disabled = disabled;
     }
-}
-
-/// Renders the search bar area.
-fn render_search_bar(state: &LogViewerState, frame: &mut Frame, area: Rect, theme: &Theme) {
-    let search_style = if state.disabled {
-        theme.disabled_style()
-    } else if state.focus == Focus::Search {
-        theme.focused_style()
-    } else {
-        theme.normal_style()
-    };
-
-    let prefix = if state.search_text.is_empty() {
-        "/ Search..."
-    } else {
-        ""
-    };
-
-    let display = if state.search_text.is_empty() {
-        prefix.to_string()
-    } else {
-        format!("/ {}", state.search.value())
-    };
-
-    let paragraph = Paragraph::new(display).style(search_style);
-    frame.render_widget(paragraph, area);
-
-    // Show cursor when search is focused
-    if state.focused && state.focus == Focus::Search && !state.disabled {
-        let cursor_x = area.x + 2 + state.search.cursor_display_position() as u16;
-        if cursor_x < area.right() {
-            frame.set_cursor_position(Position::new(cursor_x, area.y));
-        }
-    }
-}
-
-/// Renders the filter bar showing which severity levels are active.
-fn render_filter_bar(state: &LogViewerState, frame: &mut Frame, area: Rect, theme: &Theme) {
-    let filter_style = if state.disabled {
-        theme.disabled_style()
-    } else {
-        theme.normal_style()
-    };
-
-    let info_marker = if state.show_info { "●" } else { "○" };
-    let success_marker = if state.show_success { "●" } else { "○" };
-    let warning_marker = if state.show_warning { "●" } else { "○" };
-    let error_marker = if state.show_error { "●" } else { "○" };
-
-    let spans = vec![
-        Span::styled(
-            format!("1:{} Info ", info_marker),
-            if state.disabled {
-                filter_style
-            } else {
-                Style::default().fg(StatusLogLevel::Info.color())
-            },
-        ),
-        Span::styled(
-            format!("2:{} Success ", success_marker),
-            if state.disabled {
-                filter_style
-            } else {
-                Style::default().fg(StatusLogLevel::Success.color())
-            },
-        ),
-        Span::styled(
-            format!("3:{} Warning ", warning_marker),
-            if state.disabled {
-                filter_style
-            } else {
-                Style::default().fg(StatusLogLevel::Warning.color())
-            },
-        ),
-        Span::styled(
-            format!("4:{} Error", error_marker),
-            if state.disabled {
-                filter_style
-            } else {
-                Style::default().fg(StatusLogLevel::Error.color())
-            },
-        ),
-    ];
-
-    let line = Line::from(spans);
-    let paragraph = Paragraph::new(line);
-    frame.render_widget(paragraph, area);
-}
-
-/// Renders the log entries area.
-fn render_log(state: &LogViewerState, frame: &mut Frame, area: Rect, theme: &Theme) {
-    let visible = state.visible_entries();
-
-    let border_style = if state.disabled {
-        theme.disabled_style()
-    } else if state.focused && state.focus == Focus::Log {
-        theme.focused_border_style()
-    } else {
-        theme.border_style()
-    };
-
-    let mut block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(border_style);
-
-    if let Some(ref title) = state.title {
-        let match_count = visible.len();
-        let total_count = state.entries.len();
-        if match_count < total_count {
-            block = block.title(format!("{} ({}/{})", title, match_count, total_count));
-        } else {
-            block = block.title(format!("{} ({})", title, total_count));
-        }
-    }
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
-
-    if inner.height == 0 || inner.width == 0 {
-        return;
-    }
-
-    let items: Vec<ListItem> = visible
-        .iter()
-        .skip(state.scroll_offset)
-        .take(inner.height as usize)
-        .map(|entry| {
-            let style = if state.disabled {
-                theme.disabled_style()
-            } else {
-                Style::default().fg(entry.level().color())
-            };
-
-            let mut text = String::new();
-            text.push_str(entry.level().prefix());
-            text.push(' ');
-
-            if state.show_timestamps {
-                if let Some(ts) = entry.timestamp() {
-                    text.push_str(ts);
-                    text.push(' ');
-                }
-            }
-
-            text.push_str(entry.message());
-
-            // Highlight search matches
-            if !state.search_text.is_empty() && !state.disabled {
-                let msg_lower = text.to_lowercase();
-                let search_lower = state.search_text.to_lowercase();
-                if msg_lower.contains(&search_lower) {
-                    // For simplicity, apply a highlight style to the entire line
-                    // when it contains a match
-                    let style = style.add_modifier(Modifier::BOLD);
-                    return ListItem::new(text).style(style);
-                }
-            }
-
-            ListItem::new(text).style(style)
-        })
-        .collect();
-
-    let list = List::new(items);
-    frame.render_widget(list, inner);
 }
 
 #[cfg(test)]

--- a/src/component/log_viewer/view.rs
+++ b/src/component/log_viewer/view.rs
@@ -1,0 +1,171 @@
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+
+use super::{LogViewerState, StatusLogLevel};
+use crate::theme::Theme;
+
+/// Renders the search bar area.
+pub(super) fn render_search_bar(
+    state: &LogViewerState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+) {
+    let search_style = if state.is_disabled() {
+        theme.disabled_style()
+    } else if state.is_search_focused() {
+        theme.focused_style()
+    } else {
+        theme.normal_style()
+    };
+
+    let display = if state.search_text().is_empty() {
+        "/ Search...".to_string()
+    } else {
+        format!("/ {}", state.search_value())
+    };
+
+    let paragraph = Paragraph::new(display).style(search_style);
+    frame.render_widget(paragraph, area);
+
+    // Show cursor when search is focused
+    if state.is_focused() && state.is_search_focused() && !state.is_disabled() {
+        let cursor_x = area.x + 2 + state.search_cursor_position() as u16;
+        if cursor_x < area.right() {
+            frame.set_cursor_position(Position::new(cursor_x, area.y));
+        }
+    }
+}
+
+/// Renders the filter bar showing which severity levels are active.
+pub(super) fn render_filter_bar(
+    state: &LogViewerState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+) {
+    let filter_style = if state.is_disabled() {
+        theme.disabled_style()
+    } else {
+        theme.normal_style()
+    };
+
+    let info_marker = if state.show_info() { "●" } else { "○" };
+    let success_marker = if state.show_success() { "●" } else { "○" };
+    let warning_marker = if state.show_warning() { "●" } else { "○" };
+    let error_marker = if state.show_error() { "●" } else { "○" };
+
+    let spans = vec![
+        Span::styled(
+            format!("1:{} Info ", info_marker),
+            if state.is_disabled() {
+                filter_style
+            } else {
+                Style::default().fg(StatusLogLevel::Info.color())
+            },
+        ),
+        Span::styled(
+            format!("2:{} Success ", success_marker),
+            if state.is_disabled() {
+                filter_style
+            } else {
+                Style::default().fg(StatusLogLevel::Success.color())
+            },
+        ),
+        Span::styled(
+            format!("3:{} Warning ", warning_marker),
+            if state.is_disabled() {
+                filter_style
+            } else {
+                Style::default().fg(StatusLogLevel::Warning.color())
+            },
+        ),
+        Span::styled(
+            format!("4:{} Error", error_marker),
+            if state.is_disabled() {
+                filter_style
+            } else {
+                Style::default().fg(StatusLogLevel::Error.color())
+            },
+        ),
+    ];
+
+    let line = Line::from(spans);
+    let paragraph = Paragraph::new(line);
+    frame.render_widget(paragraph, area);
+}
+
+/// Renders the log entries area.
+pub(super) fn render_log(state: &LogViewerState, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let visible = state.visible_entries();
+
+    let border_style = if state.is_disabled() {
+        theme.disabled_style()
+    } else if state.is_focused() && !state.is_search_focused() {
+        theme.focused_border_style()
+    } else {
+        theme.border_style()
+    };
+
+    let mut block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(border_style);
+
+    if let Some(title) = state.title() {
+        let match_count = visible.len();
+        let total_count = state.len();
+        if match_count < total_count {
+            block = block.title(format!("{} ({}/{})", title, match_count, total_count));
+        } else {
+            block = block.title(format!("{} ({})", title, total_count));
+        }
+    }
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if inner.height == 0 || inner.width == 0 {
+        return;
+    }
+
+    let items: Vec<ListItem> = visible
+        .iter()
+        .skip(state.scroll_offset())
+        .take(inner.height as usize)
+        .map(|entry| {
+            let style = if state.is_disabled() {
+                theme.disabled_style()
+            } else {
+                Style::default().fg(entry.level().color())
+            };
+
+            let mut text = String::new();
+            text.push_str(entry.level().prefix());
+            text.push(' ');
+
+            if state.show_timestamps() {
+                if let Some(ts) = entry.timestamp() {
+                    text.push_str(ts);
+                    text.push(' ');
+                }
+            }
+
+            text.push_str(entry.message());
+
+            // Highlight search matches
+            if !state.search_text().is_empty() && !state.is_disabled() {
+                let msg_lower = text.to_lowercase();
+                let search_lower = state.search_text().to_lowercase();
+                if msg_lower.contains(&search_lower) {
+                    let style = style.add_modifier(Modifier::BOLD);
+                    return ListItem::new(text).style(style);
+                }
+            }
+
+            ListItem::new(text).style(style)
+        })
+        .collect();
+
+    let list = List::new(items);
+    frame.render_widget(list, inner);
+}

--- a/src/component/pane_layout/mod.rs
+++ b/src/component/pane_layout/mod.rs
@@ -267,6 +267,19 @@ impl PaneLayoutState {
     ///
     /// The resize step controls how much each grow/shrink operation changes
     /// proportions. Defaults to 0.05 (5%).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::{PaneConfig, PaneDirection};
+    /// use envision::component::PaneLayoutState;
+    ///
+    /// let state = PaneLayoutState::new(PaneDirection::Horizontal, vec![
+    ///     PaneConfig::new("a"),
+    ///     PaneConfig::new("b"),
+    /// ]).with_resize_step(0.1);
+    /// assert!((state.resize_step() - 0.1).abs() < f32::EPSILON);
+    /// ```
     pub fn with_resize_step(mut self, step: f32) -> Self {
         self.resize_step = step.clamp(0.01, 0.5);
         self
@@ -338,6 +351,19 @@ impl PaneLayoutState {
     // ---- Accessors ----
 
     /// Returns the direction.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::{PaneConfig, PaneDirection};
+    /// use envision::component::PaneLayoutState;
+    ///
+    /// let state = PaneLayoutState::new(PaneDirection::Vertical, vec![
+    ///     PaneConfig::new("top"),
+    ///     PaneConfig::new("bottom"),
+    /// ]);
+    /// assert_eq!(state.direction(), &PaneDirection::Vertical);
+    /// ```
     pub fn direction(&self) -> &PaneDirection {
         &self.direction
     }
@@ -348,6 +374,19 @@ impl PaneLayoutState {
     }
 
     /// Returns the number of panes.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::{PaneConfig, PaneDirection};
+    /// use envision::component::PaneLayoutState;
+    ///
+    /// let state = PaneLayoutState::new(PaneDirection::Horizontal, vec![
+    ///     PaneConfig::new("left"),
+    ///     PaneConfig::new("right"),
+    /// ]);
+    /// assert_eq!(state.pane_count(), 2);
+    /// ```
     pub fn pane_count(&self) -> usize {
         self.panes.len()
     }
@@ -358,11 +397,37 @@ impl PaneLayoutState {
     }
 
     /// Returns the focused pane ID, if panes exist.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::{PaneConfig, PaneDirection};
+    /// use envision::component::PaneLayoutState;
+    ///
+    /// let state = PaneLayoutState::new(PaneDirection::Horizontal, vec![
+    ///     PaneConfig::new("left"),
+    ///     PaneConfig::new("right"),
+    /// ]);
+    /// assert_eq!(state.focused_pane_id(), Some("left"));
+    /// ```
     pub fn focused_pane_id(&self) -> Option<&str> {
         self.panes.get(self.focused_pane).map(|p| p.id.as_str())
     }
 
     /// Returns a pane configuration by ID.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::{PaneConfig, PaneDirection};
+    /// use envision::component::PaneLayoutState;
+    ///
+    /// let state = PaneLayoutState::new(PaneDirection::Horizontal, vec![
+    ///     PaneConfig::new("sidebar").with_title("Files"),
+    /// ]);
+    /// let pane = state.pane("sidebar").unwrap();
+    /// assert_eq!(pane.title(), Some("Files"));
+    /// ```
     pub fn pane(&self, id: &str) -> Option<&PaneConfig> {
         self.panes.iter().find(|p| p.id == id)
     }

--- a/src/component/scrollable_text/mod.rs
+++ b/src/component/scrollable_text/mod.rs
@@ -108,12 +108,31 @@ impl ScrollableTextState {
     }
 
     /// Sets the title (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ScrollableTextState;
+    ///
+    /// let state = ScrollableTextState::new()
+    ///     .with_title("Preview");
+    /// assert_eq!(state.title(), Some("Preview"));
+    /// ```
     pub fn with_title(mut self, title: impl Into<String>) -> Self {
         self.title = Some(title.into());
         self
     }
 
     /// Sets the disabled state (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ScrollableTextState;
+    ///
+    /// let state = ScrollableTextState::new().with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn with_disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
         self
@@ -129,12 +148,34 @@ impl ScrollableTextState {
     /// Sets the text content.
     ///
     /// Resets the scroll offset to 0.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ScrollableTextState;
+    ///
+    /// let mut state = ScrollableTextState::new();
+    /// state.set_content("New content");
+    /// assert_eq!(state.content(), "New content");
+    /// assert_eq!(state.scroll_offset(), 0);
+    /// ```
     pub fn set_content(&mut self, content: impl Into<String>) {
         self.content = content.into();
         self.scroll_offset = 0;
     }
 
     /// Appends text to the content.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ScrollableTextState;
+    ///
+    /// let mut state = ScrollableTextState::new()
+    ///     .with_content("Hello");
+    /// state.append(", world!");
+    /// assert_eq!(state.content(), "Hello, world!");
+    /// ```
     pub fn append(&mut self, text: &str) {
         self.content.push_str(text);
     }
@@ -216,6 +257,17 @@ impl ScrollableTextState {
     }
 
     /// Updates the state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ScrollableTextMessage, ScrollableTextOutput, ScrollableTextState};
+    ///
+    /// let mut state = ScrollableTextState::new()
+    ///     .with_content("Line 1\nLine 2\nLine 3");
+    /// let output = state.update(ScrollableTextMessage::ScrollDown);
+    /// assert_eq!(output, Some(ScrollableTextOutput::ScrollChanged(1)));
+    /// ```
     pub fn update(&mut self, msg: ScrollableTextMessage) -> Option<ScrollableTextOutput> {
         ScrollableText::update(self, msg)
     }

--- a/src/component/step_indicator/mod.rs
+++ b/src/component/step_indicator/mod.rs
@@ -108,12 +108,30 @@ impl Step {
     }
 
     /// Sets the step status (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::{Step, StepStatus};
+    ///
+    /// let step = Step::new("Build").with_status(StepStatus::Completed);
+    /// assert_eq!(step.status(), &StepStatus::Completed);
+    /// ```
     pub fn with_status(mut self, status: StepStatus) -> Self {
         self.status = status;
         self
     }
 
     /// Sets the step description (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::Step;
+    ///
+    /// let step = Step::new("Test").with_description("Run unit tests");
+    /// assert_eq!(step.description(), Some("Run unit tests"));
+    /// ```
     pub fn with_description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());
         self
@@ -244,18 +262,51 @@ impl StepIndicatorState {
     }
 
     /// Sets the orientation (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::{Step, StepOrientation};
+    /// use envision::component::StepIndicatorState;
+    ///
+    /// let state = StepIndicatorState::new(vec![Step::new("A")])
+    ///     .with_orientation(StepOrientation::Vertical);
+    /// assert_eq!(state.orientation(), &StepOrientation::Vertical);
+    /// ```
     pub fn with_orientation(mut self, orientation: StepOrientation) -> Self {
         self.orientation = orientation;
         self
     }
 
     /// Sets the title (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::Step;
+    /// use envision::component::StepIndicatorState;
+    ///
+    /// let state = StepIndicatorState::new(vec![Step::new("A")])
+    ///     .with_title("Pipeline");
+    /// assert_eq!(state.title(), Some("Pipeline"));
+    /// ```
     pub fn with_title(mut self, title: impl Into<String>) -> Self {
         self.title = Some(title.into());
         self
     }
 
     /// Sets the connector string (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::Step;
+    /// use envision::component::StepIndicatorState;
+    ///
+    /// let state = StepIndicatorState::new(vec![Step::new("A")])
+    ///     .with_connector("-->");
+    /// assert_eq!(state.connector(), "-->");
+    /// ```
     pub fn with_connector(mut self, connector: impl Into<String>) -> Self {
         self.connector = connector.into();
         self
@@ -294,6 +345,20 @@ impl StepIndicatorState {
     }
 
     /// Returns the index of the currently active step, if any.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::{Step, StepStatus};
+    /// use envision::component::StepIndicatorState;
+    ///
+    /// let state = StepIndicatorState::new(vec![
+    ///     Step::new("Build").with_status(StepStatus::Completed),
+    ///     Step::new("Test").with_status(StepStatus::Active),
+    ///     Step::new("Deploy"),
+    /// ]);
+    /// assert_eq!(state.active_step_index(), Some(1));
+    /// ```
     pub fn active_step_index(&self) -> Option<usize> {
         self.steps
             .iter()
@@ -301,6 +366,19 @@ impl StepIndicatorState {
     }
 
     /// Returns true if all steps are completed.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::{Step, StepStatus};
+    /// use envision::component::StepIndicatorState;
+    ///
+    /// let state = StepIndicatorState::new(vec![
+    ///     Step::new("Build").with_status(StepStatus::Completed),
+    ///     Step::new("Test").with_status(StepStatus::Completed),
+    /// ]);
+    /// assert!(state.is_all_completed());
+    /// ```
     pub fn is_all_completed(&self) -> bool {
         !self.steps.is_empty()
             && self


### PR DESCRIPTION
## Summary

- Add 69 new doc tests across the 10 components with the lowest doc test coverage: button, chart, checkbox, data_grid, file_browser, loading_list, log_viewer, pane_layout, scrollable_text, and step_indicator
- Doc tests cover public accessor methods, builder methods, state manipulation methods, event handling (`handle_event`, `dispatch_event`, `update`), and instance methods
- Extract log_viewer rendering functions into a `view.rs` submodule to keep `mod.rs` under the 1000-line limit, using only public API accessors

### Per-component breakdown

| Component | New doc tests |
|-----------|:------------:|
| button | 10 |
| chart | 10 |
| data_grid | 6 |
| file_browser | 7 |
| checkbox | 6 |
| loading_list | 7 |
| log_viewer | 6 |
| pane_layout | 5 |
| scrollable_text | 5 |
| step_indicator | 7 |
| **Total** | **69** |

## Test plan

- [x] `cargo test --doc --all-features` passes (580 doc tests, 0 failures)
- [x] `cargo test --all-features --lib` passes (4070 unit tests, 0 failures)
- [x] `cargo clippy --all-features -- -D warnings` passes with no warnings
- [x] `cargo fmt` applied
- [x] All files remain under 1000 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)