### PR TITLE
Fix markdown rendering to preserve role colors

### DIFF
--- a/src/component/chat_view/render_helpers.rs
+++ b/src/component/chat_view/render_helpers.rs
@@ -162,9 +162,9 @@ fn format_message_markdown(
         return result;
     }
 
-    // Render styled content using the theme, accounting for 2-char indent
+    // Render styled content with role color as the base style
     let content_width = width.saturating_sub(2).max(1) as u16;
-    let rendered_lines = styled.render_lines(content_width, theme);
+    let rendered_lines = styled.render_lines_styled(content_width, theme, base_style);
 
     // Indent each rendered line by 2 spaces for visual nesting under the header
     for line in rendered_lines {

--- a/src/component/chat_view/tests.rs
+++ b/src/component/chat_view/tests.rs
@@ -954,6 +954,34 @@ fn test_format_message_uses_base_style() {
     assert_eq!(content_span.style, custom_style);
 }
 
+#[cfg(feature = "markdown")]
+#[test]
+fn test_markdown_format_message_uses_role_style() {
+    let msg = ChatMessage::new(ChatRole::Assistant, "**bold** and plain");
+    let role_style = Style::default().fg(Color::Green);
+    let state = ChatViewState::new()
+        .with_markdown(true)
+        .with_role_style(ChatRole::Assistant, role_style);
+    let theme = crate::theme::Theme::default();
+    let lines = super::render_helpers::format_message(&msg, &state, 40, &theme);
+    // Header uses role style with bold modifier
+    let (header, _) = &lines[0];
+    let header_span = &header.spans[0]; // "Assistant:" span
+    assert_eq!(header_span.style, role_style.add_modifier(Modifier::BOLD));
+    // Content lines use role style as base
+    // Line 1: indent + "bold" (bold) + " and " (plain) + ...
+    let (content, _) = &lines[1];
+    // First span is the 2-space indent
+    assert_eq!(content.spans[0].content.as_ref(), "  ");
+    // Second span is "bold" with role_style + BOLD modifier
+    assert_eq!(
+        content.spans[1].style,
+        role_style.add_modifier(Modifier::BOLD)
+    );
+    // Third span is " and plain" with role_style (plain text)
+    assert_eq!(content.spans[2].style, role_style);
+}
+
 #[test]
 fn test_render_with_custom_role_styles() {
     let mut state = ChatViewState::new()

--- a/src/component/styled_text/content.rs
+++ b/src/component/styled_text/content.rs
@@ -209,15 +209,36 @@ impl StyledContent {
 
     /// Renders this content into ratatui `Line` objects for display.
     pub(crate) fn render_lines(&self, width: u16, theme: &Theme) -> Vec<RatLine<'static>> {
+        self.render_lines_styled(width, theme, theme.normal_style())
+    }
+
+    /// Renders this content using a caller-provided base style for inline text.
+    ///
+    /// `base_style` replaces `theme.normal_style()` for paragraphs, list item
+    /// text, bold, italic, underline, strikethrough, and colored inlines.
+    /// Headings, code blocks, horizontal rules, and inline code retain their
+    /// semantic theme styles.
+    pub(crate) fn render_lines_styled(
+        &self,
+        width: u16,
+        theme: &Theme,
+        base_style: Style,
+    ) -> Vec<RatLine<'static>> {
         let mut lines = Vec::new();
         for block in &self.blocks {
-            render_block(block, width, theme, &mut lines);
+            render_block(block, width, theme, base_style, &mut lines);
         }
         lines
     }
 }
 
