### PR TITLE
Add ScrollState virtual scrolling infrastructure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,7 @@ pub mod harness;
 pub mod input;
 pub mod layout;
 pub mod overlay;
+pub mod scroll;
 pub mod style;
 pub mod theme;
 #[cfg(feature = "input-components")]
@@ -222,6 +223,7 @@ pub use error::{BoxedError, EnvisionError, Result};
 pub use harness::{AppHarness, Assertion, Snapshot, TestHarness};
 pub use input::{Event, EventQueue};
 pub use overlay::{Overlay, OverlayAction, OverlayStack};
+pub use scroll::{render_scrollbar, render_scrollbar_inside_border, ScrollState};
 pub use theme::Theme;
 
 /// Prelude module for convenient imports.
@@ -253,6 +255,9 @@ pub mod prelude {
 
     // Theme
     pub use crate::theme::Theme;
+
+    // Scroll infrastructure
+    pub use crate::scroll::ScrollState;
 
     // All component types (the primary user-facing API)
     pub use crate::component::*;

--- a/src/scroll/mod.rs
+++ b/src/scroll/mod.rs
@@ -1,0 +1,410 @@
+//! Virtual scrolling infrastructure for TUI components.
+//!
+//! The [`ScrollState`] struct provides composable scroll offset tracking,
+//! visible range calculation, and scrollbar rendering support. Components
+//! embed a `ScrollState` in their state to gain virtual scrolling — rendering
+//! only the visible portion of their content instead of allocating items for
+//! every row.
+//!
+//! # Two Scrolling Patterns
+//!
+//! ## Offset-based scrolling
+//!
+//! For components like log viewers and text displays where the user scrolls
+//! through content without a selection cursor:
+//!
+//! ```rust
+//! use envision::scroll::ScrollState;
+//!
+//! let mut scroll = ScrollState::new(1000); // 1000 total lines
+//! scroll.set_viewport_height(24);          // terminal is 24 lines tall
+//!
+//! // User presses Page Down
+//! scroll.page_down(scroll.viewport_height());
+//!
+//! // Render only the visible range
+//! let range = scroll.visible_range();
+//! assert_eq!(range, 24..48);
+//! ```
+//!
+//! ## Selection-based scrolling
+//!
+//! For components like lists and tables where a selected item should always
+//! remain visible:
+//!
+//! ```rust
+//! use envision::scroll::ScrollState;
+//!
+//! let mut scroll = ScrollState::new(100); // 100 items
+//! scroll.set_viewport_height(10);         // 10 visible at a time
+//!
+//! // User moves selection to item 15
+//! scroll.ensure_visible(15);
+//!
+//! // Viewport scrolled to keep item 15 in view
+//! let range = scroll.visible_range();
+//! assert!(range.contains(&15));
+//! ```
+
+#[cfg(test)]
+mod tests;
+
+use std::ops::Range;
+
+use ratatui::layout::Rect;
+use ratatui::widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState};
+use ratatui::Frame;
+
+use crate::theme::Theme;
+
+/// Tracks scroll position for virtual scrolling in TUI components.
+///
+/// `ScrollState` is a composable building block that any component can
+/// embed in its state to gain scroll offset tracking, visible range
+/// calculation, and scrollbar rendering support.
+///
+/// It supports two usage patterns:
+/// - **Offset mode**: The scroll offset is controlled directly via
+///   [`scroll_up`](Self::scroll_up), [`scroll_down`](Self::scroll_down), etc.
+///   Used by LogViewer, ChatView, ScrollableText.
+/// - **Selection mode**: The scroll offset follows a selected index via
+///   [`ensure_visible`](Self::ensure_visible), keeping it within the viewport.
+///   Used by SelectableList, Table, DataGrid, etc.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::scroll::ScrollState;
+///
+/// let mut scroll = ScrollState::new(500);
+/// scroll.set_viewport_height(20);
+///
+/// assert_eq!(scroll.offset(), 0);
+/// assert!(scroll.can_scroll());
+/// assert!(scroll.at_start());
+///
+/// scroll.scroll_down();
+/// assert_eq!(scroll.offset(), 1);
+///
+/// scroll.scroll_to_end();
+/// assert_eq!(scroll.offset(), 480); // 500 - 20
+/// ```
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct ScrollState {
+    /// The scroll offset (index of the first visible item).
+    offset: usize,
+    /// Total number of scrollable items or lines.
+    content_length: usize,
+    /// Number of items visible in the viewport.
+    viewport_height: usize,
+}
+
+impl ScrollState {
+    /// Creates a new `ScrollState` with the given content length.
+    ///
+    /// The scroll offset starts at 0 and viewport height defaults to 0
+    /// (set it in `view()` once the render area is known).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::scroll::ScrollState;
+    ///
+    /// let scroll = ScrollState::new(100);
+    /// assert_eq!(scroll.content_length(), 100);
+    /// assert_eq!(scroll.offset(), 0);
+    /// ```
+    pub fn new(content_length: usize) -> Self {
+        Self {
+            offset: 0,
+            content_length,
+            viewport_height: 0,
+        }
+    }
+
+    // =========================================================================
+    // Setters
+    // =========================================================================
+
+    /// Sets the total number of scrollable items or lines.
+    ///
+    /// If the current offset exceeds the new maximum, it is clamped.
+    pub fn set_content_length(&mut self, len: usize) {
+        self.content_length = len;
+        self.clamp_offset();
+    }
+
+    /// Sets the viewport height (number of visible items).
+    ///
+    /// Typically called in `view()` after computing the inner render area.
+    /// If the current offset exceeds the new maximum, it is clamped.
+    pub fn set_viewport_height(&mut self, height: usize) {
+        self.viewport_height = height;
+        self.clamp_offset();
+    }
+
+    /// Sets the scroll offset directly, clamped to the valid range.
+    pub fn set_offset(&mut self, offset: usize) {
+        self.offset = offset;
+        self.clamp_offset();
+    }
+
+    // =========================================================================
+    // Scroll operations
+    // =========================================================================
+
+    /// Scrolls up by one item. Returns `true` if the offset changed.
+    pub fn scroll_up(&mut self) -> bool {
+        self.scroll_up_by(1)
+    }
+
+    /// Scrolls down by one item. Returns `true` if the offset changed.
+    pub fn scroll_down(&mut self) -> bool {
+        self.scroll_down_by(1)
+    }
+
+    /// Scrolls up by `n` items. Returns `true` if the offset changed.
+    pub fn scroll_up_by(&mut self, n: usize) -> bool {
+        let old = self.offset;
+        self.offset = self.offset.saturating_sub(n);
+        self.offset != old
+    }
+
+    /// Scrolls down by `n` items. Returns `true` if the offset changed.
+    pub fn scroll_down_by(&mut self, n: usize) -> bool {
+        let old = self.offset;
+        self.offset = self.offset.saturating_add(n);
+        self.clamp_offset();
+        self.offset != old
+    }
+
+    /// Scrolls up by one page (viewport height). Returns `true` if the offset changed.
+    pub fn page_up(&mut self, page_size: usize) -> bool {
+        self.scroll_up_by(page_size)
+    }
+
+    /// Scrolls down by one page (viewport height). Returns `true` if the offset changed.
+    pub fn page_down(&mut self, page_size: usize) -> bool {
+        self.scroll_down_by(page_size)
+    }
+
+    /// Scrolls to the first item. Returns `true` if the offset changed.
+    pub fn scroll_to_start(&mut self) -> bool {
+        let old = self.offset;
+        self.offset = 0;
+        self.offset != old
+    }
+
+    /// Scrolls to the last page. Returns `true` if the offset changed.
+    pub fn scroll_to_end(&mut self) -> bool {
+        let old = self.offset;
+        self.offset = self.max_offset();
+        self.offset != old
+    }
+
+    // =========================================================================
+    // Selection tracking
+    // =========================================================================
+
+    /// Adjusts the scroll offset to ensure the given index is visible.
+    ///
+    /// If the index is above the viewport, scrolls up. If below, scrolls
+    /// down. If already visible, does nothing. Returns `true` if the
+    /// offset changed.
+    ///
+    /// This is the key method for selection-based components: after
+    /// changing the selected index, call this to keep the selection
+    /// in view.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::scroll::ScrollState;
+    ///
+    /// let mut scroll = ScrollState::new(100);
+    /// scroll.set_viewport_height(10);
+    ///
+    /// // Selection at item 25 — scrolls viewport to show it
+    /// assert!(scroll.ensure_visible(25));
+    /// assert_eq!(scroll.offset(), 16); // 25 - 10 + 1
+    ///
+    /// // Selection at item 20 — already visible, no change
+    /// assert!(!scroll.ensure_visible(20));
+    /// ```
+    pub fn ensure_visible(&mut self, index: usize) -> bool {
+        let old = self.offset;
+
+        if self.viewport_height == 0 {
+            return false;
+        }
+
+        if index < self.offset {
+            // Index is above the viewport — scroll up
+            self.offset = index;
+        } else if index >= self.offset + self.viewport_height {
+            // Index is below the viewport — scroll down
+            self.offset = index.saturating_sub(self.viewport_height.saturating_sub(1));
+        }
+
+        self.clamp_offset();
+        self.offset != old
+    }
+
+    // =========================================================================
+    // Queries
+    // =========================================================================
+
+    /// Returns the current scroll offset (index of the first visible item).
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Returns the total content length.
+    pub fn content_length(&self) -> usize {
+        self.content_length
+    }
+
+    /// Returns the viewport height.
+    pub fn viewport_height(&self) -> usize {
+        self.viewport_height
+    }
+
+    /// Returns the range of visible item indices.
+    ///
+    /// The range is `offset..min(offset + viewport_height, content_length)`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::scroll::ScrollState;
+    ///
+    /// let mut scroll = ScrollState::new(50);
+    /// scroll.set_viewport_height(10);
+    /// assert_eq!(scroll.visible_range(), 0..10);
+    ///
+    /// scroll.scroll_to_end();
+    /// assert_eq!(scroll.visible_range(), 40..50);
+    /// ```
+    pub fn visible_range(&self) -> Range<usize> {
+        let end = (self.offset + self.viewport_height).min(self.content_length);
+        self.offset..end
+    }
+
+    /// Returns the maximum valid scroll offset.
+    ///
+    /// This is `content_length.saturating_sub(viewport_height)`.
+    pub fn max_offset(&self) -> usize {
+        self.content_length.saturating_sub(self.viewport_height)
+    }
+
+    /// Returns `true` if scrolling is possible (content exceeds viewport).
+    pub fn can_scroll(&self) -> bool {
+        self.content_length > self.viewport_height
+    }
+
+    /// Returns `true` if at the top (offset is 0).
+    pub fn at_start(&self) -> bool {
+        self.offset == 0
+    }
+
+    /// Returns `true` if at the bottom (offset is at max).
+    pub fn at_end(&self) -> bool {
+        self.offset >= self.max_offset()
+    }
+
+    // =========================================================================
+    // Scrollbar integration
+    // =========================================================================
+
+    /// Creates a ratatui [`ScrollbarState`] configured for this scroll state.
+    ///
+    /// Use this with ratatui's [`Scrollbar`] widget for visual scroll
+    /// indicators.
+    pub fn scrollbar_state(&self) -> ScrollbarState {
+        ScrollbarState::default()
+            .content_length(self.content_length.saturating_sub(self.viewport_height))
+            .viewport_content_length(self.viewport_height)
+            .position(self.offset)
+    }
+
+    // =========================================================================
+    // Internal
+    // =========================================================================
+
+    /// Clamps the offset to the valid range `0..=max_offset`.
+    fn clamp_offset(&mut self) {
+        let max = self.max_offset();
+        if self.offset > max {
+            self.offset = max;
+        }
+    }
+}
+
+/// Renders a vertical scrollbar on the right edge of the given area.
+///
+/// Only renders if the content exceeds the viewport height. Uses the
+/// theme's border color for the scrollbar track and foreground color
+/// for the thumb.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # use envision::prelude::*;
+/// # use envision::scroll::{ScrollState, render_scrollbar};
+/// # let scroll = ScrollState::new(100);
+/// # let theme = Theme::default();
+/// # let area = Rect::new(0, 0, 80, 24);
+/// # let mut terminal = Terminal::new(
+/// #     envision::CaptureBackend::new(80, 24)
+/// # ).unwrap();
+/// # terminal.draw(|frame| {
+/// render_scrollbar(&scroll, frame, area, &theme);
+/// # }).unwrap();
+/// ```
+pub fn render_scrollbar(scroll: &ScrollState, frame: &mut Frame, area: Rect, theme: &Theme) {
+    if !scroll.can_scroll() {
+        return;
+    }
+
+    let mut scrollbar_state = scroll.scrollbar_state();
+    let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+        .thumb_style(theme.normal_style())
+        .track_style(theme.disabled_style());
+    frame.render_stateful_widget(scrollbar, area, &mut scrollbar_state);
+}
+
+/// Renders a vertical scrollbar inside a bordered area.
+///
+/// This accounts for the 1-cell border on each side, positioning the
+/// scrollbar within the inner area. This is the common case for
+/// components that use `Block::default().borders(Borders::ALL)`.
+///
+/// Only renders if the content exceeds the viewport height.
+pub fn render_scrollbar_inside_border(
+    scroll: &ScrollState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+) {
+    if !scroll.can_scroll() || area.height < 3 {
+        return;
+    }
+
+    // Inset by 1 on top and bottom for borders
+    let inner = Rect::new(
+        area.x,
+        area.y + 1,
+        area.width,
+        area.height.saturating_sub(2),
+    );
+
+    let mut scrollbar_state = scroll.scrollbar_state();
+    let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+        .thumb_style(theme.normal_style())
+        .track_style(theme.disabled_style());
+    frame.render_stateful_widget(scrollbar, inner, &mut scrollbar_state);
+}

