### PR TITLE
Add test-utils feature flag for AppHarness async methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ serialization = ["dep:serde", "dep:serde_json", "compact_str/serde", "ratatui/se
 tracing = ["dep:tracing"]
 clipboard = ["dep:arboard"]
 
+# Expose AppHarness async test utilities (advance_time, wait_for, etc.)
+# for integration tests and downstream crates. Not included in default or full.
+test-utils = ["tokio/test-util"]
+
 [dependencies]
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }

--- a/src/harness/app_harness/mod.rs
+++ b/src/harness/app_harness/mod.rs
@@ -405,11 +405,11 @@ impl<A: App> AppHarness<A> {
     }
 }
 
-// Time control methods - only available during tests with tokio test-util
-#[cfg(test)]
+// Time control methods - available during tests and with the test-utils feature
+#[cfg(any(test, feature = "test-utils"))]
 use std::time::Duration;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-utils"))]
 impl<A: App> AppHarness<A> {
     /// Advances time by the specified duration.
     ///

--- a/tests/integration_async.rs
+++ b/tests/integration_async.rs
@@ -408,3 +408,110 @@ async fn test_render_after_chained_async() {
     vt.render().unwrap();
     assert!(vt.contains_text("chain complete"));
 }
+
+// ===========================================================================
+// Tests: AppHarness async methods (test-utils feature)
+// ===========================================================================
+
+#[cfg(feature = "test-utils")]
+mod app_harness_tests {
+    use std::time::Duration;
+
+    use envision::harness::AppHarness;
+    use envision::{App, Command};
+    use ratatui::prelude::*;
+
+    struct TimedApp;
+
+    #[derive(Clone, Default)]
+    struct TimedState {
+        data: Option<String>,
+        loading: bool,
+    }
+
+    #[derive(Clone, Debug)]
+    enum TimedMsg {
+        StartLoad,
+        DataLoaded(String),
+    }
+
+    impl App for TimedApp {
+        type State = TimedState;
+        type Message = TimedMsg;
+
+        fn init() -> (Self::State, Command<Self::Message>) {
+            (TimedState::default(), Command::none())
+        }
+
+        fn update(state: &mut Self::State, msg: Self::Message) -> Command<Self::Message> {
+            match msg {
+                TimedMsg::StartLoad => {
+                    state.loading = true;
+                    Command::perform_async(async {
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                        Some(TimedMsg::DataLoaded("loaded".into()))
+                    })
+                }
+                TimedMsg::DataLoaded(data) => {
+                    state.loading = false;
+                    state.data = Some(data);
+                    Command::none()
+                }
+            }
+        }
+
+        fn view(state: &Self::State, frame: &mut Frame) {
+            let text = if state.loading {
+                "Loading...".to_string()
+            } else if let Some(ref data) = state.data {
+                format!("Data: {}", data)
+            } else {
+                "Idle".to_string()
+            };
+            frame.render_widget(ratatui::widgets::Paragraph::new(text), frame.area());
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_app_harness_advance_time() {
+        let mut harness = AppHarness::<TimedApp>::new(40, 10).unwrap();
+
+        harness.dispatch(TimedMsg::StartLoad);
+        assert!(harness.state().loading);
+        assert!(harness.state().data.is_none());
+
+        // Advance time past the 100ms sleep
+        harness.advance_time(Duration::from_millis(150)).await;
+
+        assert!(!harness.state().loading);
+        assert_eq!(harness.state().data, Some("loaded".to_string()));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_app_harness_wait_for() {
+        let mut harness = AppHarness::<TimedApp>::new(40, 10).unwrap();
+
+        harness.dispatch(TimedMsg::StartLoad);
+
+        let found = harness
+            .wait_for(|state| state.data.is_some(), Duration::from_secs(1))
+            .await;
+
+        assert!(found);
+        assert_eq!(harness.state().data, Some("loaded".to_string()));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_app_harness_wait_for_text() {
+        let mut harness = AppHarness::<TimedApp>::new(40, 10).unwrap();
+
+        harness.dispatch(TimedMsg::StartLoad);
+
+        let found = harness
+            .wait_for_text("Data: loaded", Duration::from_secs(1))
+            .await;
+
+        assert!(found);
+        assert!(harness.contains_text("Data: loaded"));
+    }
+}


### PR DESCRIPTION
## Summary
- Added `test-utils` feature flag (opt-in, not included in `default` or `full`)
- Changed `#[cfg(test)]` gating on `AppHarness` time-control methods (`advance_time`, `sleep`, `wait_for`, `wait_for_text`) to `#[cfg(any(test, feature = "test-utils"))]`
- Feature enables `tokio/test-util` for `tokio::time::advance()` support
- Added 3 integration tests that verify these methods work from outside the crate

## Test plan
- [x] `cargo test --features test-utils --test integration_async` passes (13 tests including 3 new)
- [x] `cargo clippy --all-features -- -D warnings` passes
- [x] `cargo test --all-features` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)