### PR TITLE
Standardize keyboard shortcuts across demo examples

### DIFF
--- a/examples/chat_markdown_demo.rs
+++ b/examples/chat_markdown_demo.rs
@@ -7,10 +7,10 @@
 //! Controls:
 //!   Enter       Submit message (rendered as markdown if enabled)
 //!   Ctrl+M      Toggle markdown rendering on/off
-//!   T           Cycle through themes
-//!   Up/Down     Scroll chat history (when not typing)
+//!   Ctrl+T      Cycle through themes
+//!   PgUp/PgDn   Scroll chat history
 //!   Ctrl+U      Clear input line
-//!   q (Ctrl+Q)  Quit (Esc also quits)
+//!   Esc         Quit
 //!
 //! Run with: cargo run --example chat_markdown_demo --features "compound-components,markdown"
 
@@ -151,11 +151,12 @@ impl Default for State {
         chat.push_assistant_with_timestamp(
             "Exactly! You can mix formatting freely. Try typing a message below \
              with markdown syntax. Toggle markdown with **Ctrl+M** to see the difference.\n\n\
-             Press **T** to cycle through themes and see how role styles change.",
+             Press **Ctrl+T** to cycle through themes and see how role styles change.",
             "09:04",
         );
 
-        let input = LineInputState::new().with_placeholder("Type a markdown message...");
+        let mut input = LineInputState::new().with_placeholder("Type a markdown message...");
+        input.set_focused(true);
 
         Self {
             active_theme: ActiveTheme::default(),
@@ -301,9 +302,9 @@ impl App for ChatMarkdownApp {
             Span::raw(" Send  "),
             Span::styled("[Ctrl+M]", theme.info_style()),
             Span::raw(" Toggle MD  "),
-            Span::styled("[T]", theme.info_style()),
+            Span::styled("[Ctrl+T]", theme.info_style()),
             Span::raw(" Theme  "),
-            Span::styled("[Up/Dn]", theme.info_style()),
+            Span::styled("[PgUp/Dn]", theme.info_style()),
             Span::raw(" Scroll  "),
             Span::styled("[Esc]", theme.error_style()),
             Span::raw(" Quit"),

--- a/examples/dashboard_demo.rs
+++ b/examples/dashboard_demo.rs
@@ -5,14 +5,14 @@
 //! and notifications.
 //!
 //! Controls:
-//!   T           Cycle through themes
+//!   Ctrl+T      Cycle through themes
 //!   Space       Start/restart simulated build tasks
 //!   1           Add info toast
 //!   2           Add success toast
 //!   3           Add warning toast
 //!   4           Add error toast
 //!   Up/Down     Scroll status log
-//!   q/Esc       Quit
+//!   Esc         Quit
 //!
 //! Run with: cargo run --example dashboard_demo --features full
 
@@ -365,11 +365,11 @@ impl App for DashboardApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
+            if key.code == KeyCode::Char('t') && key.modifiers.contains(KeyModifiers::CONTROL) {
+                return Some(Msg::CycleTheme);
+            }
             match key.code {
-                KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => {
-                    return Some(Msg::Quit);
-                }
-                KeyCode::Char('t') | KeyCode::Char('T') => return Some(Msg::CycleTheme),
+                KeyCode::Char('q') | KeyCode::Esc => return Some(Msg::Quit),
                 KeyCode::Char(' ') => return Some(Msg::StartBuild),
                 KeyCode::Char('1') => return Some(Msg::AddToast(ToastLevel::Info)),
                 KeyCode::Char('2') => return Some(Msg::AddToast(ToastLevel::Success)),
@@ -461,7 +461,7 @@ fn render_header(state: &State, frame: &mut Frame, area: Rect, theme: &Theme) {
 
 fn render_key_hints(frame: &mut Frame, area: Rect, theme: &Theme) {
     let hints = Paragraph::new(Line::from(vec![
-        Span::styled("[T]", theme.info_style()),
+        Span::styled("[Ctrl+T]", theme.info_style()),
         Span::raw(" Theme  "),
         Span::styled("[Space]", theme.info_style()),
         Span::raw(" Build  "),
@@ -469,7 +469,7 @@ fn render_key_hints(frame: &mut Frame, area: Rect, theme: &Theme) {
         Span::raw(" Toasts  "),
         Span::styled("[Up/Dn]", theme.info_style()),
         Span::raw(" Scroll  "),
-        Span::styled("[q]", theme.error_style()),
+        Span::styled("[Esc]", theme.error_style()),
         Span::raw(" Quit"),
     ]))
     .alignment(Alignment::Center)

--- a/examples/styling_showcase.rs
+++ b/examples/styling_showcase.rs
@@ -4,7 +4,7 @@
 //! letting you switch between all 6 built-in themes to see how each one renders.
 //!
 //! Controls:
-//!   T           Cycle through themes (Default → Nord → Dracula → Solarized → Gruvbox → Catppuccin)
+//!   Ctrl+T      Cycle through themes (Default → Nord → Dracula → Solarized → Gruvbox → Catppuccin)
 //!   Tab         Switch between Style Palette and Rich Text panels
 //!   Up/k        Scroll up (in Rich Text panel)
 //!   Down/j      Scroll down (in Rich Text panel)
@@ -12,7 +12,7 @@
 //!   Page Down   Scroll down one page
 //!   Home        Jump to top
 //!   End         Jump to bottom
-//!   q/Esc       Quit
+//!   Esc         Quit
 //!
 //! Run with: cargo run --example styling_showcase --features full
 
@@ -313,9 +313,11 @@ impl App for StylingShowcaseApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
+            if key.code == KeyCode::Char('t') && key.modifiers.contains(KeyModifiers::CONTROL) {
+                return Some(Msg::CycleTheme);
+            }
             match key.code {
-                KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => return Some(Msg::Quit),
-                KeyCode::Char('t') | KeyCode::Char('T') => return Some(Msg::CycleTheme),
+                KeyCode::Char('q') | KeyCode::Esc => return Some(Msg::Quit),
                 KeyCode::Tab => return Some(Msg::TogglePanel),
                 _ => {}
             }
@@ -467,7 +469,7 @@ fn render_style_palette(_state: &State, frame: &mut Frame, area: Rect, theme: &T
 
 fn render_footer(frame: &mut Frame, area: Rect, theme: &Theme) {
     let footer = Paragraph::new(Line::from(vec![
-        Span::styled("[T]", theme.info_style()),
+        Span::styled("[Ctrl+T]", theme.info_style()),
         Span::styled(" Theme  ", theme.normal_style()),
         Span::styled("[Tab]", theme.info_style()),
         Span::styled(" Panel  ", theme.normal_style()),
@@ -475,7 +477,7 @@ fn render_footer(frame: &mut Frame, area: Rect, theme: &Theme) {
         Span::styled(" Scroll  ", theme.normal_style()),
         Span::styled("[PgUp/PgDn]", theme.info_style()),
         Span::styled(" Page  ", theme.normal_style()),
-        Span::styled("[q]", theme.error_style()),
+        Span::styled("[Esc]", theme.error_style()),
         Span::styled(" Quit", theme.normal_style()),
     ]))
     .alignment(Alignment::Center)


### PR DESCRIPTION
## Summary

- Standardize shortcuts across all three demo examples:
  - **Ctrl+T** — cycle theme (all three)
  - **Esc** — quit (all three; `q` also silently accepted in non-text-input apps)
- Fix chat_markdown_demo: LineInput was never focused, causing all keystrokes to be silently dropped
- Fix status bar hints to match actual key bindings in all three demos

Supersedes #239.

## Test plan

- [ ] `cargo run --example styling_showcase --features full` — Ctrl+T cycles themes, Esc quits
- [ ] `cargo run --example chat_markdown_demo --features "compound-components,markdown"` — typing works, Ctrl+T cycles themes, Ctrl+M toggles markdown, Esc quits
- [ ] `cargo run --example dashboard_demo --features full` — Ctrl+T cycles themes, Esc quits

🤖 Generated with [Claude Code](https://claude.com/claude-code)