### PR TITLE
Add Command::request_cancel_token() for cooperative shutdown

### DIFF
--- a/src/app/command/mod.rs
+++ b/src/app/command/mod.rs
@@ -8,6 +8,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 use crate::overlay::Overlay;
+use tokio_util::sync::CancellationToken;
 
 /// A command that can produce messages or perform side effects.
 ///
@@ -50,6 +51,9 @@ pub(crate) enum CommandAction<M> {
 
     /// Pop the topmost overlay
     PopOverlay,
+
+    /// Request the runtime's cancellation token
+    RequestCancelToken(Box<dyn FnOnce(CancellationToken) -> M + Send + 'static>),
 }
 
 impl<M> Command<M> {
@@ -277,6 +281,40 @@ impl<M> Command<M> {
         }
     }
 
+    /// Creates a command that requests the runtime's cancellation token.
+    ///
+    /// When processed, the runtime calls the provided function with its
+    /// [`CancellationToken`] and dispatches the resulting message. This
+    /// lets you store the token in your application state and pass it to
+    /// background workers for cooperative shutdown.
+    ///
+    /// The token is cancelled when the runtime begins shutting down
+    /// (via [`Command::quit()`], [`App::should_quit()`](crate::App::should_quit),
+    /// or [`Runtime::quit()`](crate::Runtime::quit)).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::app::Command;
+    /// use tokio_util::sync::CancellationToken;
+    ///
+    /// #[derive(Clone)]
+    /// enum Msg {
+    ///     GotCancelToken(CancellationToken),
+    /// }
+    ///
+    /// // In App::init():
+    /// let cmd: Command<Msg> = Command::request_cancel_token(Msg::GotCancelToken);
+    /// ```
+    pub fn request_cancel_token<F>(f: F) -> Self
+    where
+        F: FnOnce(CancellationToken) -> M + Send + 'static,
+    {
+        Self {
+            actions: vec![CommandAction::RequestCancelToken(Box::new(f))],
+        }
+    }
+
     /// Creates a command that saves application state to a JSON file.
     ///
     /// Serializes the state to JSON synchronously, then writes the file
@@ -399,6 +437,12 @@ impl<M> Command<M> {
                 }
                 CommandAction::PushOverlay(_) => None,
                 CommandAction::PopOverlay => Some(CommandAction::PopOverlay),
+                CommandAction::RequestCancelToken(cb) => {
+                    let f = f.clone();
+                    Some(CommandAction::RequestCancelToken(Box::new(move |token| {
+                        f(cb(token))
+                    })))
+                }
             })
             .collect();
 
@@ -421,6 +465,9 @@ pub type BoxedFuture<M> = Pin<Box<dyn Future<Output = Option<M>> + Send + 'stati
 pub type BoxedFallibleFuture<M> =
     Pin<Box<dyn Future<Output = AsyncFallibleResult<M>> + Send + 'static>>;
 
+/// A boxed callback that accepts a cancellation token and produces a message.
+pub(crate) type CancelTokenCallback<M> = Box<dyn FnOnce(CancellationToken) -> M + Send + 'static>;
+
 /// Handles execution of commands.
 ///
 /// This handler processes sync actions immediately and collects async futures
@@ -429,6 +476,7 @@ pub struct CommandHandler<M> {
     core: super::command_core::CommandHandlerCore<M>,
     pending_futures: Vec<BoxedFuture<M>>,
     pending_fallible_futures: Vec<BoxedFallibleFuture<M>>,
+    pending_cancel_token_requests: Vec<CancelTokenCallback<M>>,
 }
 
 impl<M: Send + 'static> CommandHandler<M> {
@@ -438,6 +486,7 @@ impl<M: Send + 'static> CommandHandler<M> {
             core: super::command_core::CommandHandlerCore::new(),
             pending_futures: Vec::new(),
             pending_fallible_futures: Vec::new(),
+            pending_cancel_token_requests: Vec::new(),
         }
     }
 
@@ -458,7 +507,10 @@ impl<M: Send + 'static> CommandHandler<M> {
                     CommandAction::AsyncFallible(fut) => {
                         self.pending_fallible_futures.push(fut);
                     }
-                    _ => unreachable!("execute_action only returns async actions"),
+                    CommandAction::RequestCancelToken(cb) => {
+                        self.pending_cancel_token_requests.push(cb);
+                    }
+                    _ => unreachable!("execute_action only returns async or cancel-token actions"),
                 }
             }
         }
