### PR TITLE
Add compound-components re-export block to lib.rs (audit issue #1)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,33 @@ pub use component::{
     TabBar, TabBarMessage, TabBarOutput, TabBarState, Tabs, TabsMessage, TabsOutput, TabsState,
 };
 
+// Compound components
+#[cfg(feature = "compound-components")]
+pub use component::{
+    AlertMetric, AlertPanel, AlertPanelMessage, AlertPanelOutput, AlertPanelState, AlertState,
+    AlertThreshold, Chart, ChartKind, ChartMessage, ChartOutput, ChartState, ChatMessage, ChatRole,
+    ChatView, ChatViewMessage, ChatViewOutput, ChatViewState, ConversationMessage,
+    ConversationRole, ConversationView, ConversationViewMessage, ConversationViewOutput,
+    ConversationViewState, DataGrid, DataGridMessage, DataGridOutput, DataGridState, DataSeries,
+    DependencyGraph, DependencyGraphMessage, DependencyGraphOutput, DependencyGraphState, DiffHunk,
+    DiffLine, DiffLineType, DiffMode, DiffViewer, DiffViewerMessage, DiffViewerOutput,
+    DiffViewerState, EventLevel, EventStream, EventStreamMessage, EventStreamOutput,
+    EventStreamState, FileBrowser, FileBrowserMessage, FileBrowserOutput, FileBrowserState,
+    FlameGraph, FlameGraphMessage, FlameGraphOutput, FlameGraphState, FlameNode, Form, FormField,
+    FormFieldKind, FormMessage, FormOutput, FormState, FormValue, GraphEdge, GraphNode,
+    GraphOrientation, Heatmap, HeatmapColorScale, HeatmapMessage, HeatmapOutput, HeatmapState,
+    Histogram, HistogramMessage, HistogramState, LogCorrelation, LogCorrelationMessage,
+    LogCorrelationOutput, LogCorrelationState, LogStream, LogViewer, LogViewerMessage,
+    LogViewerOutput, LogViewerState, MessageBlock, MetricKind, MetricWidget, MetricsDashboard,
+    MetricsDashboardMessage, MetricsDashboardOutput, MetricsDashboardState, NodeStatus, PaneLayout,
+    PaneLayoutMessage, PaneLayoutOutput, PaneLayoutState, SearchableList, SearchableListMessage,
+    SearchableListOutput, SearchableListState, SelectedType, SpanNode, SpanTree, SpanTreeMessage,
+    SpanTreeOutput, SpanTreeState, SplitOrientation, SplitPanel, SplitPanelMessage,
+    SplitPanelOutput, SplitPanelState, StreamEvent, ThresholdLine, Timeline, TimelineEvent,
+    TimelineMessage, TimelineOutput, TimelineSpan, TimelineState, Treemap, TreemapMessage,
+    TreemapNode, TreemapOutput, TreemapState,
+};
+
 // Overlay components
 #[cfg(feature = "overlay-components")]
 pub use component::{


### PR DESCRIPTION
## Summary

Critical audit finding: all 23 compound components were missing from the crate root re-exports. Users could not access them via `envision::AlertPanel` — only `envision::component::AlertPanel`.

Adds `#[cfg(feature = "compound-components")]` block re-exporting all compound component types.

## Test plan
- [x] `cargo check --all-features` — passes
- [x] `cargo check --no-default-features` — passes
- [x] `cargo clippy --all-features` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)