### PR TITLE
Retrofit ScrollState into list components (SelectableList, SearchableList, LoadingList)

### DIFF
--- a/src/component/loading_list/mod.rs
+++ b/src/component/loading_list/mod.rs
@@ -41,6 +41,7 @@ use ratatui::widgets::{Block, Borders, List, ListItem};
 
 use super::{Component, Disableable, Focusable};
 use crate::input::{Event, KeyCode};
+use crate::scroll::ScrollState;
 use crate::theme::Theme;
 
 /// Loading state of an individual item.
@@ -283,6 +284,9 @@ pub struct LoadingListState<T: Clone> {
     title: Option<String>,
     /// Whether to show loading indicators.
     show_indicators: bool,
+    /// Scroll state for virtual scrolling and scrollbar rendering.
+    #[cfg_attr(feature = "serialization", serde(skip))]
+    scroll: ScrollState,
 }
 
 impl<T: Clone + PartialEq> PartialEq for LoadingListState<T> {
@@ -307,6 +311,7 @@ impl<T: Clone> Default for LoadingListState<T> {
             spinner_frame: 0,
             title: None,
             show_indicators: true,
+            scroll: ScrollState::default(),
         }
     }
 }
@@ -339,13 +344,15 @@ impl<T: Clone> LoadingListState<T> {
     where
         F: Fn(&T) -> String,
     {
-        let list_items = items
+        let list_items: Vec<LoadingListItem<T>> = items
             .into_iter()
             .map(|data| {
                 let label = label_fn(&data);
                 LoadingListItem::new(data, label)
             })
             .collect();
+
+        let scroll = ScrollState::new(list_items.len());
 
         Self {
             items: list_items,
@@ -355,6 +362,7 @@ impl<T: Clone> LoadingListState<T> {
             spinner_frame: 0,
             title: None,
             show_indicators: true,
+            scroll,
         }
     }
 
@@ -607,6 +615,7 @@ impl<T: Clone> LoadingListState<T> {
     pub fn clear(&mut self) {
         self.items.clear();
         self.selected = None;
+        self.scroll.set_content_length(0);
     }
 }
 
@@ -696,6 +705,7 @@ impl<T: Clone> Component for LoadingList<T> {
                     .map(|(i, data)| LoadingListItem::new(data, format!("Item {}", i + 1)))
                     .collect();
                 state.selected = None;
+                state.scroll.set_content_length(state.items.len());
                 None
             }
 
@@ -761,6 +771,7 @@ impl<T: Clone> Component for LoadingList<T> {
                 };
 
                 state.selected = Some(new_index);
+                state.scroll.ensure_visible(new_index);
                 Some(LoadingListOutput::SelectionChanged(new_index))
             }
 
@@ -776,6 +787,7 @@ impl<T: Clone> Component for LoadingList<T> {
                 };
 
                 state.selected = Some(new_index);
+                state.scroll.ensure_visible(new_index);
                 Some(LoadingListOutput::SelectionChanged(new_index))
             }
 
@@ -785,6 +797,7 @@ impl<T: Clone> Component for LoadingList<T> {
                 }
 
                 state.selected = Some(0);
+                state.scroll.ensure_visible(0);
                 Some(LoadingListOutput::SelectionChanged(0))
             }
 
@@ -795,6 +808,7 @@ impl<T: Clone> Component for LoadingList<T> {
 
                 let last = state.items.len() - 1;
                 state.selected = Some(last);
+                state.scroll.ensure_visible(last);
                 Some(LoadingListOutput::SelectionChanged(last))
             }
 
@@ -858,12 +872,20 @@ impl<T: Clone> Component for LoadingList<T> {
             return;
         }
 
-        let items: Vec<ListItem> = state
-            .items
+        // Construct a local ScrollState for virtual scrolling and scrollbar
+        let mut bar_scroll = ScrollState::new(state.items.len());
+        bar_scroll.set_viewport_height(inner.height as usize);
+        if let Some(sel) = state.selected {
+            bar_scroll.ensure_visible(sel);
+        }
+        let range = bar_scroll.visible_range();
+
+        let items: Vec<ListItem> = state.items[range.clone()]
             .iter()
             .enumerate()
