### PR TITLE
Add examples for remaining uncovered components

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,46 @@ required-features = ["compound-components"]
 name = "searchable_list"
 required-features = ["compound-components"]
 
+[[example]]
+name = "file_browser"
+required-features = ["compound-components"]
+
+[[example]]
+name = "multi_progress"
+required-features = ["display-components"]
+
+[[example]]
+name = "pane_layout"
+required-features = ["compound-components"]
+
+[[example]]
+name = "router"
+required-features = ["navigation-components"]
+
+[[example]]
+name = "split_panel"
+required-features = ["compound-components"]
+
+[[example]]
+name = "status_bar"
+required-features = ["display-components"]
+
+[[example]]
+name = "status_log"
+required-features = ["display-components"]
+
+[[example]]
+name = "step_indicator"
+required-features = ["navigation-components"]
+
+[[example]]
+name = "styled_text"
+required-features = ["display-components"]
+
+[[example]]
+name = "tooltip"
+required-features = ["overlay-components"]
+
 [[bench]]
 name = "capture_backend"
 harness = false

--- a/examples/file_browser.rs
+++ b/examples/file_browser.rs
@@ -1,0 +1,137 @@
+//! FileBrowser example -- navigable directory listing with filtering.
+//!
+//! Demonstrates the FileBrowser component with a virtual filesystem,
+//! showing directory navigation, filtering, and selection.
+//!
+//! Run with: cargo run --example file_browser --features compound-components
+
+use envision::prelude::*;
+
+/// Application marker type.
+struct FileBrowserApp;
+
+/// Application state.
+#[derive(Clone)]
+struct State {
+    browser: FileBrowserState,
+}
+
+/// Application messages.
+#[derive(Clone, Debug)]
+enum Msg {
+    Browser(FileBrowserMessage),
+    Quit,
+}
+
+impl App for FileBrowserApp {
+    type State = State;
+    type Message = Msg;
+
+    fn init() -> (State, Command<Msg>) {
+        let entries = vec![
+            file_browser::FileEntry::directory("src", "/project/src"),
+            file_browser::FileEntry::directory("tests", "/project/tests"),
+            file_browser::FileEntry::directory("docs", "/project/docs"),
+            file_browser::FileEntry::file("Cargo.toml", "/project/Cargo.toml").with_size(1250),
+            file_browser::FileEntry::file("README.md", "/project/README.md").with_size(4096),
+            file_browser::FileEntry::file(".gitignore", "/project/.gitignore").with_size(128),
+            file_browser::FileEntry::file("LICENSE", "/project/LICENSE").with_size(1060),
+            file_browser::FileEntry::file("rustfmt.toml", "/project/rustfmt.toml").with_size(45),
+        ];
+
+        let mut browser = FileBrowserState::new("/project", entries);
+        browser.set_focused(true);
+
+        (State { browser }, Command::none())
+    }
+
+    fn update(state: &mut State, msg: Msg) -> Command<Msg> {
+        match msg {
+            Msg::Browser(m) => {
+                FileBrowser::update(&mut state.browser, m);
+            }
+            Msg::Quit => return Command::quit(),
+        }
+        Command::none()
+    }
+
+    fn view(state: &State, frame: &mut Frame) {
+        let theme = Theme::default();
+        let area = frame.area();
+        let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
+
+        FileBrowser::view(&state.browser, frame, chunks[0], &theme);
+
+        let selected = state
+            .browser
+            .selected_entry()
+            .map(|e| e.name().to_string())
+            .unwrap_or_else(|| "None".into());
+        let filter = state.browser.filter_text();
+        let filter_display = if filter.is_empty() {
+            String::new()
+        } else {
+            format!(" | Filter: {}", filter)
+        };
+        let status = format!(
+            " Selected: {} | Entries: {}{}",
+            selected,
+            state.browser.filtered_entries().len(),
+            filter_display
+        );
+        frame.render_widget(
+            ratatui::widgets::Paragraph::new(status).style(Style::default().fg(Color::DarkGray)),
+            chunks[1],
+        );
+    }
+
+    fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
+        if let Some(key) = event.as_key() {
+            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc)
+                && state.browser.filter_text().is_empty()
+            {
+                return Some(Msg::Quit);
+            }
+        }
+        state.browser.handle_event(event).map(Msg::Browser)
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut vt = Runtime::<FileBrowserApp, _>::virtual_terminal(50, 16)?;
+
+    println!("=== FileBrowser Example ===\n");
+
+    // Initial render: project root listing
+    vt.tick()?;
+    println!("Initial state (project root):");
+    println!("{}\n", vt.display());
+
+    // Navigate down to select different entries
+    vt.dispatch(Msg::Browser(FileBrowserMessage::Down));
+    vt.dispatch(Msg::Browser(FileBrowserMessage::Down));
+    vt.dispatch(Msg::Browser(FileBrowserMessage::Down));
+    vt.tick()?;
+    println!("After navigating down 3 times:");
+    println!("{}\n", vt.display());
+
+    // Type a filter to narrow results
+    vt.dispatch(Msg::Browser(FileBrowserMessage::FilterChar('r')));
+    vt.tick()?;
+    println!("After typing filter 'r':");
+    println!("{}\n", vt.display());
+
+    // Clear filter
+    vt.dispatch(Msg::Browser(FileBrowserMessage::FilterClear));
+    vt.tick()?;
+    println!("After clearing filter:");
+    println!("{}\n", vt.display());
+
+    // Toggle hidden files
+    vt.dispatch(Msg::Browser(FileBrowserMessage::ToggleHidden));
+    vt.tick()?;
+    println!("After toggling hidden files (now hidden):");
+    println!("{}\n", vt.display());
+
+    Ok(())
+}

