### PR TITLE
Convert all 14 ignored doc tests to runnable or compile-checked

### DIFF
--- a/src/app/model/mod.rs
+++ b/src/app/model/mod.rs
@@ -11,8 +11,22 @@
 //! These call [`App::init()`] internally to create the initial state and
 //! any startup commands.
 //!
-//! ```rust,ignore
+//! ```rust
+//! # use envision::prelude::*;
+//! # struct MyApp;
+//! # #[derive(Default, Clone)]
+//! # struct MyState;
+//! # #[derive(Clone)]
+//! # enum MyMsg {}
+//! # impl App for MyApp {
+//! #     type State = MyState;
+//! #     type Message = MyMsg;
+//! #     fn init() -> (MyState, Command<MyMsg>) { (MyState, Command::none()) }
+//! #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+//! #     fn view(state: &MyState, frame: &mut Frame) {}
+//! # }
 //! let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+//! # Ok::<(), envision::EnvisionError>(())
 //! ```
 //!
 //! ## External state pattern — `init()` is bypassed
@@ -23,11 +37,25 @@
 //! called**. This is useful when initial state comes from external sources
 //! such as CLI arguments, config files, or databases.
 //!
-//! ```rust,ignore
-//! let state = MyState::from_config("config.toml")?;
+//! ```rust
+//! # use envision::prelude::*;
+//! # struct MyApp;
+//! # #[derive(Default, Clone)]
+//! # struct MyState;
+//! # #[derive(Clone)]
+//! # enum MyMsg {}
+//! # impl App for MyApp {
+//! #     type State = MyState;
+//! #     type Message = MyMsg;
+//! #     fn init() -> (MyState, Command<MyMsg>) { (MyState, Command::none()) }
+//! #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+//! #     fn view(state: &MyState, frame: &mut Frame) {}
+//! # }
+//! let state = MyState::default();
 //! let mut vt = Runtime::<MyApp, _>::virtual_terminal_with_state(
 //!     80, 24, state, Command::none(),
 //! )?;
+//! # Ok::<(), envision::EnvisionError>(())
 //! ```
 //!
 //! When using `with_state` constructors, `App::init()` does **not** need to

