### PR TITLE
Update ROADMAP and component showcase for current state

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,387 +1,137 @@
-# Envision Roadmap Plan
+# Envision Roadmap
 
-## Context
+## Current State (v0.7.0)
 
-Envision is at v0.7.0 with 42 components, 5000+ tests, and excellent API consistency. The previous roadmap (based on v0.5.0 audit) is ~90% complete and has been removed. This roadmap establishes the next phase of development focused on three goals:
+Envision has **72 components**, **5000+ tests**, and comprehensive API consistency built on The Elm Architecture (TEA). The original roadmap from v0.5.0 has been substantially completed through six major iterations of development.
 
-1. **Virtual scrolling infrastructure** — the single biggest gap for production use with real data sizes
-2. **Data visualization components** — making envision the best TUI framework for charts, graphs, and analytical displays
-3. **Novel observability components** — things no TUI framework offers, positioning envision as uniquely powerful for building monitoring, tracing, and log analysis tools
+### Completed Iterations
 
-The roadmap is sequenced by dependencies: foundational infrastructure first, then primitives that build on it, then compound components that compose primitives.
+#### Iteration 1: Virtual Scrolling Infrastructure -- COMPLETE
 
----
+`ScrollState` core module landed with offset tracking, visible range calculation, selection tracking, scrollbar rendering helpers, and full test suite. Retrofitted across offset-based components (ScrollableText, LogViewer, ChatView) and selection-based components (SelectableList, Table, LoadingList, DataGrid, SearchableList, Tree). Scrollbar theme integration completed.
 
-## Iteration 1: Virtual Scrolling Infrastructure
+#### Iteration 2: Data Visualization Primitives -- COMPLETE
 
-**Why first**: Every list, table, tree, and log component currently allocates O(n) items per frame. This blocks all observability use cases (large logs, long trace spans, high-cardinality metrics). This must land before new data-heavy components are built.
+- **Sparkline** -- compact inline data trend display wrapping ratatui's Sparkline widget
+- **Gauge** -- ratio/percentage display with Full and Line variants, threshold zones, units
+- **Canvas** -- general-purpose drawing surface with primitives (Line, Rectangle, Circle, Points, Label)
+- **Enhanced Chart** -- area chart, scatter plot, stacked/grouped bar modes, threshold lines, shared Y-axis
 
-### 1.1 ScrollState Core
+#### Iteration 3: New General-Purpose Components -- MOSTLY COMPLETE
 
-New module `src/scroll/mod.rs` with a `ScrollState` struct that provides:
+**Completed:**
+- **Slider** -- numeric range selection with keyboard control
+- **Switch** -- on/off toggle, visually distinct from checkbox
+- **NumberInput** -- numeric input with validation, increment/decrement, bounds
+- **Calendar** -- month view with date selection and event markers
+- **BigText** -- large pixel text rendering for dashboard hero numbers
+- **Divider** -- horizontal/vertical separator with optional label
+- **Paginator** -- page navigation indicator
+- **CommandPalette** -- searchable, fuzzy-filtered action/item picker
+- **HelpPanel** -- auto-generated keybinding display
+- **Collapsible** -- single expandable/collapsible section with header
 
-- Scroll offset tracking with clamping
-- Visible range calculation (`visible_range() -> Range<usize>`)
-- Selection tracking (`ensure_visible(index)` to keep selection in viewport)
-- Scroll operations (`scroll_up`, `scroll_down`, `page_up`, `page_down`, `scroll_to_start`, `scroll_to_end`)
-- Query methods (`can_scroll`, `at_start`, `at_end`, `max_offset`)
-- ratatui `ScrollbarState` generation for scrollbar rendering
-- `render_scrollbar()` and `render_scrollbar_inside_border()` helpers
-- Serialization support behind feature flag
-- Full unit test suite
+**Not yet implemented:**
+- DatePicker (date selection combining Calendar with input)
+- ScrollView / Viewport (generic scrollable container for arbitrary content)
 
-**Files**: `src/scroll/mod.rs` (new), `src/scroll/tests.rs` (new), `src/lib.rs` (re-exports)
+#### Iteration 4: Statistical Visualization -- MOSTLY COMPLETE
 
-### 1.2 Retrofit Offset-Based Components
+**Completed:**
+- **Histogram** -- binned frequency distribution display
+- **Heatmap** -- 2D color-intensity grid with row/column labels, color scales, keyboard navigation
 
-These already have `scroll_offset: usize` and use `.skip().take()` — lowest risk migration:
+**Not yet implemented:**
+- ScatterPlot (first-class scatter with labeled points, clusters, trend lines)
+- BoxPlot (statistical distribution: median, quartiles, outliers)
 
-- **ScrollableText** — replace `scroll_offset` with `ScrollState`, add scrollbar
-- **LogViewer** — replace `scroll_offset` with `ScrollState`, add scrollbar
-- **ChatView** — replace `scroll_offset` with `ScrollState`, integrate with auto_scroll
+#### Iteration 5: Observability Components -- COMPLETE
 