--- a/src/scroll/tests.rs
+++ b/src/scroll/tests.rs
@@ -1,0 +1,651 @@
+use ratatui::Terminal;
+
+use super::*;
+use crate::backend::CaptureBackend;
+
+fn setup_render(width: u16, height: u16) -> Terminal<CaptureBackend> {
+    let backend = CaptureBackend::new(width, height);
+    Terminal::new(backend).unwrap()
+}
+
+// =============================================================================
+// Construction and defaults
+// =============================================================================
+
+#[test]
+fn test_default() {
+    let scroll = ScrollState::default();
+    assert_eq!(scroll.offset(), 0);
+    assert_eq!(scroll.content_length(), 0);
+    assert_eq!(scroll.viewport_height(), 0);
+}
+
+#[test]
+fn test_new() {
+    let scroll = ScrollState::new(100);
+    assert_eq!(scroll.offset(), 0);
+    assert_eq!(scroll.content_length(), 100);
+    assert_eq!(scroll.viewport_height(), 0);
+}
+
+#[test]
+fn test_new_zero_content() {
+    let scroll = ScrollState::new(0);
+    assert_eq!(scroll.content_length(), 0);
+    assert!(!scroll.can_scroll());
+}
+
+// =============================================================================
+// Setters
+// =============================================================================
+
+#[test]
+fn test_set_content_length() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.set_content_length(200);
+    assert_eq!(scroll.content_length(), 200);
+}
+
+#[test]
+fn test_set_content_length_clamps_offset() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.scroll_to_end();
+    assert_eq!(scroll.offset(), 90);
+
+    // Shrink content — offset should clamp
+    scroll.set_content_length(50);
+    assert_eq!(scroll.offset(), 40); // 50 - 10
+}
+
+#[test]
+fn test_set_content_length_to_less_than_viewport() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.set_offset(50);
+
+    scroll.set_content_length(5);
+    assert_eq!(scroll.offset(), 0); // content < viewport, offset must be 0
+}
+
+#[test]
+fn test_set_viewport_height() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(20);
+    assert_eq!(scroll.viewport_height(), 20);
+}
+
+#[test]
+fn test_set_viewport_height_clamps_offset() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.scroll_to_end();
+    assert_eq!(scroll.offset(), 90);
+
+    // Increase viewport — offset should clamp
+    scroll.set_viewport_height(50);
+    assert_eq!(scroll.offset(), 50); // 100 - 50
+}
+
+#[test]
+fn test_set_offset() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.set_offset(25);
+    assert_eq!(scroll.offset(), 25);
+}
+
+#[test]
+fn test_set_offset_clamped() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.set_offset(999);
+    assert_eq!(scroll.offset(), 90); // max_offset
+}
+
+// =============================================================================
+// Scroll operations
+// =============================================================================
+
+#[test]
+fn test_scroll_up() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.set_offset(5);
+
+    assert!(scroll.scroll_up());
+    assert_eq!(scroll.offset(), 4);
+}
+
+#[test]
+fn test_scroll_up_at_start() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+
+    assert!(!scroll.scroll_up());
+    assert_eq!(scroll.offset(), 0);
+}
+
+#[test]
+fn test_scroll_down() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+
+    assert!(scroll.scroll_down());
+    assert_eq!(scroll.offset(), 1);
+}
+
+#[test]
+fn test_scroll_down_at_end() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.scroll_to_end();
+
+    assert!(!scroll.scroll_down());
+    assert_eq!(scroll.offset(), 90);
+}
+
+#[test]
+fn test_scroll_up_by() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.set_offset(20);
+
+    assert!(scroll.scroll_up_by(5));
+    assert_eq!(scroll.offset(), 15);
+}
+
+#[test]
+fn test_scroll_up_by_saturates() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.set_offset(3);
+
+    assert!(scroll.scroll_up_by(10));
+    assert_eq!(scroll.offset(), 0); // saturating_sub
+}
+
+#[test]
+fn test_scroll_down_by() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+
+    assert!(scroll.scroll_down_by(5));
+    assert_eq!(scroll.offset(), 5);
+}
+
+#[test]
+fn test_scroll_down_by_clamped() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.set_offset(85);
+
+    assert!(scroll.scroll_down_by(20));
+    assert_eq!(scroll.offset(), 90); // clamped to max_offset
+}
+
+#[test]
+fn test_page_up() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.set_offset(25);
+
+    assert!(scroll.page_up(10));
+    assert_eq!(scroll.offset(), 15);
+}
+
+#[test]
+fn test_page_down() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+
+    assert!(scroll.page_down(10));
+    assert_eq!(scroll.offset(), 10);
+}
+
+#[test]
+fn test_scroll_to_start() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.set_offset(50);
+
+    assert!(scroll.scroll_to_start());
+    assert_eq!(scroll.offset(), 0);
+}
+
+#[test]
+fn test_scroll_to_start_already_there() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+
+    assert!(!scroll.scroll_to_start());
+}
+
+#[test]
+fn test_scroll_to_end() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+
+    assert!(scroll.scroll_to_end());
+    assert_eq!(scroll.offset(), 90);
+}
+
+#[test]
+fn test_scroll_to_end_already_there() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.scroll_to_end();
+
+    assert!(!scroll.scroll_to_end());
+}
+
+// =============================================================================
+// Selection tracking
+// =============================================================================
+
+#[test]
+fn test_ensure_visible_already_visible() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+
+    // Item 5 is in range 0..10, already visible
+    assert!(!scroll.ensure_visible(5));
+    assert_eq!(scroll.offset(), 0);
+}
+
+#[test]
+fn test_ensure_visible_scrolls_down() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+
+    // Item 15 is below viewport 0..10
+    assert!(scroll.ensure_visible(15));
+    assert_eq!(scroll.offset(), 6); // 15 - 10 + 1
+    assert!(scroll.visible_range().contains(&15));
+}
+
+#[test]
+fn test_ensure_visible_scrolls_up() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.set_offset(20);
+
+    // Item 5 is above viewport 20..30
+    assert!(scroll.ensure_visible(5));
+    assert_eq!(scroll.offset(), 5);
+    assert!(scroll.visible_range().contains(&5));
+}
+
+#[test]
+fn test_ensure_visible_at_viewport_boundary_bottom() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+
+    // Item 9 is the last visible item in 0..10 — should not scroll
+    assert!(!scroll.ensure_visible(9));
+    assert_eq!(scroll.offset(), 0);
+}
+
+#[test]
+fn test_ensure_visible_just_below_viewport() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+
+    // Item 10 is just below viewport 0..10
+    assert!(scroll.ensure_visible(10));
+    assert_eq!(scroll.offset(), 1); // 10 - 10 + 1
+}
+
+#[test]
+fn test_ensure_visible_at_viewport_boundary_top() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.set_offset(5);
+
+    // Item 5 is the first visible item in 5..15 — should not scroll
+    assert!(!scroll.ensure_visible(5));
+    assert_eq!(scroll.offset(), 5);
+}
+
+#[test]
+fn test_ensure_visible_just_above_viewport() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.set_offset(5);
+
+    // Item 4 is just above viewport 5..15
+    assert!(scroll.ensure_visible(4));
+    assert_eq!(scroll.offset(), 4);
+}
+
+#[test]
+fn test_ensure_visible_last_item() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+
+    assert!(scroll.ensure_visible(99));
+    assert_eq!(scroll.offset(), 90); // max_offset
+    assert!(scroll.visible_range().contains(&99));
+}
+
+#[test]
+fn test_ensure_visible_first_item() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.set_offset(50);
+
+    assert!(scroll.ensure_visible(0));
+    assert_eq!(scroll.offset(), 0);
+}
+
+#[test]
+fn test_ensure_visible_zero_viewport() {
+    let mut scroll = ScrollState::new(100);
+    // viewport_height is 0 — should not change anything
+    assert!(!scroll.ensure_visible(50));
+    assert_eq!(scroll.offset(), 0);
+}
+
+// =============================================================================
+// Queries
+// =============================================================================
+
+#[test]
+fn test_visible_range() {
+    let mut scroll = ScrollState::new(50);
+    scroll.set_viewport_height(10);
+
+    assert_eq!(scroll.visible_range(), 0..10);
+
+    scroll.set_offset(20);
+    assert_eq!(scroll.visible_range(), 20..30);
+
+    scroll.scroll_to_end();
+    assert_eq!(scroll.visible_range(), 40..50);
+}
+
+#[test]
+fn test_visible_range_content_smaller_than_viewport() {
+    let mut scroll = ScrollState::new(5);
+    scroll.set_viewport_height(10);
+
+    assert_eq!(scroll.visible_range(), 0..5);
+}
+
+#[test]
+fn test_visible_range_empty_content() {
+    let mut scroll = ScrollState::new(0);
+    scroll.set_viewport_height(10);
+
+    assert_eq!(scroll.visible_range(), 0..0);
+}
+
+#[test]
+fn test_max_offset() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    assert_eq!(scroll.max_offset(), 90);
+}
+
+#[test]
+fn test_max_offset_content_smaller_than_viewport() {
+    let mut scroll = ScrollState::new(5);
+    scroll.set_viewport_height(10);
+    assert_eq!(scroll.max_offset(), 0);
+}
+
+#[test]
+fn test_can_scroll() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    assert!(scroll.can_scroll());
+}
+
+#[test]
+fn test_can_scroll_false() {
+    let mut scroll = ScrollState::new(5);
+    scroll.set_viewport_height(10);
+    assert!(!scroll.can_scroll());
+}
+
+#[test]
+fn test_can_scroll_equal() {
+    let mut scroll = ScrollState::new(10);
+    scroll.set_viewport_height(10);
+    assert!(!scroll.can_scroll());
+}
+
+#[test]
+fn test_at_start() {
+    let scroll = ScrollState::new(100);
+    assert!(scroll.at_start());
+}
+
+#[test]
+fn test_at_start_false() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.scroll_down();
+    assert!(!scroll.at_start());
+}
+
+#[test]
+fn test_at_end() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.scroll_to_end();
+    assert!(scroll.at_end());
+}
+
+#[test]
+fn test_at_end_false() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    assert!(!scroll.at_end());
+}
+
+#[test]
+fn test_at_end_when_content_fits_viewport() {
+    let mut scroll = ScrollState::new(5);
+    scroll.set_viewport_height(10);
+    assert!(scroll.at_end()); // max_offset is 0, offset is 0
+}
+
+// =============================================================================
+// Scrollbar integration
+// =============================================================================
+
+#[test]
+fn test_scrollbar_state() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.set_offset(25);
+
+    let state = scroll.scrollbar_state();
+    // ScrollbarState doesn't expose internals directly, but we can verify
+    // it was created without panicking
+    let _ = state;
+}
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
+#[test]
+fn test_single_item() {
+    let mut scroll = ScrollState::new(1);
+    scroll.set_viewport_height(10);
+
+    assert!(!scroll.can_scroll());
+    assert!(scroll.at_start());
+    assert!(scroll.at_end());
+    assert_eq!(scroll.visible_range(), 0..1);
+    assert!(!scroll.scroll_down());
+    assert!(!scroll.scroll_up());
+}
+
+#[test]
+fn test_viewport_equals_content() {
+    let mut scroll = ScrollState::new(10);
+    scroll.set_viewport_height(10);
+
+    assert!(!scroll.can_scroll());
+    assert_eq!(scroll.max_offset(), 0);
+    assert_eq!(scroll.visible_range(), 0..10);
+}
+
+#[test]
+fn test_viewport_one_more_than_content() {
+    let mut scroll = ScrollState::new(9);
+    scroll.set_viewport_height(10);
+
+    assert!(!scroll.can_scroll());
+    assert_eq!(scroll.visible_range(), 0..9);
+}
+
+#[test]
+fn test_content_one_more_than_viewport() {
+    let mut scroll = ScrollState::new(11);
+    scroll.set_viewport_height(10);
+
+    assert!(scroll.can_scroll());
+    assert_eq!(scroll.max_offset(), 1);
+
+    scroll.scroll_down();
+    assert_eq!(scroll.visible_range(), 1..11);
+    assert!(scroll.at_end());
+}
+
+#[test]
+fn test_large_content() {
+    let mut scroll = ScrollState::new(1_000_000);
+    scroll.set_viewport_height(50);
+
+    scroll.scroll_to_end();
+    assert_eq!(scroll.offset(), 999_950);
+    assert_eq!(scroll.visible_range(), 999_950..1_000_000);
+
+    scroll.ensure_visible(500_000);
+    assert!(scroll.visible_range().contains(&500_000));
+}
+
+#[test]
+fn test_scroll_down_by_zero() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    assert!(!scroll.scroll_down_by(0));
+    assert_eq!(scroll.offset(), 0);
+}
+
+#[test]
+fn test_scroll_up_by_zero() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.set_offset(5);
+    assert!(!scroll.scroll_up_by(0));
+    assert_eq!(scroll.offset(), 5);
+}
+
+#[test]
+fn test_page_up_from_near_start() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.set_offset(3);
+
+    assert!(scroll.page_up(10));
+    assert_eq!(scroll.offset(), 0); // saturating sub
+}
+
+#[test]
+fn test_page_down_near_end() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.set_offset(85);
+
+    assert!(scroll.page_down(10));
+    assert_eq!(scroll.offset(), 90); // clamped
+}
+
+#[test]
+fn test_clone_and_eq() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    scroll.set_offset(25);
+
+    let cloned = scroll.clone();
+    assert_eq!(scroll, cloned);
+}
+
+#[test]
+fn test_debug_format() {
+    let scroll = ScrollState::new(100);
+    let debug = format!("{:?}", scroll);
+    assert!(debug.contains("ScrollState"));
+    assert!(debug.contains("100"));
+}
+
+// =============================================================================
+// Render helpers (smoke tests)
+// =============================================================================
+
+#[test]
+fn test_render_scrollbar_no_scroll_needed() {
+    let scroll = ScrollState::new(5);
+    let theme = Theme::default();
+    let mut terminal = setup_render(40, 10);
+
+    terminal
+        .draw(|frame| {
+            let area = frame.area();
+            render_scrollbar(&scroll, frame, area, &theme);
+        })
+        .unwrap();
+    // Should not panic — scrollbar is not rendered when can_scroll is false
+}
+
+#[test]
+fn test_render_scrollbar_with_content() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(10);
+    let theme = Theme::default();
+    let mut terminal = setup_render(40, 10);
+
+    terminal
+        .draw(|frame| {
+            let area = frame.area();
+            render_scrollbar(&scroll, frame, area, &theme);
+        })
+        .unwrap();
+    // Should render without panicking
+}
+
+#[test]
+fn test_render_scrollbar_inside_border() {
+    let mut scroll = ScrollState::new(100);
+    scroll.set_viewport_height(8); // 10 - 2 for borders
+    let theme = Theme::default();
+    let mut terminal = setup_render(40, 10);
+
+    terminal
+        .draw(|frame| {
+            let area = frame.area();
+            render_scrollbar_inside_border(&scroll, frame, area, &theme);
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_scrollbar_inside_border_too_small() {
+    let scroll = ScrollState::new(100);
+    let theme = Theme::default();
+    let mut terminal = setup_render(40, 2);
+
+    terminal
+        .draw(|frame| {
+            let area = frame.area();
+            // Area height is 2, which is < 3, so nothing should render
+            render_scrollbar_inside_border(&scroll, frame, area, &theme);
+        })
+        .unwrap();
+}


### PR DESCRIPTION
## Summary

New `scroll` module providing the foundational virtual scrolling infrastructure for envision. This is Iteration 1.1 of the roadmap — the building block that all subsequent component retrofits and new data-heavy components will use.

- **`ScrollState` struct**: Composable scroll offset tracking with visible range calculation. Components embed this in their state to render only visible items instead of O(n) allocations per frame.
- **Two scrolling patterns**: Offset mode (`scroll_up`/`scroll_down`) for log viewers and text displays, and selection mode (`ensure_visible(index)`) for lists and tables.
- **Scrollbar rendering**: `render_scrollbar()` and `render_scrollbar_inside_border()` helpers using ratatui's `Scrollbar` widget with theme integration.
- **Serialization support**: Behind `serialization` feature flag.
- **63 unit tests** + **7 doc tests** covering all operations and edge cases (construction, setters, scroll operations, selection tracking, queries, render helpers, edge cases with empty/single/large content).

## Next steps

After this merges, the retrofit PRs will integrate `ScrollState` into existing components:
1. Offset-based: ScrollableText, LogViewer, ChatView
2. Selection-based: SelectableList, Table, LoadingList, DataGrid, SearchableList
3. Tree

## Test plan

- [x] `cargo test --all-features --lib scroll` — 63 tests pass (175 including related)
- [x] `cargo test --all-features --doc` — 830 pass, 0 ignored
- [x] `cargo clippy --all-features` — 0 warnings
- [x] `cargo check --no-default-features` — builds clean
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)