### PR TITLE
Add LineInputState::visual_rows_at_width() for dynamic layouts

### DIFF
--- a/src/component/line_input/mod.rs
+++ b/src/component/line_input/mod.rs
@@ -293,6 +293,26 @@ impl LineInputState {
         self.last_display_width
     }
 
+    /// Returns the number of visual rows the buffer would occupy at the
+    /// given display width.
+    ///
+    /// This is useful for dynamic-height layouts where a parent container
+    /// needs to allocate the correct number of rows for the input.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use envision::component::LineInputState;
+    ///
+    /// let state = LineInputState::with_value("Hello, world!");
+    /// assert_eq!(state.visual_rows_at_width(20), 1);
+    /// assert_eq!(state.visual_rows_at_width(7), 2);
+    /// assert_eq!(state.visual_rows_at_width(5), 3);
+    /// ```
+    pub fn visual_rows_at_width(&self, width: usize) -> usize {
+        chunk_buffer(&self.buffer, width).len()
+    }
+
     /// Returns the maximum character length, or `None` if unlimited.
     ///
     /// # Example

--- a/src/component/line_input/tests.rs
+++ b/src/component/line_input/tests.rs
@@ -886,3 +886,34 @@ fn test_annotation_emitted() {
     assert!(!regions[0].annotation.focused);
     assert!(!regions[0].annotation.disabled);
 }
+
+#[test]
+fn visual_rows_at_width_empty() {
+    let state = LineInputState::new();
+    assert_eq!(state.visual_rows_at_width(10), 1);
+    assert_eq!(state.visual_rows_at_width(0), 1);
+}
+
+#[test]
+fn visual_rows_at_width_fits_single_row() {
+    let state = LineInputState::with_value("Hello");
+    assert_eq!(state.visual_rows_at_width(10), 1);
+    assert_eq!(state.visual_rows_at_width(5), 1);
+}
+
+#[test]
+fn visual_rows_at_width_wraps() {
+    let state = LineInputState::with_value("Hello, world!");
+    // 13 chars at width 7 → 2 rows
+    assert_eq!(state.visual_rows_at_width(7), 2);
+    // 13 chars at width 5 → 3 rows
+    assert_eq!(state.visual_rows_at_width(5), 3);
+}
+
+#[test]
+fn visual_rows_at_width_cjk() {
+    // Each CJK character takes 2 columns
+    let state = LineInputState::with_value("世界你好");
+    // 4 CJK chars = 8 columns, width 4 → 2 rows (2 chars per row)
+    assert_eq!(state.visual_rows_at_width(4), 2);
+}


### PR DESCRIPTION
## Summary
- Adds `visual_rows_at_width(width: usize) -> usize` to `LineInputState`
- Returns the number of visual rows the buffer would occupy at a given width
- Enables dynamic-height layouts where a parent container allocates the correct number of rows without recomputing the visual layout

## Motivation
User feedback: "chunk_buffer is pub(crate) so dynamic-height layouts have to recompute the row count" — this provides a clean public API for the same information.

## Test plan
- [x] Doc test with realistic examples
- [x] Unit tests: empty buffer, single row, wrapping, CJK characters
- [x] `cargo test --all-features`
- [x] `cargo clippy --all-features -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)