### PR TITLE
Add integration, stress, and async test suites

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,20 +1,23 @@
 #![cfg(feature = "full")]
 //! Integration tests exercising multi-component workflows through the public API.
 
+use envision::component::{
+    SearchableList, SearchableListMessage, SearchableListOutput, SearchableListState,
+};
 use envision::{
-    Accordion, AccordionPanel, AccordionState, App, AppHarness, Breadcrumb, BreadcrumbSegment,
-    BreadcrumbState, Button, ButtonOutput, ButtonState, CaptureBackend, Checkbox, CheckboxMessage,
-    CheckboxOutput, CheckboxState, Column, Command, Component, Dialog, DialogButton, DialogMessage,
-    DialogOutput, DialogState, Dropdown, DropdownState, Event, FocusManager, Focusable, InputField,
-    InputFieldMessage, InputFieldOutput, InputFieldState, KeyHint, KeyHints, KeyHintsState,
-    LineInput, LineInputState, LoadingList, LoadingListState, Menu, MenuItem, MenuState,
-    MultiProgress, MultiProgressState, ProgressBar, ProgressBarState, RadioGroup,
-    RadioGroupMessage, RadioGroupOutput, RadioGroupState, ScrollableText, ScrollableTextState,
-    Select, SelectState, SelectableList, SelectableListMessage, SelectableListOutput,
-    SelectableListState, Spinner, SpinnerState, StatusBar, StatusBarState, StatusLog,
-    StatusLogState, Table, TableRow, TableState, Tabs, TabsMessage, TabsOutput, TabsState,
-    TextArea, TextAreaState, Theme, TitleCard, TitleCardState, Toast, ToastState, Toggleable,
-    Tooltip, TooltipState, Tree, TreeNode, TreeState,
+    Accordion, AccordionPanel, AccordionState, App, AppHarness, Breadcrumb, BreadcrumbMessage,
+    BreadcrumbOutput, BreadcrumbSegment, BreadcrumbState, Button, ButtonOutput, ButtonState,
+    CaptureBackend, Checkbox, CheckboxMessage, CheckboxOutput, CheckboxState, Column, Command,
+    Component, Dialog, DialogButton, DialogMessage, DialogOutput, DialogState, Dropdown,
+    DropdownState, Event, FocusManager, Focusable, InputField, InputFieldMessage, InputFieldOutput,
+    InputFieldState, KeyHint, KeyHints, KeyHintsState, LineInput, LineInputState, LoadingList,
+    LoadingListState, Menu, MenuItem, MenuState, MultiProgress, MultiProgressState, ProgressBar,
+    ProgressBarState, RadioGroup, RadioGroupMessage, RadioGroupOutput, RadioGroupState,
+    ScrollableText, ScrollableTextState, Select, SelectState, SelectableList,
+    SelectableListMessage, SelectableListOutput, SelectableListState, Spinner, SpinnerState,
+    StatusBar, StatusBarState, StatusLog, StatusLogState, Table, TableRow, TableState, Tabs,
+    TabsMessage, TabsOutput, TabsState, TextArea, TextAreaState, Theme, TitleCard, TitleCardState,
+    Toast, ToastState, Toggleable, Tooltip, TooltipState, Tree, TreeNode, TreeState,
 };
 use ratatui::prelude::*;
 use ratatui::Terminal;
