### PR TITLE
Make test_utils::setup_render public (audit #18)

### DIFF
--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -824,7 +824,7 @@ pub trait Disableable: Component {
     }
 }
 
-#[cfg(test)]
-mod test_utils;
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;
 #[cfg(test)]
 mod tests;

--- a/src/component/test_utils.rs
+++ b/src/component/test_utils.rs
@@ -2,7 +2,20 @@ use crate::backend::CaptureBackend;
 use crate::theme::Theme;
 use ratatui::Terminal;
 
-pub(crate) fn setup_render(width: u16, height: u16) -> (Terminal<CaptureBackend>, Theme) {
+/// Creates a terminal and theme for rendering tests.
+///
+/// Returns a `(Terminal<CaptureBackend>, Theme)` tuple configured
+/// with the given dimensions and the default theme.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::component::test_utils::setup_render;
+///
+/// let (mut terminal, theme) = setup_render(80, 24);
+/// assert_eq!(terminal.backend().width(), 80);
+/// ```
+pub fn setup_render(width: u16, height: u16) -> (Terminal<CaptureBackend>, Theme) {
     let backend = CaptureBackend::new(width, height);
     let terminal = Terminal::new(backend).unwrap();
     (terminal, Theme::default())


### PR DESCRIPTION
Makes component test_utils accessible to downstream crates via the test-utils feature flag.