### PR TITLE
Fix Default implementations for State types

### DIFF
--- a/src/component/select/mod.rs
+++ b/src/component/select/mod.rs
@@ -64,7 +64,7 @@ pub enum SelectOutput {
 }
 
 /// State for a Select component.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)
@@ -86,6 +86,32 @@ pub struct SelectState {
     disabled: bool,
 }
 
+impl Default for SelectState {
+    /// Creates a default empty select with `"Select..."` placeholder.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SelectState;
+    ///
+    /// let state = SelectState::default();
+    /// assert!(state.options().is_empty());
+    /// assert!(state.selected_index().is_none());
+    /// assert_eq!(state.placeholder(), "Select...");
+    /// ```
+    fn default() -> Self {
+        Self {
+            options: Vec::new(),
+            selected_index: None,
+            highlighted_index: 0,
+            is_open: false,
+            focused: false,
+            placeholder: String::from("Select..."),
+            disabled: false,
+        }
+    }
+}
+
 impl SelectState {
     /// Creates a new select with the given options.
     ///
@@ -101,12 +127,7 @@ impl SelectState {
     pub fn new<S: Into<String>>(options: Vec<S>) -> Self {
         Self {
             options: options.into_iter().map(|s| s.into()).collect(),
-            selected_index: None,
-            highlighted_index: 0,
-            is_open: false,
-            focused: false,
-            placeholder: String::from("Select..."),
-            disabled: false,
+            ..Self::default()
         }
     }
 
@@ -132,10 +153,7 @@ impl SelectState {
             options: options_vec,
             selected_index,
             highlighted_index: selected_index.unwrap_or(0),
-            is_open: false,
-            focused: false,
-            placeholder: String::from("Select..."),
-            disabled: false,
+            ..Self::default()
         }
     }
 

--- a/src/component/status_bar/mod.rs
+++ b/src/component/status_bar/mod.rs
@@ -174,7 +174,7 @@ pub enum StatusBarMessage {
 }
 
 /// State for a StatusBar component.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)
@@ -194,6 +194,33 @@ pub struct StatusBarState {
     disabled: bool,
 }
 
+impl Default for StatusBarState {
+    /// Creates a default empty status bar with `" | "` separator and
+    /// `DarkGray` background.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarState;
+    ///
+    /// let state = StatusBarState::default();
+    /// assert!(state.left().is_empty());
+    /// assert!(state.center().is_empty());
+    /// assert!(state.right().is_empty());
+    /// assert_eq!(state.separator(), " | ");
+    /// ```
+    fn default() -> Self {
+        Self {
+            left: Vec::new(),
+            center: Vec::new(),
+            right: Vec::new(),
+            separator: " | ".to_string(),
+            background: Color::DarkGray,
+            disabled: false,
+        }
+    }
+}
+
 impl StatusBarState {
     /// Creates a new empty status bar.
     ///
@@ -208,14 +235,7 @@ impl StatusBarState {
     /// assert!(state.right().is_empty());
     /// ```
     pub fn new() -> Self {
-        Self {
-            left: Vec::new(),
-            center: Vec::new(),
-            right: Vec::new(),
-            separator: " | ".to_string(),
-            background: Color::DarkGray,
-            disabled: false,
-        }
+        Self::default()
     }
 
     /// Creates a status bar with a custom separator.
@@ -231,7 +251,7 @@ impl StatusBarState {
     pub fn with_separator(separator: impl Into<String>) -> Self {
         Self {
             separator: separator.into(),
-            ..Self::new()
+            ..Self::default()
         }
     }
 

--- a/src/component/status_bar/tests/component.rs
+++ b/src/component/status_bar/tests/component.rs
@@ -504,8 +504,7 @@ fn test_init_returns_empty_state() {
     assert!(state.is_empty());
     assert_eq!(state.len(), 0);
     assert!(!state.is_disabled());
-    // init() uses Default, which gives an empty separator
-    assert_eq!(state.separator(), "");
+    assert_eq!(state.separator(), " | ");
 }
 
 // Annotation tests

--- a/src/component/status_bar/tests/state.rs
+++ b/src/component/status_bar/tests/state.rs
@@ -480,7 +480,7 @@ fn test_default_vs_new() {
     let default_state = StatusBarState::default();
     let new_state = StatusBarState::new();
 
-    // Both are empty
+    // default() and new() produce identical state
     assert_eq!(default_state.left().len(), new_state.left().len());
     assert_eq!(default_state.center().len(), new_state.center().len());
     assert_eq!(default_state.right().len(), new_state.right().len());
@@ -488,9 +488,8 @@ fn test_default_vs_new() {
     assert_eq!(default_state.is_empty(), new_state.is_empty());
     assert_eq!(default_state.len(), new_state.len());
 
-    // Default uses derive(Default), which gives empty separator
-    // new() explicitly sets separator to " | "
-    assert_eq!(default_state.separator(), "");
+    // Both use the same separator
+    assert_eq!(default_state.separator(), " | ");
     assert_eq!(new_state.separator(), " | ");
 }
 

--- a/src/component/styled_text/mod.rs
+++ b/src/component/styled_text/mod.rs
@@ -91,7 +91,7 @@ pub enum StyledTextOutput {
 /// assert_eq!(state.title(), Some("Preview"));
 /// assert_eq!(state.scroll_offset(), 0);
 /// ```
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct StyledTextState {
     content: StyledContent,
     scroll_offset: usize,
@@ -99,6 +99,31 @@ pub struct StyledTextState {
     disabled: bool,
     title: Option<String>,
     show_border: bool,
+}
+
+impl Default for StyledTextState {
+    /// Creates a default styled text state with border enabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StyledTextState;
+    ///
+    /// let state = StyledTextState::default();
+    /// assert_eq!(state.scroll_offset(), 0);
+    /// assert!(state.show_border());
+    /// assert!(!state.is_focused());
+    /// ```
+    fn default() -> Self {
+        Self {
+            content: StyledContent::default(),
+            scroll_offset: 0,
+            focused: false,
+            disabled: false,
+            title: None,
+            show_border: true,
+        }
+    }
 }
 
 impl StyledTextState {
@@ -115,10 +140,7 @@ impl StyledTextState {
     /// assert!(!state.is_focused());
     /// ```
     pub fn new() -> Self {
-        Self {
-            show_border: true,
-            ..Self::default()
-        }
+        Self::default()
     }
 
     /// Sets the content (builder pattern).
@@ -422,7 +444,7 @@ impl Component for StyledText {
     type Output = StyledTextOutput;
 
     fn init() -> Self::State {
-        StyledTextState::new()
+        StyledTextState::default()
     }
 
     fn handle_event(state: &Self::State, event: &Event) -> Option<Self::Message> {


### PR DESCRIPTION
Replace derive(Default) with manual impl Default for SelectState, StatusBarState, and StyledTextState. Each new() constructor now delegates to Self::default().