### PR TITLE
Retrofit ScrollState into ChatView component

### DIFF
--- a/src/component/chat_view/component_impl.rs
+++ b/src/component/chat_view/component_impl.rs
@@ -174,29 +174,28 @@ impl Component for ChatView {
                 None
             }
             ChatViewMessage::ScrollUp => {
-                if state.scroll_offset > 0 {
-                    state.scroll_offset -= 1;
-                    state.auto_scroll = false;
-                }
+                state.scroll.set_content_length(state.messages.len());
+                state.scroll.scroll_up();
+                state.auto_scroll = false;
                 None
             }
             ChatViewMessage::ScrollDown => {
-                let max = state.messages.len().saturating_sub(1);
-                if state.scroll_offset < max {
-                    state.scroll_offset += 1;
-                    if state.scroll_offset >= max {
-                        state.auto_scroll = true;
-                    }
+                state.scroll.set_content_length(state.messages.len());
+                state.scroll.scroll_down();
+                if state.scroll.at_end() {
+                    state.auto_scroll = true;
                 }
                 None
             }
             ChatViewMessage::ScrollToTop => {
-                state.scroll_offset = 0;
+                state.scroll.set_content_length(state.messages.len());
+                state.scroll.scroll_to_start();
                 state.auto_scroll = false;
                 None
             }
             ChatViewMessage::ScrollToBottom => {
-                state.scroll_to_bottom();
+                state.scroll.set_content_length(state.messages.len());
+                state.scroll.scroll_to_end();
                 state.auto_scroll = true;
                 None
             }

--- a/src/component/chat_view/mod.rs
+++ b/src/component/chat_view/mod.rs
@@ -41,6 +41,7 @@ use ratatui::prelude::*;
 
 use super::{Component, TextAreaState};
 use crate::input::Event;
+use crate::scroll::ScrollState;
 
 /// State for a ChatView component.
 ///
@@ -51,8 +52,8 @@ pub struct ChatViewState {
     messages: Vec<ChatMessage>,
     /// The text input area.
     input: TextAreaState,
-    /// Scroll offset for the message history.
-    scroll_offset: usize,
+    /// Scroll state for the message history.
+    scroll: ScrollState,
     /// Whether to auto-scroll to bottom on new messages.
     auto_scroll: bool,
     /// Maximum number of messages to keep.
@@ -78,7 +79,7 @@ impl Default for ChatViewState {
         Self {
             messages: Vec::new(),
             input: TextAreaState::with_placeholder("Type a message..."),
-            scroll_offset: 0,
+            scroll: ScrollState::default(),
             auto_scroll: true,
             max_messages: 1000,
             focus: Focus::Input,
@@ -95,7 +96,7 @@ impl Default for ChatViewState {
 impl PartialEq for ChatViewState {
     fn eq(&self, other: &Self) -> bool {
         self.messages == other.messages
-            && self.scroll_offset == other.scroll_offset
+            && self.scroll == other.scroll
             && self.auto_scroll == other.auto_scroll
             && self.max_messages == other.max_messages
             && self.focus == other.focus
@@ -217,6 +218,7 @@ impl ChatViewState {
         while self.messages.len() > self.max_messages {
             self.messages.remove(0);
         }
+        self.scroll.set_content_length(self.messages.len());
         if self.auto_scroll {
             self.scroll_to_bottom();
         }
@@ -309,7 +311,7 @@ impl ChatViewState {
     /// ```
     pub fn clear_messages(&mut self) {
         self.messages.clear();
-        self.scroll_offset = 0;
+        self.scroll = ScrollState::default();
     }
 
     // ---- Accessors ----
@@ -400,7 +402,7 @@ impl ChatViewState {
     /// assert_eq!(state.scroll_offset(), 0);
     /// ```
     pub fn scroll_offset(&self) -> usize {
-        self.scroll_offset
+        self.scroll.offset()
     }
 
     /// Returns the maximum number of messages.
@@ -525,7 +527,8 @@ impl ChatViewState {
 
     /// Scrolls the message history to the bottom (newest).
     fn scroll_to_bottom(&mut self) {
-        self.scroll_offset = self.messages.len().saturating_sub(1);
+        self.scroll.set_content_length(self.messages.len());
+        self.scroll.scroll_to_end();
     }
 
     // ---- Instance methods ----

--- a/src/component/chat_view/render_helpers.rs
+++ b/src/component/chat_view/render_helpers.rs
@@ -47,7 +47,7 @@ pub(super) fn render_history(state: &ChatViewState, frame: &mut Frame, area: Rec
         total_lines.saturating_sub(visible_lines)
     } else {
         // Approximate: each message is roughly 2+ lines
-        let estimated_line = state.scroll_offset.saturating_mul(2);
+        let estimated_line = state.scroll.offset().saturating_mul(2);
         estimated_line.min(total_lines.saturating_sub(visible_lines))
     };
 
@@ -60,6 +60,14 @@ pub(super) fn render_history(state: &ChatViewState, frame: &mut Frame, area: Rec
 
     let list = List::new(items);
     frame.render_widget(list, inner);
+
+    // Render scrollbar when content exceeds viewport
+    if total_lines > visible_lines {
+        let mut bar_scroll = crate::scroll::ScrollState::new(total_lines);
+        bar_scroll.set_viewport_height(visible_lines);
+        bar_scroll.set_offset(line_offset);
+        crate::scroll::render_scrollbar_inside_border(&bar_scroll, frame, area, theme);
+    }
 }
 
 /// Formats a chat message into display lines.

--- a/src/component/chat_view/tests.rs
+++ b/src/component/chat_view/tests.rs
@@ -369,8 +369,8 @@ fn test_focus_history() {
 #[test]
 fn test_scroll_down() {
     let mut state = state_with_messages();
-    state.auto_scroll = false;
-    state.scroll_offset = 0;
+    state.set_auto_scroll(false);
+    state.scroll.set_offset(0);
     ChatView::update(&mut state, ChatViewMessage::ScrollDown);
     assert_eq!(state.scroll_offset(), 1);
 }
@@ -378,8 +378,9 @@ fn test_scroll_down() {
 #[test]
 fn test_scroll_up() {
     let mut state = state_with_messages();
-    state.auto_scroll = false;
-    state.scroll_offset = 2;
+    state.set_auto_scroll(false);
+    state.scroll.set_content_length(state.messages().len());
+    state.scroll.set_offset(2);
     ChatView::update(&mut state, ChatViewMessage::ScrollUp);
     assert_eq!(state.scroll_offset(), 1);
 }
@@ -387,7 +388,7 @@ fn test_scroll_up() {
 #[test]
 fn test_scroll_up_at_top() {
     let mut state = state_with_messages();
-    state.scroll_offset = 0;
+    state.scroll.set_offset(0);
     ChatView::update(&mut state, ChatViewMessage::ScrollUp);
     assert_eq!(state.scroll_offset(), 0);
 }
@@ -395,7 +396,8 @@ fn test_scroll_up_at_top() {
 #[test]
 fn test_scroll_to_top() {
     let mut state = state_with_messages();
-    state.scroll_offset = 2;
+    state.scroll.set_content_length(state.messages().len());
+    state.scroll.set_offset(2);
     ChatView::update(&mut state, ChatViewMessage::ScrollToTop);
     assert_eq!(state.scroll_offset(), 0);
     assert!(!state.auto_scroll());
@@ -404,10 +406,10 @@ fn test_scroll_to_top() {
 #[test]
 fn test_scroll_to_bottom() {
     let mut state = state_with_messages();
-    state.auto_scroll = false;
-    state.scroll_offset = 0;
+    state.set_auto_scroll(false);
+    state.scroll.set_offset(0);
     ChatView::update(&mut state, ChatViewMessage::ScrollToBottom);
-    assert_eq!(state.scroll_offset(), 2);
+    assert!(state.scroll.at_end());
     assert!(state.auto_scroll());
 }
 


### PR DESCRIPTION
## Summary

- Replace manual `scroll_offset: usize` field in `ChatViewState` with the composable `ScrollState` type from `crate::scroll`, continuing the ScrollState retrofit series (PR 3)
- All scroll operations (ScrollUp, ScrollDown, ScrollToTop, ScrollToBottom) now delegate to `ScrollState` methods with proper content_length synchronization
- A scrollbar is now rendered inside the chat history border when content exceeds the viewport height

## Changes

### State (`mod.rs`)
- Added `use crate::scroll::ScrollState` import
- Replaced `scroll_offset: usize` with `scroll: ScrollState`
- `scroll_offset()` accessor now returns `self.scroll.offset()`
- `scroll_to_bottom()` delegates to `scroll.set_content_length()` + `scroll.scroll_to_end()`
- `push_message()` syncs `scroll.set_content_length()` after pushing
- `clear_messages()` resets to `ScrollState::default()`
- Updated `PartialEq` and `Default` impls

### Update logic (`component_impl.rs`)
- All four scroll message handlers set content_length before operating
- `ScrollUp` / `ScrollToTop` use `scroll.scroll_up()` / `scroll.scroll_to_start()`
- `ScrollDown` uses `scroll.scroll_down()` with `scroll.at_end()` check for auto_scroll
- `ScrollToBottom` uses `scroll.scroll_to_end()`

### Rendering (`render_helpers.rs`)
- Replaced `state.scroll_offset` with `state.scroll.offset()` in line offset calculation
- Added scrollbar rendering via `render_scrollbar_inside_border` when content exceeds viewport

### Tests (`tests.rs`)
- Updated scroll tests to use public API (`set_auto_scroll()`, `scroll.set_offset()`, `scroll.set_content_length()`) instead of direct field access
- `test_scroll_to_bottom` now asserts `scroll.at_end()` instead of a specific numeric offset

## Test plan

- [x] `cargo fmt` -- clean
- [x] `cargo clippy --all-features` -- 0 warnings
- [x] `cargo test --all-features --lib chat_view` -- all 122 tests pass
- [x] `cargo test --all-features --doc` -- all 830 doc tests pass
- [x] `cargo check --no-default-features` -- builds
- [x] `cargo test --all-features` -- full suite (4242 unit + 830 doc tests) passes
- [x] Snapshot tests unchanged (scrollbar only appears when content exceeds viewport)

🤖 Generated with [Claude Code](https://claude.com/claude-code)