### PR TITLE
Use foreground color for assistant role in chat demo

### DIFF
--- a/examples/chat_markdown_demo.rs
+++ b/examples/chat_markdown_demo.rs
@@ -87,7 +87,7 @@ fn apply_role_styles(chat: &mut ChatViewState, theme: &Theme) {
     // automatically adds BOLD on top, so don't include BOLD here — otherwise
     // markdown **bold** text becomes indistinguishable from plain text.
     chat.set_role_style(ChatRole::User, Style::default().fg(theme.primary));
-    chat.set_role_style(ChatRole::Assistant, Style::default().fg(theme.success));
+    chat.set_role_style(ChatRole::Assistant, Style::default().fg(theme.foreground));
     chat.set_role_style(
         ChatRole::System,
         Style::default()


### PR DESCRIPTION
## Summary

- Change assistant role style from `theme.success` (green) to `theme.foreground` (white) for cleaner contrast against the primary-colored user messages

## Test plan

- [ ] `cargo run --example chat_markdown_demo --features "compound-components,markdown"` — assistant messages render in white/foreground color

🤖 Generated with [Claude Code](https://claude.com/claude-code)