### PR TITLE
Add event-flow tracing to Component trait

### DIFF
--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -437,13 +437,20 @@ pub trait Component: Sized {
     ///
     /// This is the primary method users should call for event routing.
     fn dispatch_event(state: &mut Self::State, event: &Event) -> Option<Self::Output> {
-        if let Some(msg) = Self::handle_event(state, event) {
-            #[cfg(feature = "tracing")]
-            let _span = tracing::debug_span!(
-                "component_dispatch",
-                component = std::any::type_name::<Self>(),
-            )
-            .entered();
+        #[cfg(feature = "tracing")]
+        let _span = tracing::debug_span!(
+            "component_dispatch",
+            component = std::any::type_name::<Self>(),
+            event_kind = event.kind_name(),
+        )
+        .entered();
+
+        let msg = Self::handle_event(state, event);
+
+        #[cfg(feature = "tracing")]
+        tracing::trace!(produced_message = msg.is_some(), "handle_event complete");
+
+        if let Some(msg) = msg {
             let output = Self::update(state, msg);
             #[cfg(feature = "tracing")]
             tracing::trace!(has_output = output.is_some(), "update complete");

--- a/src/input/events/mod.rs
+++ b/src/input/events/mod.rs
@@ -249,6 +249,33 @@ impl Event {
             _ => None,
         }
     }
+
+    /// Returns a short string identifying the event variant.
+    ///
+    /// This is useful for logging and tracing. It returns the variant
+    /// name (e.g., `"Key"`, `"Mouse"`, `"Resize"`) without the inner data.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::{Event, KeyCode};
+    ///
+    /// assert_eq!(Event::char('a').kind_name(), "Key");
+    /// assert_eq!(Event::click(0, 0).kind_name(), "Mouse");
+    /// assert_eq!(Event::Resize(80, 24).kind_name(), "Resize");
+    /// assert_eq!(Event::FocusGained.kind_name(), "FocusGained");
+    /// assert_eq!(Event::FocusLost.kind_name(), "FocusLost");
+    /// ```
+    pub fn kind_name(&self) -> &'static str {
+        match self {
+            Event::Key(_) => "Key",
+            Event::Mouse(_) => "Mouse",
+            Event::Resize(_, _) => "Resize",
+            Event::FocusGained => "FocusGained",
+            Event::FocusLost => "FocusLost",
+            Event::Paste(_) => "Paste",
+        }
+    }
 }
 
 impl From<KeyEvent> for Event {

--- a/src/input/events/tests.rs
+++ b/src/input/events/tests.rs
@@ -374,3 +374,37 @@ fn test_mouse_event_builder_default() {
     assert_eq!(event.row, 0);
     assert!(matches!(event.kind, MouseEventKind::Moved));
 }
+
+// -------------------------------------------------------------------------
+// Event::kind_name
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_kind_name_key() {
+    assert_eq!(Event::char('a').kind_name(), "Key");
+    assert_eq!(Event::key(KeyCode::Enter).kind_name(), "Key");
+    assert_eq!(Event::ctrl('c').kind_name(), "Key");
+}
+
+#[test]
+fn test_kind_name_mouse() {
+    assert_eq!(Event::click(0, 0).kind_name(), "Mouse");
+    assert_eq!(Event::mouse_move(5, 5).kind_name(), "Mouse");
+    assert_eq!(Event::scroll_up(0, 0).kind_name(), "Mouse");
+}
+
+#[test]
+fn test_kind_name_resize() {
+    assert_eq!(Event::Resize(80, 24).kind_name(), "Resize");
+}
+
+#[test]
+fn test_kind_name_focus() {
+    assert_eq!(Event::FocusGained.kind_name(), "FocusGained");
+    assert_eq!(Event::FocusLost.kind_name(), "FocusLost");
+}
+
+#[test]
+fn test_kind_name_paste() {
+    assert_eq!(Event::Paste("hello".to_string()).kind_name(), "Paste");
+}


### PR DESCRIPTION
## Summary

- Enhances the existing tracing in `Component::dispatch_event()` to cover the full event-to-message-to-update flow, not just the update step
- Adds `event_kind` field to the `component_dispatch` debug span so traces show whether a Key, Mouse, Resize, etc. event was received
- Adds a trace-level log after `handle_event` reporting whether a message was produced, enabling diagnosis of "why didn't my key press do anything" scenarios
- Adds `Event::kind_name()` method returning a short variant identifier (`"Key"`, `"Mouse"`, `"Resize"`, etc.) with doc tests and unit tests
- All tracing remains behind `#[cfg(feature = "tracing")]` with zero cost when disabled

## Test plan

- [x] `cargo test --all-features` passes (788 tests)
- [x] `cargo test --no-default-features` passes (141 tests)
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] New unit tests for `Event::kind_name()` covering all 6 variants
- [x] New doc tests for `Event::kind_name()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)