--- a/src/app/runtime/config.rs
+++ b/src/app/runtime/config.rs
@@ -128,7 +128,7 @@ impl RuntimeConfig {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust
     /// use std::sync::Arc;
     /// use envision::RuntimeConfig;
     ///
@@ -152,7 +152,7 @@ impl RuntimeConfig {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust
     /// use std::sync::Arc;
     /// use envision::RuntimeConfig;
     ///
@@ -175,7 +175,7 @@ impl RuntimeConfig {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust
     /// use envision::RuntimeConfig;
     ///
     /// let config = RuntimeConfig::new()
@@ -207,7 +207,7 @@ impl RuntimeConfig {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust
     /// use envision::RuntimeConfig;
     ///
     /// let config = RuntimeConfig::new()

--- a/src/app/runtime/mod.rs
+++ b/src/app/runtime/mod.rs
@@ -12,11 +12,23 @@
 //!
 //! For running applications in a real terminal:
 //!
-//! ```rust,ignore
-//! // requires real terminal
+//! ```rust,no_run
+//! # use envision::prelude::*;
+//! # struct MyApp;
+//! # #[derive(Default, Clone)]
+//! # struct MyState;
+//! # #[derive(Clone)]
+//! # enum MyMsg {}
+//! # impl App for MyApp {
+//! #     type State = MyState;
+//! #     type Message = MyMsg;
+//! #     fn init() -> (MyState, Command<MyMsg>) { (MyState, Command::none()) }
+//! #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+//! #     fn view(state: &MyState, frame: &mut Frame) {}
+//! # }
 //! #[tokio::main]
 //! async fn main() -> envision::Result<()> {
-//!     let _final_state = Runtime::<MyApp>::new_terminal()?.run_terminal().await?;
+//!     let _final_state = Runtime::<MyApp, _>::new_terminal()?.run_terminal().await?;
 //!     Ok(())
 //! }
 //! ```
@@ -115,9 +127,23 @@ pub struct Runtime<A: App, B: Backend> {
 ///
 /// # Example
 ///
-/// ```rust,ignore
-/// // requires real terminal
+/// ```rust,no_run
+/// # use envision::prelude::*;
+/// # use envision::TerminalRuntime;
+/// # struct MyApp;
+/// # #[derive(Default, Clone)]
+/// # struct MyState;
+/// # #[derive(Clone)]
+/// # enum MyMsg {}
+/// # impl App for MyApp {
+/// #     type State = MyState;
+/// #     type Message = MyMsg;
+/// #     fn init() -> (MyState, Command<MyMsg>) { (MyState, Command::none()) }
+/// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+/// #     fn view(state: &MyState, frame: &mut Frame) {}
+/// # }
 /// let runtime: TerminalRuntime<MyApp> = Runtime::new_terminal()?;
+/// # Ok::<(), envision::EnvisionError>(())
 /// ```
 pub type TerminalRuntime<A> = Runtime<A, CrosstermBackend<Stdout>>;
 

--- a/src/app/runtime/terminal.rs
+++ b/src/app/runtime/terminal.rs
@@ -44,11 +44,23 @@ impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
-    /// // requires real terminal
+    /// ```rust,no_run
+    /// # use envision::prelude::*;
+    /// # struct MyApp;
+    /// # #[derive(Default, Clone)]
+    /// # struct MyState;
+    /// # #[derive(Clone)]
+    /// # enum MyMsg {}
+    /// # impl App for MyApp {
+    /// #     type State = MyState;
+    /// #     type Message = MyMsg;
+    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState, Command::none()) }
+    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+    /// #     fn view(state: &MyState, frame: &mut Frame) {}
+    /// # }
     /// #[tokio::main]
     /// async fn main() -> envision::Result<()> {
-    ///     let _final_state = Runtime::<MyApp>::new_terminal()?.run_terminal().await?;
+    ///     let _final_state = Runtime::<MyApp, _>::new_terminal()?.run_terminal().await?;
     ///     Ok(())
     /// }
     /// ```
@@ -81,11 +93,27 @@ impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
-    /// // requires real terminal
-    /// let state = MyState::from_config("config.toml")?;
-    /// let runtime = Runtime::<MyApp>::new_terminal_with_state(state, Command::none())?;
+    /// ```rust,no_run
+    /// # use envision::prelude::*;
+    /// # struct MyApp;
+    /// # #[derive(Default, Clone)]
+    /// # struct MyState;
+    /// # #[derive(Clone)]
+    /// # enum MyMsg {}
+    /// # impl App for MyApp {
+    /// #     type State = MyState;
+    /// #     type Message = MyMsg;
+    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState, Command::none()) }
+    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+    /// #     fn view(state: &MyState, frame: &mut Frame) {}
+    /// # }
+    /// # #[tokio::main]
+    /// # async fn main() -> envision::Result<()> {
+    /// let state = MyState::default();
+    /// let runtime = Runtime::<MyApp, _>::new_terminal_with_state(state, Command::none())?;
     /// runtime.run_terminal().await?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn new_terminal_with_state(
         state: A::State,
@@ -128,11 +156,23 @@ impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
-    /// // requires real terminal
+    /// ```rust,no_run
+    /// # use envision::prelude::*;
+    /// # struct MyApp;
+    /// # #[derive(Default, Clone)]
+    /// # struct MyState { count: u32 }
+    /// # #[derive(Clone)]
+    /// # enum MyMsg {}
+    /// # impl App for MyApp {
+    /// #     type State = MyState;
+    /// #     type Message = MyMsg;
+    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState { count: 0 }, Command::none()) }
+    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+    /// #     fn view(state: &MyState, frame: &mut Frame) {}
+    /// # }
     /// #[tokio::main]
     /// async fn main() -> envision::Result<()> {
-    ///     let final_state = Runtime::<MyApp>::new_terminal()?.run_terminal().await?;
+    ///     let final_state = Runtime::<MyApp, _>::new_terminal()?.run_terminal().await?;
     ///     println!("Final count: {}", final_state.count);
     ///     Ok(())
     /// }
