### PR TITLE
Prepare v0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-03-09
+
+### Added
+
+- **ChatView markdown rendering**: Parse and render markdown in chat messages
+  when the `markdown` feature is enabled. Supports headings, bold, italic,
+  strikethrough, inline code, fenced code blocks, bullet/numbered lists,
+  horizontal rules, and links. Role-specific colors are preserved through
+  the rendering pipeline via `StyledContent::render_lines_styled()`.
+  - `ChatViewState::with_markdown()` / `set_markdown_enabled()` /
+    `markdown_enabled()` for opt-in markdown support
+  - `StyledContent::from_blocks()` constructor for pre-built block vectors
+  - `StyledContent::render_lines_styled()` for caller-provided base style
+
+- **`Command::spawn()`** for fire-and-forget async tasks that don't produce
+  messages. Useful for logging, analytics, or background cleanup.
+
+- **Command inspection methods** for testing: `is_none()`, `is_quit()`,
+  `is_batch()`, `is_async()` allow tests to verify command types without
+  executing them.
+
+- **`App::init()` default implementation** — `init()` now has a default that
+  panics with a descriptive message. Applications using `with_state`
+  constructors no longer need to implement `init()`.
+
+- **`EnvisionError::Other(BoxedError)` variant** — catch-all error variant
+  for wrapping arbitrary errors that don't fit the structured categories.
+  Includes `EnvisionError::other()` convenience constructor.
+
+- **`LineInputState::visual_rows_at_width()`** — calculates the number of
+  visual rows a line input would occupy at a given width, useful for
+  dynamic layout sizing.
+
+- **Tracing instrumentation widened** — `tracing` spans now cover runtime
+  event loops, command handler task spawning, subscription registration,
+  and async message processing (previously limited to `dispatch_event`
+  and `view`).
+
+- **Standalone examples** for components that previously lacked them:
+  `confirm_dialog`, `file_browser`, `pane_layout`, `step_indicator`,
+  `styled_text`. Five existing examples converted to interactive terminal
+  mode.
+
+- **`FileBrowserState` Debug impl** expanded to include all fields.
+
+- **CompactString rationale** documented in `EnhancedCell` module docs,
+  explaining the inline-storage optimization for terminal cell buffers.
+
+### Changed
+
+- **Breaking**: `TerminalHook` type widened from
+  `Arc<dyn Fn() -> io::Result<()> + Send + Sync>` to
+  `Arc<dyn Fn() -> envision::Result<()> + Send + Sync>`. Lifecycle hooks
+  (`on_setup`, `on_teardown`, `on_setup_once`, `on_teardown_once`) now
+  accept and return `envision::Result` instead of `io::Result`.
+  See `MIGRATION.md` for upgrade guide.
+
+- **Breaking**: `SearchableList` matcher function type (`MatcherFn`) now
+  requires `Send + Sync` bounds. Closures passed to `with_matcher()` must
+  be thread-safe.
+
+- ChatView component implementation extracted to `component_impl.rs`
+  submodule to stay within the 1000-line file limit.
+
+### Fixed
+
+- Clippy `io_other_error` lint compatibility with Rust 1.94.
+- Re-export gaps for subscription types and runtime aliases from crate root.
+
 ## [0.6.0] - 2026-03-08
 
 ### Added
@@ -417,7 +486,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Renders to both a real terminal and CaptureBackend
   - Useful for visual debugging while testing
 
-[Unreleased]: https://github.com/ryanoneill/envision/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/ryanoneill/envision/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/ryanoneill/envision/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/ryanoneill/envision/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/ryanoneill/envision/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/ryanoneill/envision/compare/v0.4.0...v0.4.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "envision"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arboard",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envision"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.81"
 description = "A ratatui framework for collaborative TUI development with headless testing support"

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,89 @@
 # Migration Guide
 
