### PR TITLE
Improve doc test coverage for lowest-coverage components

### DIFF
--- a/src/component/diff_viewer/mod.rs
+++ b/src/component/diff_viewer/mod.rs
@@ -310,12 +310,28 @@ impl DiffViewerState {
     }
 
     /// Sets the number of context lines for compute_diff (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let state = DiffViewerState::new().with_context_lines(5);
+    /// ```
     pub fn with_context_lines(mut self, lines: usize) -> Self {
         self.context_lines = lines;
         self
     }
 
     /// Sets whether to show line numbers (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let state = DiffViewerState::new().with_show_line_numbers(false);
+    /// ```
     pub fn with_show_line_numbers(mut self, show: bool) -> Self {
         self.show_line_numbers = show;
         self
@@ -336,18 +352,43 @@ impl DiffViewerState {
     }
 
     /// Sets the label for the old file (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let state = DiffViewerState::new().with_old_label("original.rs");
+    /// ```
     pub fn with_old_label(mut self, label: impl Into<String>) -> Self {
         self.old_label = Some(label.into());
         self
     }
 
     /// Sets the label for the new file (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let state = DiffViewerState::new().with_new_label("modified.rs");
+    /// ```
     pub fn with_new_label(mut self, label: impl Into<String>) -> Self {
         self.new_label = Some(label.into());
         self
     }
 
     /// Sets the disabled state (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let state = DiffViewerState::new().with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn with_disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
         self
@@ -371,11 +412,29 @@ impl DiffViewerState {
     }
 
     /// Returns the total number of displayable lines across all hunks.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let state = DiffViewerState::from_texts("old line", "new line");
+    /// assert!(state.total_lines() > 0);
+    /// ```
     pub fn total_lines(&self) -> usize {
         count_total_lines(&self.hunks)
     }
 
     /// Returns the count of added lines across all hunks.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let state = DiffViewerState::from_texts("old", "new\nextra");
+    /// assert!(state.added_count() >= 1);
+    /// ```
     pub fn added_count(&self) -> usize {
         self.hunks
             .iter()
@@ -385,6 +444,15 @@ impl DiffViewerState {
     }
 
     /// Returns the count of removed lines across all hunks.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let state = DiffViewerState::from_texts("old\nextra", "new");
+    /// assert!(state.removed_count() >= 1);
+    /// ```
     pub fn removed_count(&self) -> usize {
         self.hunks
             .iter()
@@ -394,11 +462,32 @@ impl DiffViewerState {
     }
 
     /// Returns the count of changed lines (added + removed).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let state = DiffViewerState::from_texts("old line", "new line");
+    /// assert_eq!(state.changed_count(), state.added_count() + state.removed_count());
+    /// ```
     pub fn changed_count(&self) -> usize {
         self.added_count() + self.removed_count()
     }
 
     /// Returns the display mode.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{DiffViewerState, DiffMode};
+    ///
+    /// let state = DiffViewerState::new();
+    /// assert_eq!(state.mode(), &DiffMode::Unified);
+    ///
+    /// let state = DiffViewerState::new().with_mode(DiffMode::SideBySide);
+    /// assert_eq!(state.mode(), &DiffMode::SideBySide);
+    /// ```
     pub fn mode(&self) -> &DiffMode {
         &self.mode
     }

--- a/src/component/file_browser/mod.rs
+++ b/src/component/file_browser/mod.rs
@@ -290,6 +290,17 @@ impl FileBrowserState {
     }
 
     /// Sets the sort field (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState, FileSortField};
+    ///
+    /// let state = FileBrowserState::new("/", vec![
+    ///     FileEntry::file("a.txt", "/a.txt"),
+    /// ]).with_sort_field(FileSortField::Size);
+    /// assert_eq!(state.sort_field(), &FileSortField::Size);
+    /// ```
     pub fn with_sort_field(mut self, field: FileSortField) -> Self {
         self.sort_field = field;
         self.sort_and_filter();
@@ -297,6 +308,17 @@ impl FileBrowserState {
     }
 
     /// Sets the sort direction (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState, FileSortDirection};
+    ///
+    /// let state = FileBrowserState::new("/", vec![
+    ///     FileEntry::file("a.txt", "/a.txt"),
+    /// ]).with_sort_direction(FileSortDirection::Descending);
+    /// assert_eq!(state.sort_direction(), &FileSortDirection::Descending);
+    /// ```
     pub fn with_sort_direction(mut self, direction: FileSortDirection) -> Self {
         self.sort_direction = direction;
         self.sort_and_filter();
@@ -340,6 +362,15 @@ impl FileBrowserState {
     }
 
     /// Returns the path segments for breadcrumb display.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState};
+    ///
+    /// let state = FileBrowserState::new("/home/user", vec![]);
+    /// assert_eq!(state.path_segments(), &["/", "home", "user"]);
+    /// ```
     pub fn path_segments(&self) -> &[String] {
         &self.path_segments
     }
@@ -355,6 +386,18 @@ impl FileBrowserState {
     }
 
     /// Returns the filtered entries.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState};
+    ///
+    /// let state = FileBrowserState::new("/", vec![
+    ///     FileEntry::file("readme.md", "/readme.md"),
+    ///     FileEntry::directory("src", "/src"),
+    /// ]);
+    /// assert_eq!(state.filtered_entries().len(), 2);
+    /// ```
     pub fn filtered_entries(&self) -> Vec<&FileEntry> {
         self.filtered_indices
             .iter()
@@ -403,6 +446,15 @@ impl FileBrowserState {
     }
 
     /// Returns the selected paths (for multi-select mode).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState};
+    ///
+    /// let state = FileBrowserState::new("/", vec![]);
+    /// assert!(state.selected_paths().is_empty());
+    /// ```
     pub fn selected_paths(&self) -> &[String] {
         &self.selected_paths
     }

--- a/src/component/file_browser/types.rs
+++ b/src/component/file_browser/types.rs
@@ -72,12 +72,30 @@ impl FileEntry {
     }
 
     /// Sets the file size (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::FileEntry;
+    ///
+    /// let entry = FileEntry::file("data.bin", "/data.bin").with_size(1024);
+    /// assert_eq!(entry.size(), Some(1024));
+    /// ```
     pub fn with_size(mut self, size: u64) -> Self {
         self.size = Some(size);
         self
     }
 
     /// Sets the modification timestamp (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::FileEntry;
+    ///
+    /// let entry = FileEntry::file("data.bin", "/data.bin").with_modified(1700000000);
+    /// assert_eq!(entry.modified(), Some(1700000000));
+    /// ```
     pub fn with_modified(mut self, modified: u64) -> Self {
         self.modified = Some(modified);
         self
@@ -109,11 +127,35 @@ impl FileEntry {
     }
 
     /// Returns the file extension, if any.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::FileEntry;
+    ///
+    /// let entry = FileEntry::file("main.rs", "/main.rs");
+    /// assert_eq!(entry.extension(), Some("rs"));
+    ///
+    /// let dir = FileEntry::directory("src", "/src");
+    /// assert_eq!(dir.extension(), None);
+    /// ```
     pub fn extension(&self) -> Option<&str> {
         self.extension.as_deref()
     }
 
     /// Returns true if this is a hidden entry.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::FileEntry;
+    ///
+    /// let hidden = FileEntry::file(".gitignore", "/.gitignore");
+    /// assert!(hidden.is_hidden());
+    ///
+    /// let visible = FileEntry::file("README.md", "/README.md");
+    /// assert!(!visible.is_hidden());
+    /// ```
     pub fn is_hidden(&self) -> bool {
         self.hidden
     }

--- a/src/component/loading_list/mod.rs
+++ b/src/component/loading_list/mod.rs
@@ -90,6 +90,15 @@ impl ItemState {
     }
 
     /// Returns true if the item is ready.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ItemState;
+    ///
+    /// assert!(ItemState::Ready.is_ready());
+    /// assert!(!ItemState::Loading.is_ready());
+    /// ```
     pub fn is_ready(&self) -> bool {
         matches!(self, Self::Ready)
     }
@@ -161,6 +170,16 @@ impl<T: Clone + PartialEq> PartialEq for LoadingListItem<T> {
 
 impl<T: Clone> LoadingListItem<T> {
     /// Creates a new item.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListItem;
+    ///
+    /// let item = LoadingListItem::new("data", "Label");
+    /// assert_eq!(item.label(), "Label");
+    /// assert!(item.is_ready());
+    /// ```
     pub fn new(data: T, label: impl Into<String>) -> Self {
         Self {
             data,
@@ -170,6 +189,15 @@ impl<T: Clone> LoadingListItem<T> {
     }
 
     /// Returns the underlying data.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListItem;
+    ///
+    /// let item = LoadingListItem::new(42, "Answer");
+    /// assert_eq!(*item.data(), 42);
+    /// ```
     pub fn data(&self) -> &T {
         &self.data
     }
@@ -318,6 +346,16 @@ impl<T: Clone> Default for LoadingListState<T> {
 
 impl<T: Clone> LoadingListState<T> {
     /// Creates a new empty LoadingList state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let state = LoadingListState::<String>::new();
+    /// assert!(state.is_empty());
+    /// assert_eq!(state.len(), 0);
+    /// ```
     pub fn new() -> Self {
         Self::default()
     }
@@ -429,6 +467,15 @@ impl<T: Clone> LoadingListState<T> {
     }
 
     /// Sets the disabled state using builder pattern.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let state = LoadingListState::<String>::new().with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn with_disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
         self
@@ -572,6 +619,25 @@ impl<T: Clone> LoadingListState<T> {
     }
 
     /// Returns the number of items with errors.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// #[derive(Clone)]
+    /// struct Task { name: String }
+    ///
+    /// let mut state = LoadingListState::with_items(
+    ///     vec![
+    ///         Task { name: "A".to_string() },
+    ///         Task { name: "B".to_string() },
+    ///     ],
+    ///     |t| t.name.clone(),
+    /// );
+    /// state.set_error(0, "failed");
+    /// assert_eq!(state.error_count(), 1);
+    /// ```
     pub fn error_count(&self) -> usize {
         self.items.iter().filter(|i| i.is_error()).count()
     }
@@ -582,6 +648,23 @@ impl<T: Clone> LoadingListState<T> {
     }
 
     /// Returns true if any item has an error.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// #[derive(Clone)]
+    /// struct Task { name: String }
+    ///
+    /// let mut state = LoadingListState::with_items(
+    ///     vec![Task { name: "Build".to_string() }],
+    ///     |t| t.name.clone(),
+    /// );
+    /// assert!(!state.has_errors());
+    /// state.set_error(0, "Failed to build");
+    /// assert!(state.has_errors());
+    /// ```
     pub fn has_errors(&self) -> bool {
         self.items.iter().any(|i| i.is_error())
     }

--- a/src/component/log_viewer/mod.rs
+++ b/src/component/log_viewer/mod.rs
@@ -270,6 +270,15 @@ impl LogViewerState {
     }
 
     /// Sets the disabled state (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let state = LogViewerState::new().with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn with_disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
         self
@@ -308,16 +317,46 @@ impl LogViewerState {
     }
 
     /// Adds a warning-level entry, returning its ID.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new();
+    /// let id = state.push_warning("Disk space low");
+    /// assert_eq!(state.len(), 1);
+    /// ```
     pub fn push_warning(&mut self, message: impl Into<String>) -> u64 {
         self.push_entry(message.into(), StatusLogLevel::Warning, None)
     }
 
     /// Adds an error-level entry, returning its ID.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new();
+    /// let id = state.push_error("Connection refused");
+    /// assert_eq!(state.len(), 1);
+    /// ```
     pub fn push_error(&mut self, message: impl Into<String>) -> u64 {
         self.push_entry(message.into(), StatusLogLevel::Error, None)
     }
 
     /// Adds an info-level entry with a timestamp, returning its ID.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new().with_timestamps(true);
+    /// let id = state.push_info_with_timestamp("Server started", "12:00:00");
+    /// assert_eq!(state.len(), 1);
+    /// ```
     pub fn push_info_with_timestamp(
         &mut self,
         message: impl Into<String>,
@@ -429,6 +468,17 @@ impl LogViewerState {
     // ---- Accessors ----
 
     /// Returns all entries in insertion order.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new();
+    /// state.push_info("first");
+    /// state.push_error("second");
+    /// assert_eq!(state.entries().len(), 2);
+    /// ```
     pub fn entries(&self) -> &[StatusLogEntry] {
         &self.entries
     }
@@ -449,6 +499,16 @@ impl LogViewerState {
     }
 
     /// Sets the maximum number of entries.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new();
+    /// state.set_max_entries(200);
+    /// assert_eq!(state.max_entries(), 200);
+    /// ```
     pub fn set_max_entries(&mut self, max: usize) {
         self.max_entries = max;
         while self.entries.len() > self.max_entries {
@@ -457,6 +517,15 @@ impl LogViewerState {
     }
 
     /// Returns the current search text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let state = LogViewerState::new();
+    /// assert_eq!(state.search_text(), "");
+    /// ```
     pub fn search_text(&self) -> &str {
         &self.search_text
     }
@@ -495,6 +564,15 @@ impl LogViewerState {
     }
 
     /// Returns true if info entries are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let state = LogViewerState::new();
+    /// assert!(state.show_info());
+    /// ```
     pub fn show_info(&self) -> bool {
         self.show_info
     }

--- a/src/component/multi_progress/mod.rs
+++ b/src/component/multi_progress/mod.rs
@@ -119,11 +119,29 @@ impl ProgressItem {
     }
 
     /// Returns the item ID.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressItem;
+    ///
+    /// let item = ProgressItem::new("task-1", "Download");
+    /// assert_eq!(item.id(), "task-1");
+    /// ```
     pub fn id(&self) -> &str {
         &self.id
     }
 
     /// Returns the label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressItem;
+    ///
+    /// let item = ProgressItem::new("t1", "Uploading");
+    /// assert_eq!(item.label(), "Uploading");
+    /// ```
     pub fn label(&self) -> &str {
         &self.label
     }
@@ -134,11 +152,29 @@ impl ProgressItem {
     }
 
     /// Returns the status.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ProgressItem, ProgressItemStatus};
+    ///
+    /// let item = ProgressItem::new("t1", "Task");
+    /// assert_eq!(item.status(), ProgressItemStatus::Pending);
+    /// ```
     pub fn status(&self) -> ProgressItemStatus {
         self.status
     }
 
     /// Returns the optional message.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressItem;
+    ///
+    /// let item = ProgressItem::new("t1", "Task");
+    /// assert_eq!(item.message(), None);
+    /// ```
     pub fn message(&self) -> Option<&str> {
         self.message.as_deref()
     }
@@ -274,12 +310,30 @@ impl MultiProgressState {
     }
 
     /// Sets the maximum number of visible items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let state = MultiProgressState::new().with_max_visible(5);
+    /// assert_eq!(state.max_visible(), 5);
+    /// ```
     pub fn with_max_visible(mut self, max: usize) -> Self {
         self.max_visible = max;
         self
     }
 
     /// Sets whether to auto-remove completed items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let state = MultiProgressState::new().with_auto_remove(true);
+    /// assert!(state.auto_remove_completed());
+    /// ```
     pub fn with_auto_remove(mut self, auto_remove: bool) -> Self {
         self.auto_remove_completed = auto_remove;
         self
@@ -301,6 +355,15 @@ impl MultiProgressState {
     }
 
     /// Sets whether to show percentages.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let state = MultiProgressState::new().with_percentages(false);
+    /// assert!(!state.show_percentages());
+    /// ```
     pub fn with_percentages(mut self, show: bool) -> Self {
         self.show_percentages = show;
         self
@@ -330,11 +393,33 @@ impl MultiProgressState {
     }
 
     /// Returns all items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let mut state = MultiProgressState::new();
+    /// state.add("t1", "Task 1");
+    /// assert_eq!(state.items().len(), 1);
+    /// assert_eq!(state.items()[0].label(), "Task 1");
+    /// ```
     pub fn items(&self) -> &[ProgressItem] {
         &self.items
     }
 
     /// Returns the number of items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let mut state = MultiProgressState::new();
+    /// assert_eq!(state.len(), 0);
+    /// state.add("t1", "Task");
+    /// assert_eq!(state.len(), 1);
+    /// ```
     pub fn len(&self) -> usize {
         self.items.len()
     }
@@ -345,6 +430,18 @@ impl MultiProgressState {
     }
 
     /// Returns the number of completed items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{MultiProgress, MultiProgressState, MultiProgressMessage, Component};
+    ///
+    /// let mut state = MultiProgressState::new();
+    /// state.add("t1", "Task 1");
+    /// state.add("t2", "Task 2");
+    /// MultiProgress::update(&mut state, MultiProgressMessage::Complete("t1".to_string()));
+    /// assert_eq!(state.completed_count(), 1);
+    /// ```
     pub fn completed_count(&self) -> usize {
         self.items
             .iter()
@@ -353,6 +450,20 @@ impl MultiProgressState {
     }
 
     /// Returns the number of failed items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{MultiProgress, MultiProgressState, MultiProgressMessage, Component};
+    ///
+    /// let mut state = MultiProgressState::new();
+    /// state.add("t1", "Task 1");
+    /// MultiProgress::update(&mut state, MultiProgressMessage::Fail {
+    ///     id: "t1".to_string(),
+    ///     message: Some("timeout".to_string()),
+    /// });
+    /// assert_eq!(state.failed_count(), 1);
+    /// ```
     pub fn failed_count(&self) -> usize {
         self.items
             .iter()
@@ -361,6 +472,20 @@ impl MultiProgressState {
     }
 
     /// Returns the number of active items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{MultiProgress, MultiProgressState, MultiProgressMessage, Component};
+    ///
+    /// let mut state = MultiProgressState::new();
+    /// state.add("t1", "Task 1");
+    /// MultiProgress::update(&mut state, MultiProgressMessage::SetProgress {
+    ///     id: "t1".to_string(),
+    ///     progress: 0.5,
+    /// });
+    /// assert_eq!(state.active_count(), 1);
+    /// ```
     pub fn active_count(&self) -> usize {
         self.items
             .iter()
@@ -410,6 +535,17 @@ impl MultiProgressState {
     }
 
     /// Finds a mutable item by ID.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let mut state = MultiProgressState::new();
+    /// state.add("dl", "Download");
+    /// assert!(state.find_mut("dl").is_some());
+    /// assert!(state.find_mut("missing").is_none());
+    /// ```
     pub fn find_mut(&mut self, id: &str) -> Option<&mut ProgressItem> {
         self.items.iter_mut().find(|i| i.id == id)
     }
@@ -433,12 +569,32 @@ impl MultiProgressState {
     }
 
     /// Clears all items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let mut state = MultiProgressState::new();
+    /// state.add("t1", "Task");
+    /// state.clear();
+    /// assert!(state.is_empty());
+    /// ```
     pub fn clear(&mut self) {
         self.items.clear();
         self.scroll_offset = 0;
     }
 
     /// Returns the maximum visible items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let state = MultiProgressState::new();
+    /// assert_eq!(state.max_visible(), 8); // default
+    /// ```
     pub fn max_visible(&self) -> usize {
         self.max_visible
     }
@@ -509,6 +665,15 @@ impl MultiProgressState {
     }
 
     /// Sets the disabled state using builder pattern.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let state = MultiProgressState::new().with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn with_disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
         self

--- a/src/component/pane_layout/mod.rs
+++ b/src/component/pane_layout/mod.rs
@@ -89,6 +89,16 @@ pub struct PaneConfig {
 
 impl PaneConfig {
     /// Creates a new pane with default proportion (equal share).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::PaneConfig;
+    ///
+    /// let pane = PaneConfig::new("sidebar");
+    /// assert_eq!(pane.id(), "sidebar");
+    /// assert_eq!(pane.title(), None);
+    /// ```
     pub fn new(id: impl Into<String>) -> Self {
         Self {
             id: id.into(),
@@ -100,6 +110,15 @@ impl PaneConfig {
     }
 
     /// Sets the title (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::PaneConfig;
+    ///
+    /// let pane = PaneConfig::new("sidebar").with_title("Files");
+    /// assert_eq!(pane.title(), Some("Files"));
+    /// ```
     pub fn with_title(mut self, title: impl Into<String>) -> Self {
         self.title = Some(title.into());
         self
@@ -108,12 +127,30 @@ impl PaneConfig {
     /// Sets the proportion (builder pattern).
     ///
     /// Proportions are normalized relative to other panes' proportions.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::PaneConfig;
+    ///
+    /// let pane = PaneConfig::new("main").with_proportion(0.7);
+    /// assert!((pane.proportion() - 0.7).abs() < f32::EPSILON);
+    /// ```
     pub fn with_proportion(mut self, proportion: f32) -> Self {
         self.proportion = proportion.max(0.0);
         self
     }
 
     /// Sets the minimum size in cells (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::PaneConfig;
+    ///
+    /// let pane = PaneConfig::new("sidebar").with_min_size(20);
+    /// assert_eq!(pane.min_size(), 20);
+    /// ```
     pub fn with_min_size(mut self, min_size: u16) -> Self {
         self.min_size = min_size.max(1);
         self
@@ -122,6 +159,15 @@ impl PaneConfig {
     /// Sets the maximum size in cells (builder pattern).
     ///
     /// A value of 0 means no maximum.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::PaneConfig;
+    ///
+    /// let pane = PaneConfig::new("sidebar").with_max_size(60);
+    /// assert_eq!(pane.max_size(), 60);
+    /// ```
     pub fn with_max_size(mut self, max_size: u16) -> Self {
         self.max_size = max_size;
         self
@@ -259,6 +305,20 @@ impl PaneLayoutState {
     /// Creates a new pane layout with the given direction and panes.
     ///
     /// Pane proportions are automatically normalized to sum to 1.0.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::{PaneConfig, PaneDirection};
+    /// use envision::component::PaneLayoutState;
+    ///
+    /// let state = PaneLayoutState::new(PaneDirection::Horizontal, vec![
+    ///     PaneConfig::new("left"),
+    ///     PaneConfig::new("right"),
+    /// ]);
+    /// assert_eq!(state.pane_count(), 2);
+    /// assert_eq!(state.focused_pane_id(), Some("left"));
+    /// ```
     pub fn new(direction: PaneDirection, panes: Vec<PaneConfig>) -> Self {
         let mut state = Self {
             direction,
@@ -292,6 +352,18 @@ impl PaneLayoutState {
     }
 
     /// Sets the disabled state (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::{PaneConfig, PaneDirection};
+    /// use envision::component::PaneLayoutState;
+    ///
+    /// let state = PaneLayoutState::new(PaneDirection::Horizontal, vec![
+    ///     PaneConfig::new("a"),
+    /// ]).with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn with_disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
         self
@@ -348,6 +420,22 @@ impl PaneLayoutState {
     }
 
     /// Returns the area for a specific pane by ID.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::{PaneConfig, PaneDirection};
+    /// use envision::component::PaneLayoutState;
+    /// use ratatui::prelude::Rect;
+    ///
+    /// let state = PaneLayoutState::new(PaneDirection::Horizontal, vec![
+    ///     PaneConfig::new("left").with_proportion(0.5),
+    ///     PaneConfig::new("right").with_proportion(0.5),
+    /// ]);
+    /// let area = Rect::new(0, 0, 80, 24);
+    /// let left_area = state.pane_area(area, "left").unwrap();
+    /// assert_eq!(left_area.width, 40);
+    /// ```
     pub fn pane_area(&self, area: Rect, pane_id: &str) -> Option<Rect> {
         let index = self.panes.iter().position(|p| p.id == pane_id)?;
         let rects = self.layout(area);
@@ -375,6 +463,20 @@ impl PaneLayoutState {
     }
 
     /// Returns the pane configurations.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::{PaneConfig, PaneDirection};
+    /// use envision::component::PaneLayoutState;
+    ///
+    /// let state = PaneLayoutState::new(PaneDirection::Horizontal, vec![
+    ///     PaneConfig::new("left").with_title("Left"),
+    ///     PaneConfig::new("right").with_title("Right"),
+    /// ]);
+    /// assert_eq!(state.panes().len(), 2);
+    /// assert_eq!(state.panes()[0].title(), Some("Left"));
+    /// ```
     pub fn panes(&self) -> &[PaneConfig] {
         &self.panes
     }
@@ -398,6 +500,19 @@ impl PaneLayoutState {
     }
 
     /// Returns the focused pane index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::{PaneConfig, PaneDirection};
+    /// use envision::component::PaneLayoutState;
+    ///
+    /// let state = PaneLayoutState::new(PaneDirection::Horizontal, vec![
+    ///     PaneConfig::new("left"),
+    ///     PaneConfig::new("right"),
+    /// ]);
+    /// assert_eq!(state.focused_pane_index(), 0);
+    /// ```
     pub fn focused_pane_index(&self) -> usize {
         self.focused_pane
     }

--- a/src/component/split_panel/mod.rs
+++ b/src/component/split_panel/mod.rs
@@ -193,6 +193,16 @@ impl SplitPanelState {
     }
 
     /// Sets the orientation.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SplitPanelState, SplitOrientation};
+    ///
+    /// let mut state = SplitPanelState::new(SplitOrientation::Vertical);
+    /// state.set_orientation(SplitOrientation::Horizontal);
+    /// assert_eq!(state.orientation(), &SplitOrientation::Horizontal);
+    /// ```
     pub fn set_orientation(&mut self, orientation: SplitOrientation) {
         self.orientation = orientation;
     }
@@ -206,11 +216,31 @@ impl SplitPanelState {
     }
 
     /// Sets the split ratio, clamped to `[min_ratio, max_ratio]`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SplitPanelState, SplitOrientation};
+    ///
+    /// let mut state = SplitPanelState::new(SplitOrientation::Vertical);
+    /// state.set_ratio(0.7);
+    /// assert!((state.ratio() - 0.7).abs() < f32::EPSILON);
+    /// ```
     pub fn set_ratio(&mut self, ratio: f32) {
         self.ratio = ratio.clamp(self.min_ratio, self.max_ratio);
     }
 
     /// Returns true if the first pane has focus.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SplitPanelState, SplitOrientation};
+    ///
+    /// let state = SplitPanelState::new(SplitOrientation::Vertical);
+    /// assert!(state.is_first_pane_focused());
+    /// assert!(!state.is_second_pane_focused());
+    /// ```
     pub fn is_first_pane_focused(&self) -> bool {
         self.focused_pane == Pane::First
     }
@@ -279,6 +309,15 @@ impl SplitPanelState {
     }
 
     /// Sets the disabled state (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SplitPanelState, SplitOrientation};
+    ///
+    /// let state = SplitPanelState::new(SplitOrientation::Vertical).with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn with_disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
         self
@@ -302,6 +341,18 @@ impl SplitPanelState {
     /// Computes the layout areas for the two panes.
     ///
     /// Returns `(first_pane_area, second_pane_area)`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SplitPanelState, SplitOrientation};
+    /// use ratatui::prelude::Rect;
+    ///
+    /// let state = SplitPanelState::new(SplitOrientation::Vertical);
+    /// let area = Rect::new(0, 0, 80, 24);
+    /// let (first, second) = state.layout(area);
+    /// assert_eq!(first.width + second.width, 80);
+    /// ```
     pub fn layout(&self, area: Rect) -> (Rect, Rect) {
         let direction = match self.orientation {
             SplitOrientation::Vertical => Direction::Horizontal,

--- a/src/component/tab_bar/mod.rs
+++ b/src/component/tab_bar/mod.rs
@@ -109,64 +109,185 @@ impl Tab {
     }
 
     /// Sets whether the tab is closable (builder).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Tab;
+    ///
+    /// let tab = Tab::new("t1", "File").with_closable(true);
+    /// assert!(tab.closable());
+    /// ```
     pub fn with_closable(mut self, closable: bool) -> Self {
         self.closable = closable;
         self
     }
 
     /// Sets whether the tab is modified (builder).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Tab;
+    ///
+    /// let tab = Tab::new("t1", "File").with_modified(true);
+    /// assert!(tab.modified());
+    /// ```
     pub fn with_modified(mut self, modified: bool) -> Self {
         self.modified = modified;
         self
     }
 
     /// Sets an icon for the tab (builder).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Tab;
+    ///
+    /// let tab = Tab::new("t1", "File").with_icon("R");
+    /// assert_eq!(tab.icon(), Some("R"));
+    /// ```
     pub fn with_icon(mut self, icon: impl Into<String>) -> Self {
         self.icon = Some(icon.into());
         self
     }
 
     /// Returns the tab's unique identifier.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Tab;
+    ///
+    /// let tab = Tab::new("editor-1", "main.rs");
+    /// assert_eq!(tab.id(), "editor-1");
+    /// ```
     pub fn id(&self) -> &str {
         &self.id
     }
 
     /// Returns the tab's display label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Tab;
+    ///
+    /// let tab = Tab::new("t1", "Overview");
+    /// assert_eq!(tab.label(), "Overview");
+    /// ```
     pub fn label(&self) -> &str {
         &self.label
     }
 
     /// Returns whether the tab is closable.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Tab;
+    ///
+    /// let tab = Tab::new("t1", "File");
+    /// assert!(!tab.closable());
+    ///
+    /// let tab = Tab::new("t1", "File").with_closable(true);
+    /// assert!(tab.closable());
+    /// ```
     pub fn closable(&self) -> bool {
         self.closable
     }
 
     /// Returns whether the tab has unsaved modifications.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Tab;
+    ///
+    /// let tab = Tab::new("t1", "File").with_modified(true);
+    /// assert!(tab.modified());
+    /// ```
     pub fn modified(&self) -> bool {
         self.modified
     }
 
     /// Returns the tab's icon, if any.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Tab;
+    ///
+    /// let tab = Tab::new("t1", "File");
+    /// assert_eq!(tab.icon(), None);
+    ///
+    /// let tab = Tab::new("t1", "File").with_icon("R");
+    /// assert_eq!(tab.icon(), Some("R"));
+    /// ```
     pub fn icon(&self) -> Option<&str> {
         self.icon.as_deref()
     }
 
     /// Sets the label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Tab;
+    ///
+    /// let mut tab = Tab::new("t1", "Old Name");
+    /// tab.set_label("New Name");
+    /// assert_eq!(tab.label(), "New Name");
+    /// ```
     pub fn set_label(&mut self, label: impl Into<String>) {
         self.label = label.into();
     }
 
     /// Sets the closable flag.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Tab;
+    ///
+    /// let mut tab = Tab::new("t1", "File");
+    /// tab.set_closable(true);
+    /// assert!(tab.closable());
+    /// ```
     pub fn set_closable(&mut self, closable: bool) {
         self.closable = closable;
     }
 
     /// Sets the modified flag.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Tab;
+    ///
+    /// let mut tab = Tab::new("t1", "File");
+    /// tab.set_modified(true);
+    /// assert!(tab.modified());
+    /// ```
     pub fn set_modified(&mut self, modified: bool) {
         self.modified = modified;
     }
 
     /// Sets the icon.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Tab;
+    ///
+    /// let mut tab = Tab::new("t1", "File");
+    /// tab.set_icon(Some("R".to_string()));
+    /// assert_eq!(tab.icon(), Some("R"));
+    ///
+    /// tab.set_icon(None);
+    /// assert_eq!(tab.icon(), None);
+    /// ```
     pub fn set_icon(&mut self, icon: Option<String>) {
         self.icon = icon;
     }
@@ -385,42 +506,123 @@ impl TabBarState {
     // -- Accessors -----------------------------------------------------------
 
     /// Returns the tabs.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState};
+    ///
+    /// let state = TabBarState::new(vec![
+    ///     Tab::new("a", "Alpha"),
+    ///     Tab::new("b", "Beta"),
+    /// ]);
+    /// assert_eq!(state.tabs().len(), 2);
+    /// assert_eq!(state.tabs()[0].label(), "Alpha");
+    /// ```
     pub fn tabs(&self) -> &[Tab] {
         &self.tabs
     }
 
     /// Returns a mutable reference to the tabs.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState};
+    ///
+    /// let mut state = TabBarState::new(vec![Tab::new("a", "Alpha")]);
+    /// state.tabs_mut()[0].set_label("Renamed");
+    /// assert_eq!(state.tabs()[0].label(), "Renamed");
+    /// ```
     pub fn tabs_mut(&mut self) -> &mut [Tab] {
         &mut self.tabs
     }
 
     /// Returns the currently active tab index, or `None` if empty.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState};
+    ///
+    /// let state = TabBarState::new(vec![Tab::new("a", "A"), Tab::new("b", "B")]);
+    /// assert_eq!(state.active_index(), Some(0));
+    ///
+    /// let empty = TabBarState::new(vec![]);
+    /// assert_eq!(empty.active_index(), None);
+    /// ```
     pub fn active_index(&self) -> Option<usize> {
         self.active
     }
 
     /// Returns the currently active tab, or `None` if empty.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState};
+    ///
+    /// let state = TabBarState::new(vec![Tab::new("a", "Alpha")]);
+    /// assert_eq!(state.active_tab().unwrap().label(), "Alpha");
+    /// ```
     pub fn active_tab(&self) -> Option<&Tab> {
         self.tabs.get(self.active?)
     }
 
     /// Returns a mutable reference to the active tab.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState};
+    ///
+    /// let mut state = TabBarState::new(vec![Tab::new("a", "Alpha")]);
+    /// state.active_tab_mut().unwrap().set_modified(true);
+    /// assert!(state.active_tab().unwrap().modified());
+    /// ```
     pub fn active_tab_mut(&mut self) -> Option<&mut Tab> {
         let idx = self.active?;
         self.tabs.get_mut(idx)
     }
 
     /// Returns the number of tabs.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState};
+    ///
+    /// let state = TabBarState::new(vec![Tab::new("a", "A"), Tab::new("b", "B")]);
+    /// assert_eq!(state.len(), 2);
+    /// ```
     pub fn len(&self) -> usize {
         self.tabs.len()
     }
 
     /// Returns true if there are no tabs.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TabBarState;
+    ///
+    /// let state = TabBarState::new(vec![]);
+    /// assert!(state.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.tabs.is_empty()
     }
 
     /// Returns the scroll offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState};
+    ///
+    /// let state = TabBarState::new(vec![Tab::new("a", "A")]);
+    /// assert_eq!(state.scroll_offset(), 0);
+    /// ```
     pub fn scroll_offset(&self) -> usize {
         self.scroll_offset
     }
@@ -445,6 +647,22 @@ impl TabBarState {
     /// Sets the active tab by index.
     ///
     /// `None` clears the selection. `Some(i)` is clamped to the valid range.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState};
+    ///
+    /// let mut state = TabBarState::new(vec![
+    ///     Tab::new("a", "A"),
+    ///     Tab::new("b", "B"),
+    /// ]);
+    /// state.set_active(Some(1));
+    /// assert_eq!(state.active_index(), Some(1));
+    ///
+    /// state.set_active(None);
+    /// assert_eq!(state.active_index(), None);
+    /// ```
     pub fn set_active(&mut self, index: Option<usize>) {
         match index {
             Some(i) if !self.tabs.is_empty() => {
@@ -455,11 +673,31 @@ impl TabBarState {
     }
 
     /// Sets the scroll offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState};
+    ///
+    /// let mut state = TabBarState::new(vec![Tab::new("a", "A")]);
+    /// state.set_scroll_offset(5);
+    /// assert_eq!(state.scroll_offset(), 5);
+    /// ```
     pub fn set_scroll_offset(&mut self, offset: usize) {
         self.scroll_offset = offset;
     }
 
     /// Sets the max tab width.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState};
+    ///
+    /// let mut state = TabBarState::new(vec![Tab::new("a", "A")]);
+    /// state.set_max_tab_width(Some(15));
+    /// assert_eq!(state.max_tab_width(), Some(15));
+    /// ```
     pub fn set_max_tab_width(&mut self, max: Option<usize>) {
         self.max_tab_width = max;
     }
@@ -475,6 +713,17 @@ impl TabBarState {
     }
 
     /// Replaces all tabs, clamping or clearing the active index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState};
+    ///
+    /// let mut state = TabBarState::new(vec![Tab::new("a", "A")]);
+    /// state.set_tabs(vec![Tab::new("x", "X"), Tab::new("y", "Y")]);
+    /// assert_eq!(state.len(), 2);
+    /// assert_eq!(state.tabs()[0].label(), "X");
+    /// ```
     pub fn set_tabs(&mut self, tabs: Vec<Tab>) {
         self.tabs = tabs;
         if self.tabs.is_empty() {
@@ -488,6 +737,22 @@ impl TabBarState {
     }
 
     /// Returns a tab by its id, if present.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState};
+    ///
+    /// let state = TabBarState::new(vec![
+    ///     Tab::new("file1", "main.rs"),
+    ///     Tab::new("file2", "lib.rs"),
+    /// ]);
+    /// let (index, tab) = state.find_tab_by_id("file2").unwrap();
+    /// assert_eq!(index, 1);
+    /// assert_eq!(tab.label(), "lib.rs");
+    ///
+    /// assert!(state.find_tab_by_id("missing").is_none());
+    /// ```
     pub fn find_tab_by_id(&self, id: &str) -> Option<(usize, &Tab)> {
         self.tabs.iter().enumerate().find(|(_, t)| t.id() == id)
     }
@@ -495,16 +760,59 @@ impl TabBarState {
     // -- Instance methods that delegate to component -------------------------
 
     /// Maps an input event to a tab bar message.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState, TabBarMessage};
+    /// use envision::input::{Event, KeyCode};
+    ///
+    /// let mut state = TabBarState::new(vec![Tab::new("a", "A")]);
+    /// state.set_focused(true);
+    ///
+    /// let msg = state.handle_event(&Event::key(KeyCode::Right));
+    /// assert_eq!(msg, Some(TabBarMessage::NextTab));
+    /// ```
     pub fn handle_event(&self, event: &Event) -> Option<TabBarMessage> {
         TabBar::handle_event(self, event)
     }
 
     /// Dispatches an event, updating state and returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState, TabBarOutput};
+    /// use envision::input::{Event, KeyCode};
+    ///
+    /// let mut state = TabBarState::new(vec![
+    ///     Tab::new("a", "A"),
+    ///     Tab::new("b", "B"),
+    /// ]);
+    /// state.set_focused(true);
+    ///
+    /// let output = state.dispatch_event(&Event::key(KeyCode::Right));
+    /// assert_eq!(output, Some(TabBarOutput::TabSelected(1)));
+    /// ```
     pub fn dispatch_event(&mut self, event: &Event) -> Option<TabBarOutput> {
         TabBar::dispatch_event(self, event)
     }
 
     /// Updates the tab bar state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState, TabBarMessage, TabBarOutput};
+    ///
+    /// let mut state = TabBarState::new(vec![
+    ///     Tab::new("a", "A"),
+    ///     Tab::new("b", "B"),
+    /// ]);
+    /// let output = state.update(TabBarMessage::NextTab);
+    /// assert_eq!(output, Some(TabBarOutput::TabSelected(1)));
+    /// assert_eq!(state.active_index(), Some(1));
+    /// ```
     pub fn update(&mut self, msg: TabBarMessage) -> Option<TabBarOutput> {
         TabBar::update(self, msg)
     }

--- a/src/component/table/mod.rs
+++ b/src/component/table/mod.rs
@@ -286,11 +286,52 @@ impl<T: TableRow> TableState<T> {
     /// Returns the current sort configuration.
     ///
     /// Returns `None` if no sort is applied.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Column, Table, TableRow, TableState, TableMessage, SortDirection, Component};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let mut state = TableState::new(
+    ///     vec![Item { name: "B".into() }, Item { name: "A".into() }],
+    ///     vec![Column::new("Name", Constraint::Length(10)).sortable()],
+    /// );
+    /// assert_eq!(state.sort(), None);
+    ///
+    /// Table::<Item>::update(&mut state, TableMessage::SortBy(0));
+    /// assert_eq!(state.sort(), Some((0, SortDirection::Ascending)));
+    /// ```
     pub fn sort(&self) -> Option<(usize, SortDirection)> {
         self.sort
     }
 
     /// Returns the number of rows.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Column, TableRow, TableState};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = TableState::new(
+    ///     vec![Item { name: "A".into() }, Item { name: "B".into() }],
+    ///     vec![Column::new("Name", Constraint::Length(10))],
+    /// );
+    /// assert_eq!(state.len(), 2);
+    /// ```
     pub fn len(&self) -> usize {
         self.rows.len()
     }
@@ -394,11 +435,53 @@ impl<T: TableRow> TableState<T> {
     }
 
     /// Returns the current filter text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Column, TableRow, TableState};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let mut state = TableState::new(
+    ///     vec![Item { name: "A".into() }],
+    ///     vec![Column::new("Name", Constraint::Length(10))],
+    /// );
+    /// assert_eq!(state.filter_text(), "");
+    /// state.set_filter_text("A");
+    /// assert_eq!(state.filter_text(), "A");
+    /// ```
     pub fn filter_text(&self) -> &str {
         &self.filter_text
     }
 
     /// Returns the number of rows visible after filtering.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Column, TableRow, TableState};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let mut state = TableState::new(
+    ///     vec![Item { name: "Alice".into() }, Item { name: "Bob".into() }],
+    ///     vec![Column::new("Name", Constraint::Length(10))],
+    /// );
+    /// assert_eq!(state.visible_count(), 2);
+    /// state.set_filter_text("Alice");
+    /// assert_eq!(state.visible_count(), 1);
+    /// ```
     pub fn visible_count(&self) -> usize {
         self.display_order.len()
     }

--- a/src/component/table/types.rs
+++ b/src/component/table/types.rs
@@ -67,6 +67,17 @@ impl Column {
     /// Creates a new column with the given header and width.
     ///
     /// The column is not sortable by default.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Column;
+    /// use ratatui::layout::Constraint;
+    ///
+    /// let col = Column::new("Name", Constraint::Length(20));
+    /// assert_eq!(col.header(), "Name");
+    /// assert!(!col.is_sortable());
+    /// ```
     pub fn new(header: impl Into<String>, width: Constraint) -> Self {
         Self {
             header: header.into(),
@@ -79,6 +90,16 @@ impl Column {
     ///
     /// Sortable columns can be sorted by clicking/selecting the header
     /// or using `TableMessage::SortBy`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Column;
+    /// use ratatui::layout::Constraint;
+    ///
+    /// let col = Column::new("Name", Constraint::Length(20)).sortable();
+    /// assert!(col.is_sortable());
+    /// ```
     pub fn sortable(mut self) -> Self {
         self.sortable = true;
         self
@@ -162,6 +183,15 @@ pub enum SortDirection {
 
 impl SortDirection {
     /// Returns the opposite sort direction.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SortDirection;
+    ///
+    /// assert_eq!(SortDirection::Ascending.toggle(), SortDirection::Descending);
+    /// assert_eq!(SortDirection::Descending.toggle(), SortDirection::Ascending);
+    /// ```
     pub fn toggle(self) -> Self {
         match self {
             SortDirection::Ascending => SortDirection::Descending,

--- a/src/component/terminal_output/mod.rs
+++ b/src/component/terminal_output/mod.rs
@@ -371,6 +371,20 @@ impl TerminalOutputState {
     }
 
     /// Returns all output lines.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "display-components")]
+    /// # {
+    /// use envision::component::TerminalOutputState;
+    ///
+    /// let mut state = TerminalOutputState::new();
+    /// state.push_line("line 1");
+    /// state.push_line("line 2");
+    /// assert_eq!(state.lines(), &["line 1", "line 2"]);
+    /// # }
+    /// ```
     pub fn lines(&self) -> &[String] {
         &self.lines
     }
@@ -400,6 +414,19 @@ impl TerminalOutputState {
     }
 
     /// Sets the maximum number of lines.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "display-components")]
+    /// # {
+    /// use envision::component::TerminalOutputState;
+    ///
+    /// let mut state = TerminalOutputState::new();
+    /// state.set_max_lines(500);
+    /// assert_eq!(state.max_lines(), 500);
+    /// # }
+    /// ```
     pub fn set_max_lines(&mut self, max: usize) {
         self.max_lines = max;
         self.enforce_max_lines();
@@ -436,11 +463,41 @@ impl TerminalOutputState {
     }
 
     /// Returns the exit code, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "display-components")]
+    /// # {
+    /// use envision::component::TerminalOutputState;
+    ///
+    /// let mut state = TerminalOutputState::new();
+    /// assert_eq!(state.exit_code(), None);
+    /// state.set_exit_code(Some(0));
+    /// assert_eq!(state.exit_code(), Some(0));
+    /// # }
+    /// ```
     pub fn exit_code(&self) -> Option<i32> {
         self.exit_code
     }
 
     /// Sets the exit code.
+    ///
+    /// Setting an exit code also sets `running` to `false`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "display-components")]
+    /// # {
+    /// use envision::component::TerminalOutputState;
+    ///
+    /// let mut state = TerminalOutputState::new().with_running(true);
+    /// state.set_exit_code(Some(0));
+    /// assert_eq!(state.exit_code(), Some(0));
+    /// assert!(!state.running());
+    /// # }
+    /// ```
     pub fn set_exit_code(&mut self, code: Option<i32>) {
         self.exit_code = code;
         if code.is_some() {
@@ -449,6 +506,21 @@ impl TerminalOutputState {
     }
 
     /// Returns whether the process is running.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "display-components")]
+    /// # {
+    /// use envision::component::TerminalOutputState;
+    ///
+    /// let state = TerminalOutputState::new();
+    /// assert!(!state.running());
+    ///
+    /// let state = TerminalOutputState::new().with_running(true);
+    /// assert!(state.running());
+    /// # }
+    /// ```
     pub fn running(&self) -> bool {
         self.running
     }


### PR DESCRIPTION
## Summary

- Added doc tests to public methods across the 10 lowest-coverage components: `tab_bar`, `multi_progress`, `pane_layout`, `loading_list`, `log_viewer`, `file_browser`, `split_panel`, `diff_viewer`, `table`, and `terminal_output`
- Each doc test demonstrates real usage with meaningful assertions (not trivial `assert!(true)` patterns)
- All 1618 doc tests pass, clippy clean, no warnings

### Components improved (with approximate new doc test counts):

| Component | New Doc Tests |
|-----------|--------------|
| `tab_bar` | ~25 (Tab + TabBarState methods) |
| `multi_progress` | ~15 (ProgressItem + MultiProgressState methods) |
| `pane_layout` | ~10 (PaneConfig + PaneLayoutState methods) |
| `loading_list` | ~8 (ItemState + LoadingListItem + LoadingListState methods) |
| `log_viewer` | ~8 (push/filter/accessor methods) |
| `file_browser` | ~8 (FileEntry + FileBrowserState methods) |
| `split_panel` | ~6 (orientation/ratio/layout methods) |
| `diff_viewer` | ~10 (builder + count/mode methods) |
| `table` | ~8 (sort/filter/count + Column/SortDirection methods) |
| `terminal_output` | ~6 (lines/exit_code/running methods) |

## Test plan

- [x] `cargo test --all-features --doc` passes (1618 doc tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt` applied
- [x] No implementation changes - documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)