### PR TITLE
Add interactive styling demo examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,6 +237,18 @@ required-features = ["compound-components"]
 name = "progress_bar"
 required-features = ["display-components"]
 
+[[example]]
+name = "styling_showcase"
+required-features = ["full"]
+
+[[example]]
+name = "chat_markdown_demo"
+required-features = ["compound-components", "markdown"]
+
+[[example]]
+name = "dashboard_demo"
+required-features = ["full"]
+
 [[bench]]
 name = "capture_backend"
 harness = false

--- a/examples/chat_markdown_demo.rs
+++ b/examples/chat_markdown_demo.rs
@@ -1,0 +1,356 @@
+//! Chat Markdown Demo — interactive chat with markdown rendering and role styles.
+//!
+//! This demo exercises ChatView's markdown rendering, custom role styles per theme,
+//! and the LineInput component for message composition. Pre-populated with markdown
+//! content to showcase heading, bold, italic, code, and list rendering.
+//!
+//! Controls:
+//!   Enter       Submit message (rendered as markdown if enabled)
+//!   Ctrl+M      Toggle markdown rendering on/off
+//!   T           Cycle through themes
+//!   Up/Down     Scroll chat history (when not typing)
+//!   Ctrl+U      Clear input line
+//!   q (Ctrl+Q)  Quit (Esc also quits)
+//!
+//! Run with: cargo run --example chat_markdown_demo --features "compound-components,markdown"
+
+use envision::component::{
+    ChatView, ChatViewState, Component, LineInput, LineInputMessage, LineInputOutput,
+    LineInputState,
+};
+use envision::prelude::*;
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+// ---------------------------------------------------------------------------
+// Theme cycling
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum ActiveTheme {
+    #[default]
+    Default,
+    Nord,
+    Dracula,
+    SolarizedDark,
+    GruvboxDark,
+    CatppuccinMocha,
+}
+
+impl ActiveTheme {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Default => "Default",
+            Self::Nord => "Nord",
+            Self::Dracula => "Dracula",
+            Self::SolarizedDark => "Solarized Dark",
+            Self::GruvboxDark => "Gruvbox Dark",
+            Self::CatppuccinMocha => "Catppuccin Mocha",
+        }
+    }
+
+    fn next(&self) -> Self {
+        match self {
+            Self::Default => Self::Nord,
+            Self::Nord => Self::Dracula,
+            Self::Dracula => Self::SolarizedDark,
+            Self::SolarizedDark => Self::GruvboxDark,
+            Self::GruvboxDark => Self::CatppuccinMocha,
+            Self::CatppuccinMocha => Self::Default,
+        }
+    }
+
+    fn theme(&self) -> Theme {
+        match self {
+            Self::Default => Theme::default(),
+            Self::Nord => Theme::nord(),
+            Self::Dracula => Theme::dracula(),
+            Self::SolarizedDark => Theme::solarized_dark(),
+            Self::GruvboxDark => Theme::gruvbox_dark(),
+            Self::CatppuccinMocha => Theme::catppuccin_mocha(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct State {
+    active_theme: ActiveTheme,
+    chat: ChatViewState,
+    input: LineInputState,
+}
+
+fn apply_role_styles(chat: &mut ChatViewState, theme: &Theme) {
+    chat.set_role_style(
+        ChatRole::User,
+        Style::default()
+            .fg(theme.primary)
+            .add_modifier(Modifier::BOLD),
+    );
+    chat.set_role_style(
+        ChatRole::Assistant,
+        Style::default()
+            .fg(theme.success)
+            .add_modifier(Modifier::BOLD),
+    );
+    chat.set_role_style(
+        ChatRole::System,
+        Style::default()
+            .fg(theme.disabled)
+            .add_modifier(Modifier::ITALIC),
+    );
+}
+
+impl Default for State {
+    fn default() -> Self {
+        let mut chat = ChatViewState::new()
+            .with_markdown(true)
+            .with_timestamps(true)
+            .with_input_height(0);
+
+        let theme = ActiveTheme::default().theme();
+        apply_role_styles(&mut chat, &theme);
+
+        // Pre-populate with markdown content
+        chat.push_system_with_timestamp(
+            "Welcome to the Chat Markdown Demo! Markdown rendering is enabled.",
+            "09:00",
+        );
+
+        chat.push_user_with_timestamp("Can you show me some **markdown** features?", "09:01");
+
+        chat.push_assistant_with_timestamp(
+            "Sure! Here are the supported markdown features:\n\n\
+             # Heading 1\n\
+             ## Heading 2\n\
+             ### Heading 3\n\n\
+             **Bold text** and *italic text* and `inline code`.\n\n\
+             - Bullet point one\n\
+             - Bullet point two\n\
+             - Bullet point three\n\n\
+             ```rust\n\
+             fn main() {\n\
+                 println!(\"Hello, world!\");\n\
+             }\n\
+             ```\n\n\
+             ---\n\n\
+             You can also use ~~strikethrough~~ text!",
+            "09:02",
+        );
+
+        chat.push_user_with_timestamp(
+            "That's great! What about **nested** formatting?\n\n\
+             1. First item with *emphasis*\n\
+             2. Second item with `code`\n\
+             3. Third item with **bold**",
+            "09:03",
+        );
+
+        chat.push_assistant_with_timestamp(
+            "Exactly! You can mix formatting freely. Try typing a message below \
+             with markdown syntax. Toggle markdown with **Ctrl+M** to see the difference.\n\n\
+             Press **T** to cycle through themes and see how role styles change.",
+            "09:04",
+        );
+
+        let input = LineInputState::new().with_placeholder("Type a markdown message...");
+
+        Self {
+            active_theme: ActiveTheme::default(),
+            chat,
+            input,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+enum Msg {
+    Input(LineInputMessage),
+    InputOutput(LineInputOutput),
+    CycleTheme,
+    ToggleMarkdown,
+    ScrollUp,
+    ScrollDown,
+    Quit,
+}
+
+// ---------------------------------------------------------------------------
+// App
+// ---------------------------------------------------------------------------
+
+struct ChatMarkdownApp;
+
+impl App for ChatMarkdownApp {
+    type State = State;
+    type Message = Msg;
+
+    fn init() -> (State, Command<Msg>) {
+        (State::default(), Command::none())
+    }
+
+    fn update(state: &mut State, msg: Msg) -> Command<Msg> {
+        match msg {
+            Msg::Input(m) => {
+                if let Some(output) = LineInput::update(&mut state.input, m) {
+                    return Self::update(state, Msg::InputOutput(output));
+                }
+            }
+            Msg::InputOutput(output) => match output {
+                LineInputOutput::Submitted(text) => {
+                    if !text.trim().is_empty() {
+                        state.chat.push_user(&text);
+                        // Echo back with a markdown-aware response
+                        let response = format!(
+                            "You said:\n\n> {}\n\n*Message received and rendered with markdown {}.*",
+                            text.lines().collect::<Vec<_>>().join("\n> "),
+                            if state.chat.markdown_enabled() {
+                                "**enabled**"
+                            } else {
+                                "disabled"
+                            }
+                        );
+                        state.chat.push_assistant(&response);
+                    }
+                }
+                LineInputOutput::Changed(_) | LineInputOutput::Copied(_) => {}
+            },
+            Msg::CycleTheme => {
+                state.active_theme = state.active_theme.next();
+                let theme = state.active_theme.theme();
+                apply_role_styles(&mut state.chat, &theme);
+                state.chat.push_system(format!(
+                    "Theme switched to **{}**",
+                    state.active_theme.name()
+                ));
+            }
+            Msg::ToggleMarkdown => {
+                let enabled = !state.chat.markdown_enabled();
+                state.chat.set_markdown_enabled(enabled);
+                state.chat.push_system(format!(
+                    "Markdown rendering **{}**",
+                    if enabled { "enabled" } else { "disabled" }
+                ));
+            }
+            Msg::ScrollUp => {
+                ChatView::update(&mut state.chat, ChatViewMessage::ScrollUp);
+            }
+            Msg::ScrollDown => {
+                ChatView::update(&mut state.chat, ChatViewMessage::ScrollDown);
+            }
+            Msg::Quit => return Command::quit(),
+        }
+        Command::none()
+    }
+
+    fn view(state: &State, frame: &mut Frame) {
+        let theme = state.active_theme.theme();
+        let area = frame.area();
+
+        // Background
+        frame.render_widget(Block::default().style(theme.normal_style()), area);
+
+        let chunks = Layout::vertical([
+            Constraint::Length(3), // Header
+            Constraint::Min(6),    // Chat messages
+            Constraint::Length(3), // Input
+            Constraint::Length(1), // Status bar
+        ])
+        .split(area);
+
+        // Header
+        let md_status = if state.chat.markdown_enabled() {
+            Span::styled(" MD:ON ", theme.success_style())
+        } else {
+            Span::styled(" MD:OFF ", theme.disabled_style())
+        };
+        let header = Paragraph::new(Line::from(vec![
+            Span::styled(
+                " Chat Markdown Demo ",
+                Style::default()
+                    .fg(theme.primary)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" | Theme: "),
+            Span::styled(state.active_theme.name(), theme.focused_bold_style()),
+            Span::raw(" | "),
+            md_status,
+        ]))
+        .alignment(Alignment::Center)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(theme.focused_border_style()),
+        );
+        frame.render_widget(header, chunks[0]);
+
+        // Chat messages
+        ChatView::view(&state.chat, frame, chunks[1], &theme);
+
+        // Input
+        LineInput::view(&state.input, frame, chunks[2], &theme);
+
+        // Status bar
+        let status = Paragraph::new(Line::from(vec![
+            Span::styled("[Enter]", theme.info_style()),
+            Span::raw(" Send  "),
+            Span::styled("[Ctrl+M]", theme.info_style()),
+            Span::raw(" Toggle MD  "),
+            Span::styled("[T]", theme.info_style()),
+            Span::raw(" Theme  "),
+            Span::styled("[Up/Dn]", theme.info_style()),
+            Span::raw(" Scroll  "),
+            Span::styled("[Esc]", theme.error_style()),
+            Span::raw(" Quit"),
+        ]))
+        .alignment(Alignment::Center)
+        .style(theme.normal_style());
+        frame.render_widget(status, chunks[3]);
+    }
+
+    fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
+        if let Some(key) = event.as_key() {
+            // Ctrl+M toggles markdown
+            if key.code == KeyCode::Char('m') && key.modifiers.contains(KeyModifiers::CONTROL) {
+                return Some(Msg::ToggleMarkdown);
+            }
+            // Ctrl+Q or Esc to quit
+            if key.code == KeyCode::Esc {
+                return Some(Msg::Quit);
+            }
+            if key.code == KeyCode::Char('q') && key.modifiers.contains(KeyModifiers::CONTROL) {
+                return Some(Msg::Quit);
+            }
+            // T for theme cycling (only when not in the middle of typing)
+            if key.code == KeyCode::Char('t') && key.modifiers.contains(KeyModifiers::CONTROL) {
+                return Some(Msg::CycleTheme);
+            }
+            // Page Up/Down for scrolling
+            if key.code == KeyCode::PageUp {
+                return Some(Msg::ScrollUp);
+            }
+            if key.code == KeyCode::PageDown {
+                return Some(Msg::ScrollDown);
+            }
+        }
+        // Delegate to input
+        state.input.handle_event(event).map(Msg::Input)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> envision::Result<()> {
+    let _final_state = TerminalRuntime::<ChatMarkdownApp>::new_terminal()?
+        .run_terminal()
+        .await?;
+    Ok(())
+}

--- a/examples/dashboard_demo.rs
+++ b/examples/dashboard_demo.rs
@@ -1,0 +1,589 @@
+//! Dashboard Demo — interactive multi-component dashboard with live styling.
+//!
+//! Combines Chart, MultiProgress, StatusLog, Toast, and StatusBar in a single
+//! interactive dashboard. Simulates a CI/CD pipeline with build tasks, metrics,
+//! and notifications.
+//!
+//! Controls:
+//!   T           Cycle through themes
+//!   Space       Start/restart simulated build tasks
+//!   1           Add info toast
+//!   2           Add success toast
+//!   3           Add warning toast
+//!   4           Add error toast
+//!   Up/Down     Scroll status log
+//!   q/Esc       Quit
+//!
+//! Run with: cargo run --example dashboard_demo --features full
+
+use std::time::Duration;
+
+use envision::app::UnboundedChannelSubscription;
+use envision::prelude::*;
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+// ---------------------------------------------------------------------------
+// Theme cycling
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum ActiveTheme {
+    #[default]
+    Default,
+    Nord,
+    Dracula,
+    SolarizedDark,
+    GruvboxDark,
+    CatppuccinMocha,
+}
+
+impl ActiveTheme {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Default => "Default",
+            Self::Nord => "Nord",
+            Self::Dracula => "Dracula",
+            Self::SolarizedDark => "Solarized Dark",
+            Self::GruvboxDark => "Gruvbox Dark",
+            Self::CatppuccinMocha => "Catppuccin Mocha",
+        }
+    }
+
+    fn next(&self) -> Self {
+        match self {
+            Self::Default => Self::Nord,
+            Self::Nord => Self::Dracula,
+            Self::Dracula => Self::SolarizedDark,
+            Self::SolarizedDark => Self::GruvboxDark,
+            Self::GruvboxDark => Self::CatppuccinMocha,
+            Self::CatppuccinMocha => Self::Default,
+        }
+    }
+
+    fn theme(&self) -> Theme {
+        match self {
+            Self::Default => Theme::default(),
+            Self::Nord => Theme::nord(),
+            Self::Dracula => Theme::dracula(),
+            Self::SolarizedDark => Theme::solarized_dark(),
+            Self::GruvboxDark => Theme::gruvbox_dark(),
+            Self::CatppuccinMocha => Theme::catppuccin_mocha(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Build task names
+// ---------------------------------------------------------------------------
+
+const BUILD_TASKS: &[(&str, &str)] = &[
+    ("lint", "Lint & Format"),
+    ("test", "Unit Tests"),
+    ("build", "Build Release"),
+    ("docker", "Docker Image"),
+    ("deploy", "Deploy to Staging"),
+];
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct State {
+    active_theme: ActiveTheme,
+    chart: ChartState,
+    multi_progress: MultiProgressState,
+    status_log: StatusLogState,
+    toasts: ToastState,
+    status_bar: StatusBarState,
+    build_running: bool,
+    build_count: u64,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        // Chart: build times over last 8 runs
+        let build_series = DataSeries::new(
+            "Build Time (s)",
+            vec![45.0, 52.0, 48.0, 41.0, 55.0, 39.0, 44.0, 50.0],
+        )
+        .with_color(Color::Cyan);
+        let test_series = DataSeries::new(
+            "Test Time (s)",
+            vec![22.0, 28.0, 25.0, 20.0, 30.0, 18.0, 24.0, 26.0],
+        )
+        .with_color(Color::Green);
+        let chart = ChartState::line(vec![build_series, test_series])
+            .with_title("Pipeline History")
+            .with_legend(true);
+
+        // Multi-progress: build tasks
+        let mut multi_progress = MultiProgressState::new()
+            .with_title("Build Pipeline")
+            .with_percentages(true);
+        for (id, label) in BUILD_TASKS {
+            multi_progress.add(*id, *label);
+        }
+
+        // Status log
+        let mut status_log = StatusLogState::new()
+            .with_title("Activity")
+            .with_max_entries(30);
+        status_log.set_focused(true);
+        status_log.info("Dashboard initialized");
+        status_log.info("Press Space to start a build");
+
+        // Toasts
+        let mut toasts = ToastState::with_duration(4000);
+        toasts.set_max_visible(4);
+
+        // Status bar
+        let mut status_bar = StatusBarState::new();
+        status_bar.push_left(StatusBarItem::new("IDLE").with_style(StatusBarStyle::Muted));
+        status_bar.push_center(StatusBarItem::new("CI/CD Dashboard"));
+        status_bar.push_right(StatusBarItem::counter().with_label("Builds"));
+        status_bar.push_right(StatusBarItem::elapsed_time().with_style(StatusBarStyle::Muted));
+
+        Self {
+            active_theme: ActiveTheme::default(),
+            chart,
+            multi_progress,
+            status_log,
+            toasts,
+            status_bar,
+            build_running: false,
+            build_count: 0,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+enum Msg {
+    CycleTheme,
+    StartBuild,
+    TaskStarted(String),
+    TaskProgress(String, f32),
+    TaskCompleted(String),
+    BuildDone,
+    AddToast(ToastLevel),
+    Log(StatusLogMessage),
+    Tick,
+    Quit,
+}
+
+// ---------------------------------------------------------------------------
+// App
+// ---------------------------------------------------------------------------
+
+struct DashboardApp;
+
+impl App for DashboardApp {
+    type State = State;
+    type Message = Msg;
+
+    fn init() -> (State, Command<Msg>) {
+        (State::default(), Command::none())
+    }
+
+    fn update(state: &mut State, msg: Msg) -> Command<Msg> {
+        match msg {
+            Msg::CycleTheme => {
+                state.active_theme = state.active_theme.next();
+                state
+                    .status_log
+                    .info(format!("Theme: {}", state.active_theme.name()));
+            }
+            Msg::StartBuild => {
+                if state.build_running {
+                    state.toasts.warning("Build already in progress");
+                    return Command::none();
+                }
+                state.build_running = true;
+                state.build_count += 1;
+                state
+                    .status_log
+                    .info(format!("Build #{} started", state.build_count));
+                state.toasts.info("Build pipeline started");
+
+                // Reset progress items
+                for (id, label) in BUILD_TASKS {
+                    state.multi_progress.remove(id);
+                    state.multi_progress.add(*id, *label);
+                }
+
+                // Update status bar
+                StatusBar::update(
+                    &mut state.status_bar,
+                    StatusBarMessage::SetLeftItems(vec![
+                        StatusBarItem::new("BUILDING").with_style(StatusBarStyle::Warning)
+                    ]),
+                );
+                StatusBar::update(
+                    &mut state.status_bar,
+                    StatusBarMessage::SetCounter {
+                        section: Section::Right,
+                        index: 0,
+                        value: state.build_count,
+                    },
+                );
+
+                // Spawn background simulation
+                // Use channel-based approach; this path is only hit in DashboardApp
+                // which is not used directly. DashboardChannelApp intercepts StartBuild.
+                return Command::none();
+            }
+            Msg::TaskStarted(id) => {
+                MultiProgress::update(
+                    &mut state.multi_progress,
+                    MultiProgressMessage::SetStatus {
+                        id: id.clone(),
+                        status: ProgressItemStatus::Active,
+                    },
+                );
+                if let Some(item) = state.multi_progress.find(&id) {
+                    state.status_log.info(format!("Started: {}", item.label()));
+                }
+            }
+            Msg::TaskProgress(id, progress) => {
+                MultiProgress::update(
+                    &mut state.multi_progress,
+                    MultiProgressMessage::SetProgress { id, progress },
+                );
+            }
+            Msg::TaskCompleted(id) => {
+                if let Some(item) = state.multi_progress.find(&id) {
+                    state
+                        .status_log
+                        .success(format!("Completed: {}", item.label()));
+                }
+                MultiProgress::update(
+                    &mut state.multi_progress,
+                    MultiProgressMessage::Complete(id),
+                );
+            }
+            Msg::BuildDone => {
+                state.build_running = false;
+                state.toasts.success("Build pipeline completed!");
+                state.status_log.success(format!(
+                    "Build #{} finished successfully",
+                    state.build_count
+                ));
+
+                // Add new data point to chart
+                let build_time = 38.0 + (state.build_count as f64 * 3.0) % 20.0;
+                let test_time = 18.0 + (state.build_count as f64 * 2.0) % 15.0;
+                if let Some(series) = state.chart.series_mut().first_mut() {
+                    series.push_bounded(build_time, 12);
+                }
+                if let Some(series) = state.chart.series_mut().get_mut(1) {
+                    series.push_bounded(test_time, 12);
+                }
+
+                // Update status bar
+                StatusBar::update(
+                    &mut state.status_bar,
+                    StatusBarMessage::SetLeftItems(vec![
+                        StatusBarItem::new("IDLE").with_style(StatusBarStyle::Success)
+                    ]),
+                );
+            }
+            Msg::AddToast(level) => match level {
+                ToastLevel::Info => {
+                    state.toasts.info("Informational notification");
+                }
+                ToastLevel::Success => {
+                    state.toasts.success("Operation successful!");
+                }
+                ToastLevel::Warning => {
+                    state.toasts.warning("Warning: check configuration");
+                }
+                ToastLevel::Error => {
+                    state.toasts.error("Error: connection timeout");
+                }
+            },
+            Msg::Log(m) => {
+                StatusLog::update(&mut state.status_log, m);
+            }
+            Msg::Tick => {
+                // Advance toast timers
+                Toast::update(&mut state.toasts, ToastMessage::Tick(250));
+                // Advance status bar timer
+                StatusBar::update(&mut state.status_bar, StatusBarMessage::Tick(250));
+            }
+            Msg::Quit => return Command::quit(),
+        }
+        Command::none()
+    }
+
+    fn view(state: &State, frame: &mut Frame) {
+        let theme = state.active_theme.theme();
+        let area = frame.area();
+
+        // Background
+        frame.render_widget(Block::default().style(theme.normal_style()), area);
+
+        let main_chunks = Layout::vertical([
+            Constraint::Length(3), // Header
+            Constraint::Min(10),   // Content
+            Constraint::Length(1), // Status bar
+            Constraint::Length(1), // Key hints
+        ])
+        .split(area);
+
+        // Header
+        render_header(state, frame, main_chunks[0], &theme);
+
+        // Content: left (chart + progress) | right (log)
+        let content_chunks =
+            Layout::horizontal([Constraint::Percentage(55), Constraint::Percentage(45)])
+                .split(main_chunks[1]);
+
+        // Left column: chart on top, progress below
+        let left_chunks =
+            Layout::vertical([Constraint::Percentage(50), Constraint::Percentage(50)])
+                .split(content_chunks[0]);
+
+        Chart::view(&state.chart, frame, left_chunks[0], &theme);
+        MultiProgress::view(&state.multi_progress, frame, left_chunks[1], &theme);
+
+        // Right column: status log
+        StatusLog::view(&state.status_log, frame, content_chunks[1], &theme);
+
+        // Toast overlay (renders on top of everything)
+        Toast::view(&state.toasts, frame, area, &theme);
+
+        // Status bar
+        StatusBar::view(&state.status_bar, frame, main_chunks[2], &theme);
+
+        // Key hints
+        render_key_hints(frame, main_chunks[3], &theme);
+    }
+
+    fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
+        if let Some(key) = event.as_key() {
+            match key.code {
+                KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => {
+                    return Some(Msg::Quit);
+                }
+                KeyCode::Char('t') | KeyCode::Char('T') => return Some(Msg::CycleTheme),
+                KeyCode::Char(' ') => return Some(Msg::StartBuild),
+                KeyCode::Char('1') => return Some(Msg::AddToast(ToastLevel::Info)),
+                KeyCode::Char('2') => return Some(Msg::AddToast(ToastLevel::Success)),
+                KeyCode::Char('3') => return Some(Msg::AddToast(ToastLevel::Warning)),
+                KeyCode::Char('4') => return Some(Msg::AddToast(ToastLevel::Error)),
+                _ => {}
+            }
+        }
+        // Delegate scroll to status log
+        state.status_log.handle_event(event).map(Msg::Log)
+    }
+
+    fn on_tick(state: &State) -> Option<Msg> {
+        // Use on_tick for toast/timer advancement
+        let _ = state;
+        Some(Msg::Tick)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Background build simulation
+// ---------------------------------------------------------------------------
+
+/// Spawns a background task that sends granular progress updates via a channel.
+fn spawn_build_worker(tx: tokio::sync::mpsc::UnboundedSender<Msg>) {
+    tokio::spawn(async move {
+        for (id, _label) in BUILD_TASKS {
+            // Start task
+            if tx.send(Msg::TaskStarted(id.to_string())).is_err() {
+                return;
+            }
+
+            // Simulate progress in steps
+            for step in 1..=5 {
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                let progress = step as f32 / 5.0;
+                if tx
+                    .send(Msg::TaskProgress(id.to_string(), progress))
+                    .is_err()
+                {
+                    return;
+                }
+            }
+
+            // Complete task
+            if tx.send(Msg::TaskCompleted(id.to_string())).is_err() {
+                return;
+            }
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        let _ = tx.send(Msg::BuildDone);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Rendering helpers
+// ---------------------------------------------------------------------------
+
+fn render_header(state: &State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let status_indicator = if state.build_running {
+        Span::styled(" BUILDING ", theme.warning_style())
+    } else {
+        Span::styled(" IDLE ", theme.success_style())
+    };
+
+    let header = Paragraph::new(Line::from(vec![
+        Span::styled(
+            " Dashboard Demo ",
+            Style::default()
+                .fg(theme.primary)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(" | "),
+        status_indicator,
+        Span::raw(" | Theme: "),
+        Span::styled(state.active_theme.name(), theme.focused_bold_style()),
+        Span::raw(format!(" | Builds: {} ", state.build_count)),
+    ]))
+    .alignment(Alignment::Center)
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(theme.focused_border_style()),
+    );
+    frame.render_widget(header, area);
+}
+
+fn render_key_hints(frame: &mut Frame, area: Rect, theme: &Theme) {
+    let hints = Paragraph::new(Line::from(vec![
+        Span::styled("[T]", theme.info_style()),
+        Span::raw(" Theme  "),
+        Span::styled("[Space]", theme.info_style()),
+        Span::raw(" Build  "),
+        Span::styled("[1-4]", theme.info_style()),
+        Span::raw(" Toasts  "),
+        Span::styled("[Up/Dn]", theme.info_style()),
+        Span::raw(" Scroll  "),
+        Span::styled("[q]", theme.error_style()),
+        Span::raw(" Quit"),
+    ]))
+    .alignment(Alignment::Center)
+    .style(theme.normal_style());
+    frame.render_widget(hints, area);
+}
+
+// ---------------------------------------------------------------------------
+// Main — with channel subscription for build updates
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> envision::Result<()> {
+    // We override the StartBuild handling to use the channel-based approach
+    // by creating a custom wrapper that intercepts the StartBuild command.
+
+    let (state, _) = <DashboardApp as App>::init();
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Msg>();
+
+    let mut runtime = TerminalRuntime::<DashboardChannelApp>::new_terminal_with_state(
+        ChannelState {
+            inner: state,
+            build_tx: tx,
+        },
+        Command::none(),
+    )?;
+
+    runtime.subscribe(UnboundedChannelSubscription::new(rx));
+
+    let _final_state = runtime.run_terminal().await?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Channel-aware wrapper app
+// ---------------------------------------------------------------------------
+
+/// Wraps the dashboard state with a channel sender for build updates.
+#[derive(Clone)]
+struct ChannelState {
+    inner: State,
+    build_tx: tokio::sync::mpsc::UnboundedSender<Msg>,
+}
+
+struct DashboardChannelApp;
+
+impl App for DashboardChannelApp {
+    type State = ChannelState;
+    type Message = Msg;
+
+    fn init() -> (ChannelState, Command<Msg>) {
+        // Not used — we use with_state constructor
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        (
+            ChannelState {
+                inner: State::default(),
+                build_tx: tx,
+            },
+            Command::none(),
+        )
+    }
+
+    fn update(state: &mut ChannelState, msg: Msg) -> Command<Msg> {
+        match &msg {
+            Msg::StartBuild if !state.inner.build_running => {
+                // Intercept to spawn the channel-based worker
+                state.inner.build_running = true;
+                state.inner.build_count += 1;
+                state
+                    .inner
+                    .status_log
+                    .info(format!("Build #{} started", state.inner.build_count));
+                state.inner.toasts.info("Build pipeline started");
+
+                // Reset progress items
+                for (id, label) in BUILD_TASKS {
+                    state.inner.multi_progress.remove(id);
+                    state.inner.multi_progress.add(*id, *label);
+                }
+
+                StatusBar::update(
+                    &mut state.inner.status_bar,
+                    StatusBarMessage::SetLeftItems(vec![
+                        StatusBarItem::new("BUILDING").with_style(StatusBarStyle::Warning)
+                    ]),
+                );
+                StatusBar::update(
+                    &mut state.inner.status_bar,
+                    StatusBarMessage::SetCounter {
+                        section: Section::Right,
+                        index: 0,
+                        value: state.inner.build_count,
+                    },
+                );
+
+                spawn_build_worker(state.build_tx.clone());
+                Command::none()
+            }
+            _ => {
+                // Delegate everything else to the inner app logic
+                DashboardApp::update(&mut state.inner, msg)
+            }
+        }
+    }
+
+    fn view(state: &ChannelState, frame: &mut Frame) {
+        DashboardApp::view(&state.inner, frame);
+    }
+
+    fn handle_event_with_state(state: &ChannelState, event: &Event) -> Option<Msg> {
+        DashboardApp::handle_event_with_state(&state.inner, event)
+    }
+
+    fn on_tick(_state: &ChannelState) -> Option<Msg> {
+        Some(Msg::Tick)
+    }
+}

--- a/examples/styling_showcase.rs
+++ b/examples/styling_showcase.rs
@@ -1,0 +1,496 @@
+//! Styling Showcase — interactive exploration of all theme styles and rich text formatting.
+//!
+//! This demo exercises every theme style helper method and every StyledInline variant,
+//! letting you switch between all 6 built-in themes to see how each one renders.
+//!
+//! Controls:
+//!   T           Cycle through themes (Default → Nord → Dracula → Solarized → Gruvbox → Catppuccin)
+//!   Tab         Switch between Style Palette and Rich Text panels
+//!   Up/k        Scroll up (in Rich Text panel)
+//!   Down/j      Scroll down (in Rich Text panel)
+//!   Page Up     Scroll up one page
+//!   Page Down   Scroll down one page
+//!   Home        Jump to top
+//!   End         Jump to bottom
+//!   q/Esc       Quit
+//!
+//! Run with: cargo run --example styling_showcase --features full
+
+use envision::prelude::*;
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+// ---------------------------------------------------------------------------
+// Theme cycling
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum ActiveTheme {
+    #[default]
+    Default,
+    Nord,
+    Dracula,
+    SolarizedDark,
+    GruvboxDark,
+    CatppuccinMocha,
+}
+
+impl ActiveTheme {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Default => "Default",
+            Self::Nord => "Nord",
+            Self::Dracula => "Dracula",
+            Self::SolarizedDark => "Solarized Dark",
+            Self::GruvboxDark => "Gruvbox Dark",
+            Self::CatppuccinMocha => "Catppuccin Mocha",
+        }
+    }
+
+    fn next(&self) -> Self {
+        match self {
+            Self::Default => Self::Nord,
+            Self::Nord => Self::Dracula,
+            Self::Dracula => Self::SolarizedDark,
+            Self::SolarizedDark => Self::GruvboxDark,
+            Self::GruvboxDark => Self::CatppuccinMocha,
+            Self::CatppuccinMocha => Self::Default,
+        }
+    }
+
+    fn theme(&self) -> Theme {
+        match self {
+            Self::Default => Theme::default(),
+            Self::Nord => Theme::nord(),
+            Self::Dracula => Theme::dracula(),
+            Self::SolarizedDark => Theme::solarized_dark(),
+            Self::GruvboxDark => Theme::gruvbox_dark(),
+            Self::CatppuccinMocha => Theme::catppuccin_mocha(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Panel focus
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum Panel {
+    #[default]
+    Palette,
+    RichText,
+}
+
+impl Panel {
+    fn toggle(&self) -> Self {
+        match self {
+            Self::Palette => Self::RichText,
+            Self::RichText => Self::Palette,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct State {
+    active_theme: ActiveTheme,
+    panel: Panel,
+    styled_text: StyledTextState,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        let content = build_rich_text_content();
+        let styled_text = StyledTextState::new()
+            .with_content(content)
+            .with_title("Rich Text Formatting");
+
+        Self {
+            active_theme: ActiveTheme::default(),
+            panel: Panel::default(),
+            styled_text,
+        }
+    }
+}
+
+fn build_rich_text_content() -> styled_text::StyledContent {
+    styled_text::StyledContent::new()
+        .heading(1, "StyledInline Variants")
+        .paragraph(vec![styled_text::StyledInline::Plain(
+            "This is Plain text — the default inline style.".to_string(),
+        )])
+        .paragraph(vec![styled_text::StyledInline::Bold(
+            "This is Bold text — for emphasis and headings.".to_string(),
+        )])
+        .paragraph(vec![styled_text::StyledInline::Italic(
+            "This is Italic text — for subtle emphasis or titles.".to_string(),
+        )])
+        .paragraph(vec![styled_text::StyledInline::Underline(
+            "This is Underline text — for links or key terms.".to_string(),
+        )])
+        .paragraph(vec![styled_text::StyledInline::Strikethrough(
+            "This is Strikethrough text — for deprecated or removed items.".to_string(),
+        )])
+        .paragraph(vec![styled_text::StyledInline::Code(
+            "This is Code text — for inline code snippets.".to_string(),
+        )])
+        .blank_line()
+        .heading(2, "Colored Inline Text")
+        .paragraph(vec![
+            styled_text::StyledInline::Colored {
+                text: "Red foreground".to_string(),
+                fg: Some(Color::Red),
+                bg: None,
+            },
+            styled_text::StyledInline::Plain(" | ".to_string()),
+            styled_text::StyledInline::Colored {
+                text: "Green foreground".to_string(),
+                fg: Some(Color::Green),
+                bg: None,
+            },
+            styled_text::StyledInline::Plain(" | ".to_string()),
+            styled_text::StyledInline::Colored {
+                text: "Blue foreground".to_string(),
+                fg: Some(Color::Blue),
+                bg: None,
+            },
+        ])
+        .paragraph(vec![
+            styled_text::StyledInline::Colored {
+                text: "Cyan foreground".to_string(),
+                fg: Some(Color::Cyan),
+                bg: None,
+            },
+            styled_text::StyledInline::Plain(" | ".to_string()),
+            styled_text::StyledInline::Colored {
+                text: "Magenta foreground".to_string(),
+                fg: Some(Color::Magenta),
+                bg: None,
+            },
+            styled_text::StyledInline::Plain(" | ".to_string()),
+            styled_text::StyledInline::Colored {
+                text: "Yellow foreground".to_string(),
+                fg: Some(Color::Yellow),
+                bg: None,
+            },
+        ])
+        .paragraph(vec![styled_text::StyledInline::Colored {
+            text: " Highlighted text with background ".to_string(),
+            fg: Some(Color::White),
+            bg: Some(Color::Blue),
+        }])
+        .blank_line()
+        .heading(2, "Mixed Inline Styles")
+        .paragraph(vec![
+            styled_text::StyledInline::Plain("You can ".to_string()),
+            styled_text::StyledInline::Bold("mix".to_string()),
+            styled_text::StyledInline::Plain(" and ".to_string()),
+            styled_text::StyledInline::Italic("match".to_string()),
+            styled_text::StyledInline::Plain(" different styles within a ".to_string()),
+            styled_text::StyledInline::Code("single paragraph".to_string()),
+            styled_text::StyledInline::Plain(". Here's ".to_string()),
+            styled_text::StyledInline::Colored {
+                text: "colored".to_string(),
+                fg: Some(Color::Cyan),
+                bg: None,
+            },
+            styled_text::StyledInline::Plain(" text too.".to_string()),
+        ])
+        .blank_line()
+        .heading(2, "Block-Level Elements")
+        .text("Bullet lists group related items:")
+        .bullet_list(vec![
+            vec![
+                styled_text::StyledInline::Bold("First item".to_string()),
+                styled_text::StyledInline::Plain(" — with bold label".to_string()),
+            ],
+            vec![
+                styled_text::StyledInline::Italic("Second item".to_string()),
+                styled_text::StyledInline::Plain(" — with italic label".to_string()),
+            ],
+            vec![styled_text::StyledInline::Plain(
+                "Third item — plain text".to_string(),
+            )],
+        ])
+        .text("Numbered lists for ordered content:")
+        .numbered_list(vec![
+            vec![styled_text::StyledInline::Plain(
+                "Install envision".to_string(),
+            )],
+            vec![styled_text::StyledInline::Plain(
+                "Create your App".to_string(),
+            )],
+            vec![styled_text::StyledInline::Plain(
+                "Run and enjoy!".to_string(),
+            )],
+        ])
+        .text("Code blocks for source code:")
+        .code_block(
+            Some("rust"),
+            "use envision::prelude::*;\n\nfn main() -> envision::Result<()> {\n    let _state = TerminalRuntime::<MyApp>::new_terminal()?\n        .run_terminal()\n        .await?;\n    Ok(())\n}",
+        )
+        .horizontal_rule()
+        .text("Use Up/Down to scroll. Press Tab to switch panels. Press T to change themes.")
+}
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+enum Msg {
+    CycleTheme,
+    TogglePanel,
+    StyledText(StyledTextMessage),
+    Quit,
+}
+
+// ---------------------------------------------------------------------------
+// App
+// ---------------------------------------------------------------------------
+
+struct StylingShowcaseApp;
+
+impl App for StylingShowcaseApp {
+    type State = State;
+    type Message = Msg;
+
+    fn init() -> (State, Command<Msg>) {
+        (State::default(), Command::none())
+    }
+
+    fn update(state: &mut State, msg: Msg) -> Command<Msg> {
+        match msg {
+            Msg::CycleTheme => {
+                state.active_theme = state.active_theme.next();
+            }
+            Msg::TogglePanel => {
+                state.panel = state.panel.toggle();
+                // Update focus on styled text
+                let focused = state.panel == Panel::RichText;
+                state.styled_text.set_focused(focused);
+            }
+            Msg::StyledText(m) => {
+                StyledText::update(&mut state.styled_text, m);
+            }
+            Msg::Quit => return Command::quit(),
+        }
+        Command::none()
+    }
+
+    fn view(state: &State, frame: &mut Frame) {
+        let theme = state.active_theme.theme();
+        let area = frame.area();
+
+        // Background
+        frame.render_widget(Block::default().style(theme.normal_style()), area);
+
+        let main_chunks = Layout::vertical([
+            Constraint::Length(3), // Header
+            Constraint::Min(10),   // Content
+            Constraint::Length(1), // Footer
+        ])
+        .split(area);
+
+        // Header — theme name
+        render_header(state, frame, main_chunks[0], &theme);
+
+        // Content — two panels side by side
+        let panels = Layout::horizontal([Constraint::Percentage(45), Constraint::Percentage(55)])
+            .split(main_chunks[1]);
+
+        // Left panel: Style Palette
+        render_style_palette(state, frame, panels[0], &theme);
+
+        // Right panel: Rich Text
+        StyledText::view(&state.styled_text, frame, panels[1], &theme);
+
+        // Footer — key hints
+        render_footer(frame, main_chunks[2], &theme);
+    }
+
+    fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
+        if let Some(key) = event.as_key() {
+            match key.code {
+                KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => return Some(Msg::Quit),
+                KeyCode::Char('t') | KeyCode::Char('T') => return Some(Msg::CycleTheme),
+                KeyCode::Tab => return Some(Msg::TogglePanel),
+                _ => {}
+            }
+        }
+        if state.panel == Panel::RichText {
+            state.styled_text.handle_event(event).map(Msg::StyledText)
+        } else {
+            None
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering helpers
+// ---------------------------------------------------------------------------
+
+fn render_header(state: &State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let header = Paragraph::new(Line::from(vec![
+        Span::styled(
+            " Styling Showcase ",
+            Style::default()
+                .fg(theme.primary)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(" — Theme: "),
+        Span::styled(state.active_theme.name(), theme.focused_bold_style()),
+    ]))
+    .alignment(Alignment::Center)
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(theme.focused_border_style())
+            .title(" envision "),
+    );
+    frame.render_widget(header, area);
+}
+
+fn render_style_palette(_state: &State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme.border_style())
+        .title(" Style Palette ");
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    // Build lines showing each theme style method
+    let lines: Vec<Line> = vec![
+        Line::from(vec![
+            Span::styled("  normal_style():          ", theme.normal_style()),
+            Span::styled("Sample Text", theme.normal_style()),
+        ]),
+        Line::from(vec![
+            Span::styled("  focused_style():         ", theme.normal_style()),
+            Span::styled("Sample Text", theme.focused_style()),
+        ]),
+        Line::from(vec![
+            Span::styled("  focused_bold_style():    ", theme.normal_style()),
+            Span::styled("Sample Text", theme.focused_bold_style()),
+        ]),
+        Line::from(vec![
+            Span::styled("  focused_border_style():  ", theme.normal_style()),
+            Span::styled("Sample Text", theme.focused_border_style()),
+        ]),
+        Line::from(vec![
+            Span::styled("  selected_style(true):    ", theme.normal_style()),
+            Span::styled("Sample Text", theme.selected_style(true)),
+        ]),
+        Line::from(vec![
+            Span::styled("  selected_style(false):   ", theme.normal_style()),
+            Span::styled("Sample Text", theme.selected_style(false)),
+        ]),
+        Line::from(vec![
+            Span::styled("  selection_style():       ", theme.normal_style()),
+            Span::styled("Sample Text", theme.selection_style()),
+        ]),
+        Line::from(vec![
+            Span::styled("  disabled_style():        ", theme.normal_style()),
+            Span::styled("Sample Text", theme.disabled_style()),
+        ]),
+        Line::from(vec![
+            Span::styled("  placeholder_style():     ", theme.normal_style()),
+            Span::styled("Sample Text", theme.placeholder_style()),
+        ]),
+        Line::from(vec![
+            Span::styled("  border_style():          ", theme.normal_style()),
+            Span::styled("Sample Text", theme.border_style()),
+        ]),
+        Line::from(vec![
+            Span::styled("  primary_style():         ", theme.normal_style()),
+            Span::styled("Sample Text", theme.primary_style()),
+        ]),
+        Line::from(vec![
+            Span::styled("  success_style():         ", theme.normal_style()),
+            Span::styled("Sample Text", theme.success_style()),
+        ]),
+        Line::from(vec![
+            Span::styled("  warning_style():         ", theme.normal_style()),
+            Span::styled("Sample Text", theme.warning_style()),
+        ]),
+        Line::from(vec![
+            Span::styled("  error_style():           ", theme.normal_style()),
+            Span::styled("Sample Text", theme.error_style()),
+        ]),
+        Line::from(vec![
+            Span::styled("  info_style():            ", theme.normal_style()),
+            Span::styled("Sample Text", theme.info_style()),
+        ]),
+        Line::from(vec![
+            Span::styled("  progress_filled_style(): ", theme.normal_style()),
+            Span::styled("Sample Text", theme.progress_filled_style()),
+        ]),
+        // Color swatch section
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Color Fields:",
+            Style::default()
+                .fg(theme.primary)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(vec![
+            Span::styled(
+                "  background  ",
+                Style::default().bg(theme.background).fg(theme.foreground),
+            ),
+            Span::styled("  foreground  ", Style::default().fg(theme.foreground)),
+            Span::styled("  border  ", Style::default().fg(theme.border)),
+        ]),
+        Line::from(vec![
+            Span::styled("  focused  ", Style::default().fg(theme.focused)),
+            Span::styled("  selected  ", Style::default().fg(theme.selected)),
+            Span::styled("  disabled  ", Style::default().fg(theme.disabled)),
+        ]),
+        Line::from(vec![
+            Span::styled("  primary  ", Style::default().fg(theme.primary)),
+            Span::styled("  success  ", Style::default().fg(theme.success)),
+            Span::styled("  warning  ", Style::default().fg(theme.warning)),
+            Span::styled("  error  ", Style::default().fg(theme.error)),
+        ]),
+        Line::from(vec![
+            Span::styled("  info  ", Style::default().fg(theme.info)),
+            Span::styled("  placeholder  ", Style::default().fg(theme.placeholder)),
+            Span::styled("  progress  ", Style::default().fg(theme.progress_filled)),
+        ]),
+    ];
+
+    let palette = Paragraph::new(lines).style(theme.normal_style());
+    frame.render_widget(palette, inner);
+}
+
+fn render_footer(frame: &mut Frame, area: Rect, theme: &Theme) {
+    let footer = Paragraph::new(Line::from(vec![
+        Span::styled("[T]", theme.info_style()),
+        Span::styled(" Theme  ", theme.normal_style()),
+        Span::styled("[Tab]", theme.info_style()),
+        Span::styled(" Panel  ", theme.normal_style()),
+        Span::styled("[Up/Dn]", theme.info_style()),
+        Span::styled(" Scroll  ", theme.normal_style()),
+        Span::styled("[PgUp/PgDn]", theme.info_style()),
+        Span::styled(" Page  ", theme.normal_style()),
+        Span::styled("[q]", theme.error_style()),
+        Span::styled(" Quit", theme.normal_style()),
+    ]))
+    .alignment(Alignment::Center)
+    .style(theme.normal_style());
+    frame.render_widget(footer, area);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> envision::Result<()> {
+    let _final_state = TerminalRuntime::<StylingShowcaseApp>::new_terminal()?
+        .run_terminal()
+        .await?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Add three interactive terminal examples for testing and exploring styling features:
  - **`styling_showcase`** — Side-by-side theme style palette (all 16 style methods) and StyledText rich formatting (all StyledInline variants, block elements, code blocks). Theme cycling with `T`, panel switching with `Tab`.
  - **`chat_markdown_demo`** — ChatView with markdown rendering, custom role styles per theme, LineInput composition. Toggle markdown with `Ctrl+M`, theme switching with `Ctrl+T`.
  - **`dashboard_demo`** — Multi-component dashboard combining Chart (line chart with colored series), MultiProgress (simulated CI pipeline), StatusLog (scrollable activity feed), Toast (notifications at all 4 levels), and StatusBar (with counter and timer). Background build simulation via channel subscription.
- All three use `TerminalRuntime::run_terminal()` for fully interactive exploration
- All support cycling through all 6 built-in themes

## Test plan

- [ ] `cargo build --examples --all-features` compiles all examples
- [ ] `cargo clippy --all-features -- -D warnings` passes
- [ ] `cargo fmt --check` passes
- [ ] `cargo run --example styling_showcase --features full` — verify theme palette and rich text display
- [ ] `cargo run --example chat_markdown_demo --features "compound-components,markdown"` — verify markdown rendering and role styles
- [ ] `cargo run --example dashboard_demo --features full` — verify dashboard with build simulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)