@@ -549,6 +601,11 @@ impl<M: Send + 'static> CommandHandler<M> {
     /// Takes the count of pending overlay pops and resets the counter.
     pub fn take_overlay_pops(&mut self) -> usize {
         self.core.take_overlay_pops()
+    }
+
+    /// Takes all pending cancel token request callbacks.
+    pub(crate) fn take_cancel_token_requests(&mut self) -> Vec<CancelTokenCallback<M>> {
+        std::mem::take(&mut self.pending_cancel_token_requests)
     }
 
     /// Returns true if any async futures are pending.

--- a/src/app/command_core/mod.rs
+++ b/src/app/command_core/mod.rs
@@ -61,9 +61,9 @@ impl<M> CommandHandlerCore<M> {
                 self.pending_overlay_pops += 1;
                 None
             }
-            async_action @ (CommandAction::Async(_) | CommandAction::AsyncFallible(_)) => {
-                Some(async_action)
-            }
+            async_action @ (CommandAction::Async(_)
+            | CommandAction::AsyncFallible(_)
+            | CommandAction::RequestCancelToken(_)) => Some(async_action),
         }
     }
 

--- a/src/app/runtime/mod.rs
+++ b/src/app/runtime/mod.rs
@@ -556,6 +556,12 @@ impl<A: App, B: Backend> Runtime<A, B> {
         for _ in 0..self.commands.take_overlay_pops() {
             self.core.overlay_stack.pop();
         }
+
+        // Process cancel token requests
+        for cb in self.commands.take_cancel_token_requests() {
+            let msg = cb(self.cancel_token.clone());
+            self.dispatch(msg);
+        }
     }
 
     /// Processes messages received from async tasks.

--- a/src/app/runtime/tests/mod.rs
+++ b/src/app/runtime/tests/mod.rs
@@ -200,6 +200,51 @@ fn test_runtime_cancellation_token() {
 }
 
 #[test]
+fn test_command_request_cancel_token() {
+    // Use an app that stores the cancel token via init command
+    struct TokenApp;
+    #[derive(Default)]
+    struct TokenState {
+        token: Option<tokio_util::sync::CancellationToken>,
+    }
+    #[derive(Clone)]
+    enum TokenMsg {
+        GotToken(tokio_util::sync::CancellationToken),
+    }
+    impl crate::app::App for TokenApp {
+        type State = TokenState;
+        type Message = TokenMsg;
+        fn init() -> (TokenState, Command<TokenMsg>) {
+            (
+                TokenState::default(),
+                Command::request_cancel_token(TokenMsg::GotToken),
+            )
+        }
+        fn update(state: &mut TokenState, msg: TokenMsg) -> Command<TokenMsg> {
+            match msg {
+                TokenMsg::GotToken(token) => state.token = Some(token),
+            }
+            Command::none()
+        }
+        fn view(_state: &TokenState, _frame: &mut ratatui::Frame) {}
+    }
+
+    let mut runtime: Runtime<TokenApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    runtime.tick().unwrap();
+
+    // The cancel token should now be stored in state
+    assert!(runtime.state().token.is_some());
+    let stored_token = runtime.state().token.as_ref().unwrap().clone();
+
+    // It should not be cancelled yet
+    assert!(!stored_token.is_cancelled());
+
+    // After quitting, the stored token should be cancelled
+    runtime.quit();
+    assert!(stored_token.is_cancelled());
+}
+
+#[test]
 fn test_runtime_message_sender() {
     let runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
     let _sender = runtime.message_sender();


### PR DESCRIPTION
## Summary
- Adds `Command::request_cancel_token()` which allows applications to obtain the runtime's `CancellationToken` through the command system
- Enables cooperative shutdown of background tasks spawned by the application
- New `CommandAction::RequestCancelToken` variant processed during `Runtime::process_commands()`
- Includes unit test verifying token delivery and cancellation on quit

## Motivation
Claudio's Round 4 feedback identified this as a nice-to-have for real-world adoption: applications that spawn background work (e.g., via `tokio::spawn`) need a way to signal those tasks to stop when the runtime shuts down. This provides a type-safe, TEA-idiomatic way to do that.

## Test plan
- [x] New test `test_command_request_cancel_token` verifies token is delivered and cancelled on quit
- [x] Full test suite passes (4099 unit + 793 doc tests)
- [x] Clippy clean with all features

🤖 Generated with [Claude Code](https://claude.com/claude-code)