### PR TITLE
Return final state from run_terminal()

### DIFF
--- a/src/app/runtime/mod.rs
+++ b/src/app/runtime/mod.rs
@@ -16,7 +16,8 @@
 //! // requires real terminal
 //! #[tokio::main]
 //! async fn main() -> std::io::Result<()> {
-//!     Runtime::<MyApp>::new_terminal()?.run_terminal().await
+//!     let _final_state = Runtime::<MyApp>::new_terminal()?.run_terminal().await?;
+//!     Ok(())
 //! }
 //! ```
 //!

--- a/src/app/runtime/terminal.rs
+++ b/src/app/runtime/terminal.rs
@@ -45,7 +45,8 @@ impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
     /// // requires real terminal
     /// #[tokio::main]
     /// async fn main() -> std::io::Result<()> {
-    ///     Runtime::<MyApp>::new_terminal()?.run_terminal().await
+    ///     let _final_state = Runtime::<MyApp>::new_terminal()?.run_terminal().await?;
+    ///     Ok(())
     /// }
     /// ```
     pub fn new_terminal() -> io::Result<Self> {
@@ -89,10 +90,12 @@ impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
     /// // requires real terminal
     /// #[tokio::main]
     /// async fn main() -> std::io::Result<()> {
-    ///     Runtime::<MyApp>::new_terminal()?.run_terminal().await
+    ///     let final_state = Runtime::<MyApp>::new_terminal()?.run_terminal().await?;
+    ///     println!("Final count: {}", final_state.count);
+    ///     Ok(())
     /// }
     /// ```
-    pub async fn run_terminal(mut self) -> io::Result<()> {
+    pub async fn run_terminal(mut self) -> io::Result<A::State> {
         use futures_util::StreamExt;
 
         #[cfg(feature = "tracing")]
@@ -193,8 +196,9 @@ impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
         // Call on_exit
         A::on_exit(&self.core.state);
 
-        // Return the first error if any
-        result.and(cleanup_result)
+        // Return the first error if any, otherwise return the final state
+        result.and(cleanup_result)?;
+        Ok(self.core.state)
     }
 
     /// Runs the interactive terminal event loop, blocking the current thread.
@@ -213,10 +217,12 @@ impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
     /// ```rust,ignore
     /// // requires real terminal
     /// fn main() -> std::io::Result<()> {
-    ///     Runtime::<MyApp>::new_terminal()?.run_terminal_blocking()
+    ///     let final_state = Runtime::<MyApp>::new_terminal()?.run_terminal_blocking()?;
+    ///     println!("Final count: {}", final_state.count);
+    ///     Ok(())
     /// }
     /// ```
-    pub fn run_terminal_blocking(self) -> io::Result<()> {
+    pub fn run_terminal_blocking(self) -> io::Result<A::State> {
         let rt = tokio::runtime::Runtime::new().map_err(io::Error::other)?;
         rt.block_on(self.run_terminal())
     }

--- a/src/app/runtime/tests/mod.rs
+++ b/src/app/runtime/tests/mod.rs
@@ -583,7 +583,7 @@ fn test_run_terminal_blocking_exists() {
     // Verify that run_terminal_blocking is available on the terminal runtime type.
     // We can't actually call it (requires a real terminal), but we can verify
     // the method exists by taking a function pointer to it.
-    let _: fn(Runtime<CounterApp, CrosstermBackend<Stdout>>) -> io::Result<()> =
+    let _: fn(Runtime<CounterApp, CrosstermBackend<Stdout>>) -> io::Result<CounterState> =
         Runtime::<CounterApp, CrosstermBackend<Stdout>>::run_terminal_blocking;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,8 @@
 //! // requires real terminal
 //! #[tokio::main]
 //! async fn main() -> std::io::Result<()> {
-//!     Runtime::<MyApp>::new_terminal()?.run_terminal().await
+//!     let _final_state = Runtime::<MyApp>::new_terminal()?.run_terminal().await?;
+//!     Ok(())
 //! }
 //! ```
 //!
@@ -24,7 +25,8 @@
 //! ```rust,ignore
 //! // requires real terminal
 //! fn main() -> std::io::Result<()> {
-//!     Runtime::<MyApp>::new_terminal()?.run_terminal_blocking()
+//!     let _final_state = Runtime::<MyApp>::new_terminal()?.run_terminal_blocking()?;
+//!     Ok(())
 //! }
 //! ```
 //!


### PR DESCRIPTION
## Summary

- `run_terminal()` now returns `io::Result<A::State>` instead of `io::Result<()>`
- `run_terminal_blocking()` similarly returns `io::Result<A::State>`
- Allows callers to access the final application state after the event loop exits (e.g., to persist state, log results, or return data to a parent process)
- Updates all doc examples and the signature test to reflect the new return type

## Example

```rust
#[tokio::main]
async fn main() -> std::io::Result<()> {
    let final_state = Runtime::<MyApp>::new_terminal()?.run_terminal().await?;
    println!("Final count: {}", final_state.count);
    Ok(())
}
```

## Test plan

- [x] All 4,960 tests pass
- [x] Clippy clean, format clean
- [x] Existing `test_run_terminal_blocking_exists` updated for new return type

🤖 Generated with [Claude Code](https://claude.com/claude-code)