### PR TITLE
Retrofit ScrollState into Table, DataGrid, and Tree components

### DIFF
--- a/src/component/data_grid/mod.rs
+++ b/src/component/data_grid/mod.rs
@@ -49,6 +49,7 @@ use super::{
     Column, Component, Disableable, Focusable, InputFieldMessage, InputFieldState, TableRow,
 };
 use crate::input::{Event, KeyCode};
+use crate::scroll::ScrollState;
 use crate::theme::Theme;
 
 /// Messages that can be sent to a DataGrid.
@@ -127,6 +128,8 @@ pub struct DataGridState<T: TableRow> {
     focused: bool,
     /// Whether the component is disabled.
     disabled: bool,
+    /// Scroll state for scrollbar rendering.
+    scroll: ScrollState,
 }
 
 impl<T: TableRow + PartialEq> PartialEq for DataGridState<T> {
@@ -153,6 +156,7 @@ impl<T: TableRow> Default for DataGridState<T> {
             original_value: String::new(),
             focused: false,
             disabled: false,
+            scroll: ScrollState::default(),
         }
     }
 }
@@ -183,6 +187,7 @@ impl<T: TableRow> DataGridState<T> {
     /// ```
     pub fn new(rows: Vec<T>, columns: Vec<Column>) -> Self {
         let selected_row = if rows.is_empty() { None } else { Some(0) };
+        let scroll = ScrollState::new(rows.len());
         Self {
             rows,
             columns,
@@ -193,6 +198,7 @@ impl<T: TableRow> DataGridState<T> {
             original_value: String::new(),
             focused: false,
             disabled: false,
+            scroll,
         }
     }
 
@@ -424,6 +430,7 @@ impl<T: TableRow> DataGridState<T> {
     pub fn set_rows(&mut self, rows: Vec<T>) {
         self.editing = false;
         self.rows = rows;
+        self.scroll.set_content_length(self.rows.len());
         if self.rows.is_empty() {
             self.selected_row = None;
         } else {
@@ -768,6 +775,17 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
         let mut table_state = ratatui::widgets::TableState::default();
         table_state.select(state.selected_row);
         frame.render_stateful_widget(table, area, &mut table_state);
+
+        // Render scrollbar by mirroring the offset from ratatui's TableState
+        let inner = area.inner(Margin::new(1, 1));
+        // Viewport for data rows: inner height minus header row (1) and bottom margin (1)
+        let data_viewport = (inner.height as usize).saturating_sub(2);
+        if data_viewport > 0 && state.rows.len() > data_viewport {
+            let mut bar_scroll = ScrollState::new(state.rows.len());
+            bar_scroll.set_viewport_height(data_viewport);
+            bar_scroll.set_offset(table_state.offset());
+            crate::scroll::render_scrollbar_inside_border(&bar_scroll, frame, area, theme);
+        }
 
         // Show cursor when editing
         if state.editing && state.focused {

--- a/src/component/table/mod.rs
+++ b/src/component/table/mod.rs
@@ -67,6 +67,7 @@ use ratatui::widgets::{Block, Borders, Cell, Row};
 
 use super::{Component, Disableable, Focusable};
 use crate::input::{Event, KeyCode};
+use crate::scroll::ScrollState;
 use crate::theme::Theme;
 
 /// State for a Table component.
@@ -86,6 +87,8 @@ pub struct TableState<T: TableRow> {
     focused: bool,
     disabled: bool,
     filter_text: String,
+    #[cfg_attr(feature = "serialization", serde(skip))]
+    scroll: ScrollState,
 }
 
 impl<T: TableRow + PartialEq> PartialEq for TableState<T> {
@@ -112,6 +115,7 @@ impl<T: TableRow> Default for TableState<T> {
             focused: false,
             disabled: false,
             filter_text: String::new(),
+            scroll: ScrollState::default(),
         }
     }
 }
@@ -146,6 +150,7 @@ impl<T: TableRow> TableState<T> {
     pub fn new(rows: Vec<T>, columns: Vec<Column>) -> Self {
         let display_order: Vec<usize> = (0..rows.len()).collect();
         let selected = if rows.is_empty() { None } else { Some(0) };
+        let scroll = ScrollState::new(display_order.len());
         Self {
             rows,
             columns,
@@ -155,6 +160,7 @@ impl<T: TableRow> TableState<T> {
             focused: false,
             disabled: false,
             filter_text: String::new(),
+            scroll,
         }
     }
 
@@ -168,6 +174,7 @@ impl<T: TableRow> TableState<T> {
         } else {
             Some(selected.min(rows.len() - 1))
         };
+        let scroll = ScrollState::new(display_order.len());
         Self {
             rows,
             columns,
@@ -177,6 +184,7 @@ impl<T: TableRow> TableState<T> {
             focused: false,
             disabled: false,
             filter_text: String::new(),
+            scroll,
         }
     }
 
@@ -301,6 +309,7 @@ impl<T: TableRow> TableState<T> {
         self.filter_text.clear();
         self.display_order = (0..self.rows.len()).collect();
         self.sort = None;
+        self.scroll.set_content_length(self.display_order.len());
 
         if self.rows.is_empty() {
             self.selected = None;
@@ -445,6 +454,8 @@ impl<T: TableRow> TableState<T> {
                 }
             });
         }
+
+        self.scroll.set_content_length(self.display_order.len());
 
         // Preserve selection
         if let Some(orig) = selected_original {
@@ -769,6 +780,17 @@ impl<T: TableRow + 'static> Component for Table<T> {
         let mut table_state = ratatui::widgets::TableState::default();
         table_state.select(state.selected);
         frame.render_stateful_widget(table, area, &mut table_state);
+
+        // Render scrollbar by mirroring the offset from ratatui's TableState
+        let inner = area.inner(Margin::new(1, 1));
+        // Viewport for data rows: inner height minus header row (1) and bottom margin (1)
+        let data_viewport = (inner.height as usize).saturating_sub(2);
+        if data_viewport > 0 && state.display_order.len() > data_viewport {
+            let mut bar_scroll = ScrollState::new(state.display_order.len());
+            bar_scroll.set_viewport_height(data_viewport);
+            bar_scroll.set_offset(table_state.offset());
+            crate::scroll::render_scrollbar_inside_border(&bar_scroll, frame, area, theme);
+        }
     }
 }
 

--- a/src/component/tree/mod.rs
+++ b/src/component/tree/mod.rs
@@ -32,6 +32,7 @@ use ratatui::widgets::Paragraph;
 
 use super::{Component, Disableable, Focusable};
 use crate::input::{Event, KeyCode};
+use crate::scroll::ScrollState;
 use crate::theme::Theme;
 
 mod traversal;
@@ -233,6 +234,9 @@ pub struct TreeState<T> {
     disabled: bool,
     /// Current filter text for searching nodes by label.
     filter_text: String,
+    /// Scroll state for scrollbar rendering.
+    #[cfg_attr(feature = "serialization", serde(skip))]
+    scroll: ScrollState,
 }
 
 impl<T: Clone + PartialEq> PartialEq for TreeState<T> {
@@ -276,6 +280,7 @@ impl<T: Clone> TreeState<T> {
             focused: false,
             disabled: false,
             filter_text: String::new(),
+            scroll: ScrollState::default(),
         }
     }
 
@@ -347,6 +352,7 @@ impl<T: Clone> TreeState<T> {
         self.roots = roots;
         self.filter_text.clear();
         self.selected_index = if self.roots.is_empty() { None } else { Some(0) };
+        self.scroll.set_content_length(self.flatten().len());
     }
 
     /// Returns the currently selected index in the flattened view.
@@ -466,6 +472,7 @@ impl<T: Clone> TreeState<T> {
         for root in &mut self.roots {
             Self::expand_all_recursive(root);
         }
+        self.scroll.set_content_length(self.flatten().len());
     }
 
     /// Collapses all nodes in the tree.
@@ -487,6 +494,7 @@ impl<T: Clone> TreeState<T> {
         }
         // Reset selection to ensure it's still valid
         self.selected_index = if self.roots.is_empty() { None } else { Some(0) };
+        self.scroll.set_content_length(self.flatten().len());
     }
 
     /// Returns the number of visible nodes.
@@ -524,6 +532,7 @@ impl<T: Clone> TreeState<T> {
         let prev_path = self.selected_path();
         self.filter_text = text.to_string();
         self.revalidate_selection(prev_path);
+        self.scroll.set_content_length(self.flatten().len());
     }
 
     /// Clears the filter, showing all nodes with their original expanded state.
@@ -531,6 +540,7 @@ impl<T: Clone> TreeState<T> {
         let prev_path = self.selected_path();
         self.filter_text.clear();
         self.revalidate_selection(prev_path);
+        self.scroll.set_content_length(self.flatten().len());
     }
 }
 
@@ -777,6 +787,7 @@ impl<T: Clone + 'static> Component for Tree<T> {
                         let path = node_info.path.clone();
                         if let Some(node) = state.get_node_mut(&path) {
                             node.expand();
+                            state.scroll.set_content_length(state.flatten().len());
                             return Some(TreeOutput::Expanded(path));
                         }
                     }
@@ -794,6 +805,7 @@ impl<T: Clone + 'static> Component for Tree<T> {
                             if selected >= new_flat.len() {
                                 state.selected_index = Some(new_flat.len().saturating_sub(1));
                             }
+                            state.scroll.set_content_length(new_flat.len());
                             return Some(TreeOutput::Collapsed(path));
                         }
                     }
