### PR TITLE
Document CompactString rationale in EnhancedCell module

### DIFF
--- a/src/backend/cell/mod.rs
+++ b/src/backend/cell/mod.rs
@@ -1,4 +1,9 @@
 //! Enhanced cell type that captures more information than ratatui's Cell.
+//!
+//! Uses [`CompactString`] for cell symbols to avoid heap allocation for typical
+//! single-character cells. At 80×24, a terminal has 1,920 cells per frame;
+//! `CompactString` stores up to 24 bytes inline, eliminating thousands of
+//! small allocations per render cycle.
 
 use compact_str::CompactString;
 use ratatui::style::{Color, Modifier, Style};


### PR DESCRIPTION
## Summary
- Adds module-level documentation explaining why `CompactString` is used for cell symbols
- At 80×24, a terminal has 1,920 cells per frame; CompactString stores up to 24 bytes inline, eliminating thousands of small heap allocations per render cycle

## Test plan
- [x] Documentation-only change, no behavioral impact
- [x] `cargo doc --all-features` builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)