-### 1.3 Retrofit Selection-Based Components
+- **Timeline** -- horizontal timeline with events/spans, zoom, pan, selection
+- **SpanTree** -- hierarchical tree with timing bars (Gantt-style trace visualization)
+- **FlameGraph** -- interactive flame graph with zoom, search, color-by modes
+- **EventStream** -- real-time filterable event feed with structured fields
+- **AlertPanel** -- metric display with threshold states (OK/Warning/Critical)
 
-These currently create ListItem/Row for ALL items — highest performance impact:
+#### Iteration 6: Advanced Visualization -- MOSTLY COMPLETE
 
-- **SelectableList** — add `ScrollState`, render only `visible_range()` items, adjust ListState selection relative to window
-- **Table** — same pattern with TableState
-- **LoadingList** — same pattern as SelectableList
-- **DataGrid** — same pattern as Table
-- **SearchableList** — update render.rs to use ScrollState
+**Completed:**
+- **Treemap** -- nested rectangles showing hierarchical proportions
+- **DiffViewer** -- side-by-side and unified diff display with hunk navigation
+- **DependencyGraph** -- service/component relationship visualization with directed graph
+- **LogCorrelation** -- side-by-side time-aligned log streams with synchronized scrolling
 
-### 1.4 Retrofit Tree
+**Not yet implemented:**
+- Sankey Diagram (flow visualization between categories)
 
-- Add `ScrollState` to `TreeState<T>`
-- Render only lines in visible range from flattened output
-- Use `ensure_visible(selected_index)` for selection tracking
+#### Additional Components (Beyond Original Roadmap)
 
-### 1.5 Scrollbar Theme Integration
+These components were added outside the original iteration plan, including the "Claude Code" family of components built for AI-assisted TUI development:
 
-- Add scrollbar style methods to `Theme` (thumb color, track color)
-- Ensure consistent scrollbar appearance across all retrofitted components
-
----
-
-## Iteration 2: Data Visualization Primitives
-
-**Why second**: These are the building blocks for all visualization components. ratatui already has underlying widgets (Sparkline, Gauge, Canvas) that envision doesn't yet wrap. Low effort, high value.
-
-### 2.1 Sparkline Component
-
-Compact inline data trend display (1-2 rows tall). Wraps ratatui's `Sparkline` widget. Distinct from Chart — designed for embedding in dashboards, status bars, and table cells.
-
-- State: `Vec<u64>` data, optional label, max display points, direction (L→R or R→L)
-- Push/clear data, bounded push with max length
-- Display-only (no focus/interaction needed)
-
-### 2.2 Gauge Component
-
-Ratio/percentage display with visual fill bar and centered label. Wraps ratatui's `Gauge` and `LineGauge`. Distinct from ProgressBar — shows ratios and measurements, not task progress.
-
-- Two variants: full Gauge (block fill) and LineGauge (single-line compact)
-- Configurable threshold zones (green/yellow/red) with custom breakpoints
-- Units display ("75% CPU", "3.2 GB / 8 GB")
-- Optional label, color customization per zone
-
-### 2.3 Canvas Component
-
-General-purpose drawing surface wrapping ratatui's `Canvas`. Enables custom visualizations without building new components.
-
-- Drawing primitives: Line, Rectangle, Circle, Points, Label
-- Coordinate system with x/y bounds
-- Custom `Shape` trait support for user-defined shapes
-- Focusable for pan/zoom interaction
-- Foundation for Heatmap, ScatterPlot, FlameGraph, etc.
-
-### 2.4 Enhanced Chart
-
-Extend existing Chart component with missing capabilities:
-
-- **Area chart** mode (filled line chart)
-- **Stacked bar** and **grouped bar** modes
-- **Scatter plot** mode with labeled points
-- **Threshold/reference lines** (horizontal markers at configurable values)
-- **Shared Y-axis** for multi-series line charts (currently stacks vertically)
-- Manual min/max scaling (currently always auto-scales)
-- Data point interaction (navigate to individual points, emit selection)
-- Use ratatui's full `Chart` widget with `Axis` for proper axes rendering
+- **CodeBlock** -- syntax-highlighted code display with line numbers, scrolling, 10+ languages
+- **TerminalOutput** -- ANSI-aware terminal output rendering
+- **MarkdownRenderer** -- Markdown rendering with headings, lists, code blocks, emphasis
+- **ConversationView** -- chat-style conversation display (user/assistant messages)
+- **Accordion** -- multi-section expandable/collapsible container
+- **Breadcrumb** -- hierarchical navigation path indicator
+- **Dropdown** -- single-selection dropdown menu
+- **KeyHints** -- compact keybinding hints display
+- **MultiProgress** -- multiple concurrent progress tracking
+- **Select** -- enhanced selection component
+- **StatusBar** -- application status bar
+- **StatusLog** -- timestamped status message log
+- **StepIndicator** -- multi-step process progress (wizard-style)
+- **StyledText** -- rich text with inline styling
+- **TabBar** -- enhanced tab navigation bar
+- **TitleCard** -- titled content card with borders
+- **Tooltip** -- contextual tooltip overlays
+- **UsageDisplay** -- resource usage visualization
+- **Router** -- view routing/navigation management
+- **ConfirmDialog** -- simplified confirmation dialog
 
 ---
 