@@ -685,4 +688,240 @@ fn test_app_harness_counter_workflow() {
 
     // Also verify old value is no longer displayed
     harness.assert_not_contains("Count: 5");
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: Settings panel workflow with tabs, input, radio, checkbox
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_settings_panel_with_tabs_and_components() {
+    #[derive(Clone, PartialEq, Debug)]
+    enum Panel {
+        General,
+        Appearance,
+        Keybinds,
+    }
+
+    let mut focus =
+        FocusManager::with_initial_focus(vec![Panel::General, Panel::Appearance, Panel::Keybinds]);
+
+    // Components for each tab
+    let mut tabs = TabsState::new(vec![
+        "General".to_string(),
+        "Appearance".to_string(),
+        "Keybinds".to_string(),
+    ]);
+    let mut input = InputFieldState::new(); // General tab
+    let mut radio = RadioGroupState::new(vec![
+        // Appearance tab
+        "Light".to_string(),
+        "Dark".to_string(),
+        "System".to_string(),
+    ]);
+    let mut checkbox = CheckboxState::new("Vim Mode"); // Keybinds tab
+
+    // Start on General tab, type a name
+    assert_eq!(focus.focused(), Some(&Panel::General));
+    InputField::set_focused(&mut input, true);
+    for c in "MyApp".chars() {
+        InputField::update(&mut input, InputFieldMessage::Insert(c));
+    }
+    assert_eq!(input.value(), "MyApp");
+
+    // Switch to Appearance tab
+    Tabs::<String>::update(&mut tabs, TabsMessage::Right);
+    assert_eq!(tabs.selected_index(), Some(1));
+    focus.focus_next();
+    InputField::set_focused(&mut input, false);
+    RadioGroup::<String>::set_focused(&mut radio, true);
+
+    // Select "Dark" theme
+    RadioGroup::<String>::update(&mut radio, RadioGroupMessage::Down);
+    let output = RadioGroup::<String>::update(&mut radio, RadioGroupMessage::Confirm);
+    assert_eq!(
+        output,
+        Some(RadioGroupOutput::Confirmed("Dark".to_string()))
+    );
+    assert_eq!(radio.selected_index(), Some(1));
+
+    // Switch to Keybinds tab
+    Tabs::<String>::update(&mut tabs, TabsMessage::Right);
+    focus.focus_next();
+    RadioGroup::<String>::set_focused(&mut radio, false);
+    Checkbox::set_focused(&mut checkbox, true);
+
+    // Toggle vim mode
+    let output = Checkbox::update(&mut checkbox, CheckboxMessage::Toggle);
+    assert_eq!(output, Some(CheckboxOutput::Toggled(true)));
+    assert!(checkbox.is_checked());
+
+    // Switch back to General tab — verify state preserved
+    Tabs::<String>::update(&mut tabs, TabsMessage::Left);
+    Tabs::<String>::update(&mut tabs, TabsMessage::Left);
+    assert_eq!(tabs.selected_index(), Some(0));
+    focus.focus_first();
+    Checkbox::set_focused(&mut checkbox, false);
+    InputField::set_focused(&mut input, true);
+
+    // All states preserved
+    assert_eq!(input.value(), "MyApp");
+    assert_eq!(radio.selected_index(), Some(1));
+    assert!(checkbox.is_checked());
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: Master-detail with dialog confirmation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_master_detail_with_dialog_confirmation() {
+    let mut list = SelectableListState::new(vec![
+        "Document A".to_string(),
+        "Document B".to_string(),
+        "Document C".to_string(),
+        "Document D".to_string(),
+        "Document E".to_string(),
+    ]);
+    SelectableList::<String>::set_focused(&mut list, true);
+
+    // Navigate to item 2
+    SelectableList::<String>::update(&mut list, SelectableListMessage::Down);
+    SelectableList::<String>::update(&mut list, SelectableListMessage::Down);
+    assert_eq!(list.selected_index(), Some(2));
+    assert_eq!(list.selected_item(), Some(&"Document C".to_string()));
+
+    // Open a confirmation dialog for deletion
+    let mut dialog = DialogState::confirm("Delete?", "Delete Document C permanently?");
+    Dialog::update(&mut dialog, DialogMessage::Open);
+    assert!(Dialog::is_visible(&dialog));
+    SelectableList::<String>::set_focused(&mut list, false);
+
+    // Navigate to Cancel and press — should close dialog without change
+    Dialog::update(&mut dialog, DialogMessage::FocusPrev);
+    let output = Dialog::update(&mut dialog, DialogMessage::Press);
+    assert_eq!(output, Some(DialogOutput::ButtonPressed("cancel".into())));
+    assert!(!Dialog::is_visible(&dialog));
+
+    // List still has 5 items, selection preserved
+    assert_eq!(list.items().len(), 5);
+    assert_eq!(list.selected_index(), Some(2));
+
+    // Re-open dialog, this time confirm
+    Dialog::update(&mut dialog, DialogMessage::Open);
+    assert_eq!(dialog.focused_button(), 1); // OK is primary
+    let output = Dialog::update(&mut dialog, DialogMessage::Press);
+    assert_eq!(output, Some(DialogOutput::ButtonPressed("ok".into())));
+
+    // Simulate deletion: rebuild list without item 2
+    let remaining: Vec<String> = list
+        .items()
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i != 2)
+        .map(|(_, item)| item.clone())
+        .collect();
+    let mut list = SelectableListState::new(remaining);
+    assert_eq!(list.items().len(), 4);
+    // Selection should be at the new index 2 (was "Document D")
+    SelectableList::<String>::update(&mut list, SelectableListMessage::Down);
+    SelectableList::<String>::update(&mut list, SelectableListMessage::Down);
+    assert_eq!(list.selected_item(), Some(&"Document D".to_string()));
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: Breadcrumb navigation coordinated with tabs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_breadcrumb_tab_navigation_coordination() {
+    let mut tabs = TabsState::new(vec![
+        "Dashboard".to_string(),
+        "Settings".to_string(),
+        "Help".to_string(),
+    ]);
+
+    // Breadcrumb reflects current location
+    let mut breadcrumb = BreadcrumbState::new(vec![
+        BreadcrumbSegment::new("Home"),
+        BreadcrumbSegment::new("Dashboard"),
+    ]);
+
+    // Initially on Dashboard
+    assert_eq!(tabs.selected_index(), Some(0));
+    assert_eq!(breadcrumb.segments().len(), 2);
+
+    // Switch tab to Settings (Right emits SelectionChanged with new index)
+    let output = Tabs::<String>::update(&mut tabs, TabsMessage::Right);
+    assert_eq!(output, Some(TabsOutput::SelectionChanged(1)));
+    assert_eq!(tabs.selected_index(), Some(1));
+
+    // Update breadcrumb to reflect
+    breadcrumb = BreadcrumbState::new(vec![
+        BreadcrumbSegment::new("Home"),
+        BreadcrumbSegment::new("Settings"),
+    ]);
+
+    // Navigate breadcrumb to "Home" (first segment)
+    Breadcrumb::set_focused(&mut breadcrumb, true);
+    Breadcrumb::update(&mut breadcrumb, BreadcrumbMessage::First);
+    let output = Breadcrumb::update(&mut breadcrumb, BreadcrumbMessage::Select);
+    assert_eq!(output, Some(BreadcrumbOutput::Selected(0)));
+
+    // This would trigger tab reset to Dashboard in a real app
+    Tabs::<String>::update(&mut tabs, TabsMessage::Left);
+    assert_eq!(tabs.selected_index(), Some(0));
+
+    breadcrumb = BreadcrumbState::new(vec![
+        BreadcrumbSegment::new("Home"),
+        BreadcrumbSegment::new("Dashboard"),
+    ]);
+    assert_eq!(breadcrumb.segments().len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: SearchableList filter, navigate, select, clear workflow
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_searchable_list_filter_and_select_workflow() {
+    let items = vec![
+        "Apple".to_string(),
+        "Apricot".to_string(),
+        "Banana".to_string(),
+        "Blueberry".to_string(),
+        "Cherry".to_string(),
+        "Cranberry".to_string(),
+        "Date".to_string(),
+        "Elderberry".to_string(),
+        "Fig".to_string(),
+        "Grape".to_string(),
+    ];
+    let mut state = SearchableListState::new(items.clone());
+    SearchableList::<String>::set_focused(&mut state, true);
+
+    // Verify all items visible initially
+    assert_eq!(state.items().len(), 10);
+    assert_eq!(state.filtered_items().len(), 10);
+
+    // Type "Apri" to filter (case-insensitive substring)
+    for c in "Apri".chars() {
+        SearchableList::<String>::update(&mut state, SearchableListMessage::FilterChar(c));
+    }
+
+    // Should filter to "Apricot" only
+    assert_eq!(state.filtered_items().len(), 1);
+    assert_eq!(state.filter_text(), "Apri");
+
+    // Select — should return "Apricot"
+    let output = SearchableList::<String>::update(&mut state, SearchableListMessage::Select);
+    assert_eq!(
+        output,
+        Some(SearchableListOutput::Selected("Apricot".to_string()))
+    );
+
+    // Clear filter — all items restored
+    SearchableList::<String>::update(&mut state, SearchableListMessage::FilterClear);
+    assert_eq!(state.filtered_items().len(), 10);
+    assert_eq!(state.filter_text(), "");
 }

--- a/tests/integration_async.rs
+++ b/tests/integration_async.rs
@@ -1,0 +1,410 @@
+#![cfg(feature = "full")]
+//! Async integration tests exercising commands, message channels, and error handling.
+//!
+//! NOTE: Subscription tests (TickSubscription, TimerSubscription, ChannelSubscription)
+//! are intentionally omitted. Subscription streams are created via `subscribe()` but
+//! are not polled by `tick()`, `process_pending()`, or `run()`. This is a known gap
+//! that requires redesigning the subscription polling mechanism. See the planned
+//! runtime API redesign for details.
+
+use std::time::Duration;
+
+use envision::{App, Command, Runtime};
+use ratatui::prelude::*;
+
+// ===========================================================================
+// Shared App: AsyncLoader (tests Command::perform_async)
+// ===========================================================================
+
+struct AsyncLoaderApp;
+
+#[derive(Clone, Default)]
+struct AsyncLoaderState {
+    data: Option<String>,
+    loading: bool,
+}
+
+#[derive(Clone, Debug)]
+enum AsyncLoaderMsg {
+    StartLoad,
+    DataLoaded(String),
+}
+
+impl App for AsyncLoaderApp {
+    type State = AsyncLoaderState;
+    type Message = AsyncLoaderMsg;
+
+    fn init() -> (Self::State, Command<Self::Message>) {
+        (AsyncLoaderState::default(), Command::none())
+    }
+
+    fn update(state: &mut Self::State, msg: Self::Message) -> Command<Self::Message> {
+        match msg {
+            AsyncLoaderMsg::StartLoad => {
+                state.loading = true;
+                Command::perform_async(async {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                    Some(AsyncLoaderMsg::DataLoaded("hello world".into()))
+                })
+            }
+            AsyncLoaderMsg::DataLoaded(data) => {
+                state.loading = false;
+                state.data = Some(data);
+                Command::none()
+            }
+        }
+    }
+
+    fn view(state: &Self::State, frame: &mut Frame) {
+        let text = if state.loading {
+            "Loading...".to_string()
+        } else if let Some(ref data) = state.data {
+            format!("Data: {}", data)
+        } else {
+            "Idle".to_string()
+        };
+        frame.render_widget(ratatui::widgets::Paragraph::new(text), frame.area());
+    }
+}
+
+// ===========================================================================
+// Shared App: FallibleApp (tests try_perform_async)
+// ===========================================================================
+
+struct FallibleApp;
+
+#[derive(Clone, Default)]
+struct FallibleState {
+    data: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+enum FallibleMsg {
+    StartFailing,
+    StartSucceeding,
+    DataLoaded(String),
+}
+
+impl App for FallibleApp {
+    type State = FallibleState;
+    type Message = FallibleMsg;
+
+    fn init() -> (Self::State, Command<Self::Message>) {
+        (FallibleState::default(), Command::none())
+    }
+
+    fn update(state: &mut Self::State, msg: Self::Message) -> Command<Self::Message> {
+        match msg {
+            FallibleMsg::StartFailing => Command::try_perform_async(
+                async {
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "resource not found",
+                    ))
+                },
+                |_: ()| Some(FallibleMsg::DataLoaded("unreachable".into())),
+            ),
+            FallibleMsg::StartSucceeding => Command::try_perform_async(
+                async { Ok::<_, std::io::Error>("success data".to_string()) },
+                |data| Some(FallibleMsg::DataLoaded(data)),
+            ),
+            FallibleMsg::DataLoaded(data) => {
+                state.data = Some(data);
+                Command::none()
+            }
+        }
+    }
+
+    fn view(state: &Self::State, frame: &mut Frame) {
+        let text = state.data.as_deref().unwrap_or("no data");
+        frame.render_widget(ratatui::widgets::Paragraph::new(text), frame.area());
+    }
+}
+
+// ===========================================================================
+// Shared App: TickCounter (tests message channel delivery)
+// ===========================================================================
+
+struct TickCounterApp;
+
+#[derive(Clone, Default)]
+struct TickCounterState {
+    count: u32,
+}
+
+#[derive(Clone, Debug)]
+enum TickCounterMsg {
+    Tick,
+}
+
+impl App for TickCounterApp {
+    type State = TickCounterState;
+    type Message = TickCounterMsg;
+
+    fn init() -> (Self::State, Command<Self::Message>) {
+        (TickCounterState::default(), Command::none())
+    }
+
+    fn update(state: &mut Self::State, msg: Self::Message) -> Command<Self::Message> {
+        match msg {
+            TickCounterMsg::Tick => state.count += 1,
+        }
+        Command::none()
+    }
+
+    fn view(state: &Self::State, frame: &mut Frame) {
+        let text = format!("Count: {}", state.count);
+        frame.render_widget(ratatui::widgets::Paragraph::new(text), frame.area());
+    }
+}
+
+// ===========================================================================
+// Shared App: ChainedApp (tests command chaining: one async triggers another)
+// ===========================================================================
+
+struct ChainedApp;
+
+#[derive(Clone, Default)]
+struct ChainedState {
+    step1_done: bool,
+    step2_done: bool,
+    final_result: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+enum ChainedMsg {
+    StartChain,
+    Step1Complete,
+    Step2Complete(String),
+}
+
+impl App for ChainedApp {
+    type State = ChainedState;
+    type Message = ChainedMsg;
+
+    fn init() -> (Self::State, Command<Self::Message>) {
+        (ChainedState::default(), Command::none())
+    }
+
+    fn update(state: &mut Self::State, msg: Self::Message) -> Command<Self::Message> {
+        match msg {
+            ChainedMsg::StartChain => {
+                // Step 1: async operation
+                Command::perform_async(async {
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                    Some(ChainedMsg::Step1Complete)
+                })
+            }
+            ChainedMsg::Step1Complete => {
+                state.step1_done = true;
+                // Step 2: another async triggered by step 1
+                Command::perform_async(async {
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                    Some(ChainedMsg::Step2Complete("chain complete".into()))
+                })
+            }
+            ChainedMsg::Step2Complete(result) => {
+                state.step2_done = true;
+                state.final_result = Some(result);
+                Command::none()
+            }
+        }
+    }
+
+    fn view(state: &Self::State, frame: &mut Frame) {
+        let text = state.final_result.as_deref().unwrap_or("pending");
+        frame.render_widget(ratatui::widgets::Paragraph::new(text), frame.area());
+    }
+}
+
+// ===========================================================================
+// Tests: Command::perform_async
+// ===========================================================================
+
+#[tokio::test]
+async fn test_command_perform_async_updates_state() {
+    let mut vt = Runtime::<AsyncLoaderApp, _>::virtual_terminal(40, 10).unwrap();
+
+    assert!(vt.state().data.is_none());
+    assert!(!vt.state().loading);
+
+    // Dispatch the load command
+    vt.dispatch(AsyncLoaderMsg::StartLoad);
+    assert!(vt.state().loading);
+
+    // Wait for the async task to complete
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    vt.process_pending();
+
+    assert!(!vt.state().loading);
+    assert_eq!(vt.state().data, Some("hello world".to_string()));
+}
+
+#[tokio::test]
+async fn test_command_perform_async_chained() {
+    let mut vt = Runtime::<ChainedApp, _>::virtual_terminal(40, 10).unwrap();
+
+    // Start the chain
+    vt.dispatch(ChainedMsg::StartChain);
+
+    // Wait for step 1
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    vt.process_pending();
+    assert!(vt.state().step1_done);
+
+    // Wait for step 2 (triggered by step 1)
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    vt.process_pending();
+    assert!(vt.state().step2_done);
+    assert_eq!(vt.state().final_result, Some("chain complete".to_string()));
+}
+
+// ===========================================================================
+// Tests: try_perform_async
+// ===========================================================================
+
+#[tokio::test]
+async fn test_try_perform_async_error_reporting() {
+    let mut vt = Runtime::<FallibleApp, _>::virtual_terminal(40, 10).unwrap();
+
+    vt.dispatch(FallibleMsg::StartFailing);
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    vt.process_pending();
+
+    // State should NOT have been updated
+    assert!(vt.state().data.is_none());
+
+    // Error should be collected
+    let errors = vt.take_errors();
+    assert_eq!(errors.len(), 1);
+    assert!(errors[0].to_string().contains("resource not found"));
+}
+
+#[tokio::test]
+async fn test_try_perform_async_success_updates_state() {
+    let mut vt = Runtime::<FallibleApp, _>::virtual_terminal(40, 10).unwrap();
+
+    vt.dispatch(FallibleMsg::StartSucceeding);
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    vt.process_pending();
+
+    assert_eq!(vt.state().data, Some("success data".to_string()));
+}
+
+#[tokio::test]
+async fn test_try_perform_async_error_then_success() {
+    let mut vt = Runtime::<FallibleApp, _>::virtual_terminal(40, 10).unwrap();
+
+    // First: a failing command
+    vt.dispatch(FallibleMsg::StartFailing);
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    vt.process_pending();
+
+    assert!(vt.state().data.is_none());
+    let errors = vt.take_errors();
+    assert_eq!(errors.len(), 1);
+
+    // Second: a succeeding command — state should update despite previous error
+    vt.dispatch(FallibleMsg::StartSucceeding);
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    vt.process_pending();
+
+    assert_eq!(vt.state().data, Some("success data".to_string()));
+    // No new errors
+    assert!(vt.take_errors().is_empty());
+}
+
+// ===========================================================================
+// Tests: Message channel
+// ===========================================================================
+
+#[tokio::test]
+async fn test_message_channel_delivers_messages() {
+    let mut vt = Runtime::<TickCounterApp, _>::virtual_terminal(40, 10).unwrap();
+    let tx = vt.message_sender();
+
+    // Send messages via the channel
+    tx.send(TickCounterMsg::Tick).await.unwrap();
+    tx.send(TickCounterMsg::Tick).await.unwrap();
+    tx.send(TickCounterMsg::Tick).await.unwrap();
+
+    vt.process_pending();
+    assert_eq!(vt.state().count, 3);
+}
+
+#[tokio::test]
+async fn test_message_channel_interleaved_with_dispatch() {
+    let mut vt = Runtime::<TickCounterApp, _>::virtual_terminal(40, 10).unwrap();
+    let tx = vt.message_sender();
+
+    // Direct dispatch
+    vt.dispatch(TickCounterMsg::Tick);
+    assert_eq!(vt.state().count, 1);
+
+    // Channel message
+    tx.send(TickCounterMsg::Tick).await.unwrap();
+    vt.process_pending();
+    assert_eq!(vt.state().count, 2);
+
+    // Another direct dispatch
+    vt.dispatch(TickCounterMsg::Tick);
+    assert_eq!(vt.state().count, 3);
+}
+
+#[tokio::test]
+async fn test_message_channel_from_spawned_task() {
+    let mut vt = Runtime::<TickCounterApp, _>::virtual_terminal(40, 10).unwrap();
+    let tx = vt.message_sender();
+
+    // Spawn a task that sends messages
+    tokio::spawn(async move {
+        for _ in 0..10 {
+            tx.send(TickCounterMsg::Tick).await.unwrap();
+        }
+    });
+
+    // Wait for spawned task to complete
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    vt.process_pending();
+
+    assert_eq!(vt.state().count, 10);
+}
+
+// ===========================================================================
+// Tests: Render after async operations
+// ===========================================================================
+
+#[tokio::test]
+async fn test_render_reflects_async_state() {
+    let mut vt = Runtime::<AsyncLoaderApp, _>::virtual_terminal(40, 10).unwrap();
+
+    vt.render().unwrap();
+    assert!(vt.contains_text("Idle"));
+
+    vt.dispatch(AsyncLoaderMsg::StartLoad);
+    vt.render().unwrap();
+    assert!(vt.contains_text("Loading..."));
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    vt.process_pending();
+    vt.render().unwrap();
+    assert!(vt.contains_text("Data: hello world"));
+    assert!(!vt.contains_text("Loading..."));
+}
+
+#[tokio::test]
+async fn test_render_after_chained_async() {
+    let mut vt = Runtime::<ChainedApp, _>::virtual_terminal(60, 10).unwrap();
+
+    vt.render().unwrap();
+    assert!(vt.contains_text("pending"));
+
+    vt.dispatch(ChainedMsg::StartChain);
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    vt.process_pending();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    vt.process_pending();
+
+    vt.render().unwrap();
+    assert!(vt.contains_text("chain complete"));
+}

--- a/tests/integration_stress.rs
+++ b/tests/integration_stress.rs
@@ -1,0 +1,374 @@
+#![cfg(feature = "full")]
+//! Stress tests exercising components with large datasets (10,000+ items).
+
+use envision::component::{DataGrid, DataGridMessage, DataGridState};
+use envision::{
+    Accordion, AccordionMessage, AccordionPanel, AccordionState, CaptureBackend, Column, Component,
+    LoadingList, LoadingListMessage, LoadingListState, SelectableList, SelectableListMessage,
+    SelectableListState, Table, TableMessage, TableRow, TableState, Theme, Tree, TreeMessage,
+    TreeNode, TreeState,
+};
+use ratatui::prelude::*;
+use ratatui::Terminal;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, PartialEq, Debug)]
+struct StressRow {
+    id: u32,
+    name: String,
+    value: String,
+}
+
+impl TableRow for StressRow {
+    fn cells(&self) -> Vec<String> {
+        vec![self.id.to_string(), self.name.clone(), self.value.clone()]
+    }
+}
+
+fn make_stress_rows(count: u32) -> Vec<StressRow> {
+    (0..count)
+        .map(|i| StressRow {
+            id: i,
+            name: format!("Item {}", i),
+            value: format!("val-{}", i % 100),
+        })
+        .collect()
+}
+
+fn stress_columns() -> Vec<Column> {
+    vec![
+        Column::new("ID", Constraint::Length(8)).sortable(),
+        Column::new("Name", Constraint::Length(20)).sortable(),
+        Column::new("Value", Constraint::Length(12)).sortable(),
+    ]
+}
+
+/// Renders a view function into a terminal of the given size without panicking.
+fn assert_renders_ok<F>(name: &str, width: u16, height: u16, render_fn: F)
+where
+    F: FnOnce(&mut Frame, Rect, &Theme),
+{
+    let backend = CaptureBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let theme = Theme::default();
+    terminal
+        .draw(|frame| {
+            render_fn(frame, frame.area(), &theme);
+        })
+        .unwrap_or_else(|e| panic!("{} panicked during render: {}", name, e));
+}
+
+// ---------------------------------------------------------------------------
+// Table stress test: 10,000 rows
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_table_stress_10000_rows() {
+    let rows = make_stress_rows(10_000);
+    let columns = stress_columns();
+    let mut state = TableState::new(rows, columns);
+    state.set_focused(true);
+
+    assert_eq!(state.selected_index(), Some(0));
+
+    // Navigate down 100 times
+    for _ in 0..100 {
+        Table::<StressRow>::update(&mut state, TableMessage::Down);
+    }
+    assert_eq!(state.selected_index(), Some(100));
+
+    // Jump to last
+    Table::<StressRow>::update(&mut state, TableMessage::Last);
+    assert_eq!(state.selected_index(), Some(9999));
+    assert_eq!(state.selected_row().unwrap().name, "Item 9999");
+
+    // Jump to first
+    Table::<StressRow>::update(&mut state, TableMessage::First);
+    assert_eq!(state.selected_index(), Some(0));
+    assert_eq!(state.selected_row().unwrap().name, "Item 0");
+
+    // Sort by column 0 (ascending)
+    let output = Table::<StressRow>::update(&mut state, TableMessage::SortBy(0));
+    assert!(output.is_some());
+
+    // Render to verify no panics with large dataset
+    assert_renders_ok("Table-10k", 80, 24, |frame, area, theme| {
+        Table::<StressRow>::view(&state, frame, area, theme);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Tree stress test: 11,100 nodes (100 roots × 10 children × 10 grandchildren)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_tree_stress_10000_nodes() {
+    let roots: Vec<TreeNode<String>> = (0..100)
+        .map(|r| {
+            let mut root = TreeNode::new(format!("Root {}", r), format!("root-{}", r));
+            for c in 0..10 {
+                let mut child =
+                    TreeNode::new(format!("Child {}-{}", r, c), format!("child-{}-{}", r, c));
+                for g in 0..10 {
+                    child.add_child(TreeNode::new(
+                        format!("Grand {}-{}-{}", r, c, g),
+                        format!("grand-{}-{}-{}", r, c, g),
+                    ));
+                }
+                root.add_child(child);
+            }
+            root
+        })
+        .collect();
+
+    let mut state = TreeState::new(roots);
+    state.set_focused(true);
+
+    assert_eq!(state.selected_index(), Some(0));
+
+    // Expand all nodes
+    Tree::<String>::update(&mut state, TreeMessage::ExpandAll);
+    let visible = state.visible_count();
+    assert_eq!(visible, 11_100); // 100 + 1000 + 10000
+
+    // Navigate down 50 times
+    for _ in 0..50 {
+        Tree::<String>::update(&mut state, TreeMessage::Down);
+    }
+    assert_eq!(state.selected_index(), Some(50));
+
+    // Collapse all
+    Tree::<String>::update(&mut state, TreeMessage::CollapseAll);
+    assert_eq!(state.visible_count(), 100); // only roots visible
+
+    // Navigate back to the top and expand first root
+    for _ in 0..100 {
+        Tree::<String>::update(&mut state, TreeMessage::Up);
+    }
+    assert_eq!(state.selected_index(), Some(0));
+    Tree::<String>::update(&mut state, TreeMessage::Expand);
+    Tree::<String>::update(&mut state, TreeMessage::Down);
+    assert_eq!(state.selected_index(), Some(1)); // first child of root 0
+
+    // Render to verify no panics with large tree
+    assert_renders_ok("Tree-11k", 100, 40, |frame, area, theme| {
+        Tree::<String>::view(&state, frame, area, theme);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// LoadingList stress test: 10,000 items with state changes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_loading_list_stress_10000_items() {
+    let items: Vec<String> = (0..10_000).map(|i| format!("Task {}", i)).collect();
+    let mut state = LoadingListState::with_items(items, |s| s.clone());
+    state.set_focused(true);
+
+    // LoadingList starts with no selection; select the first item
+    LoadingList::<String>::update(&mut state, LoadingListMessage::First);
+    assert_eq!(state.selected_index(), Some(0));
+
+    // Navigate down 500 times
+    for _ in 0..500 {
+        LoadingList::<String>::update(&mut state, LoadingListMessage::Down);
+    }
+    assert_eq!(state.selected_index(), Some(500));
+
+    // Set loading on 100 items
+    for i in 0..100 {
+        LoadingList::<String>::update(&mut state, LoadingListMessage::SetLoading(i * 100));
+    }
+
+    // Set ready on first 50
+    for i in 0..50 {
+        LoadingList::<String>::update(&mut state, LoadingListMessage::SetReady(i * 100));
+    }
+
+    // Set error on next 50
+    for i in 50..100 {
+        LoadingList::<String>::update(
+            &mut state,
+            LoadingListMessage::SetError {
+                index: i * 100,
+                message: format!("Error at {}", i * 100),
+            },
+        );
+    }
+
+    // Navigate to last
+    LoadingList::<String>::update(&mut state, LoadingListMessage::Last);
+    assert_eq!(state.selected_index(), Some(9999));
+
+    // Navigate to first
+    LoadingList::<String>::update(&mut state, LoadingListMessage::First);
+    assert_eq!(state.selected_index(), Some(0));
+
+    // Render to verify no panics
+    assert_renders_ok("LoadingList-10k", 80, 30, |frame, area, theme| {
+        LoadingList::<String>::view(&state, frame, area, theme);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// SelectableList stress test: 50,000 items with large page operations
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_selectable_list_stress_50000_items() {
+    let items: Vec<String> = (0..50_000).map(|i| format!("Item {}", i)).collect();
+    let mut state = SelectableListState::new(items);
+    state.set_focused(true);
+
+    assert_eq!(state.selected_index(), Some(0));
+
+    // PageDown by 10,000
+    SelectableList::<String>::update(&mut state, SelectableListMessage::PageDown(10_000));
+    assert_eq!(state.selected_index(), Some(10_000));
+
+    // PageDown by another 10,000
+    SelectableList::<String>::update(&mut state, SelectableListMessage::PageDown(10_000));
+    assert_eq!(state.selected_index(), Some(20_000));
+
+    // PageDown by 50,000 (should clamp to last)
+    SelectableList::<String>::update(&mut state, SelectableListMessage::PageDown(50_000));
+    assert_eq!(state.selected_index(), Some(49_999));
+
+    // PageUp by 50,000 (should clamp to first)
+    SelectableList::<String>::update(&mut state, SelectableListMessage::PageUp(50_000));
+    assert_eq!(state.selected_index(), Some(0));
+
+    // Last and First
+    SelectableList::<String>::update(&mut state, SelectableListMessage::Last);
+    assert_eq!(state.selected_index(), Some(49_999));
+    assert_eq!(state.selected_item(), Some(&"Item 49999".to_string()));
+
+    SelectableList::<String>::update(&mut state, SelectableListMessage::First);
+    assert_eq!(state.selected_index(), Some(0));
+    assert_eq!(state.selected_item(), Some(&"Item 0".to_string()));
+
+    // Render to verify no panics with massive list
+    assert_renders_ok("SelectableList-50k", 80, 24, |frame, area, theme| {
+        SelectableList::<String>::view(&state, frame, area, theme);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Accordion stress test: 1,000 panels
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_accordion_stress_1000_panels() {
+    let panels: Vec<AccordionPanel> = (0..1_000)
+        .map(|i| AccordionPanel::new(format!("Panel {}", i), format!("Content for panel {}", i)))
+        .collect();
+    let mut state = AccordionState::new(panels);
+    state.set_focused(true);
+
+    assert_eq!(state.selected_index(), Some(0));
+
+    // Navigate down 500 times
+    for _ in 0..500 {
+        Accordion::update(&mut state, AccordionMessage::Down);
+    }
+    assert_eq!(state.selected_index(), Some(500));
+
+    // Expand all, then collapse all
+    Accordion::update(&mut state, AccordionMessage::ExpandAll);
+    assert!(state.is_all_expanded());
+
+    Accordion::update(&mut state, AccordionMessage::CollapseAll);
+    assert!(!state.is_any_expanded());
+
+    // Navigate to first and last
+    Accordion::update(&mut state, AccordionMessage::First);
+    assert_eq!(state.selected_index(), Some(0));
+
+    Accordion::update(&mut state, AccordionMessage::Last);
+    assert_eq!(state.selected_index(), Some(999));
+
+    // Render to verify no panics
+    assert_renders_ok("Accordion-1k", 80, 40, |frame, area, theme| {
+        Accordion::view(&state, frame, area, theme);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// DataGrid stress test: 10,000 rows with navigation and editing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_data_grid_stress_10000_rows() {
+    let rows = make_stress_rows(10_000);
+    let columns = stress_columns();
+    let mut state = DataGridState::new(rows, columns);
+    state.set_focused(true);
+
+    assert_eq!(state.selected_index(), Some(0));
+
+    // Navigate down 200 rows
+    for _ in 0..200 {
+        DataGrid::<StressRow>::update(&mut state, DataGridMessage::Down);
+    }
+    assert_eq!(state.selected_index(), Some(200));
+
+    // Navigate right to column 2
+    DataGrid::<StressRow>::update(&mut state, DataGridMessage::Right);
+    DataGrid::<StressRow>::update(&mut state, DataGridMessage::Right);
+    assert_eq!(state.selected_column(), 2);
+
+    // Enter edit mode, type a character, confirm edit
+    DataGrid::<StressRow>::update(&mut state, DataGridMessage::Enter);
+    assert!(state.is_editing());
+    DataGrid::<StressRow>::update(&mut state, DataGridMessage::Input('X'));
+    DataGrid::<StressRow>::update(&mut state, DataGridMessage::Enter);
+    assert!(!state.is_editing());
+
+    // Navigate to last row
+    DataGrid::<StressRow>::update(&mut state, DataGridMessage::Last);
+    assert_eq!(state.selected_index(), Some(9999));
+
+    // Render to verify no panics
+    assert_renders_ok("DataGrid-10k", 120, 40, |frame, area, theme| {
+        DataGrid::<StressRow>::view(&state, frame, area, theme);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Rapid input stress test: 10,000 events on a SelectableList
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_rapid_input_10000_events() {
+    let items: Vec<String> = (0..100).map(|i| format!("Item {}", i)).collect();
+    let mut state = SelectableListState::new(items);
+    state.set_focused(true);
+
+    // Send 10,000 alternating Down/Up events via dispatch_event
+    let down = envision::Event::key(crossterm::event::KeyCode::Down);
+    let up = envision::Event::key(crossterm::event::KeyCode::Up);
+
+    for i in 0..10_000 {
+        if i % 2 == 0 {
+            state.dispatch_event(&down);
+        } else {
+            state.dispatch_event(&up);
+        }
+    }
+
+    // After 10,000 alternating events (starting at 0):
+    // even iterations go down, odd go back up → net movement is 0
+    // index should be at 0
+    assert_eq!(state.selected_index(), Some(0));
+
+    // Now rapid all-down to verify we hit the boundary correctly
+    for _ in 0..10_000 {
+        state.dispatch_event(&down);
+    }
+    // Clamped to last item (index 99)
+    assert_eq!(state.selected_index(), Some(99));
+}


### PR DESCRIPTION
## Summary

- Add 4 multi-component workflow integration tests (settings panel, master-detail with dialog, breadcrumb-tab coordination, searchable list filter/select)
- Add 7 stress tests exercising components with 10,000+ item datasets (Table, Tree, LoadingList, SelectableList, Accordion, DataGrid, rapid input)
- Add 10 async integration tests for `Command::perform_async`, `try_perform_async` error handling, message channels, and render-after-async verification

Expands integration test coverage from 11 to 32 tests across three files. Documents the known subscription polling gap (streams stored but never polled by runtime).

## Test plan

- [x] `cargo test --all-features` — all tests pass (782 total including 32 integration)
- [x] `cargo clippy --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)