### PR TITLE
Add UnboundedChannelSubscription

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -99,6 +99,6 @@ pub use subscription::{
     ChannelSubscription, DebounceSubscription, FilterSubscription, IntervalImmediateBuilder,
     IntervalImmediateSubscription, MappedSubscription, StreamSubscription, Subscription,
     SubscriptionExt, TakeSubscription, TerminalEventSubscription, ThrottleSubscription,
-    TickSubscription, TickSubscriptionBuilder, TimerSubscription,
+    TickSubscription, TickSubscriptionBuilder, TimerSubscription, UnboundedChannelSubscription,
 };
 pub use update::{FnUpdate, StateExt, Update, UpdateResult};

--- a/src/app/subscription/core.rs
+++ b/src/app/subscription/core.rs
@@ -204,6 +204,56 @@ impl<M: Send + 'static> Subscription<M> for ChannelSubscription<M> {
     }
 }
 
+/// A subscription that receives messages from an unbounded channel.
+///
+/// This is the unbounded counterpart of [`ChannelSubscription`]. Use this
+/// when the sender should never block, at the cost of unbounded memory
+/// growth if messages are produced faster than consumed.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::app::UnboundedChannelSubscription;
+///
+/// let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+/// let subscription = UnboundedChannelSubscription::new(rx);
+/// ```
+pub struct UnboundedChannelSubscription<M> {
+    receiver: mpsc::UnboundedReceiver<M>,
+}
+
+impl<M> UnboundedChannelSubscription<M> {
+    /// Creates a subscription from an unbounded channel receiver.
+    pub fn new(receiver: mpsc::UnboundedReceiver<M>) -> Self {
+        Self { receiver }
+    }
+}
+
+impl<M: Send + 'static> Subscription<M> for UnboundedChannelSubscription<M> {
+    fn into_stream(
+        self: Box<Self>,
+        cancel: CancellationToken,
+    ) -> Pin<Box<dyn Stream<Item = M> + Send>> {
+        let mut receiver = self.receiver;
+
+        Box::pin(async_stream::stream! {
+            loop {
+                tokio::select! {
+                    msg = receiver.recv() => {
+                        match msg {
+                            Some(m) => yield m,
+                            None => break, // Channel closed
+                        }
+                    }
+                    _ = cancel.cancelled() => {
+                        break;
+                    }
+                }
+            }
+        })
+    }
+}
+
 /// A subscription that wraps a stream directly.
 ///
 /// This allows using any async stream as a subscription.

--- a/src/app/subscription/mod.rs
+++ b/src/app/subscription/mod.rs
@@ -27,7 +27,7 @@ pub use combinators::{
 };
 pub use core::{
     tick, BoxedSubscription, ChannelSubscription, StreamSubscription, Subscription,
-    TickSubscription, TickSubscriptionBuilder, TimerSubscription,
+    TickSubscription, TickSubscriptionBuilder, TimerSubscription, UnboundedChannelSubscription,
 };
 pub use ext::SubscriptionExt;
 pub use interval::{interval_immediate, IntervalImmediateBuilder, IntervalImmediateSubscription};

--- a/src/app/subscription/tests/core.rs
+++ b/src/app/subscription/tests/core.rs
@@ -93,6 +93,56 @@ async fn test_channel_subscription() {
 }
 
 #[tokio::test]
+async fn test_unbounded_channel_subscription() {
+    let cancel = CancellationToken::new();
+    let (tx, rx) = mpsc::unbounded_channel();
+    let sub = Box::new(UnboundedChannelSubscription::new(rx));
+
+    let mut stream = sub.into_stream(cancel.clone());
+
+    // Send messages (unbounded send is synchronous, never blocks)
+    tx.send(TestMsg::Value(10)).unwrap();
+    tx.send(TestMsg::Value(20)).unwrap();
+
+    // Receive messages
+    let msg = stream.next().await;
+    assert_eq!(msg, Some(TestMsg::Value(10)));
+
+    let msg = stream.next().await;
+    assert_eq!(msg, Some(TestMsg::Value(20)));
+
+    // Drop sender to close channel
+    drop(tx);
+
+    // Stream should end
+    let msg = stream.next().await;
+    assert_eq!(msg, None);
+}
+
+#[tokio::test]
+async fn test_unbounded_channel_subscription_cancellation() {
+    let cancel = CancellationToken::new();
+    let (tx, rx) = mpsc::unbounded_channel();
+    let sub = Box::new(UnboundedChannelSubscription::new(rx));
+
+    let mut stream = sub.into_stream(cancel.clone());
+
+    tx.send(TestMsg::Value(1)).unwrap();
+    let msg = stream.next().await;
+    assert_eq!(msg, Some(TestMsg::Value(1)));
+
+    // Cancel the subscription
+    cancel.cancel();
+
+    // Stream should end
+    let msg = stream.next().await;
+    assert_eq!(msg, None);
+
+    // Sender still alive but stream is done
+    drop(tx);
+}
+
+#[tokio::test]
 async fn test_stream_subscription() {
     let cancel = CancellationToken::new();
     let values = vec![TestMsg::Value(1), TestMsg::Value(2), TestMsg::Value(3)];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ pub use app::{
     IntervalImmediateBuilder, IntervalImmediateSubscription, MappedSubscription, Runtime,
     RuntimeConfig, StreamSubscription, Subscription, SubscriptionExt, TakeSubscription,
     TerminalEventSubscription, TerminalRuntime, ThrottleSubscription, TickSubscription,
-    TickSubscriptionBuilder, TimerSubscription, VirtualRuntime,
+    TickSubscriptionBuilder, TimerSubscription, UnboundedChannelSubscription, VirtualRuntime,
 };
 pub use backend::{CaptureBackend, EnhancedCell, FrameSnapshot};
 // Core component traits and utilities (always available)


### PR DESCRIPTION
## Summary

- Adds `UnboundedChannelSubscription` that accepts `tokio::sync::mpsc::UnboundedReceiver<M>`, complementing the existing bounded `ChannelSubscription`
- Useful when senders should never block (e.g., event bridges from external systems, high-throughput message sources)
- Re-exported at `envision::UnboundedChannelSubscription` and `envision::app::UnboundedChannelSubscription`

## Test plan

- [x] 2 new unit tests: message delivery and cancellation
- [x] All existing subscription tests pass (24 total)
- [x] Clippy clean, format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)