-fn render_block(block: &StyledBlock, width: u16, theme: &Theme, lines: &mut Vec<RatLine<'static>>) {
+fn render_block(
+    block: &StyledBlock,
+    width: u16,
+    theme: &Theme,
+    base_style: Style,
+    lines: &mut Vec<RatLine<'static>>,
+) {
     match block {
         StyledBlock::Heading { level, text } => {
             let style = match level {
@@ -225,20 +246,18 @@ fn render_block(block: &StyledBlock, width: u16, theme: &Theme, lines: &mut Vec<
                     .focused_style()
                     .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
                 2 => theme.info_style().add_modifier(Modifier::BOLD),
-                _ => theme
-                    .normal_style()
-                    .add_modifier(Modifier::BOLD | Modifier::ITALIC),
+                _ => base_style.add_modifier(Modifier::BOLD | Modifier::ITALIC),
             };
             lines.push(RatLine::from(RatSpan::styled(text.clone(), style)));
         }
         StyledBlock::Paragraph(inlines) => {
-            render_paragraph(inlines, width, theme, lines);
+            render_paragraph(inlines, theme, base_style, lines);
         }
         StyledBlock::BulletList(items) => {
             for item in items {
-                let mut spans = vec![RatSpan::styled("  * ", theme.normal_style())];
+                let mut spans = vec![RatSpan::styled("  * ", base_style)];
                 for inline in item {
-                    spans.push(render_inline(inline, theme));
+                    spans.push(render_inline(inline, theme, base_style));
                 }
                 lines.push(RatLine::from(spans));
             }
@@ -246,9 +265,9 @@ fn render_block(block: &StyledBlock, width: u16, theme: &Theme, lines: &mut Vec<
         StyledBlock::NumberedList(items) => {
             for (i, item) in items.iter().enumerate() {
                 let prefix = format!("  {}. ", i + 1);
-                let mut spans = vec![RatSpan::styled(prefix, theme.normal_style())];
+                let mut spans = vec![RatSpan::styled(prefix, base_style)];
                 for inline in item {
-                    spans.push(render_inline(inline, theme));
+                    spans.push(render_inline(inline, theme, base_style));
                 }
                 lines.push(RatLine::from(spans));
             }
@@ -263,14 +282,14 @@ fn render_block(block: &StyledBlock, width: u16, theme: &Theme, lines: &mut Vec<
             for line in content.lines() {
                 lines.push(RatLine::from(RatSpan::styled(
                     format!("    {}", line),
-                    theme.normal_style(),
+                    base_style,
                 )));
             }
             // Handle empty code blocks
             if content.is_empty() {
                 lines.push(RatLine::from(RatSpan::styled(
                     "    ".to_string(),
-                    theme.normal_style(),
+                    base_style,
                 )));
             }
         }
@@ -289,35 +308,26 @@ fn render_block(block: &StyledBlock, width: u16, theme: &Theme, lines: &mut Vec<
 
 fn render_paragraph(
     inlines: &[StyledInline],
-    _width: u16,
     theme: &Theme,
+    base_style: Style,
     lines: &mut Vec<RatLine<'static>>,
 ) {
-    let spans: Vec<RatSpan<'static>> = inlines.iter().map(|i| render_inline(i, theme)).collect();
+    let spans: Vec<RatSpan<'static>> = inlines
+        .iter()
+        .map(|i| render_inline(i, theme, base_style))
+        .collect();
     lines.push(RatLine::from(spans));
 }
 
-fn render_inline(inline: &StyledInline, theme: &Theme) -> RatSpan<'static> {
+fn render_inline(inline: &StyledInline, theme: &Theme, base_style: Style) -> RatSpan<'static> {
     match inline {
-        StyledInline::Plain(text) => RatSpan::styled(text.clone(), theme.normal_style()),
-        StyledInline::Bold(text) => RatSpan::styled(
+        // Code and Colored use theme-specific styles; everything else uses base_style
+        StyledInline::Code(text) => RatSpan::styled(
             text.clone(),
-            theme.normal_style().add_modifier(Modifier::BOLD),
-        ),
-        StyledInline::Italic(text) => RatSpan::styled(
-            text.clone(),
-            theme.normal_style().add_modifier(Modifier::ITALIC),
-        ),
-        StyledInline::Underline(text) => RatSpan::styled(
-            text.clone(),
-            theme.normal_style().add_modifier(Modifier::UNDERLINED),
-        ),
-        StyledInline::Strikethrough(text) => RatSpan::styled(
-            text.clone(),
-            theme.normal_style().add_modifier(Modifier::CROSSED_OUT),
+            theme.info_style().add_modifier(Modifier::BOLD),
         ),
         StyledInline::Colored { text, fg, bg } => {
-            let mut style = theme.normal_style();
+            let mut style = base_style;
             if let Some(fg) = fg {
                 style = style.fg(*fg);
             }
@@ -326,9 +336,38 @@ fn render_inline(inline: &StyledInline, theme: &Theme) -> RatSpan<'static> {
             }
             RatSpan::styled(text.clone(), style)
         }
-        StyledInline::Code(text) => RatSpan::styled(
-            text.clone(),
-            theme.info_style().add_modifier(Modifier::BOLD),
-        ),
+        other => render_inline_styled(other, base_style),
+    }
+}
+
+/// Renders an inline element using a given base style (no theme needed).
+fn render_inline_styled(inline: &StyledInline, base_style: Style) -> RatSpan<'static> {
+    match inline {
+        StyledInline::Plain(text) => RatSpan::styled(text.clone(), base_style),
+        StyledInline::Bold(text) => {
+            RatSpan::styled(text.clone(), base_style.add_modifier(Modifier::BOLD))
+        }
+        StyledInline::Italic(text) => {
+            RatSpan::styled(text.clone(), base_style.add_modifier(Modifier::ITALIC))
+        }
+        StyledInline::Underline(text) => {
+            RatSpan::styled(text.clone(), base_style.add_modifier(Modifier::UNDERLINED))
+        }
+        StyledInline::Strikethrough(text) => {
+            RatSpan::styled(text.clone(), base_style.add_modifier(Modifier::CROSSED_OUT))
+        }
+        StyledInline::Colored { text, fg, bg } => {
+            let mut style = base_style;
+            if let Some(fg) = fg {
+                style = style.fg(*fg);
+            }
+            if let Some(bg) = bg {
+                style = style.bg(*bg);
+            }
+            RatSpan::styled(text.clone(), style)
+        }
+        StyledInline::Code(text) => {
+            RatSpan::styled(text.clone(), base_style.add_modifier(Modifier::BOLD))
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `StyledContent::render_lines_styled(width, theme, base_style)` that threads a caller-provided base style through the rendering pipeline
- Markdown body text (paragraphs, bold, italic, strikethrough, lists, code blocks) now uses the role's color instead of `theme.normal_style()`
- Headings (H1/H2), inline code (`theme.info_style()`), and horizontal rules retain semantic theme styles
- Existing `render_lines()` delegates to `render_lines_styled(theme.normal_style())` — fully backward compatible for StyledText component
- Adds test verifying role style flows through bold and plain markdown text

## Test plan

- [x] New test `test_markdown_format_message_uses_role_style` passes
- [x] All 4179 unit tests pass
- [x] All 809 doc tests pass
- [x] Clippy clean with `--all-features`
- [x] `cargo fmt --check` passes
- [x] StyledText snapshot tests unaffected (backward compatible)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)