-## Iteration 3: New General-Purpose Components
+## What's Next
 
-**Why third**: Fills the gaps that make envision feel incomplete compared to other frameworks. These are all broadly useful, not observability-specific.
+### Remaining Items from Iterations 3-6
 
-### Input Components
+These components from the original roadmap have not yet been implemented:
 
-**3.1 Slider** — Numeric range selection with keyboard control. Horizontal/vertical orientation, configurable min/max/step, visual track and thumb.
+| Component | Original Iteration | Description |
+|-----------|-------------------|-------------|
+| DatePicker | Iteration 3 | Date selection combining Calendar with input field |
+| ScrollView / Viewport | Iteration 3 | Generic scrollable container for arbitrary widget content |
+| ScatterPlot | Iteration 4 | First-class scatter plot with labeled points, clusters, trend lines |
+| BoxPlot | Iteration 4 | Statistical distribution visualization (median, quartiles, outliers) |
+| Sankey Diagram | Iteration 6 | Flow visualization between categories showing magnitude |
 
-**3.2 Switch/Toggle** — On/off toggle, visually distinct from checkbox. Animated slide between states.
+### Iteration 7: Existing Component Enhancements
 
-**3.3 NumberInput** — Numeric input with validation, increment/decrement (Up/Down arrows), optional min/max bounds, step size.
+These improve existing components. Can be tackled incrementally as needed:
 
-**3.4 DatePicker** — Date selection combining a Calendar widget with input. Month navigation, day selection, configurable date format.
+- **LogViewer**: regex search, structured field columns, follow mode indicator, context lines, timestamp filtering, search history
+- **Chart**: animation/transitions, legend toggle, tooltip on selection, export to clipboard
+- **Table**: multi-column sort, custom comparators, column resizing, row grouping, row expansion
+- **MetricsDashboard**: configurable thresholds, units display, visual gauge bars, comparison/delta display, error states
+- **DataGrid**: cell validation hooks, read-only columns, column hiding/reordering, multi-cell selection, undo/redo
+- **TextArea / InputField**: syntax highlighting, line numbers, find/replace
 
-### Display Components
+### Infrastructure
 
