### PR TITLE
Fix missing feature gate on diff_viewer module

### DIFF
--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -140,6 +140,7 @@ mod data_grid;
 #[cfg(feature = "compound-components")]
 pub mod dependency_graph;
 
+#[cfg(feature = "compound-components")]
 pub mod diff_viewer;
 #[cfg(feature = "compound-components")]
 mod event_stream;


### PR DESCRIPTION
Fixes no-default-features build failure caused by missing #[cfg(feature = "compound-components")] on diff_viewer module declaration.