+## v0.6.0 to v0.7.0
+
+### Breaking Changes
+
+#### 1. Lifecycle Hook Error Type Widened
+
+`TerminalHook` now returns `envision::Result<()>` instead of `io::Result<()>`.
+This affects the `on_setup`, `on_teardown`, `on_setup_once`, and
+`on_teardown_once` methods on `RuntimeConfig`.
+
+```rust
+// Before (v0.6.0)
+use std::io;
+
+let config = RuntimeConfig::default()
+    .on_setup_once(|| -> io::Result<()> {
+        // setup logic
+        Ok(())
+    });
+
+// After (v0.7.0)
+let config = RuntimeConfig::default()
+    .on_setup_once(|| -> envision::Result<()> {
+        // setup logic
+        Ok(())
+    });
+```
+
+Since `EnvisionError` implements `From<io::Error>`, existing hooks that only
+produce `io::Error` continue to compile with the `?` operator. The change
+primarily affects explicit return type annotations and error matching.
+
+If your hooks use explicit `io::Result<()>` return types, update them to
+`envision::Result<()>`. If they use `Ok(())` with implicit return types, no
+change is needed.
+
+#### 2. SearchableList Matcher Requires `Send + Sync`
+
+The `MatcherFn` type used by `SearchableList::with_matcher()` now requires
+`Send + Sync` bounds. This ensures matcher closures are safe to use across
+async boundaries.
+
+```rust
+// Before (v0.6.0) -- non-Send closures worked
+let local_data = Rc::new(vec!["data"]);
+state.set_matcher(move |query, item| {
+    // closure capturing Rc (not Send)
+    Some(0)
+});
+
+// After (v0.7.0) -- closures must be Send + Sync
+let shared_data = Arc::new(vec!["data"]);
+state.set_matcher(move |query, item| {
+    // closure capturing Arc (Send + Sync)
+    Some(0)
+});
+```
+
+Most closures that capture only owned types (`String`, `Vec`, `Arc`, etc.)
+already satisfy `Send + Sync`. Only closures capturing `Rc`, `Cell`,
+`RefCell`, or other non-thread-safe types need adjustment.
+
+### New Features (Non-Breaking)
+
+- **ChatView markdown rendering**: Enable with `with_markdown(true)` when the
+  `markdown` feature is active. Supports headings, bold, italic, code blocks,
+  lists, and more.
+
+- **`Command::spawn()`**: Fire-and-forget async tasks that don't produce
+  messages.
+
+- **Command inspection**: `is_none()`, `is_quit()`, `is_batch()`, `is_async()`
+  for testing command types without executing them.
+
+- **`App::init()` default**: Applications using `with_state` constructors no
+  longer need to implement `init()`.
+
+- **`EnvisionError::Other`**: Catch-all error variant for arbitrary errors.
+
+- **`LineInputState::visual_rows_at_width()`**: Calculate visual row count for
+  dynamic layout sizing.
+
+---
+
 ## v0.5.0 to v0.6.0
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A [ratatui](https://github.com/ratatui/ratatui) framework for collaborative TUI 
 
 ## Features
 
-- **Component Library** - 37 ready-to-use UI components following TEA pattern
+- **Component Library** - 42 ready-to-use UI components following TEA pattern
 - **Headless Testing** - Render your TUI without a terminal using `CaptureBackend`
 - **TEA Architecture** - The Elm Architecture pattern with `App`, `Runtime`, and `Command`
 - **Async Runtime** - Full async support with subscriptions, timers, and async commands
@@ -154,44 +154,48 @@ cargo run --example component_showcase
 
 ## Components
 
-Envision provides a comprehensive library of reusable UI components, all following the TEA (The Elm Architecture) pattern with `Component`, `Focusable`, and `Toggleable` traits.
+Envision provides a comprehensive library of 42 reusable UI components, all following the TEA (The Elm Architecture) pattern with `Component`, `Focusable`, `Disableable`, and `Toggleable` traits.
 
 ### Input Components
 
 | Component | Description |
 |-----------|-------------|
+| `Button` | Clickable button with keyboard activation |
+| `Checkbox` | Toggleable checkbox with label |
+| `Dropdown` | Searchable/filterable select with type-to-filter |
 | `InputField` | Single-line text input with cursor navigation |
 | `LineInput` | Single-line input with visual wrapping, history, undo/redo |
-| `TextArea` | Multi-line text editor with scrolling |
-| `Checkbox` | Toggleable checkbox with label |
 | `RadioGroup` | Single-selection radio button group |
 | `Select` | Dropdown selection widget |
-| `Dropdown` | Searchable/filterable select with type-to-filter |
+| `TextArea` | Multi-line text editor with scrolling |
 
 ### Display Components
 
 | Component | Description |
 |-----------|-------------|
-| `ProgressBar` | Visual progress indicator with percentage |
+| `KeyHints` | Keyboard shortcut display bar |
 | `MultiProgress` | Concurrent progress indicators for batch operations |
-| `Spinner` | Animated loading indicator (multiple styles) |
+| `ProgressBar` | Visual progress indicator with percentage |
 | `ScrollableText` | Scrollable read-only text display with CJK support |
+| `Spinner` | Animated loading indicator (multiple styles) |
+| `StatusBar` | Application status bar with sections, timers, counters |
+| `StatusLog` | Scrolling status messages with severity levels |
+| `StepIndicator` | Multi-step workflow progress display |
+| `StyledText` | Rich text display with inline styling |
 | `TitleCard` | Centered title display with subtitle and prefix/suffix |
 | `Toast` | Non-modal notification system with auto-dismiss |
 | `Tooltip` | Contextual information overlay |
-| `StatusBar` | Application status bar with sections, timers, counters |
-| `StatusLog` | Scrolling status messages with severity levels |
 
 ### Navigation Components
 
 | Component | Description |
 |-----------|-------------|
-| `Tabs` | Horizontal tab navigation |
-| `Menu` | Keyboard-navigable menu with shortcuts |
-| `Breadcrumb` | Navigation breadcrumb trail |
-| `Router` | Multi-screen navigation with history |
-| `Tree` | Hierarchical tree view with expand/collapse |
 | `Accordion` | Collapsible panel container |
+| `Breadcrumb` | Navigation breadcrumb trail |
+| `Menu` | Keyboard-navigable menu with shortcuts |
+| `Router` | Multi-screen navigation with history |
+| `Tabs` | Horizontal tab navigation |
+| `Tree` | Hierarchical tree view with expand/collapse |
 
 ### Data Components
 
@@ -205,18 +209,21 @@ Envision provides a comprehensive library of reusable UI components, all followi
 
 | Component | Description |
 |-----------|-------------|
+| `ConfirmDialog` | Preset confirmation dialog with Yes/No buttons |
 | `Dialog` | Modal dialog overlay with buttons |
 
 ### Compound Components
 
 | Component | Description |
 |-----------|-------------|
-| `ChatView` | Chat interface with message history and input |
+| `ChatView` | Chat interface with message history and markdown rendering |
 | `Chart` | Data visualization with line and bar charts |
 | `DataGrid` | Editable data table with cell navigation |
+| `FileBrowser` | File system browser with pluggable backend |
 | `Form` | Multi-field form with validation |
 | `LogViewer` | Filterable log display with search |
 | `MetricsDashboard` | Dashboard with charts, counters, and gauges |
+| `PaneLayout` | Resizable split-pane layouts with configurable proportions |
 | `SearchableList` | Filterable list with search input |
 | `SplitPanel` | Resizable dual-panel layout |
 
@@ -224,9 +231,7 @@ Envision provides a comprehensive library of reusable UI components, all followi
 
 | Component | Description |
 |-----------|-------------|
-| `Button` | Clickable button with keyboard activation |
 | `FocusManager` | Keyboard focus coordination |
-| `KeyHints` | Keyboard shortcut display bar |
 
 ### Component Example
 
@@ -272,7 +277,7 @@ Envision follows The Elm Architecture (TEA) pattern:
 
 | Module | Description |
 |--------|-------------|
-| `component` | 37 reusable UI components with `Component`, `Focusable`, `Toggleable` traits |
+| `component` | 42 reusable UI components with `Component`, `Focusable`, `Toggleable` traits |
 | `backend` | `CaptureBackend` for headless rendering |
 | `app` | TEA architecture: `App`, `Runtime`, `Command`, subscriptions |
 | `harness` | `TestHarness` and `AppHarness` for testing |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,9 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.5.x   | Yes       |
-| < 0.5   | No        |
+| 0.7.x   | Yes       |
+| 0.6.x   | Yes       |
+| < 0.6   | No        |
 
 ## Security Model
 


### PR DESCRIPTION
## Summary

- Bump version to 0.7.0 in `Cargo.toml`
- Add CHANGELOG entry for v0.7.0 covering all changes since v0.6.0:
  - ChatView markdown rendering (behind `markdown` feature flag)
  - `Command::spawn()` for fire-and-forget async tasks
  - Command inspection methods (`is_none()`, `is_quit()`, `is_batch()`, `is_async()`)
  - `App::init()` default implementation
  - `EnvisionError::Other(BoxedError)` catch-all variant
  - `LineInputState::visual_rows_at_width()`
  - Widened tracing instrumentation
  - Two breaking changes: `TerminalHook` error type, `MatcherFn` Send+Sync bounds
- Update README: component count 37 → 42, add all missing components to tables (Button, ConfirmDialog, FileBrowser, KeyHints, PaneLayout, StepIndicator, StyledText), add `Disableable` trait mention, update ChatView description for markdown
- Add v0.6.0 → v0.7.0 migration section to `MIGRATION.md` with before/after code examples for both breaking changes
- Update `SECURITY.md` supported versions (0.7.x and 0.6.x)

## Test plan

- [x] `cargo test --all-features` passes (9295 tests, 0 failures)
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Verify component count in README matches audit tool output (42)
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)