### PR TITLE
Widen tracing instrumentation to runtime and command handler

### DIFF
--- a/src/app/command/mod.rs
+++ b/src/app/command/mod.rs
@@ -56,6 +56,27 @@ pub(crate) enum CommandAction<M> {
     RequestCancelToken(Box<dyn FnOnce(CancellationToken) -> M + Send + 'static>),
 }
 
+impl<M> CommandAction<M> {
+    /// Returns a human-readable name for this action kind.
+    ///
+    /// Used for tracing instrumentation to identify which type of command
+    /// action is being executed.
+    #[cfg(feature = "tracing")]
+    pub(crate) fn kind_name(&self) -> &'static str {
+        match self {
+            CommandAction::Message(_) => "message",
+            CommandAction::Batch(_) => "batch",
+            CommandAction::Quit => "quit",
+            CommandAction::Callback(_) => "callback",
+            CommandAction::Async(_) => "async",
+            CommandAction::AsyncFallible(_) => "async_fallible",
+            CommandAction::PushOverlay(_) => "push_overlay",
+            CommandAction::PopOverlay => "pop_overlay",
+            CommandAction::RequestCancelToken(_) => "request_cancel_token",
+        }
+    }
+}
+
 impl<M> Command<M> {
     /// Creates an empty command (no-op).
     ///
@@ -497,7 +518,7 @@ impl<M: Send + 'static> CommandHandler<M> {
     pub fn execute(&mut self, command: Command<M>) {
         for action in command.into_actions() {
             #[cfg(feature = "tracing")]
-            tracing::trace!("executing command action");
+            tracing::debug!(action = action.kind_name(), "executing command action");
 
             if let Some(async_action) = self.core.execute_action(action) {
                 match async_action {

--- a/src/app/command_core/mod.rs
+++ b/src/app/command_core/mod.rs
@@ -44,6 +44,9 @@ impl<M> CommandHandlerCore<M> {
                 None
             }
             CommandAction::Quit => {
+                #[cfg(feature = "tracing")]
+                tracing::info!("quit command received");
+
                 self.should_quit = true;
                 None
             }

--- a/src/app/runtime/mod.rs
+++ b/src/app/runtime/mod.rs
@@ -447,12 +447,18 @@ impl<A: App, B: Backend> Runtime<A, B> {
     /// The subscription stops when it ends naturally, when the runtime's
     /// cancellation token is triggered, or when the message channel is closed.
     pub fn subscribe(&mut self, subscription: impl Subscription<A::Message>) {
+        #[cfg(feature = "tracing")]
+        tracing::info!("registering subscription");
+
         let stream = Box::new(subscription).into_stream(self.cancel_token.clone());
         Self::spawn_subscription(stream, self.message_tx.clone(), self.cancel_token.clone());
     }
 
     /// Adds multiple subscriptions to the runtime.
     pub fn subscribe_all(&mut self, subscriptions: Vec<BoxedSubscription<A::Message>>) {
+        #[cfg(feature = "tracing")]
+        tracing::info!(count = subscriptions.len(), "registering subscriptions");
+
         for sub in subscriptions {
             let stream = sub.into_stream(self.cancel_token.clone());
             Self::spawn_subscription(stream, self.message_tx.clone(), self.cancel_token.clone());
@@ -688,6 +694,9 @@ impl<A: App, B: Backend> Runtime<A, B> {
 
     /// Sets the quit flag and cancels all async operations.
     pub fn quit(&mut self) {
+        #[cfg(feature = "tracing")]
+        tracing::info!("runtime quit requested");
+
         self.core.should_quit = true;
         self.cancel_token.cancel();
     }
@@ -701,6 +710,9 @@ impl<A: App, B: Backend> Runtime<A, B> {
     ///
     /// Returns an error if rendering to the terminal backend fails.
     pub async fn run(&mut self) -> error::Result<()> {
+        #[cfg(feature = "tracing")]
+        tracing::info!("starting runtime event loop");
+
         let mut tick_interval = tokio::time::interval(self.config.tick_rate);
         let mut render_interval = tokio::time::interval(self.config.frame_rate);
 
@@ -711,6 +723,9 @@ impl<A: App, B: Backend> Runtime<A, B> {
             tokio::select! {
                 // Handle async messages from spawned tasks
                 Some(msg) = self.message_rx.recv() => {
+                    #[cfg(feature = "tracing")]
+                    tracing::debug!("runtime received async message");
+
                     self.dispatch(msg);
                 }
 
@@ -743,11 +758,17 @@ impl<A: App, B: Backend> Runtime<A, B> {
 
                 // Handle cancellation
                 _ = self.cancel_token.cancelled() => {
+                    #[cfg(feature = "tracing")]
+                    tracing::info!("runtime received cancellation");
+
                     self.core.should_quit = true;
                 }
             }
 
             if self.core.should_quit {
+                #[cfg(feature = "tracing")]
+                tracing::info!("runtime shutting down");
+
                 break;
             }
         }
@@ -800,6 +821,9 @@ impl<A: App, B: Backend> Runtime<A, B> {
     /// This is useful in tests with `tokio::time::pause()` to process
     /// all pending messages without running the full event loop.
     pub fn process_pending(&mut self) {
+        #[cfg(feature = "tracing")]
+        let _span = tracing::debug_span!("process_pending").entered();
+
         // Process commands
         self.process_commands();
 

--- a/src/app/runtime/terminal.rs
+++ b/src/app/runtime/terminal.rs
@@ -157,6 +157,9 @@ impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
                     match maybe_event {
                         Some(Ok(event)) => {
                             if let Some(envision_event) = Self::convert_crossterm_event(&event) {
+                                #[cfg(feature = "tracing")]
+                                tracing::debug!(event = ?envision_event, "terminal received event");
+
                                 match self.core.overlay_stack.handle_event(&envision_event) {
                                     OverlayAction::Consumed => {}
                                     OverlayAction::KeepAndMessage(msg) => self.dispatch(msg),
@@ -189,6 +192,9 @@ impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
 
                 // Handle async messages from spawned tasks
                 Some(msg) = self.message_rx.recv() => {
+                    #[cfg(feature = "tracing")]
+                    tracing::debug!("terminal received async message");
+
                     self.dispatch(msg);
                 }
 
@@ -223,6 +229,9 @@ impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
 
                 // Handle cancellation
                 _ = self.cancel_token.cancelled() => {
+                    #[cfg(feature = "tracing")]
+                    tracing::info!("terminal received cancellation");
+
                     self.core.should_quit = true;
                 }
             }

--- a/src/app/runtime_core/mod.rs
+++ b/src/app/runtime_core/mod.rs
@@ -57,6 +57,9 @@ impl<A: App, B: Backend> RuntimeCore<A, B> {
     /// since dispatch logic differs between sync and async runtimes.
     pub(crate) fn process_event(&mut self) -> ProcessEventResult<A::Message> {
         if let Some(event) = self.events.pop() {
+            #[cfg(feature = "tracing")]
+            tracing::debug!(event = ?event, "processing event from queue");
+
             match self.overlay_stack.handle_event(&event) {
                 OverlayAction::Consumed => ProcessEventResult::Consumed,
                 OverlayAction::KeepAndMessage(msg) => ProcessEventResult::Dispatch(msg),


### PR DESCRIPTION
## Summary
- Add `#[cfg(feature = "tracing")]` instrumentation to runtime lifecycle operations (subscribe, run, quit, process_pending), terminal event loop, command handler execution, and core event processing
- Use `tracing::info!` for lifecycle events (startup, shutdown, quit, subscription registration) and `tracing::debug!` for high-frequency operations (events, async messages, command actions)
- Add `CommandAction::kind_name()` helper behind the tracing feature to provide human-readable action type names in debug logs

## Test plan
- [x] `cargo clippy --all-features -- -D warnings` passes with zero warnings
- [x] `cargo test --all-features --lib` passes (4105 tests)
- [x] `cargo test --all-features --doc` passes (795 tests)
- [x] All tracing code is behind `#[cfg(feature = "tracing")]` for zero-cost when disabled
- [x] No files exceed 1000 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)