@@ -265,10 +305,22 @@ impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
-    /// // requires real terminal
+    /// ```rust,no_run
+    /// # use envision::prelude::*;
+    /// # struct MyApp;
+    /// # #[derive(Default, Clone)]
+    /// # struct MyState { count: u32 }
+    /// # #[derive(Clone)]
+    /// # enum MyMsg {}
+    /// # impl App for MyApp {
+    /// #     type State = MyState;
+    /// #     type Message = MyMsg;
+    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState { count: 0 }, Command::none()) }
+    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+    /// #     fn view(state: &MyState, frame: &mut Frame) {}
+    /// # }
     /// fn main() -> envision::Result<()> {
-    ///     let final_state = Runtime::<MyApp>::new_terminal()?.run_terminal_blocking()?;
+    ///     let final_state = Runtime::<MyApp, _>::new_terminal()?.run_terminal_blocking()?;
     ///     println!("Final count: {}", final_state.count);
     ///     Ok(())
     /// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,21 +11,45 @@
 //!
 //! ### Terminal Mode - For Interactive Use
 //!
-//! ```rust,ignore
-//! // requires real terminal
+//! ```rust,no_run
+//! # use envision::prelude::*;
+//! # struct MyApp;
+//! # #[derive(Default, Clone)]
+//! # struct MyState;
+//! # #[derive(Clone)]
+//! # enum MyMsg {}
+//! # impl App for MyApp {
+//! #     type State = MyState;
+//! #     type Message = MyMsg;
+//! #     fn init() -> (MyState, Command<MyMsg>) { (MyState, Command::none()) }
+//! #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+//! #     fn view(state: &MyState, frame: &mut Frame) {}
+//! # }
 //! #[tokio::main]
 //! async fn main() -> envision::Result<()> {
-//!     let _final_state = Runtime::<MyApp>::new_terminal()?.run_terminal().await?;
+//!     let _final_state = Runtime::<MyApp, _>::new_terminal()?.run_terminal().await?;
 //!     Ok(())
 //! }
 //! ```
 //!
 //! Or without your own tokio runtime:
 //!
-//! ```rust,ignore
-//! // requires real terminal
+//! ```rust,no_run
+//! # use envision::prelude::*;
+//! # struct MyApp;
+//! # #[derive(Default, Clone)]
+//! # struct MyState;
+//! # #[derive(Clone)]
+//! # enum MyMsg {}
+//! # impl App for MyApp {
+//! #     type State = MyState;
+//! #     type Message = MyMsg;
+//! #     fn init() -> (MyState, Command<MyMsg>) { (MyState, Command::none()) }
+//! #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
+//! #     fn view(state: &MyState, frame: &mut Frame) {}
+//! # }
 //! fn main() -> envision::Result<()> {
-//!     let _final_state = Runtime::<MyApp>::new_terminal()?.run_terminal_blocking()?;
+//!     let _final_state = Runtime::<MyApp, _>::new_terminal()?.run_terminal_blocking()?;
 //!     Ok(())
 //! }
 //! ```


### PR DESCRIPTION
## Summary

- **4 RuntimeConfig doc tests** (`on_setup`, `on_teardown`, `on_setup_once`, `on_teardown_once`): `ignore` → fully runnable. These only construct a `RuntimeConfig` and don't need a real terminal.
- **2 model/mod.rs doc tests**: `ignore` → fully runnable using `virtual_terminal` instead of requiring a real terminal.
- **8 terminal-dependent doc tests** (lib.rs, runtime/mod.rs, terminal.rs): `ignore` → `no_run` with proper `MyApp` boilerplate so they compile-check on every test run but don't execute.
- Fixed turbofish syntax: `Runtime::<MyApp>` → `Runtime::<MyApp, _>` to satisfy Rust's requirement to specify all generic parameters.

**Result**: 823 doc tests pass, 0 ignored (was 809 passed, 14 ignored).

## Test plan

- [x] `cargo test --all-features --doc` — 823 passed, 0 failed, 0 ignored
- [x] `cargo test --all-features --lib` — 4179 passed
- [x] `cargo clippy --all-features` — 0 warnings
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)