@@ -813,8 +825,10 @@ impl<T: Clone + 'static> Component for Tree<T> {
                                 if selected >= new_flat.len() {
                                     state.selected_index = Some(new_flat.len().saturating_sub(1));
                                 }
+                                state.scroll.set_content_length(new_flat.len());
                                 return Some(TreeOutput::Collapsed(path));
                             } else {
+                                state.scroll.set_content_length(state.flatten().len());
                                 return Some(TreeOutput::Expanded(path));
                             }
                         }
@@ -827,10 +841,12 @@ impl<T: Clone + 'static> Component for Tree<T> {
                 .map(|node_info| TreeOutput::Selected(node_info.path.clone())),
             TreeMessage::ExpandAll => {
                 state.expand_all();
+                // scroll content length already updated by expand_all()
                 None
             }
             TreeMessage::CollapseAll => {
                 state.collapse_all();
+                // scroll content length already updated by collapse_all()
                 None
             }
             TreeMessage::SetFilter(_) | TreeMessage::ClearFilter => {
@@ -859,8 +875,24 @@ impl<T: Clone + 'static> Component for Tree<T> {
     }
 
     fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
-        let lines = Self::render_lines(state, area.width, theme);
-        let text = Text::from(lines);
+        let all_lines = Self::render_lines(state, area.width, theme);
+        let viewport_height = area.height as usize;
+
+        // Use a local ScrollState for scrollbar rendering and virtual scrolling
+        let mut bar_scroll = ScrollState::new(all_lines.len());
+        bar_scroll.set_viewport_height(viewport_height);
+        if let Some(idx) = state.selected_index {
+            bar_scroll.ensure_visible(idx);
+        }
+
+        let range = bar_scroll.visible_range();
+        let visible_lines: Vec<Line<'static>> = all_lines
+            .into_iter()
+            .skip(range.start)
+            .take(range.len())
+            .collect();
+
+        let text = Text::from(visible_lines);
         let paragraph = Paragraph::new(text);
 
         let annotation = crate::annotation::Annotation::new(crate::annotation::WidgetType::Tree)
