### PR TITLE
Re-export all subscription types from crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,9 +125,12 @@ pub mod util;
 pub use adapter::{DualBackend, DualBackendBuilder};
 pub use annotation::{Annotate, Annotation, AnnotationRegistry, WidgetType};
 pub use app::{
-    App, Command, DebounceSubscription, FilterSubscription, IntervalImmediateSubscription, Runtime,
-    RuntimeConfig, Subscription, SubscriptionExt, TakeSubscription, TerminalEventSubscription,
-    ThrottleSubscription, TickSubscription, TimerSubscription,
+    batch, interval_immediate, terminal_events, tick, App, BatchSubscription, BoxedSubscription,
+    ChannelSubscription, Command, DebounceSubscription, FilterSubscription,
+    IntervalImmediateBuilder, IntervalImmediateSubscription, MappedSubscription, Runtime,
+    RuntimeConfig, StreamSubscription, Subscription, SubscriptionExt, TakeSubscription,
+    TerminalEventSubscription, ThrottleSubscription, TickSubscription, TickSubscriptionBuilder,
+    TimerSubscription,
 };
 pub use backend::{CaptureBackend, EnhancedCell, FrameSnapshot};
 // Core component traits and utilities (always available)
@@ -206,7 +209,10 @@ pub mod prelude {
     pub use crate::app::{App, Command, Runtime, RuntimeConfig};
 
     // Subscriptions
-    pub use crate::app::{Subscription, SubscriptionExt, Update};
+    pub use crate::app::{
+        batch, interval_immediate, tick, BoxedSubscription, ChannelSubscription, Subscription,
+        SubscriptionExt, Update,
+    };
 
     // Input
     pub use crate::input::{Event, EventQueue, KeyCode, KeyModifiers};


### PR DESCRIPTION
## Summary
- Added 7 missing type re-exports and 4 missing function re-exports from `src/lib.rs` that were already available in `src/app/mod.rs`
- Added key subscription types (`BoxedSubscription`, `ChannelSubscription`) and builder functions (`batch`, `interval_immediate`, `tick`) to the prelude
- Users can now write `envision::ChannelSubscription` instead of `envision::app::ChannelSubscription`

## Test plan
- [x] `cargo test --doc` passes (782 doc tests)
- [x] `cargo clippy --all-features -- -D warnings` passes
- [x] `cargo test --all-features` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)