-            .map(|(idx, item)| {
-                let is_selected = state.selected == Some(idx);
+            .map(|(view_idx, item)| {
+                let actual_idx = range.start + view_idx;
+                let is_selected = state.selected == Some(actual_idx);
                 let select_marker = if is_selected { "▸" } else { " " };
 
                 let content = if state.show_indicators {
@@ -895,6 +917,9 @@ impl<T: Clone> Component for LoadingList<T> {
 
         let list = List::new(items);
         frame.render_widget(list, inner);
+
+        // Render scrollbar when content exceeds viewport
+        crate::scroll::render_scrollbar_inside_border(&bar_scroll, frame, area, theme);
     }
 }
 

--- a/src/component/searchable_list/mod.rs
+++ b/src/component/searchable_list/mod.rs
@@ -45,6 +45,7 @@ use ratatui::widgets::ListState;
 
 use super::{Component, Disableable, Focusable};
 use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::scroll::ScrollState;
 use crate::theme::Theme;
 
 /// A matcher function that takes `(query, item_text)` and returns
@@ -124,6 +125,9 @@ pub struct SearchableListState<T: Clone> {
     /// Ratatui list state for scroll tracking.
     #[cfg_attr(feature = "serialization", serde(skip))]
     pub(super) list_state: ListState,
+    /// Scroll state for scrollbar rendering.
+    #[cfg_attr(feature = "serialization", serde(skip))]
+    pub(super) scroll: ScrollState,
     /// Which sub-component has internal focus.
     pub(super) internal_focus: Focus,
     /// Whether the overall component is focused.
@@ -147,6 +151,7 @@ impl<T: Clone> Clone for SearchableListState<T> {
             filter_text: self.filter_text.clone(),
             selected: self.selected,
             list_state: self.list_state.clone(),
+            scroll: self.scroll.clone(),
             internal_focus: self.internal_focus.clone(),
             focused: self.focused,
             disabled: self.disabled,
@@ -195,6 +200,7 @@ impl<T: Clone> Default for SearchableListState<T> {
             filter_text: String::new(),
             selected: None,
             list_state: ListState::default(),
+            scroll: ScrollState::default(),
             internal_focus: Focus::Filter,
             focused: false,
             disabled: false,
@@ -225,12 +231,14 @@ impl<T: Clone> SearchableListState<T> {
         let selected = if items.is_empty() { None } else { Some(0) };
         let mut list_state = ListState::default();
         list_state.select(selected);
+        let scroll = ScrollState::new(filtered_indices.len());
         Self {
             items,
             filtered_indices,
             filter_text: String::new(),
             selected,
             list_state,
+            scroll,
             internal_focus: Focus::Filter,
             focused: false,
             disabled: false,
@@ -698,6 +706,8 @@ impl<T: Clone + Display + 'static> SearchableListState<T> {
                 .map(|(i, _)| i)
                 .collect();
         };
+
+        self.scroll.set_content_length(self.filtered_indices.len());
 
         // Reset selection to first filtered item
         if self.filtered_indices.is_empty() {

--- a/src/component/searchable_list/render.rs
+++ b/src/component/searchable_list/render.rs
@@ -6,6 +6,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
 
 use super::{Focus, SearchableListState};
+use crate::scroll::ScrollState;
 use crate::theme::Theme;
 
 /// Renders the searchable list component.
@@ -91,6 +92,8 @@ pub(super) fn render_searchable_list<T: Clone + Display>(
         .borders(Borders::ALL)
         .border_style(list_border_style);
 
+    let list_inner = list_block.inner(chunks[1]);
+
     let list_widget = List::new(items)
         .block(list_block)
         .highlight_style(highlight_style)
@@ -98,6 +101,14 @@ pub(super) fn render_searchable_list<T: Clone + Display>(
 
     let mut list_state = state.list_state.clone();
     frame.render_stateful_widget(list_widget, chunks[1], &mut list_state);
+
+    // Render scrollbar when content exceeds viewport
+    if state.filtered_indices.len() > list_inner.height as usize {
+        let mut bar_scroll = ScrollState::new(state.filtered_indices.len());
+        bar_scroll.set_viewport_height(list_inner.height as usize);
+        bar_scroll.set_offset(list_state.offset());
+        crate::scroll::render_scrollbar_inside_border(&bar_scroll, frame, chunks[1], theme);
+    }
 
     crate::annotation::with_registry(|reg| {
         reg.close();

--- a/src/component/selectable_list/mod.rs
+++ b/src/component/selectable_list/mod.rs
@@ -32,6 +32,7 @@ use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
 
 use super::{Component, Disableable, Focusable};
 use crate::input::{Event, KeyCode};
+use crate::scroll::ScrollState;
 use crate::theme::Theme;
 
 /// Messages that can be sent to a SelectableList.
@@ -82,6 +83,8 @@ pub struct SelectableListState<T: Clone> {
     disabled: bool,
     filter_text: String,
     filtered_indices: Vec<usize>,
+    #[cfg_attr(feature = "serialization", serde(skip))]
+    scroll: ScrollState,
 }
 
 impl<T: Clone + PartialEq> PartialEq for SelectableListState<T> {
@@ -103,6 +106,7 @@ impl<T: Clone> Default for SelectableListState<T> {
             disabled: false,
             filter_text: String::new(),
             filtered_indices: Vec::new(),
+            scroll: ScrollState::default(),
         }
     }
 }
@@ -137,6 +141,7 @@ impl<T: Clone> SelectableListState<T> {
     /// ```
     pub fn with_items(items: Vec<T>) -> Self {
         let filtered_indices: Vec<usize> = (0..items.len()).collect();
+        let scroll = ScrollState::new(filtered_indices.len());
         let mut state = Self {
             items,
             list_state: ListState::default(),
@@ -144,6 +149,7 @@ impl<T: Clone> SelectableListState<T> {
             disabled: false,
             filter_text: String::new(),
             filtered_indices,
+            scroll,
         };
         if !state.items.is_empty() {
             state.list_state.select(Some(0));
@@ -205,6 +211,7 @@ impl<T: Clone> SelectableListState<T> {
         self.items = items;
         self.filter_text.clear();
         self.filtered_indices = (0..self.items.len()).collect();
+        self.scroll.set_content_length(self.filtered_indices.len());
         if self.filtered_indices.is_empty() {
             self.list_state.select(None);
         } else {
@@ -454,6 +461,8 @@ impl<T: Clone + std::fmt::Display + 'static> SelectableListState<T> {
                 .collect();
         }
 
+        self.scroll.set_content_length(self.filtered_indices.len());
+
         // Try to preserve the previously selected item
         if let Some(prev_idx) = previously_selected {
             if let Some(new_pos) = self.filtered_indices.iter().position(|&i| i == prev_idx) {
@@ -632,14 +641,25 @@ impl<T: Clone + std::fmt::Display + 'static> Component for SelectableList<T> {
             theme.selected_highlight_style(state.focused)
         };
 
+        let block = Block::default().borders(Borders::ALL);
+        let inner = block.inner(area);
+
         let list = List::new(items)
-            .block(Block::default().borders(Borders::ALL))
+            .block(block)
             .highlight_style(highlight_style)
             .highlight_symbol("> ");
 
         // We need to clone the state for rendering since StatefulWidget needs &mut
         let mut list_state = state.list_state.clone();
         frame.render_stateful_widget(list, area, &mut list_state);
+
+        // Render scrollbar when content exceeds viewport
+        if state.filtered_indices.len() > inner.height as usize {
+            let mut bar_scroll = ScrollState::new(state.filtered_indices.len());
+            bar_scroll.set_viewport_height(inner.height as usize);
+            bar_scroll.set_offset(list_state.offset());
+            crate::scroll::render_scrollbar_inside_border(&bar_scroll, frame, area, theme);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Retrofit ScrollState into the three list-based components (Iteration 1.3).

### SelectableList
- Added `scroll: ScrollState` field alongside existing `ListState`
- Mirrors `ListState` offset after `render_stateful_widget` for scrollbar rendering
- Content length maintained on `set_items`, `apply_filter`

### SearchableList
- Same pattern as SelectableList
- Scrollbar rendered on the list area (not the search input area)
- Content length maintained on `refilter`, `set_items`

### LoadingList
- Virtual scrolling implemented (no `ListState` to lean on)
- Uses `ensure_visible(selected)` + `visible_range()` to render only visible items
- Scrollbar rendered when content exceeds viewport

## Test plan

- [x] `cargo test --all-features` — 4242 unit + 830 doc tests pass
- [x] `cargo clippy --all-features` — 0 warnings
- [x] `cargo check --no-default-features` — builds
- [x] All files under 1000 lines (687, 992, 947)

🤖 Generated with [Claude Code](https://claude.com/claude-code)