### PR TITLE
Add VirtualRuntime and TerminalRuntime type aliases

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -93,7 +93,7 @@ pub use command::{BoxedError, Command, CommandHandler};
 pub use model::App;
 #[cfg(feature = "serialization")]
 pub use persistence::load_state;
-pub use runtime::{Runtime, RuntimeConfig};
+pub use runtime::{Runtime, RuntimeConfig, TerminalRuntime, VirtualRuntime};
 pub use subscription::{
     batch, interval_immediate, terminal_events, tick, BatchSubscription, BoxedSubscription,
     ChannelSubscription, DebounceSubscription, FilterSubscription, IntervalImmediateBuilder,

--- a/src/app/runtime/mod.rs
+++ b/src/app/runtime/mod.rs
@@ -55,9 +55,9 @@ mod config;
 mod terminal;
 pub use config::RuntimeConfig;
 
-use std::io;
+use std::io::{self, Stdout};
 
-use ratatui::backend::Backend;
+use ratatui::backend::{Backend, CrosstermBackend};
 use ratatui::Terminal;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -103,6 +103,48 @@ pub struct Runtime<A: App, B: Backend> {
     /// Active subscriptions as streams
     subscriptions: Vec<std::pin::Pin<Box<dyn tokio_stream::Stream<Item = A::Message> + Send>>>,
 }
+
+/// Alias for a runtime using the crossterm terminal backend (production).
+///
+/// This is the type returned by [`Runtime::new_terminal()`] and
+/// [`Runtime::terminal_with_config()`]. Use this alias when you need to
+/// store or pass a terminal-mode runtime without spelling out the backend type.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// // requires real terminal
+/// let runtime: TerminalRuntime<MyApp> = Runtime::new_terminal()?;
+/// ```
+pub type TerminalRuntime<A> = Runtime<A, CrosstermBackend<Stdout>>;
+
+/// Alias for a runtime using the virtual capture backend (testing/automation).
+///
+/// This is the type returned by [`Runtime::virtual_terminal()`] and
+/// [`Runtime::virtual_terminal_with_config()`]. Use this alias when you need
+/// to store or pass a virtual-terminal runtime without spelling out the backend type.
+///
+/// # Example
+///
+/// ```rust
+/// # use envision::prelude::*;
+/// # use envision::VirtualRuntime;
+/// # struct MyApp;
+/// # #[derive(Default, Clone)]
+/// # struct MyState;
+/// # #[derive(Clone)]
+/// # enum MyMsg {}
+/// # impl App for MyApp {
+/// #     type State = MyState;
+/// #     type Message = MyMsg;
+/// #     fn init() -> (MyState, Command<MyMsg>) { (MyState, Command::none()) }
+/// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+/// #     fn view(state: &MyState, frame: &mut Frame) {}
+/// # }
+/// let vt: VirtualRuntime<MyApp> = Runtime::virtual_terminal(80, 24)?;
+/// # Ok::<(), std::io::Error>(())
+/// ```
+pub type VirtualRuntime<A> = Runtime<A, CaptureBackend>;
 
 // =============================================================================
 // Virtual Terminal Mode - for programmatic control (agents, testing)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,8 +129,8 @@ pub use app::{
     ChannelSubscription, Command, DebounceSubscription, FilterSubscription,
     IntervalImmediateBuilder, IntervalImmediateSubscription, MappedSubscription, Runtime,
     RuntimeConfig, StreamSubscription, Subscription, SubscriptionExt, TakeSubscription,
-    TerminalEventSubscription, ThrottleSubscription, TickSubscription, TickSubscriptionBuilder,
-    TimerSubscription,
+    TerminalEventSubscription, TerminalRuntime, ThrottleSubscription, TickSubscription,
+    TickSubscriptionBuilder, TimerSubscription, VirtualRuntime,
 };
 pub use backend::{CaptureBackend, EnhancedCell, FrameSnapshot};
 // Core component traits and utilities (always available)
@@ -206,7 +206,7 @@ pub use theme::Theme;
 /// ```
 pub mod prelude {
     // Core framework
-    pub use crate::app::{App, Command, Runtime, RuntimeConfig};
+    pub use crate::app::{App, Command, Runtime, RuntimeConfig, TerminalRuntime, VirtualRuntime};
 
     // Subscriptions
     pub use crate::app::{


### PR DESCRIPTION
## Summary
- Added `VirtualRuntime<A>` and `TerminalRuntime<A>` type aliases to hide ratatui's `Backend` trait from user code
- Users can now write `VirtualRuntime<MyApp>` instead of `Runtime<MyApp, CaptureBackend>`
- Re-exported from `app` module, crate root, and prelude

## Test plan
- [x] `cargo test --doc` passes (783 doc tests, including new VirtualRuntime doc test)
- [x] `cargo clippy --all-features -- -D warnings` passes
- [x] `cargo test --all-features` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)