### PR TITLE
Fix chat demo role styles so markdown bold is visible

### DIFF
--- a/examples/chat_markdown_demo.rs
+++ b/examples/chat_markdown_demo.rs
@@ -83,18 +83,11 @@ struct State {
 }
 
 fn apply_role_styles(chat: &mut ChatViewState, theme: &Theme) {
-    chat.set_role_style(
-        ChatRole::User,
-        Style::default()
-            .fg(theme.primary)
-            .add_modifier(Modifier::BOLD),
-    );
-    chat.set_role_style(
-        ChatRole::Assistant,
-        Style::default()
-            .fg(theme.success)
-            .add_modifier(Modifier::BOLD),
-    );
+    // Role styles set the base content style. The header (username) line
+    // automatically adds BOLD on top, so don't include BOLD here — otherwise
+    // markdown **bold** text becomes indistinguishable from plain text.
+    chat.set_role_style(ChatRole::User, Style::default().fg(theme.primary));
+    chat.set_role_style(ChatRole::Assistant, Style::default().fg(theme.success));
     chat.set_role_style(
         ChatRole::System,
         Style::default()


### PR DESCRIPTION
## Summary

- Remove `BOLD` modifier from User and Assistant role styles in the chat markdown demo
- The role style sets the base content style for message text. The header (username) line adds `BOLD` separately. With `BOLD` already on the base style, markdown `**bold**` was visually identical to plain text — no way to tell bold from non-bold.

## Test plan

- [ ] `cargo run --example chat_markdown_demo --features "compound-components,markdown"` — type `**Hello** how are you doing?` and verify "Hello" appears bold while the rest does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)