### PR TITLE
Make App::init() optional with default panic implementation

### DIFF
--- a/examples/production_app.rs
+++ b/examples/production_app.rs
@@ -131,16 +131,7 @@ impl App for ProcessorApp {
     type State = ProcessorState;
     type Message = ProcessorMsg;
 
-    /// Stub init — we use `with_state` instead, so this is never called.
-    fn init() -> (Self::State, Command<Self::Message>) {
-        // Provide a valid fallback in case someone constructs the runtime
-        // without `with_state`. The real entrypoint builds state from config.
-        let stub_config = AppConfig {
-            files: Vec::new(),
-            output_dir: String::new(),
-        };
-        (ProcessorState::from_config(&stub_config), Command::none())
-    }
+    // init() is not implemented — this app uses with_state constructors
 
     fn update(state: &mut Self::State, msg: Self::Message) -> Command<Self::Message> {
         match msg {

--- a/src/app/model/mod.rs
+++ b/src/app/model/mod.rs
@@ -30,9 +30,9 @@
 //! )?;
 //! ```
 //!
-//! Even when using `with_state` constructors, `App::init()` must still be
-//! implemented because it is a required trait method. A simple stub returning
-//! default values is sufficient.
+//! When using `with_state` constructors, `App::init()` does **not** need to
+//! be implemented — the default implementation will panic if called, which
+//! is safe because `with_state` constructors never call it.
 //!
 //! [`Runtime::new_terminal()`]: crate::app::Runtime::new_terminal
 //! [`Runtime::virtual_terminal()`]: crate::app::Runtime::virtual_terminal
@@ -71,9 +71,12 @@ use crate::input::Event;
 /// - **External state**: The `with_state` constructors
 ///   ([`Runtime::new_terminal_with_state()`](crate::app::Runtime::new_terminal_with_state),
 ///   [`Runtime::virtual_terminal_with_state()`](crate::app::Runtime::virtual_terminal_with_state),
-///   etc.) accept a pre-built state and **skip** `init()` entirely.
+///   etc.) accept a pre-built state and **skip** `init()` entirely. In this
+///   case, `init()` does not need to be implemented.
 ///
-/// # Example
+/// # Examples
+///
+/// ## Standard pattern — implementing `init()`
 ///
 /// ```rust
 /// use envision::app::{App, Command};
@@ -113,6 +116,44 @@ use crate::input::Event;
 ///     }
 /// }
 /// ```
+///
+/// ## External state pattern — omitting `init()`
+///
+/// When using `with_state` constructors, `init()` can be omitted:
+///
+/// ```rust
+/// use envision::app::{App, Command};
+/// use ratatui::Frame;
+///
+/// struct ExternalApp;
+///
+/// struct ExternalState {
+///     config_value: String,
+/// }
+///
+/// #[derive(Clone)]
+/// enum ExternalMsg {
+///     Update(String),
+/// }
+///
+/// impl App for ExternalApp {
+///     type State = ExternalState;
+///     type Message = ExternalMsg;
+///
+///     // init() is not implemented — this app uses with_state constructors
+///
+///     fn update(state: &mut Self::State, msg: Self::Message) -> Command<Self::Message> {
+///         match msg {
+///             ExternalMsg::Update(v) => state.config_value = v,
+///         }
+///         Command::none()
+///     }
+///
+///     fn view(state: &Self::State, frame: &mut Frame) {
+///         // Render UI
+///     }
+/// }
+/// ```
 pub trait App: Sized {
     /// The application state type.
     ///
@@ -133,20 +174,26 @@ pub trait App: Sized {
     /// [`Runtime::virtual_terminal_with_state()`]), this method is **not
     /// called** — the provided state is used directly instead.
     ///
-    /// If you only use `with_state` constructors, this can be a simple stub:
+    /// # Default Implementation
     ///
-    /// ```rust,ignore
-    /// fn init() -> (Self::State, Command<Self::Message>) {
-    ///     // Not called when using with_state constructors
-    ///     (MyState::default(), Command::none())
-    /// }
-    /// ```
+    /// The default implementation panics with a descriptive message. This
+    /// allows applications that exclusively use `with_state` constructors
+    /// to omit `init()` entirely, since it will never be called. If you
+    /// use [`Runtime::new_terminal()`] or [`Runtime::virtual_terminal()`],
+    /// you **must** override this method to provide valid initial state.
     ///
     /// [`Runtime::new_terminal()`]: crate::app::Runtime::new_terminal
     /// [`Runtime::virtual_terminal()`]: crate::app::Runtime::virtual_terminal
     /// [`Runtime::new_terminal_with_state()`]: crate::app::Runtime::new_terminal_with_state
     /// [`Runtime::virtual_terminal_with_state()`]: crate::app::Runtime::virtual_terminal_with_state
-    fn init() -> (Self::State, Command<Self::Message>);
+    fn init() -> (Self::State, Command<Self::Message>) {
+        panic!(
+            "App::init() is not implemented. \
+             Override this method when using Runtime::new_terminal() or \
+             Runtime::virtual_terminal(). When using with_state constructors, \
+             this method is never called and can be left unimplemented."
+        );
+    }
 
     /// Handle a message and update the state.
     ///

--- a/src/app/model/tests.rs
+++ b/src/app/model/tests.rs
@@ -282,3 +282,52 @@ fn test_handle_event_with_state_default_delegation() {
     let msg = CustomApp::handle_event_with_state(&state, &event);
     assert!(matches!(msg, Some(CustomMsg::KeyPressed('a'))));
 }
+
+// Test that App::init() can be omitted when using with_state constructors
+struct WithStateApp;
+
+struct WithStateState {
+    config_value: String,
+}
+
+#[derive(Clone)]
+enum WithStateMsg {
+    Update(String),
+}
+
+impl App for WithStateApp {
+    type State = WithStateState;
+    type Message = WithStateMsg;
+
+    // init() deliberately omitted — uses the default panic implementation
+
+    fn update(state: &mut Self::State, msg: Self::Message) -> Command<Self::Message> {
+        match msg {
+            WithStateMsg::Update(v) => state.config_value = v,
+        }
+        Command::none()
+    }
+
+    fn view(_state: &Self::State, _frame: &mut Frame) {}
+}
+
+#[test]
+fn test_with_state_app_compiles_without_init() {
+    // Verify that an App impl without init() compiles and works correctly
+    // when state is constructed externally (as with_state constructors do).
+    let mut state = WithStateState {
+        config_value: "from_config".into(),
+    };
+    assert_eq!(state.config_value, "from_config");
+
+    WithStateApp::update(&mut state, WithStateMsg::Update("updated".into()));
+    assert_eq!(state.config_value, "updated");
+}
+
+#[test]
+#[should_panic(expected = "App::init() is not implemented")]
+fn test_default_init_panics_with_helpful_message() {
+    // The default init() should panic with a descriptive message
+    // when called on an App that hasn't overridden it.
+    let _ = WithStateApp::init();
+}

--- a/tests/integration_with_state.rs
+++ b/tests/integration_with_state.rs
@@ -75,9 +75,7 @@ impl App for InitCmdApp {
     type State = InitCmdState;
     type Message = InitCmdMsg;
 
-    fn init() -> (Self::State, Command<Self::Message>) {
-        (InitCmdState::default(), Command::none())
-    }
+    // init() omitted — this app only uses with_state constructors
 
     fn update(state: &mut Self::State, msg: Self::Message) -> Command<Self::Message> {
         match msg {


### PR DESCRIPTION
## Summary
- Makes `App::init()` a provided trait method with a default implementation that panics
- When using `with_state` constructors, `init()` is never called, so apps that only use `with_state` no longer need a dead-code stub
- Adds comprehensive documentation and doc test showing the external state pattern
- Updates production_app example to omit `init()` since it uses `with_state`

## Motivation
Claudio feedback: "App::init() is dead code with with_state constructors" — users had to implement a stub method that was never called.

## Test plan
- [x] Unit test: `test_app_init_default_panics` verifies panic message
- [x] Doc test: external state pattern compiles and works
- [x] `cargo test --all-features`
- [x] `cargo clippy --all-features -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)