### PR TITLE
Retrofit ScrollState into ScrollableText component

### DIFF
--- a/src/component/scrollable_text/mod.rs
+++ b/src/component/scrollable_text/mod.rs
@@ -32,6 +32,7 @@ use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
 use super::{Component, Disableable, Focusable};
 use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::scroll::ScrollState;
 use crate::theme::Theme;
 
 /// Messages that can be sent to a ScrollableText.
@@ -71,8 +72,8 @@ pub enum ScrollableTextOutput {
 pub struct ScrollableTextState {
     /// The text content.
     content: String,
-    /// Current scroll offset (in wrapped lines).
-    scroll_offset: usize,
+    /// Scroll state tracking offset and providing scrollbar support.
+    scroll: ScrollState,
     /// Whether the component is focused.
     focused: bool,
     /// Whether the component is disabled.
@@ -110,6 +111,8 @@ impl ScrollableTextState {
     /// ```
     pub fn with_content(mut self, content: impl Into<String>) -> Self {
         self.content = content.into();
+        self.scroll
+            .set_content_length(self.content.lines().count().max(1));
         self
     }
 
@@ -167,7 +170,7 @@ impl ScrollableTextState {
     /// ```
     pub fn set_content(&mut self, content: impl Into<String>) {
         self.content = content.into();
-        self.scroll_offset = 0;
+        self.scroll = ScrollState::new(self.content.lines().count().max(1));
     }
 
     /// Appends text to the content.
@@ -200,14 +203,16 @@ impl ScrollableTextState {
 
     /// Returns the current scroll offset.
     pub fn scroll_offset(&self) -> usize {
-        self.scroll_offset
+        self.scroll.offset()
     }
 
     /// Sets the scroll offset.
     ///
-    /// The offset is not clamped here; it will be clamped during rendering.
+    /// The offset is clamped to the valid range based on the current
+    /// content length estimate. The precise clamping to wrapped line
+    /// count happens during rendering.
     pub fn set_scroll_offset(&mut self, offset: usize) {
-        self.scroll_offset = offset;
+        self.scroll.set_offset(offset);
     }
 
     /// Returns the number of visual lines the content would occupy
@@ -331,49 +336,50 @@ impl Component for ScrollableText {
     fn update(state: &mut Self::State, msg: Self::Message) -> Option<Self::Output> {
         match msg {
             ScrollableTextMessage::ScrollUp => {
-                if state.scroll_offset > 0 {
-                    state.scroll_offset -= 1;
-                    Some(ScrollableTextOutput::ScrollChanged(state.scroll_offset))
+                if state.scroll.scroll_up() {
+                    Some(ScrollableTextOutput::ScrollChanged(state.scroll.offset()))
                 } else {
                     None
                 }
             }
             ScrollableTextMessage::ScrollDown => {
-                // We allow scrolling freely; clamping happens in view.
-                // Use saturating_add to prevent overflow when scroll_offset
-                // is usize::MAX (e.g., after End).
-                state.scroll_offset = state.scroll_offset.saturating_add(1);
-                Some(ScrollableTextOutput::ScrollChanged(state.scroll_offset))
+                if state.scroll.scroll_down() {
+                    Some(ScrollableTextOutput::ScrollChanged(state.scroll.offset()))
+                } else {
+                    None
+                }
             }
             ScrollableTextMessage::PageUp(n) => {
-                let old = state.scroll_offset;
-                state.scroll_offset = state.scroll_offset.saturating_sub(n);
-                if state.scroll_offset != old {
-                    Some(ScrollableTextOutput::ScrollChanged(state.scroll_offset))
+                if state.scroll.page_up(n) {
+                    Some(ScrollableTextOutput::ScrollChanged(state.scroll.offset()))
                 } else {
                     None
                 }
             }
             ScrollableTextMessage::PageDown(n) => {
-                state.scroll_offset = state.scroll_offset.saturating_add(n);
-                Some(ScrollableTextOutput::ScrollChanged(state.scroll_offset))
+                if state.scroll.page_down(n) {
+                    Some(ScrollableTextOutput::ScrollChanged(state.scroll.offset()))
+                } else {
+                    None
+                }
             }
             ScrollableTextMessage::Home => {
-                if state.scroll_offset > 0 {
-                    state.scroll_offset = 0;
+                if state.scroll.scroll_to_start() {
                     Some(ScrollableTextOutput::ScrollChanged(0))
                 } else {
                     None
                 }
             }
             ScrollableTextMessage::End => {
-                // Set to a large value; view will clamp
-                state.scroll_offset = usize::MAX;
-                Some(ScrollableTextOutput::ScrollChanged(state.scroll_offset))
+                if state.scroll.scroll_to_end() {
+                    Some(ScrollableTextOutput::ScrollChanged(state.scroll.offset()))
+                } else {
+                    None
+                }
             }
             ScrollableTextMessage::SetContent(content) => {
                 state.content = content;
-                state.scroll_offset = 0;
+                state.scroll = ScrollState::new(state.content.lines().count().max(1));
                 None
             }
         }
@@ -420,11 +426,11 @@ impl Component for ScrollableText {
             return;
         }
 
-        // Clamp scroll offset to valid range
+        // Compute scroll dimensions and clamp offset
         let total_lines = state.line_count(inner.width as usize);
         let visible_lines = inner.height as usize;
         let max_scroll = total_lines.saturating_sub(visible_lines);
-        let effective_scroll = state.scroll_offset.min(max_scroll);
+        let effective_scroll = state.scroll.offset().min(max_scroll);
 
         let paragraph = Paragraph::new(state.content.as_str())
             .style(text_style)
@@ -432,6 +438,14 @@ impl Component for ScrollableText {
             .scroll((effective_scroll as u16, 0));
 
         frame.render_widget(paragraph, inner);
+
+        // Render scrollbar when content exceeds viewport
+        if total_lines > visible_lines {
+            let mut bar_scroll = ScrollState::new(total_lines);
+            bar_scroll.set_viewport_height(visible_lines);
+            bar_scroll.set_offset(effective_scroll);
+            crate::scroll::render_scrollbar_inside_border(&bar_scroll, frame, area, theme);
+        }
     }
 }
 

--- a/src/component/scrollable_text/snapshots/envision__component__scrollable_text__tests__view_scrolled.snap
+++ b/src/component/scrollable_text/snapshots/envision__component__scrollable_text__tests__view_scrolled.snap
@@ -1,11 +1,11 @@
 ---
 source: src/component/scrollable_text/tests.rs
-assertion_line: 396
+assertion_line: 402
 expression: terminal.backend().to_string()
 ---
 ┌──────────────────────────────────────┐
-│Line 4                                │
-│Line 5                                │
-│Line 6                                │
-│Line 7                                │
+│Line 4                                ▲
+│Line 5                                ║
+│Line 6                                █
+│Line 7                                ▼
 └──────────────────────────────────────┘

--- a/src/component/scrollable_text/tests.rs
+++ b/src/component/scrollable_text/tests.rs
@@ -135,10 +135,11 @@ fn test_scroll_up_at_top() {
 #[test]
 fn test_page_up() {
     let mut state = content_state();
-    state.set_scroll_offset(15);
-    let output = ScrollableText::update(&mut state, ScrollableTextMessage::PageUp(10));
-    assert_eq!(state.scroll_offset(), 5);
-    assert_eq!(output, Some(ScrollableTextOutput::ScrollChanged(5)));
+    // content_state has 10 lines; set offset to 9 (max for 10-line content)
+    state.set_scroll_offset(9);
+    let output = ScrollableText::update(&mut state, ScrollableTextMessage::PageUp(5));
+    assert_eq!(state.scroll_offset(), 4);
+    assert_eq!(output, Some(ScrollableTextOutput::ScrollChanged(4)));
 }
 
 #[test]
@@ -176,9 +177,11 @@ fn test_home_already_at_top() {
 #[test]
 fn test_end() {
     let mut state = content_state();
+    // content_state has 10 lines; End scrolls to max_offset (content_length - viewport_height).
+    // With content_length=10 and viewport_height=0 (no render yet), max_offset=10.
     let output = ScrollableText::update(&mut state, ScrollableTextMessage::End);
     assert!(output.is_some());
-    assert_eq!(state.scroll_offset(), usize::MAX);
+    assert_eq!(state.scroll_offset(), 10);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

First ScrollState retrofit (Iteration 1.2) — proves the pattern for offset-based components.

- Replace `scroll_offset: usize` with `scroll: ScrollState` in `ScrollableTextState`
- Backward-compatible API: `scroll_offset()` and `set_scroll_offset()` delegate to ScrollState
- Update logic uses ScrollState methods which return `bool` (changed or not), eliminating manual arithmetic
- Content length tracked eagerly (unwrapped line count); view computes precise wrapped count for scrollbar
- Scrollbar rendered via `render_scrollbar_inside_border()` when content exceeds viewport
- ScrollDown now properly returns `None` when at bottom (behavior improvement)

## Test plan

- [x] `cargo test --all-features` — 5,200 tests pass (4242 unit + 128 integration + 830 doc)
- [x] `cargo clippy --all-features` — 0 warnings
- [x] `cargo fmt -- --check` — clean
- [x] `cargo check --no-default-features` — builds
- [x] Snapshot updated: scrollbar visible when content exceeds viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)