### PR TITLE
Fix StyledText word wrapping and use bullet character

### DIFF
--- a/src/component/styled_text/content.rs
+++ b/src/component/styled_text/content.rs
@@ -255,7 +255,7 @@ fn render_block(
         }
         StyledBlock::BulletList(items) => {
             for item in items {
-                let mut spans = vec![RatSpan::styled("  * ", base_style)];
+                let mut spans = vec![RatSpan::styled("  • ", base_style)];
                 for inline in item {
                     spans.push(render_inline(inline, theme, base_style));
                 }

--- a/src/component/styled_text/mod.rs
+++ b/src/component/styled_text/mod.rs
@@ -38,7 +38,7 @@ pub mod content;
 pub use content::{StyledBlock, StyledContent, StyledInline};
 
 use ratatui::prelude::*;
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
 use super::{Component, Focusable};
 use crate::input::{Event, KeyCode, KeyModifiers};
@@ -558,13 +558,15 @@ impl Component for StyledText {
         }
 
         let rendered_lines = state.content.render_lines(inner.width, theme);
-        let total_lines = rendered_lines.len();
+        let total_visual_rows = visual_row_count(&rendered_lines, inner.width as usize);
         let visible_lines = inner.height as usize;
-        let max_scroll = total_lines.saturating_sub(visible_lines);
+        let max_scroll = total_visual_rows.saturating_sub(visible_lines);
         let effective_scroll = state.scroll_offset.min(max_scroll);
 
         let text = Text::from(rendered_lines);
-        let paragraph = Paragraph::new(text).scroll((effective_scroll as u16, 0));
+        let paragraph = Paragraph::new(text)
+            .wrap(Wrap { trim: false })
+            .scroll((effective_scroll as u16, 0));
 
         frame.render_widget(paragraph, render_area);
     }
@@ -578,6 +580,25 @@ impl Focusable for StyledText {
     fn set_focused(state: &mut Self::State, focused: bool) {
         state.focused = focused;
     }
+}
+
+/// Counts the total visual rows that a set of rendered lines will occupy
+/// when word-wrapped at the given width.
+fn visual_row_count(lines: &[Line<'static>], width: usize) -> usize {
+    if width == 0 {
+        return lines.len();
+    }
+    lines
+        .iter()
+        .map(|line| {
+            let line_width = line.width();
+            if line_width == 0 {
+                1
+            } else {
+                line_width.div_ceil(width)
+            }
+        })
+        .sum()
 }
 
 #[cfg(test)]

--- a/src/component/styled_text/snapshots/envision__component__styled_text__tests__view_bullet_list.snap
+++ b/src/component/styled_text/snapshots/envision__component__styled_text__tests__view_bullet_list.snap
@@ -1,13 +1,13 @@
 ---
 source: src/component/styled_text/tests.rs
-assertion_line: 534
+assertion_line: 532
 expression: display
 ---
 ┌────────────────────────────────────────────────┐
 │Items                                           │
-│  * First item                                  │
-│  * Second item                                 │
-│  * Bold item                                   │
+│  • First item                                  │
+│  • Second item                                 │
+│  • Bold item                                   │
 │                                                │
 │                                                │
 └────────────────────────────────────────────────┘

--- a/src/component/styled_text/snapshots/envision__component__styled_text__tests__view_mixed_content.snap
+++ b/src/component/styled_text/snapshots/envision__component__styled_text__tests__view_mixed_content.snap
@@ -1,6 +1,6 @@
 ---
 source: src/component/styled_text/tests.rs
-assertion_line: 668
+assertion_line: 666
 expression: display
 ---
 ┌──────────────────────────────────────────────────────────┐
@@ -9,8 +9,8 @@ expression: display
 │Introduction paragraph.                                   │
 │──────────────────────────────────────────────────────────│
 │Section                                                   │
-│  * Point A                                               │
-│  * Point B                                               │
+│  • Point A                                               │
+│  • Point B                                               │
 │                                                          │
 │    example code                                          │
 │                                                          │


### PR DESCRIPTION
## Summary

- Enable word wrapping in StyledText so long paragraphs wrap at the panel edge instead of being clipped off-screen
- Calculate visual row count accounting for wrapped lines so scroll position stays accurate
- Change bullet list prefix from `*` to `•` for a cleaner look

## Test plan

- [x] All 68 StyledText unit tests pass (2 snapshot tests updated for bullet change)
- [x] All 122 ChatView tests pass (markdown-parsed bullets use same renderer)
- [x] Full test suite (9295 tests) passes
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] `cargo run --example styling_showcase --features full` — verify right panel wraps long text

🤖 Generated with [Claude Code](https://claude.com/claude-code)