-**3.5 Calendar** — Month view with date selection and event markers. Wraps ratatui's `Calendar` widget with envision's Component pattern.
-
-**3.6 BigText / Digits** — Large pixel text rendering for dashboard hero numbers. Think: big counter displays, clocks, KPI values.
-
-**3.7 Divider / Rule** — Horizontal or vertical separator line with optional label. Simple but universally needed for layout.
-
-**3.8 Paginator** — Page navigation indicator ("Page 3 of 12", "Showing 51-100 of 2,847"). Works with virtual scrolling.
-
-### Navigation Components
-
-**3.9 CommandPalette** — Searchable, fuzzy-filtered action/item picker. The most impactful UX pattern in modern tools (k9s, Helix, VS Code). Input field + filtered list + preview area. Generic over action/item type.
-
-**3.10 HelpPanel** — Auto-generated keybinding display from a list of (key, description) pairs. Overlay or inline. Every serious TUI app needs this.
-
-### Container Components
-
-**3.11 ScrollView / Viewport** — Generic scrollable container for arbitrary widget content. The missing layout primitive — wraps any content in a scrollable viewport with virtual scrolling.
-
-**3.12 Collapsible** — Single expandable/collapsible section with header. Distinct from Accordion (which is multi-section). More composable.
+- **ratatui 0.30 support** -- Support both ratatui 0.29 and 0.30 via feature flags ([Issue #126](https://github.com/ryanoneill/envision/issues/126))
+- **Crate split** -- Consider splitting into envision (core) and envision-components crates ([Issue #124](https://github.com/ryanoneill/envision/issues/124))
 
 ---
 
-## Iteration 4: Statistical Visualization
-
-**Why fourth**: Builds on Canvas and enhanced Chart from Iteration 2. These are the analytical primitives that make envision uniquely powerful for data-heavy applications.
-
-### 4.1 Histogram
-
-Binned frequency distribution display. Distinct from bar chart — automatic binning of continuous data, bucket labels, configurable bin count/width.
-
-Use cases: latency distribution, request size distribution, error frequency.
-
-### 4.2 Heatmap
-
-2D color-intensity grid. **No TUI framework has this as a reusable widget.**
-
-- Row and column labels
-- Configurable color scale (sequential, diverging)
-- Cell value display on hover/selection
-- Keyboard navigation between cells
-
-Use cases: GitHub-style contribution graphs, correlation matrices, error rate by hour x day, latency percentiles.
-
-### 4.3 ScatterPlot
-
-First-class scatter plot with labeled points, optional clusters, and trend lines. Builds on Canvas.
-
-Use cases: correlation analysis, anomaly detection, latency vs throughput.
-
-### 4.4 BoxPlot
-
-Statistical distribution visualization showing median, quartiles, outliers. Multiple box plots side-by-side for comparison.
-
-Use cases: P50/P95/P99 latency comparison across services, response time distributions.
-
----
-
-## Iteration 5: Observability Components
-
-**Why fifth**: These are the novel, differentiating components. They compose primitives from Iterations 1-4 into compound components purpose-built for observability — but designed as general-purpose building blocks.
-
-### 5.1 Timeline
-
-Horizontal timeline with events/spans plotted along a time axis. Zoomable, pannable, with event markers.
-
-- Time-axis rendering with auto-scaling (ms/s/min/hr)
-- Event markers with severity/category coloring
-- Span bars (start time + duration)
-- Zoom in/out, scroll left/right
-- Selection and detail display
-
-Use cases: distributed trace visualization (like Jaeger UI), deployment timelines, incident timelines, CI/CD pipelines.
-
-### 5.2 SpanTree
-
-Hierarchical tree with horizontal timing bars — essentially a Gantt chart for trace spans. Combines Tree navigation with Timeline rendering.
-
-- Tree structure with expand/collapse
-- Duration bars aligned to a shared time axis
-- Color-coded by service/status
-- Selection emits span details
-
-Use cases: distributed tracing (the primary Jaeger/Zipkin view), profiler output, task dependency visualization.
-
-### 5.3 FlameGraph
-
-Interactive flame graph rendering in the terminal. **No TUI framework offers this as a composable widget.**
-
-- Stack frame rendering with width proportional to time/samples
-- Zoom into subtrees
-- Search/highlight frames matching a pattern
-- Color by: package, self-time, frequency
-
-Use cases: CPU profiling, memory allocation analysis, call stack visualization.
-
-### 5.4 EventStream
-
-Real-time filterable event feed with severity coloring and structured fields. More structured than LogViewer — each event has typed key-value fields, not just text.
-
-- Structured event display (timestamp, level, fields as columns)
-- Dynamic column visibility
-- Real-time append with rate indicator
-- Pattern detection (highlight repeated events, group bursts)
-- Virtual scrolling from day one
-
-Use cases: structured logging, audit trails, real-time event monitoring.
-
-### 5.5 AlertPanel
-
-Metric display with configurable threshold states (OK/Warning/Critical/Unknown). Visual state transitions with history.
-
-- Metric value with threshold zones
-- State badge (colored indicator)
-- Sparkline history
-- Time-in-state tracking
-- Configurable thresholds per metric
-
-Use cases: SLI/SLO dashboards, infrastructure health panels, alerting displays.
-
----
-
-## Iteration 6: Advanced Visualization
-
-**Why sixth**: These are complex compound components that build on everything before them. High effort, high differentiation.
-
-### 6.1 Treemap
-
-Nested rectangles showing hierarchical proportions. Builds on Canvas.
-
-Use cases: disk usage, memory allocation by module, request volume by service/endpoint.
-
-### 6.2 Sankey Diagram
-
-Flow visualization between categories. Shows magnitude of flow between nodes.
-
-Use cases: request routing visualization, data pipeline flows, traffic distribution.
-
-### 6.3 DiffViewer
-
-Side-by-side or unified diff display with hunk navigation. Every git TUI builds this ad-hoc — none offer it as a reusable widget.
-
-- Unified and side-by-side modes
-- Hunk navigation (next/prev change)
-- Line-level highlighting (added/removed/modified)
-- Virtual scrolling for large diffs
-
-### 6.4 DependencyGraph
-
-Service/component relationship visualization. Directed graph with nodes and edges.
-
-- Node layout (force-directed or hierarchical)
-- Edge rendering with direction indicators
-- Node status coloring (healthy/degraded/down)
-- Selection and detail display
-- Zoom and pan
-
-Use cases: service mesh topology, dependency health, architecture visualization.
-
-### 6.5 LogCorrelation
-
-Side-by-side time-aligned log streams from multiple sources. Filter independently but scroll in sync.
-
-- Multiple log panes (2-4 sources)
-- Time-synchronized scrolling
-- Independent filtering per pane
-- Cross-pane search highlighting
-- Shared timeline ruler
-
-Use cases: distributed system debugging, multi-service log analysis.
-
----
-
-## Iteration 7: Existing Component Enhancements
-
-**Why last**: These improve existing components but aren't blocking new work. Can be interleaved with other iterations as needed.
-
-### 7.1 LogViewer Enhancements
-- Regex search (not just substring)
-- Structured field columns (key=value parsing)
-- Follow mode indicator (tail -f style)
-- Context lines around search matches
-- Timestamp/date-range filtering
-- Search history
-
-### 7.2 Chart Enhancements
-- Animation/transitions between data updates
-- Legend toggle (click to show/hide series)
-- Tooltip on data point selection
-- Export data to clipboard
-
-### 7.3 Table Enhancements
-- Multi-column sort
-- Custom sort comparators (numeric, date, etc.)
-- Column resizing via keyboard
-- Row grouping/aggregation
-- Row expansion (detail view)
-
-### 7.4 MetricsDashboard Enhancements
-- Configurable threshold breakpoints (not hardcoded 70/90%)
-- Units display on metric values
-- Visual gauge bars (not just text)
-- Comparison/delta display
-- Error/degraded widget states
-- Timestamped history points
-
-### 7.5 DataGrid Enhancements
-- Cell validation hooks
-- Read-only columns
-- Column hiding/reordering
-- Multi-cell selection
-- Undo/redo for edits
-
-### 7.6 TextArea / InputField Enhancements
-- Syntax highlighting (for code input)
-- Line numbers
-- Find/replace
-
----
-
-## Dependency Graph
-
-```
-Iteration 1 (Virtual Scrolling)
-    |
-    +---> Iteration 2 (Viz Primitives: Sparkline, Gauge, Canvas, Enhanced Chart)
-    |         |
-    |         +---> Iteration 4 (Statistical: Histogram, Heatmap, ScatterPlot, BoxPlot)
-    |         |         |
-    |         |         +---> Iteration 6 (Advanced: Treemap, Sankey, DependencyGraph)
-    |         |
-    |         +---> Iteration 5 (Observability: Timeline, SpanTree, FlameGraph, EventStream, AlertPanel)
-    |                   |
-    |                   +---> Iteration 6 (Advanced: LogCorrelation, DiffViewer)
-    |
-    +---> Iteration 3 (General-Purpose: CommandPalette, Slider, Calendar, etc.)
-    |
-    +---> Iteration 7 (Existing Component Enhancements) [can be interleaved anytime]
-```
-
-## Component Count Projection
-
-| Category | Current | After Roadmap |
-|----------|---------|---------------|
-| Input | 8 | 12 (+Slider, Switch, NumberInput, DatePicker) |
-| Data | 4 | 4 (enhanced, not new) |
-| Display | 10 | 17 (+Sparkline, Gauge, BigText, Divider, Paginator, Calendar, Heatmap) |
-| Navigation | 6 | 8 (+CommandPalette, HelpPanel) |
-| Overlay | 3 | 3 |
-| Compound | 9 | 21 (+Canvas, Histogram, ScatterPlot, BoxPlot, Timeline, SpanTree, FlameGraph, EventStream, AlertPanel, Treemap, Sankey, DiffViewer, DependencyGraph, LogCorrelation, ScrollView, Collapsible) |
-| Infrastructure | 1 | 2 (+ScrollState) |
-| **Total** | **42** | **67** |
-
-## Implementation Notes
-
-- Each new component follows the established pattern: `src/component/<name>/mod.rs` + `tests.rs`
-- Feature flags: new visualization components under `visualization-components`, new observability components under `observability-components`, both included in `full`
-- Every component gets: unit tests, snapshot tests, at least one example, doc tests
-- Virtual scrolling is integrated via composition (embed `ScrollState` in component state), not inheritance
-- Canvas-based components (Heatmap, ScatterPlot, FlameGraph, Treemap, Sankey, DependencyGraph) share the Canvas primitive
-- All new components support the existing trait system (Focusable, Disableable, Toggleable where appropriate)
+## Component Count
+
+| Category | Count |
+|----------|-------|
+| Input | 12 (InputField, Checkbox, RadioGroup, Button, Slider, Switch, NumberInput, Select, Dropdown, LineInput, TextArea, Form) |
+| Data | 4 (SelectableList, Table, DataGrid, LoadingList) |
+| Display | 20 (ProgressBar, Spinner, Chart, Sparkline, Gauge, BigText, Divider, Paginator, Calendar, Heatmap, Histogram, CodeBlock, TerminalOutput, MarkdownRenderer, StyledText, StatusBar, StatusLog, MultiProgress, StepIndicator, UsageDisplay) |
+| Navigation | 10 (Menu, Tabs, TabBar, Breadcrumb, CommandPalette, HelpPanel, KeyHints, Router, Tree, FileBrowser) |
+| Overlay | 5 (Dialog, ConfirmDialog, Toast, Tooltip, TitleCard) |
+| Compound | 20 (SearchableList, SplitPanel, PaneLayout, Form, LogViewer, ChatView, ConversationView, MetricsDashboard, Canvas, Timeline, SpanTree, FlameGraph, EventStream, AlertPanel, Treemap, DiffViewer, DependencyGraph, LogCorrelation, Accordion, Collapsible) |
+| Infrastructure | 1 (FocusManager) |
+| **Total** | **72** |

--- a/examples/component_showcase.rs
+++ b/examples/component_showcase.rs
@@ -1,4 +1,4 @@
-//! Component Showcase - Demonstrating 12+ Envision components in a single application.
+//! Component Showcase - Demonstrating 18+ Envision components in a single application.
 //!
 //! This example shows how to compose multiple components together into a cohesive
 //! application using The Elm Architecture (TEA) pattern. It demonstrates:
@@ -24,14 +24,24 @@
 //! - Spinner (loading animation)
 //! - Toast (notification popups)
 //! - Dialog (modal confirmation)
+//! - Sparkline (compact data trend)
+//! - Gauge (visual measurement)
+//! - Heatmap (2D color grid)
+//! - Timeline (event/span visualization)
+//! - CommandPalette (fuzzy finder)
+//! - CodeBlock (syntax highlighting)
 //!
-//! Run with: `cargo run --example component_showcase`
+//! Run with: `cargo run --example component_showcase --features full`
 
+use envision::component::code_block::highlight::Language;
 use envision::component::{
-    ButtonState, CheckboxState, Column, Component, Dialog, DialogMessage, DialogOutput,
-    DialogState, FocusManager, InputFieldState, MenuItem, MenuOutput, MenuState, ProgressBarState,
-    RadioGroupState, SelectableListState, Spinner, SpinnerMessage, SpinnerState, Table,
-    TableOutput, TableRow, TableState, Tabs, TabsState, Toast, ToastMessage, ToastState,
+    ButtonState, CheckboxState, CodeBlock, CodeBlockState, Column, CommandPalette,
+    CommandPaletteState, Component, Dialog, DialogMessage, DialogOutput, DialogState, FocusManager,
+    Gauge, GaugeState, GaugeVariant, Heatmap, HeatmapState, InputFieldState, MenuItem, MenuOutput,
+    MenuState, PaletteItem, ProgressBarState, RadioGroupState, SelectableListState, Sparkline,
+    SparklineState, Spinner, SpinnerMessage, SpinnerState, Table, TableOutput, TableRow,
+    TableState, Tabs, TabsState, Timeline, TimelineEvent, TimelineSpan, TimelineState, Toast,
+    ToastMessage, ToastState,
 };
 use envision::prelude::*;
 use ratatui::layout::{Alignment, Constraint, Layout};
@@ -53,6 +63,10 @@ enum FocusId {
     List,
     Table,
     Progress,
+    Heatmap,
+    Timeline,
+    CommandPalette,
+    CodeBlock,
 }
 
 // ---------------------------------------------------------------------------
@@ -83,6 +97,7 @@ enum Panel {
     Form,
     Data,
     Status,
+    Viz,
 }
 
 impl std::fmt::Display for Panel {
@@ -91,6 +106,7 @@ impl std::fmt::Display for Panel {
             Panel::Form => write!(f, "Form"),
             Panel::Data => write!(f, "Data"),
             Panel::Status => write!(f, "Status"),
+            Panel::Viz => write!(f, "Viz"),
         }
     }
 }
@@ -117,6 +133,14 @@ struct State {
     spinner: SpinnerState,
     toast: ToastState,
 
+    // Viz panel
+    sparkline: SparklineState,
+    gauge: GaugeState,
+    heatmap: HeatmapState,
+    timeline: TimelineState,
+    command_palette: CommandPaletteState,
+    code_block: CodeBlockState,
+
     // Dialog overlay
     dialog: DialogState,
 
@@ -136,10 +160,14 @@ impl Default for State {
             FocusId::List,
             FocusId::Table,
             FocusId::Progress,
+            FocusId::Heatmap,
+            FocusId::Timeline,
+            FocusId::CommandPalette,
+            FocusId::CodeBlock,
         ]);
         focus.focus(&FocusId::Tabs);
 
-        let tabs = TabsState::new(vec![Panel::Form, Panel::Data, Panel::Status]);
+        let tabs = TabsState::new(vec![Panel::Form, Panel::Data, Panel::Status, Panel::Viz]);
 
         let menu = MenuState::new(vec![
             MenuItem::new("File"),
@@ -204,6 +232,64 @@ impl Default for State {
 
         let toast = ToastState::with_max_visible(3);
 
+        // Viz panel components
+        let sparkline =
+            SparklineState::with_data(vec![2, 5, 8, 12, 7, 4, 9, 15, 11, 6, 3, 8, 10, 14, 9, 5])
+                .with_title("Request Rate");
+
+        let gauge = GaugeState::new(73.0, 100.0)
+            .with_label("CPU Usage")
+            .with_units("%")
+            .with_variant(GaugeVariant::Full);
+
+        let heatmap = HeatmapState::with_data(vec![
+            vec![1.0, 3.0, 5.0, 2.0, 7.0],
+            vec![4.0, 6.0, 2.0, 8.0, 3.0],
+            vec![2.0, 1.0, 9.0, 4.0, 6.0],
+        ])
+        .with_row_labels(vec!["Mon".into(), "Tue".into(), "Wed".into()])
+        .with_col_labels(vec![
+            "00:00".into(),
+            "06:00".into(),
+            "12:00".into(),
+            "18:00".into(),
+            "24:00".into(),
+        ])
+        .with_title("Error Rate by Day/Hour");
+
+        let timeline = TimelineState::new()
+            .with_events(vec![
+                TimelineEvent::new("e1", 100.0, "Deploy v2.1"),
+                TimelineEvent::new("e2", 450.0, "Alert fired"),
+                TimelineEvent::new("e3", 800.0, "Resolved"),
+            ])
+            .with_spans(vec![
+                TimelineSpan::new("s1", 100.0, 300.0, "Build"),
+                TimelineSpan::new("s2", 300.0, 700.0, "Test"),
+                TimelineSpan::new("s3", 700.0, 900.0, "Deploy"),
+            ])
+            .with_view_range(0.0, 1000.0)
+            .with_title("CI/CD Pipeline");
+
+        let command_palette = CommandPaletteState::new(vec![
+            PaletteItem::new("open", "Open File"),
+            PaletteItem::new("save", "Save File"),
+            PaletteItem::new("quit", "Quit Application"),
+            PaletteItem::new("find", "Find in Files"),
+            PaletteItem::new("replace", "Find and Replace"),
+            PaletteItem::new("settings", "Open Settings"),
+        ])
+        .with_title("Command Palette")
+        .with_visible(true);
+
+        let code_block = CodeBlockState::new()
+            .with_code(
+                "fn main() {\n    let data = vec![1, 2, 3];\n    for item in &data {\n        println!(\"{item}\");\n    }\n}",
+            )
+            .with_language(Language::Rust)
+            .with_line_numbers(true)
+            .with_title("Example Code");
+
         let dialog = DialogState::confirm("Confirm Submission", "Submit the form?");
 
         Self {
@@ -219,6 +305,12 @@ impl Default for State {
             progress,
             spinner,
             toast,
+            sparkline,
+            gauge,
+            heatmap,
+            timeline,
+            command_palette,
+            code_block,
             dialog,
             submission_count: 0,
         }
@@ -327,6 +419,18 @@ impl App for ShowcaseApp {
                         // Progress bar isn't interactive via keyboard;
                         // could extend to handle +/- keys here.
                     }
+                    Some(FocusId::Heatmap) => {
+                        state.heatmap.dispatch_event(&event);
+                    }
+                    Some(FocusId::Timeline) => {
+                        state.timeline.dispatch_event(&event);
+                    }
+                    Some(FocusId::CommandPalette) => {
+                        state.command_palette.dispatch_event(&event);
+                    }
+                    Some(FocusId::CodeBlock) => {
+                        state.code_block.dispatch_event(&event);
+                    }
                     None => {}
                 }
             }
@@ -366,6 +470,7 @@ impl App for ShowcaseApp {
             Some(Panel::Form) => render_form_panel(state, frame, content_area, &theme),
             Some(Panel::Data) => render_data_panel(state, frame, content_area, &theme),
             Some(Panel::Status) => render_status_panel(state, frame, content_area, &theme),
+            Some(Panel::Viz) => render_viz_panel(state, frame, content_area, &theme),
             None => {}
         }
 
@@ -514,6 +619,42 @@ fn render_status_panel(state: &State, frame: &mut Frame, area: Rect, theme: &The
     Toast::view(&state.toast, frame, chunks[2], theme);
 }
 
+fn render_viz_panel(state: &State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme.border_style())
+        .title("Visualization Panel");
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    // Top row: Sparkline + Gauge | Bottom row: Heatmap + Timeline + CodeBlock
+    let rows = Layout::vertical([
+        Constraint::Length(5), // Sparkline + Gauge
+        Constraint::Length(7), // Heatmap
+        Constraint::Length(8), // Timeline
+        Constraint::Min(6),    // CommandPalette + CodeBlock
+    ])
+    .split(inner);
+
+    // Row 1: Sparkline (left) + Gauge (right)
+    let top_cols =
+        Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)]).split(rows[0]);
+    Sparkline::view(&state.sparkline, frame, top_cols[0], theme);
+    Gauge::view(&state.gauge, frame, top_cols[1], theme);
+
+    // Row 2: Heatmap (full width)
+    Heatmap::view(&state.heatmap, frame, rows[1], theme);
+
+    // Row 3: Timeline (full width)
+    Timeline::view(&state.timeline, frame, rows[2], theme);
+
+    // Row 4: CommandPalette (left) + CodeBlock (right)
+    let bottom_cols =
+        Layout::horizontal([Constraint::Percentage(40), Constraint::Percentage(60)]).split(rows[3]);
+    CommandPalette::view(&state.command_palette, frame, bottom_cols[0], theme);
+    CodeBlock::view(&state.code_block, frame, bottom_cols[1], theme);
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -535,6 +676,16 @@ fn sync_focus(state: &mut State) {
         .set_focused(focused == Some(FocusId::SubmitButton));
     state.list.set_focused(focused == Some(FocusId::List));
     state.table.set_focused(focused == Some(FocusId::Table));
+    state.heatmap.set_focused(focused == Some(FocusId::Heatmap));
+    state
+        .timeline
+        .set_focused(focused == Some(FocusId::Timeline));
+    state
+        .command_palette
+        .set_focused(focused == Some(FocusId::CommandPalette));
+    state
+        .code_block
+        .set_focused(focused == Some(FocusId::CodeBlock));
 }
 
 /// Creates a centered rectangle for dialog overlays.
@@ -549,10 +700,10 @@ fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
 // ---------------------------------------------------------------------------
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<ShowcaseApp, _>::virtual_terminal(80, 30)?;
+    let mut vt = Runtime::<ShowcaseApp, _>::virtual_terminal(80, 40)?;
 
     println!("=== Component Showcase ===\n");
-    println!("Demonstrating 12 Envision components with simplified event routing.\n");
+    println!("Demonstrating 18 Envision components with simplified event routing.\n");
 
     // Initial render (Form panel)
     vt.tick()?;
@@ -645,11 +796,36 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("--- After Submission (toast notification) ---");
     println!("{}\n", vt.display_ansi());
 
+    // Switch to Viz panel to show new components
+    vt.dispatch(Msg::FocusNext); // -> List
+    vt.dispatch(Msg::FocusNext); // -> Table
+    vt.dispatch(Msg::FocusNext); // -> Progress
+    vt.dispatch(Msg::FocusNext); // -> Heatmap
+    vt.dispatch(Msg::FocusNext); // -> Timeline
+    vt.dispatch(Msg::FocusNext); // -> CommandPalette
+    vt.dispatch(Msg::FocusNext); // -> CodeBlock
+    vt.dispatch(Msg::FocusNext); // -> Menu (wraps)
+    vt.dispatch(Msg::FocusNext); // -> Tabs
+                                 // Navigate right three times to reach Viz tab
+    vt.dispatch(Msg::ComponentEvent(Event::key(
+        crossterm::event::KeyCode::Right,
+    )));
+    vt.dispatch(Msg::ComponentEvent(Event::key(
+        crossterm::event::KeyCode::Right,
+    )));
+    vt.dispatch(Msg::ComponentEvent(Event::key(
+        crossterm::event::KeyCode::Right,
+    )));
+    vt.tick()?;
+    println!("--- Viz Panel (Sparkline, Gauge, Heatmap, Timeline, CommandPalette, CodeBlock) ---");
+    println!("{}\n", vt.display_ansi());
+
     println!("=== Showcase Complete ===");
     println!("This example demonstrated Menu, Tabs, InputField, Checkbox,");
     println!("RadioGroup, Button, SelectableList, Table, ProgressBar,");
-    println!("Spinner, Toast, and Dialog components working together.");
-    println!("\nKey improvements shown:");
+    println!("Spinner, Toast, Dialog, Sparkline, Gauge, Heatmap,");
+    println!("Timeline, CommandPalette, and CodeBlock components working together.");
+    println!("\nKey patterns shown:");
     println!("  - Msg enum: 6 variants (was 30+)");
     println!("  - sync_focus: no turbofish needed");
     println!("  - dispatch_event: routes events to focused component directly");


### PR DESCRIPTION
## Summary

- **ROADMAP.md**: Rewrote to reflect the current state of 72 components across 6 completed iterations. Marked Iterations 1-6 as COMPLETE/MOSTLY COMPLETE, documented the "Claude Code" family of components (CodeBlock, TerminalOutput, MarkdownRenderer, ConversationView, etc.), and added a "What's Next" section covering remaining items (Sankey, DatePicker, ScrollView, ScatterPlot, BoxPlot), Iteration 7 enhancements, and infrastructure work (ratatui 0.30 support via Issue #126, crate split via Issue #124).
- **component_showcase example**: Expanded from 12 to 18 components by adding a new "Viz" tab panel demonstrating Sparkline (compact trend), Gauge (visual measurement), Heatmap (2D color grid), Timeline (event/span visualization), CommandPalette (fuzzy finder), and CodeBlock (syntax highlighting). All new components integrate with the existing FocusManager, event routing, and theme system.

## Test plan

- [x] `cargo fmt` -- no formatting issues
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- no warnings
- [x] `cargo build --example component_showcase --features full` -- builds successfully
- [x] `cargo run --example component_showcase --features full` -- runs and renders all panels including the new Viz panel
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)