--- a/examples/multi_progress.rs
+++ b/examples/multi_progress.rs
@@ -1,0 +1,125 @@
+//! MultiProgress example -- multiple concurrent progress indicators.
+//!
+//! Demonstrates the MultiProgress component for tracking multiple
+//! tasks with individual progress bars, completion, and failure states.
+//!
+//! Run with: cargo run --example multi_progress --features display-components
+
+use envision::prelude::*;
+
+/// Application marker type.
+struct MultiProgressApp;
+
+/// Application state.
+#[derive(Clone)]
+struct State {
+    progress: MultiProgressState,
+}
+
+/// Application messages.
+#[derive(Clone, Debug)]
+enum Msg {
+    Progress(MultiProgressMessage),
+    Quit,
+}
+
+impl App for MultiProgressApp {
+    type State = State;
+    type Message = Msg;
+
+    fn init() -> (State, Command<Msg>) {
+        let mut progress = MultiProgressState::new().with_title("Downloads");
+
+        progress.add("file1", "linux-kernel.tar.gz");
+        progress.add("file2", "rustup-installer.sh");
+        progress.add("file3", "node-v20.tar.xz");
+        progress.add("file4", "gcc-13.2.tar.bz2");
+
+        progress.set_focused(true);
+
+        (State { progress }, Command::none())
+    }
+
+    fn update(state: &mut State, msg: Msg) -> Command<Msg> {
+        match msg {
+            Msg::Progress(m) => {
+                MultiProgress::update(&mut state.progress, m);
+            }
+            Msg::Quit => return Command::quit(),
+        }
+        Command::none()
+    }
+
+    fn view(state: &State, frame: &mut Frame) {
+        let theme = Theme::default();
+        let area = frame.area();
+        let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
+
+        MultiProgress::view(&state.progress, frame, chunks[0], &theme);
+
+        let completed = state.progress.completed_count();
+        let total = state.progress.len();
+        let status = format!(
+            " Completed: {}/{} | Overall: {:.0}%",
+            completed,
+            total,
+            state.progress.overall_progress() * 100.0
+        );
+        frame.render_widget(
+            ratatui::widgets::Paragraph::new(status).style(Style::default().fg(Color::DarkGray)),
+            chunks[1],
+        );
+    }
+
+    fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
+        if let Some(key) = event.as_key() {
+            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+                return Some(Msg::Quit);
+            }
+        }
+        state.progress.handle_event(event).map(Msg::Progress)
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut vt = Runtime::<MultiProgressApp, _>::virtual_terminal(60, 10)?;
+
+    println!("=== MultiProgress Example ===\n");
+
+    // Initial render: all items pending
+    vt.tick()?;
+    println!("Initial state (all pending):");
+    println!("{}\n", vt.display());
+
+    // Update progress on first file
+    vt.dispatch(Msg::Progress(MultiProgressMessage::SetProgress {
+        id: "file1".to_string(),
+        progress: 0.75,
+    }));
+    vt.dispatch(Msg::Progress(MultiProgressMessage::SetProgress {
+        id: "file2".to_string(),
+        progress: 0.3,
+    }));
+    vt.tick()?;
+    println!("After updating progress:");
+    println!("{}\n", vt.display());
+
+    // Complete first file
+    vt.dispatch(Msg::Progress(MultiProgressMessage::Complete(
+        "file1".to_string(),
+    )));
+    vt.tick()?;
+    println!("After completing first file:");
+    println!("{}\n", vt.display());
+
+    // Fail the fourth file
+    vt.dispatch(Msg::Progress(MultiProgressMessage::Fail {
+        id: "file4".to_string(),
+        message: Some("Timeout".to_string()),
+    }));
+    vt.tick()?;
+    println!("After fourth file failed:");
+    println!("{}\n", vt.display());
+
+    Ok(())
+}

--- a/examples/pane_layout.rs
+++ b/examples/pane_layout.rs
@@ -1,0 +1,146 @@
+//! PaneLayout example -- N-pane layout with proportional sizing.
+//!
+//! Demonstrates the PaneLayout component for managing multiple panes
+//! with configurable proportions, focus cycling, and resize operations.
+//!
+//! Run with: cargo run --example pane_layout --features compound-components
+
+use envision::prelude::*;
+
+/// Application marker type.
+struct PaneLayoutApp;
+
+/// Application state.
+#[derive(Clone)]
+struct State {
+    layout: PaneLayoutState,
+}
+
+/// Application messages.
+#[derive(Clone, Debug)]
+enum Msg {
+    Layout(PaneLayoutMessage),
+    Quit,
+}
+
+impl App for PaneLayoutApp {
+    type State = State;
+    type Message = Msg;
+
+    fn init() -> (State, Command<Msg>) {
+        let panes = vec![
+            pane_layout::PaneConfig::new("sidebar")
+                .with_title("Files")
+                .with_proportion(0.25)
+                .with_min_size(10),
+            pane_layout::PaneConfig::new("editor")
+                .with_title("Editor")
+                .with_proportion(0.50),
+            pane_layout::PaneConfig::new("terminal")
+                .with_title("Terminal")
+                .with_proportion(0.25)
+                .with_min_size(10),
+        ];
+
+        let mut layout = PaneLayoutState::new(pane_layout::PaneDirection::Horizontal, panes)
+            .with_resize_step(0.05);
+
+        layout.set_focused(true);
+
+        (State { layout }, Command::none())
+    }
+
+    fn update(state: &mut State, msg: Msg) -> Command<Msg> {
+        match msg {
+            Msg::Layout(m) => {
+                PaneLayout::update(&mut state.layout, m);
+            }
+            Msg::Quit => return Command::quit(),
+        }
+        Command::none()
+    }
+
+    fn view(state: &State, frame: &mut Frame) {
+        let theme = Theme::default();
+        let area = frame.area();
+        let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
+
+        // Render pane borders
+        PaneLayout::view(&state.layout, frame, chunks[0], &theme);
+
+        // Render content in each pane
+        let rects = state.layout.layout(chunks[0]);
+        let pane_contents = [
+            "src/\n  main.rs\n  lib.rs\n  utils.rs",
+            "fn main() {\n    println!(\n      \"Hello\"\n    );\n}",
+            "$ cargo build\n  Compiling...\n  Finished",
+        ];
+
+        for (i, rect) in rects.iter().enumerate() {
+            let inner = ratatui::widgets::Block::default()
+                .borders(ratatui::widgets::Borders::ALL)
+                .inner(*rect);
+            if let Some(content) = pane_contents.get(i) {
+                frame.render_widget(ratatui::widgets::Paragraph::new(*content), inner);
+            }
+        }
+
+        let focused_id = state.layout.focused_pane_id().unwrap_or("none").to_string();
+        let status = format!(
+            " Focus: {} | Panes: {} | Tab: cycle, Ctrl+Arrows: resize, q: quit",
+            focused_id,
+            state.layout.pane_count()
+        );
+        frame.render_widget(
+            ratatui::widgets::Paragraph::new(status).style(Style::default().fg(Color::DarkGray)),
+            chunks[1],
+        );
+    }
+
+    fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
+        if let Some(key) = event.as_key() {
+            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+                return Some(Msg::Quit);
+            }
+        }
+        state.layout.handle_event(event).map(Msg::Layout)
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut vt = Runtime::<PaneLayoutApp, _>::virtual_terminal(80, 14)?;
+
+    println!("=== PaneLayout Example ===\n");
+
+    // Initial render: three panes
+    vt.tick()?;
+    println!("Initial state (sidebar focused):");
+    println!("{}\n", vt.display());
+
+    // Cycle focus to editor pane
+    vt.dispatch(Msg::Layout(PaneLayoutMessage::FocusNext));
+    vt.tick()?;
+    println!("After Tab (editor focused):");
+    println!("{}\n", vt.display());
+
+    // Cycle focus to terminal pane
+    vt.dispatch(Msg::Layout(PaneLayoutMessage::FocusNext));
+    vt.tick()?;
+    println!("After Tab (terminal focused):");
+    println!("{}\n", vt.display());
+
+    // Grow the focused pane (terminal)
+    vt.dispatch(Msg::Layout(PaneLayoutMessage::GrowFocused));
+    vt.dispatch(Msg::Layout(PaneLayoutMessage::GrowFocused));
+    vt.tick()?;
+    println!("After growing terminal pane:");
+    println!("{}\n", vt.display());
+
+    // Reset proportions
+    vt.dispatch(Msg::Layout(PaneLayoutMessage::ResetProportions));
+    vt.tick()?;
+    println!("After resetting proportions:");
+    println!("{}\n", vt.display());
+
+    Ok(())
+}