@@ -869,6 +901,9 @@ impl<T: Clone + 'static> Component for Tree<T> {
             .with_disabled(state.disabled);
         let annotated = crate::annotation::Annotate::new(paragraph, annotation);
         frame.render_widget(annotated, area);
+
+        // Render scrollbar if content exceeds viewport
+        crate::scroll::render_scrollbar(&bar_scroll, frame, area, theme);
     }
 }
 


### PR DESCRIPTION
## Summary

- **Table**: Added `ScrollState` field to `TableState<T>`. Content length is updated when `display_order` changes (via `set_rows`, `rebuild_display_order`, filter, sort). In `view()`, after `render_stateful_widget`, mirrors ratatui's `TableState` offset to render a scrollbar inside the border when content exceeds the data viewport (inner height minus header row and margin).

- **DataGrid**: Same pattern as Table. Added `ScrollState` to `DataGridState<T>`. Content length synced on `set_rows`. Scrollbar rendered after `render_stateful_widget` by mirroring the `TableState` offset.

- **Tree**: Added `ScrollState` to `TreeState<T>`. Content length updated after expand, collapse, toggle, filter, set_roots, expand_all, and collapse_all operations. In `view()`, constructs a local `ScrollState` to compute the visible range (since view takes `&State`), slices the flattened lines to only the visible portion, and renders a scrollbar when content exceeds the viewport.

This is PR 5 in the ScrollState retrofit series (following PRs 249-251 for offset-based components).

## Test plan

- [x] `cargo fmt` -- clean
- [x] `cargo clippy --all-features` -- 0 warnings
- [x] `cargo test --all-features --lib table` -- 171 tests pass
- [x] `cargo test --all-features --lib data_grid` -- 59 tests pass
- [x] `cargo test --all-features --lib tree` -- 198 tests pass
- [x] `cargo test --all-features --doc` -- 830 doc tests pass
- [x] `cargo check --no-default-features` -- builds
- [x] `cargo test --all-features` -- full suite (4242 lib + 830 doc) passes
- [x] No file exceeds 1000 lines (table: 822, data_grid: 837, tree: 931)
- [x] All existing snapshot tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)