--- a/examples/router.rs
+++ b/examples/router.rs
@@ -1,0 +1,173 @@
+//! Router example -- multi-screen navigation with history.
+//!
+//! Demonstrates the Router component for type-safe screen navigation
+//! with a back stack, history management, and screen rendering.
+//!
+//! Run with: cargo run --example router --features navigation-components
+
+use envision::prelude::*;
+
+/// The screens in our application.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Screen {
+    Home,
+    Settings,
+    Profile,
+    About,
+}
+
+/// Application marker type.
+struct RouterApp;
+
+/// Application state.
+#[derive(Clone)]
+struct State {
+    router: RouterState<Screen>,
+}
+
+/// Application messages.
+#[derive(Clone, Debug)]
+enum Msg {
+    Navigate(Screen),
+    Back,
+    Reset,
+    Quit,
+}
+
+impl App for RouterApp {
+    type State = State;
+    type Message = Msg;
+
+    fn init() -> (State, Command<Msg>) {
+        let router = RouterState::new(Screen::Home).with_max_history(10);
+        (State { router }, Command::none())
+    }
+
+    fn update(state: &mut State, msg: Msg) -> Command<Msg> {
+        match msg {
+            Msg::Navigate(screen) => {
+                Router::update(&mut state.router, RouterMessage::Navigate(screen));
+            }
+            Msg::Back => {
+                Router::update(&mut state.router, RouterMessage::Back);
+            }
+            Msg::Reset => {
+                Router::update(&mut state.router, RouterMessage::Reset(Screen::Home));
+            }
+            Msg::Quit => return Command::quit(),
+        }
+        Command::none()
+    }
+
+    fn view(state: &State, frame: &mut Frame) {
+        let area = frame.area();
+        let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
+
+        // Render content based on current screen
+        let (title, body) = match state.router.current() {
+            Screen::Home => (
+                "Home",
+                "Welcome home!\n\n\
+                 Press 's' for Settings\n\
+                 Press 'p' for Profile\n\
+                 Press 'a' for About",
+            ),
+            Screen::Settings => (
+                "Settings",
+                "Application Settings\n\n\
+                 Theme: Dark\n\
+                 Language: English\n\
+                 Notifications: On\n\n\
+                 Press Backspace to go back",
+            ),
+            Screen::Profile => (
+                "Profile",
+                "User Profile\n\n\
+                 Name: Alice\n\
+                 Email: alice@example.com\n\
+                 Role: Administrator\n\n\
+                 Press Backspace to go back",
+            ),
+            Screen::About => (
+                "About",
+                "Envision Framework v0.1.0\n\n\
+                 A modern TUI framework\n\
+                 built with Rust.\n\n\
+                 Press Backspace to go back",
+            ),
+        };
+
+        let widget = ratatui::widgets::Paragraph::new(body).block(
+            ratatui::widgets::Block::default()
+                .borders(ratatui::widgets::Borders::ALL)
+                .title(title),
+        );
+        frame.render_widget(widget, chunks[0]);
+
+        let history_len = state.router.history_len();
+        let can_back = state.router.can_go_back();
+        let status = format!(
+            " Screen: {:?} | History: {} | Back: {}",
+            state.router.current(),
+            history_len,
+            can_back
+        );
+        frame.render_widget(
+            ratatui::widgets::Paragraph::new(status).style(Style::default().fg(Color::DarkGray)),
+            chunks[1],
+        );
+    }
+
+    fn handle_event(event: &Event) -> Option<Msg> {
+        if let Some(key) = event.as_key() {
+            match key.code {
+                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
+                KeyCode::Char('s') => Some(Msg::Navigate(Screen::Settings)),
+                KeyCode::Char('p') => Some(Msg::Navigate(Screen::Profile)),
+                KeyCode::Char('a') => Some(Msg::Navigate(Screen::About)),
+                KeyCode::Backspace => Some(Msg::Back),
+                KeyCode::Char('r') => Some(Msg::Reset),
+                _ => None,
+            }
+        } else {
+            None
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut vt = Runtime::<RouterApp, _>::virtual_terminal(50, 14)?;
+
+    println!("=== Router Example ===\n");
+
+    // Initial render: Home screen
+    vt.tick()?;
+    println!("Home screen:");
+    println!("{}\n", vt.display());
+
+    // Navigate to Settings
+    vt.dispatch(Msg::Navigate(Screen::Settings));
+    vt.tick()?;
+    println!("After navigating to Settings:");
+    println!("{}\n", vt.display());
+
+    // Navigate to Profile
+    vt.dispatch(Msg::Navigate(Screen::Profile));
+    vt.tick()?;
+    println!("After navigating to Profile:");
+    println!("{}\n", vt.display());
+
+    // Go back to Settings
+    vt.dispatch(Msg::Back);
+    vt.tick()?;
+    println!("After going back (to Settings):");
+    println!("{}\n", vt.display());
+
+    // Go back to Home
+    vt.dispatch(Msg::Back);
+    vt.tick()?;
+    println!("After going back again (to Home):");
+    println!("{}\n", vt.display());
+
+    Ok(())
+}

--- a/examples/split_panel.rs
+++ b/examples/split_panel.rs
@@ -1,0 +1,139 @@
+//! SplitPanel example -- resizable two-pane layout.
+//!
+//! Demonstrates the SplitPanel component for creating a resizable
+//! split view with focus toggling and ratio adjustment.
+//!
+//! Run with: cargo run --example split_panel --features compound-components
+
+use envision::prelude::*;
+
+/// Application marker type.
+struct SplitPanelApp;
+
+/// Application state.
+#[derive(Clone)]
+struct State {
+    split: SplitPanelState,
+}
+
+/// Application messages.
+#[derive(Clone, Debug)]
+enum Msg {
+    Split(SplitPanelMessage),
+    Quit,
+}
+
+impl App for SplitPanelApp {
+    type State = State;
+    type Message = Msg;
+
+    fn init() -> (State, Command<Msg>) {
+        let mut split = SplitPanelState::with_ratio(SplitOrientation::Vertical, 0.4)
+            .with_resize_step(0.1)
+            .with_bounds(0.2, 0.8);
+
+        split.set_focused(true);
+
+        (State { split }, Command::none())
+    }
+
+    fn update(state: &mut State, msg: Msg) -> Command<Msg> {
+        match msg {
+            Msg::Split(m) => {
+                SplitPanel::update(&mut state.split, m);
+            }
+            Msg::Quit => return Command::quit(),
+        }
+        Command::none()
+    }
+
+    fn view(state: &State, frame: &mut Frame) {
+        let area = frame.area();
+        let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
+
+        // Render the split panel borders
+        let theme = Theme::default();
+        SplitPanel::view(&state.split, frame, chunks[0], &theme);
+
+        // Render content inside each pane
+        let (first_area, second_area) = state.split.layout(chunks[0]);
+
+        // Add padding for borders
+        let first_inner = ratatui::widgets::Block::default()
+            .borders(ratatui::widgets::Borders::ALL)
+            .inner(first_area);
+        let second_inner = ratatui::widgets::Block::default()
+            .borders(ratatui::widgets::Borders::ALL)
+            .inner(second_area);
+
+        let first_content = "File List\n\n\
+             src/\n  main.rs\n  lib.rs\n\
+             tests/\n  test.rs";
+        frame.render_widget(ratatui::widgets::Paragraph::new(first_content), first_inner);
+
+        let second_content = "Preview\n\n\
+             fn main() {\n\
+             \x20\x20\x20 println!(\"Hello\");\n\
+             }";
+        frame.render_widget(
+            ratatui::widgets::Paragraph::new(second_content),
+            second_inner,
+        );
+
+        let pane = if state.split.is_first_pane_focused() {
+            "1"
+        } else {
+            "2"
+        };
+        let status = format!(
+            " Ratio: {:.0}% | Pane: {} | Tab: switch, Ctrl+Arrows: resize, q: quit",
+            state.split.ratio() * 100.0,
+            pane
+        );
+        frame.render_widget(
+            ratatui::widgets::Paragraph::new(status).style(Style::default().fg(Color::DarkGray)),
+            chunks[1],
+        );
+    }
+
+    fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
+        if let Some(key) = event.as_key() {
+            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+                return Some(Msg::Quit);
+            }
+        }
+        state.split.handle_event(event).map(Msg::Split)
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut vt = Runtime::<SplitPanelApp, _>::virtual_terminal(60, 14)?;
+
+    println!("=== SplitPanel Example ===\n");
+
+    // Initial render: 40/60 split with first pane focused
+    vt.tick()?;
+    println!("Initial state (40/60 split, pane 1 focused):");
+    println!("{}\n", vt.display());
+
+    // Toggle focus to second pane
+    vt.dispatch(Msg::Split(SplitPanelMessage::FocusOther));
+    vt.tick()?;
+    println!("After toggling focus to pane 2:");
+    println!("{}\n", vt.display());
+
+    // Grow first pane
+    vt.dispatch(Msg::Split(SplitPanelMessage::GrowFirst));
+    vt.tick()?;
+    println!("After growing first pane (50/50):");
+    println!("{}\n", vt.display());
+
+    // Reset ratio
+    vt.dispatch(Msg::Split(SplitPanelMessage::ResetRatio));
+    vt.dispatch(Msg::Split(SplitPanelMessage::FocusFirst));
+    vt.tick()?;
+    println!("After resetting ratio and focusing pane 1:");
+    println!("{}\n", vt.display());
+
+    Ok(())
+}

--- a/examples/status_bar.rs
+++ b/examples/status_bar.rs
@@ -1,0 +1,171 @@
+//! StatusBar example -- application status display with dynamic content.
+//!
+//! Demonstrates the StatusBar component with left/center/right sections,
+//! styled items, counters, and elapsed time indicators.
+//!
+//! Run with: cargo run --example status_bar --features display-components
+
+use envision::prelude::*;
+
+/// Application marker type.
+struct StatusBarApp;
+
+/// Application state.
+#[derive(Clone)]
+struct State {
+    status: StatusBarState,
+    mode: String,
+}
+
+/// Application messages.
+#[derive(Clone, Debug)]
+enum Msg {
+    StatusBar(StatusBarMessage),
+    SwitchToInsert,
+    SwitchToNormal,
+    Quit,
+}
+
+impl App for StatusBarApp {
+    type State = State;
+    type Message = Msg;
+
+    fn init() -> (State, Command<Msg>) {
+        let mut status = StatusBarState::new();
+
+        // Left: mode indicator
+        status.push_left(StatusBarItem::new("NORMAL").with_style(StatusBarStyle::Info));
+
+        // Center: filename
+        status.push_center(StatusBarItem::new("main.rs"));
+
+        // Right: position and encoding
+        status.push_right(StatusBarItem::counter().with_label("Ln"));
+        status.push_right(StatusBarItem::new("UTF-8").with_style(StatusBarStyle::Muted));
+
+        let state = State {
+            status,
+            mode: "NORMAL".to_string(),
+        };
+
+        (state, Command::none())
+    }
+
+    fn update(state: &mut State, msg: Msg) -> Command<Msg> {
+        match msg {
+            Msg::StatusBar(m) => {
+                StatusBar::update(&mut state.status, m);
+            }
+            Msg::SwitchToInsert => {
+                state.mode = "INSERT".to_string();
+                StatusBar::update(
+                    &mut state.status,
+                    StatusBarMessage::SetLeftItems(vec![
+                        StatusBarItem::new("INSERT").with_style(StatusBarStyle::Success)
+                    ]),
+                );
+            }
+            Msg::SwitchToNormal => {
+                state.mode = "NORMAL".to_string();
+                StatusBar::update(
+                    &mut state.status,
+                    StatusBarMessage::SetLeftItems(vec![
+                        StatusBarItem::new("NORMAL").with_style(StatusBarStyle::Info)
+                    ]),
+                );
+            }
+            Msg::Quit => return Command::quit(),
+        }
+        Command::none()
+    }
+
+    fn view(state: &State, frame: &mut Frame) {
+        let theme = Theme::default();
+        let area = frame.area();
+        let chunks = Layout::vertical([
+            Constraint::Min(0),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+        // Main content area
+        let content = format!(
+            "Current mode: {}\n\nPress 'i' for INSERT mode, Esc for NORMAL.\nPress 'q' to quit.",
+            state.mode
+        );
+        let widget = ratatui::widgets::Paragraph::new(content).block(
+            ratatui::widgets::Block::default()
+                .borders(ratatui::widgets::Borders::ALL)
+                .title("Editor"),
+        );
+        frame.render_widget(widget, chunks[0]);
+
+        // Status bar
+        StatusBar::view(&state.status, frame, chunks[1], &theme);
+
+        // Help line
+        frame.render_widget(
+            ratatui::widgets::Paragraph::new(" i: insert mode, Esc: normal, +/-: counter, q: quit")
+                .style(Style::default().fg(Color::DarkGray)),
+            chunks[2],
+        );
+    }
+
+    fn handle_event(event: &Event) -> Option<Msg> {
+        if let Some(key) = event.as_key() {
+            match key.code {
+                KeyCode::Char('q') => Some(Msg::Quit),
+                KeyCode::Char('i') => Some(Msg::SwitchToInsert),
+                KeyCode::Esc => Some(Msg::SwitchToNormal),
+                KeyCode::Char('+') => Some(Msg::StatusBar(StatusBarMessage::IncrementCounter {
+                    section: Section::Right,
+                    index: 0,
+                })),
+                KeyCode::Char('-') => Some(Msg::StatusBar(StatusBarMessage::DecrementCounter {
+                    section: Section::Right,
+                    index: 0,
+                })),
+                _ => None,
+            }
+        } else {
+            None
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut vt = Runtime::<StatusBarApp, _>::virtual_terminal(60, 10)?;
+
+    println!("=== StatusBar Example ===\n");
+
+    // Initial render: NORMAL mode
+    vt.tick()?;
+    println!("Initial state (NORMAL mode):");
+    println!("{}\n", vt.display());
+
+    // Switch to INSERT mode
+    vt.dispatch(Msg::SwitchToInsert);
+    vt.tick()?;
+    println!("After switching to INSERT mode:");
+    println!("{}\n", vt.display());
+
+    // Increment line counter several times
+    for _ in 0..42 {
+        vt.dispatch(Msg::StatusBar(StatusBarMessage::IncrementCounter {
+            section: Section::Right,
+            index: 0,
+        }));
+    }
+    vt.tick()?;
+    println!("After incrementing line counter to 42:");
+    println!("{}\n", vt.display());
+
+    // Switch back to NORMAL
+    vt.dispatch(Msg::SwitchToNormal);
+    vt.tick()?;
+    println!("Back to NORMAL mode:");
+    println!("{}\n", vt.display());
+
+    Ok(())
+}

--- a/examples/status_log.rs
+++ b/examples/status_log.rs
@@ -1,0 +1,129 @@
+//! StatusLog example -- scrolling status messages with severity levels.
+//!
+//! Demonstrates the StatusLog component for displaying application
+//! status messages with Info, Success, Warning, and Error levels.
+//!
+//! Run with: cargo run --example status_log --features display-components
+
+use envision::prelude::*;
+
+/// Application marker type.
+struct StatusLogApp;
+
+/// Application state.
+#[derive(Clone)]
+struct State {
+    log: StatusLogState,
+}
+
+/// Application messages.
+#[derive(Clone, Debug)]
+enum Msg {
+    Log(StatusLogMessage),
+    Quit,
+}
+
+impl App for StatusLogApp {
+    type State = State;
+    type Message = Msg;
+
+    fn init() -> (State, Command<Msg>) {
+        let mut log = StatusLogState::new()
+            .with_title("Status Log")
+            .with_max_entries(20);
+
+        log.set_focused(true);
+
+        // Add initial messages
+        log.info("Application starting...");
+        log.info("Loading configuration");
+        log.success("Configuration loaded");
+        log.info("Connecting to database");
+
+        (State { log }, Command::none())
+    }
+
+    fn update(state: &mut State, msg: Msg) -> Command<Msg> {
+        match msg {
+            Msg::Log(m) => {
+                StatusLog::update(&mut state.log, m);
+            }
+            Msg::Quit => return Command::quit(),
+        }
+        Command::none()
+    }
+
+    fn view(state: &State, frame: &mut Frame) {
+        let theme = Theme::default();
+        let area = frame.area();
+        let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
+
+        StatusLog::view(&state.log, frame, chunks[0], &theme);
+
+        let status = format!(" Entries: {} | Up/Down: scroll, q: quit", state.log.len());
+        frame.render_widget(
+            ratatui::widgets::Paragraph::new(status).style(Style::default().fg(Color::DarkGray)),
+            chunks[1],
+        );
+    }
+
+    fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
+        if let Some(key) = event.as_key() {
+            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+                return Some(Msg::Quit);
+            }
+        }
+        state.log.handle_event(event).map(Msg::Log)
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut vt = Runtime::<StatusLogApp, _>::virtual_terminal(55, 14)?;
+
+    println!("=== StatusLog Example ===\n");
+
+    // Initial render with some messages
+    vt.tick()?;
+    println!("Initial state (startup messages):");
+    println!("{}\n", vt.display());
+
+    // Add more messages including warning and error
+    vt.dispatch(Msg::Log(StatusLogMessage::Push {
+        message: "Database connected".to_string(),
+        level: StatusLogLevel::Success,
+        timestamp: None,
+    }));
+    vt.dispatch(Msg::Log(StatusLogMessage::Push {
+        message: "Slow query detected (2.5s)".to_string(),
+        level: StatusLogLevel::Warning,
+        timestamp: None,
+    }));
+    vt.dispatch(Msg::Log(StatusLogMessage::Push {
+        message: "Cache miss rate high".to_string(),
+        level: StatusLogLevel::Warning,
+        timestamp: None,
+    }));
+    vt.dispatch(Msg::Log(StatusLogMessage::Push {
+        message: "Failed to send email notification".to_string(),
+        level: StatusLogLevel::Error,
+        timestamp: None,
+    }));
+    vt.dispatch(Msg::Log(StatusLogMessage::Push {
+        message: "Retry succeeded for email".to_string(),
+        level: StatusLogLevel::Success,
+        timestamp: None,
+    }));
+    vt.tick()?;
+    println!("After adding more messages:");
+    println!("{}\n", vt.display());
+
+    // Scroll down to see older messages
+    vt.dispatch(Msg::Log(StatusLogMessage::ScrollDown));
+    vt.dispatch(Msg::Log(StatusLogMessage::ScrollDown));
+    vt.dispatch(Msg::Log(StatusLogMessage::ScrollDown));
+    vt.tick()?;
+    println!("After scrolling down:");
+    println!("{}\n", vt.display());
+
+    Ok(())
+}

--- a/examples/step_indicator.rs
+++ b/examples/step_indicator.rs
@@ -1,0 +1,139 @@
+//! StepIndicator example -- pipeline/workflow visualization.
+//!
+//! Demonstrates the StepIndicator component for showing step-by-step
+//! progress through a build pipeline with completion, failure, and
+//! skip states.
+//!
+//! Run with: cargo run --example step_indicator --features navigation-components
+
+use envision::prelude::*;
+
+/// Application marker type.
+struct StepIndicatorApp;
+
+/// Application state.
+#[derive(Clone)]
+struct State {
+    pipeline: StepIndicatorState,
+}
+
+/// Application messages.
+#[derive(Clone, Debug)]
+enum Msg {
+    Step(StepIndicatorMessage),
+    Quit,
+}
+
+impl App for StepIndicatorApp {
+    type State = State;
+    type Message = Msg;
+
+    fn init() -> (State, Command<Msg>) {
+        let steps = vec![
+            step_indicator::Step::new("Checkout")
+                .with_status(step_indicator::StepStatus::Completed)
+                .with_description("Clone repository"),
+            step_indicator::Step::new("Build")
+                .with_status(step_indicator::StepStatus::Active)
+                .with_description("Compile sources"),
+            step_indicator::Step::new("Test").with_description("Run test suite"),
+            step_indicator::Step::new("Lint").with_description("Check formatting"),
+            step_indicator::Step::new("Deploy").with_description("Push to production"),
+        ];
+
+        let mut pipeline = StepIndicatorState::new(steps)
+            .with_title("CI Pipeline")
+            .with_orientation(step_indicator::StepOrientation::Horizontal);
+
+        pipeline.set_focused(true);
+
+        (State { pipeline }, Command::none())
+    }
+
+    fn update(state: &mut State, msg: Msg) -> Command<Msg> {
+        match msg {
+            Msg::Step(m) => {
+                StepIndicator::update(&mut state.pipeline, m);
+            }
+            Msg::Quit => return Command::quit(),
+        }
+        Command::none()
+    }
+
+    fn view(state: &State, frame: &mut Frame) {
+        let theme = Theme::default();
+        let area = frame.area();
+        let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
+
+        StepIndicator::view(&state.pipeline, frame, chunks[0], &theme);
+
+        let active = state
+            .pipeline
+            .active_step_index()
+            .map(|i| {
+                state
+                    .pipeline
+                    .step(i)
+                    .map(|s| s.label().to_string())
+                    .unwrap_or_default()
+            })
+            .unwrap_or_else(|| "None".into());
+        let status = format!(
+            " Active: {} | All done: {} | Left/Right: navigate, q: quit",
+            active,
+            state.pipeline.is_all_completed()
+        );
+        frame.render_widget(
+            ratatui::widgets::Paragraph::new(status).style(Style::default().fg(Color::DarkGray)),
+            chunks[1],
+        );
+    }
+
+    fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
+        if let Some(key) = event.as_key() {
+            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+                return Some(Msg::Quit);
+            }
+        }
+        state.pipeline.handle_event(event).map(Msg::Step)
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut vt = Runtime::<StepIndicatorApp, _>::virtual_terminal(70, 5)?;
+
+    println!("=== StepIndicator Example ===\n");
+
+    // Initial render: pipeline with Build active
+    vt.tick()?;
+    println!("Initial state (Build active):");
+    println!("{}\n", vt.display());
+
+    // Complete the Build step
+    vt.dispatch(Msg::Step(StepIndicatorMessage::CompleteActive));
+    vt.tick()?;
+    println!("After completing Build:");
+    println!("{}\n", vt.display());
+
+    // Activate and complete Test
+    vt.dispatch(Msg::Step(StepIndicatorMessage::ActivateNext));
+    vt.dispatch(Msg::Step(StepIndicatorMessage::CompleteActive));
+    vt.tick()?;
+    println!("After completing Test:");
+    println!("{}\n", vt.display());
+
+    // Skip Lint and activate Deploy
+    vt.dispatch(Msg::Step(StepIndicatorMessage::Skip(3)));
+    vt.dispatch(Msg::Step(StepIndicatorMessage::ActivateNext));
+    vt.tick()?;
+    println!("After skipping Lint and activating Deploy:");
+    println!("{}\n", vt.display());
+
+    // Complete Deploy
+    vt.dispatch(Msg::Step(StepIndicatorMessage::CompleteActive));
+    vt.tick()?;
+    println!("All steps complete:");
+    println!("{}\n", vt.display());
+
+    Ok(())
+}

--- a/examples/styled_text.rs
+++ b/examples/styled_text.rs
@@ -1,0 +1,124 @@
+//! StyledText example -- rich text display with semantic formatting.
+//!
+//! Demonstrates the StyledText component for rendering headings,
+//! paragraphs, bullet lists, code blocks, and horizontal rules.
+//!
+//! Run with: cargo run --example styled_text --features display-components
+
+use envision::prelude::*;
+
+/// Application marker type.
+struct StyledTextApp;
+
+/// Application state.
+#[derive(Clone)]
+struct State {
+    text: StyledTextState,
+}
+
+/// Application messages.
+#[derive(Clone, Debug)]
+enum Msg {
+    StyledText(StyledTextMessage),
+    Quit,
+}
+
+impl App for StyledTextApp {
+    type State = State;
+    type Message = Msg;
+
+    fn init() -> (State, Command<Msg>) {
+        let content = styled_text::StyledContent::new()
+            .heading(1, "Welcome to Envision")
+            .text("A modern TUI framework built with Rust, using The Elm Architecture.")
+            .heading(2, "Features")
+            .bullet_list(vec![
+                vec![styled_text::StyledInline::Bold(
+                    "Component System".to_string(),
+                )],
+                vec![styled_text::StyledInline::Bold("Theme Support".to_string())],
+                vec![styled_text::StyledInline::Plain(
+                    "Keyboard Navigation".to_string(),
+                )],
+                vec![styled_text::StyledInline::Plain(
+                    "Virtual Terminal Testing".to_string(),
+                )],
+            ])
+            .heading(2, "Getting Started")
+            .text("Add envision to your Cargo.toml:")
+            .code_block(Some("toml"), "[dependencies]\nenvision = \"0.1\"")
+            .horizontal_rule()
+            .text("Use Up/Down or j/k to scroll. Press q to quit.");
+
+        let mut state = StyledTextState::new()
+            .with_content(content)
+            .with_title("Documentation");
+
+        state.set_focused(true);
+
+        (State { text: state }, Command::none())
+    }
+
+    fn update(state: &mut State, msg: Msg) -> Command<Msg> {
+        match msg {
+            Msg::StyledText(m) => {
+                StyledText::update(&mut state.text, m);
+            }
+            Msg::Quit => return Command::quit(),
+        }
+        Command::none()
+    }
+
+    fn view(state: &State, frame: &mut Frame) {
+        let theme = Theme::default();
+        let area = frame.area();
+        let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
+
+        StyledText::view(&state.text, frame, chunks[0], &theme);
+
+        let status = format!(
+            " Scroll: {} | Up/Down: scroll, q: quit",
+            state.text.scroll_offset()
+        );
+        frame.render_widget(
+            ratatui::widgets::Paragraph::new(status).style(Style::default().fg(Color::DarkGray)),
+            chunks[1],
+        );
+    }
+
+    fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
+        if let Some(key) = event.as_key() {
+            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+                return Some(Msg::Quit);
+            }
+        }
+        state.text.handle_event(event).map(Msg::StyledText)
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut vt = Runtime::<StyledTextApp, _>::virtual_terminal(55, 18)?;
+
+    println!("=== StyledText Example ===\n");
+
+    // Initial render: top of content
+    vt.tick()?;
+    println!("Initial state (top of document):");
+    println!("{}\n", vt.display());
+
+    // Scroll down to see more content
+    for _ in 0..5 {
+        vt.dispatch(Msg::StyledText(StyledTextMessage::ScrollDown));
+    }
+    vt.tick()?;
+    println!("After scrolling down 5 lines:");
+    println!("{}\n", vt.display());
+
+    // Scroll back to top
+    vt.dispatch(Msg::StyledText(StyledTextMessage::Home));
+    vt.tick()?;
+    println!("After scrolling back to top:");
+    println!("{}\n", vt.display());
+
+    Ok(())
+}

--- a/examples/tooltip.rs
+++ b/examples/tooltip.rs
@@ -1,0 +1,159 @@
+//! Tooltip example -- contextual information overlay.
+//!
+//! Demonstrates the Tooltip component for displaying positioned
+//! overlays with auto-hide support and configurable positioning.
+//!
+//! Run with: cargo run --example tooltip --features overlay-components
+
+use envision::prelude::*;
+
+/// Application marker type.
+struct TooltipApp;
+
+/// Application state.
+#[derive(Clone)]
+struct State {
+    tooltip: TooltipState,
+    action_count: usize,
+}
+
+/// Application messages.
+#[derive(Clone, Debug)]
+enum Msg {
+    Tooltip(TooltipMessage),
+    ShowHelp,
+    ShowWarning,
+    Quit,
+}
+
+impl App for TooltipApp {
+    type State = State;
+    type Message = Msg;
+
+    fn init() -> (State, Command<Msg>) {
+        let tooltip = TooltipState::new("Press 'h' for help, 'w' for a warning tooltip")
+            .with_title("Tip")
+            .with_position(TooltipPosition::Below);
+
+        let state = State {
+            tooltip,
+            action_count: 0,
+        };
+
+        (state, Command::none())
+    }
+
+    fn update(state: &mut State, msg: Msg) -> Command<Msg> {
+        match msg {
+            Msg::Tooltip(m) => {
+                Tooltip::update(&mut state.tooltip, m);
+            }
+            Msg::ShowHelp => {
+                state.tooltip = TooltipState::new(
+                    "Keyboard shortcuts:\nh: Help\nw: Warning\nt: Toggle\nq: Quit",
+                )
+                .with_title("Help")
+                .with_position(TooltipPosition::Below)
+                .with_duration(5000);
+                Tooltip::show(&mut state.tooltip);
+                state.action_count += 1;
+            }
+            Msg::ShowWarning => {
+                state.tooltip = TooltipState::new("Unsaved changes will be lost!")
+                    .with_title("Warning")
+                    .with_position(TooltipPosition::Below)
+                    .with_fg_color(Color::Yellow)
+                    .with_border_color(Color::Yellow)
+                    .with_duration(3000);
+                Tooltip::show(&mut state.tooltip);
+                state.action_count += 1;
+            }
+            Msg::Quit => return Command::quit(),
+        }
+        Command::none()
+    }
+
+    fn view(state: &State, frame: &mut Frame) {
+        let area = frame.area();
+        let chunks = Layout::vertical([
+            Constraint::Length(5),
+            Constraint::Min(0),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+        // Main content area
+        let content = format!(
+            "Tooltip Demo Application\n\
+             Actions taken: {}\n\
+             Tooltip visible: {}",
+            state.action_count,
+            state.tooltip.is_visible()
+        );
+        let widget = ratatui::widgets::Paragraph::new(content).block(
+            ratatui::widgets::Block::default()
+                .borders(ratatui::widgets::Borders::ALL)
+                .title("Application"),
+        );
+        frame.render_widget(widget, chunks[0]);
+
+        // Render tooltip below the main content
+        if state.tooltip.is_visible() {
+            Tooltip::view_at(&state.tooltip, frame, chunks[0], area);
+        }
+
+        // Help line
+        frame.render_widget(
+            ratatui::widgets::Paragraph::new(
+                " h: help tooltip, w: warning tooltip, t: toggle, q: quit",
+            )
+            .style(Style::default().fg(Color::DarkGray)),
+            chunks[2],
+        );
+    }
+
+    fn handle_event(event: &Event) -> Option<Msg> {
+        if let Some(key) = event.as_key() {
+            match key.code {
+                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
+                KeyCode::Char('h') => Some(Msg::ShowHelp),
+                KeyCode::Char('w') => Some(Msg::ShowWarning),
+                KeyCode::Char('t') => Some(Msg::Tooltip(TooltipMessage::Toggle)),
+                _ => None,
+            }
+        } else {
+            None
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut vt = Runtime::<TooltipApp, _>::virtual_terminal(55, 16)?;
+
+    println!("=== Tooltip Example ===\n");
+
+    // Initial render: no tooltip
+    vt.tick()?;
+    println!("Initial state (no tooltip):");
+    println!("{}\n", vt.display());
+
+    // Show help tooltip
+    vt.dispatch(Msg::ShowHelp);
+    vt.tick()?;
+    println!("After showing help tooltip:");
+    println!("{}\n", vt.display());
+
+    // Hide it
+    vt.dispatch(Msg::Tooltip(TooltipMessage::Hide));
+    vt.tick()?;
+    println!("After hiding tooltip:");
+    println!("{}\n", vt.display());
+
+    // Show warning tooltip
+    vt.dispatch(Msg::ShowWarning);
+    vt.tick()?;
+    println!("After showing warning tooltip:");
+    println!("{}\n", vt.display());
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Add runnable examples for the 10 components that had no examples: `file_browser`, `multi_progress`, `pane_layout`, `router`, `split_panel`, `status_bar`, `status_log`, `step_indicator`, `styled_text`, and `tooltip`
- Each example uses the virtual terminal pattern (CaptureBackend) for headless rendering, demonstrating component initialization, event handling, state updates, and visual output
- Register all 10 new examples in Cargo.toml with appropriate `required-features` flags

## Components covered

| Component | Feature Group | Key Features Demonstrated |
|-----------|--------------|--------------------------|
| `file_browser` | compound-components | Directory listing, navigation, filtering, hidden files |
| `multi_progress` | display-components | Multiple progress bars, completion, failure states |
| `pane_layout` | compound-components | N-pane layout, focus cycling, proportional resizing |
| `router` | navigation-components | Screen navigation, history stack, back navigation |
| `split_panel` | compound-components | Two-pane split, ratio adjustment, focus toggling |
| `status_bar` | display-components | Left/center/right sections, styled items, counters |
| `status_log` | display-components | Severity levels, scrolling, message management |
| `step_indicator` | navigation-components | Pipeline visualization, completion, skip, failure |
| `styled_text` | display-components | Rich text, headings, lists, code blocks, scrolling |
| `tooltip` | overlay-components | Positioned overlays, auto-hide, toggle visibility |

## Test plan

- [x] `cargo build --examples --all-features` compiles without errors
- [x] `cargo clippy --examples --all-features -- -D warnings` passes with no warnings
- [x] `cargo fmt` applied
- [x] `cargo test --all-features` passes (580 tests)
- [x] Verified examples run correctly (multi_progress, router, step_indicator tested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)