### PR TITLE
Add doc tests to lowest-coverage components

### DIFF
--- a/src/component/loading_list/mod.rs
+++ b/src/component/loading_list/mod.rs
@@ -482,6 +482,19 @@ impl<T: Clone> LoadingListState<T> {
     }
 
     /// Returns all items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let state = LoadingListState::with_items(
+    ///     vec!["alpha".to_string(), "beta".to_string()],
+    ///     |s| s.clone(),
+    /// );
+    /// assert_eq!(state.items().len(), 2);
+    /// assert_eq!(state.items()[0].label(), "alpha");
+    /// ```
     pub fn items(&self) -> &[LoadingListItem<T>] {
         &self.items
     }
@@ -492,16 +505,49 @@ impl<T: Clone> LoadingListState<T> {
     }
 
     /// Returns the number of items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let state = LoadingListState::with_items(
+    ///     vec!["a".to_string(), "b".to_string()],
+    ///     |s| s.clone(),
+    /// );
+    /// assert_eq!(state.len(), 2);
+    /// ```
     pub fn len(&self) -> usize {
         self.items.len()
     }
 
     /// Returns true if there are no items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let state = LoadingListState::<String>::new();
+    /// assert!(state.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()
     }
 
     /// Returns the selected index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let state = LoadingListState::with_items(
+    ///     vec!["a".to_string()],
+    ///     |s| s.clone(),
+    /// ).with_selected(0);
+    /// assert_eq!(state.selected_index(), Some(0));
+    /// ```
     pub fn selected_index(&self) -> Option<usize> {
         self.selected
     }
@@ -670,16 +716,44 @@ impl<T: Clone> LoadingListState<T> {
     }
 
     /// Returns the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let state = LoadingListState::<String>::new().with_title("Tasks");
+    /// assert_eq!(state.title(), Some("Tasks"));
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
 
     /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let mut state = LoadingListState::<String>::new();
+    /// state.set_title(Some("Downloads".to_string()));
+    /// assert_eq!(state.title(), Some("Downloads"));
+    /// ```
     pub fn set_title(&mut self, title: Option<String>) {
         self.title = title;
     }
 
     /// Returns whether indicators are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let state = LoadingListState::<String>::new();
+    /// assert!(state.show_indicators()); // enabled by default
+    /// ```
     pub fn show_indicators(&self) -> bool {
         self.show_indicators
     }
@@ -695,6 +769,20 @@ impl<T: Clone> LoadingListState<T> {
     }
 
     /// Clears all items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let mut state = LoadingListState::with_items(
+    ///     vec!["a".to_string()],
+    ///     |s| s.clone(),
+    /// );
+    /// assert_eq!(state.len(), 1);
+    /// state.clear();
+    /// assert!(state.is_empty());
+    /// ```
     pub fn clear(&mut self) {
         self.items.clear();
         self.selected = None;

--- a/src/component/log_viewer/state.rs
+++ b/src/component/log_viewer/state.rs
@@ -430,11 +430,31 @@ impl LogViewerState {
     }
 
     /// Returns the number of entries.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new();
+    /// state.push_info("first");
+    /// state.push_error("second");
+    /// assert_eq!(state.len(), 2);
+    /// ```
     pub fn len(&self) -> usize {
         self.entries.len()
     }
 
     /// Returns true if there are no entries.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let state = LogViewerState::new();
+    /// assert!(state.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
@@ -477,6 +497,15 @@ impl LogViewerState {
     }
 
     /// Returns the scroll offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let state = LogViewerState::new();
+    /// assert_eq!(state.scroll_offset(), 0);
+    /// ```
     pub fn scroll_offset(&self) -> usize {
         self.scroll.offset()
     }
@@ -490,21 +519,62 @@ impl LogViewerState {
     }
 
     /// Returns whether timestamps are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let state = LogViewerState::new();
+    /// assert!(!state.show_timestamps()); // disabled by default
+    ///
+    /// let state = LogViewerState::new().with_timestamps(true);
+    /// assert!(state.show_timestamps());
+    /// ```
     pub fn show_timestamps(&self) -> bool {
         self.show_timestamps
     }
 
     /// Sets whether timestamps are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new();
+    /// state.set_show_timestamps(true);
+    /// assert!(state.show_timestamps());
+    /// ```
     pub fn set_show_timestamps(&mut self, show: bool) {
         self.show_timestamps = show;
     }
 
     /// Returns the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let state = LogViewerState::new().with_title("System Log");
+    /// assert_eq!(state.title(), Some("System Log"));
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
 
     /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new();
+    /// state.set_title(Some("Error Log".to_string()));
+    /// assert_eq!(state.title(), Some("Error Log"));
+    /// ```
     pub fn set_title(&mut self, title: Option<String>) {
         self.title = title;
     }
@@ -524,36 +594,103 @@ impl LogViewerState {
     }
 
     /// Returns true if success entries are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let state = LogViewerState::new();
+    /// assert!(state.show_success()); // enabled by default
+    /// ```
     pub fn show_success(&self) -> bool {
         self.show_success
     }
 
     /// Returns true if warning entries are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let state = LogViewerState::new();
+    /// assert!(state.show_warning()); // enabled by default
+    /// ```
     pub fn show_warning(&self) -> bool {
         self.show_warning
     }
 
     /// Returns true if error entries are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let state = LogViewerState::new();
+    /// assert!(state.show_error()); // enabled by default
+    /// ```
     pub fn show_error(&self) -> bool {
         self.show_error
     }
 
     /// Sets the info filter.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new();
+    /// state.set_show_info(false);
+    /// assert!(!state.show_info());
+    /// ```
     pub fn set_show_info(&mut self, show: bool) {
         self.show_info = show;
     }
 
     /// Sets the success filter.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new();
+    /// state.set_show_success(false);
+    /// assert!(!state.show_success());
+    /// ```
     pub fn set_show_success(&mut self, show: bool) {
         self.show_success = show;
     }
 
     /// Sets the warning filter.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new();
+    /// state.set_show_warning(false);
+    /// assert!(!state.show_warning());
+    /// ```
     pub fn set_show_warning(&mut self, show: bool) {
         self.show_warning = show;
     }
 
     /// Sets the error filter.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new();
+    /// state.set_show_error(false);
+    /// assert!(!state.show_error());
+    /// ```
     pub fn set_show_error(&mut self, show: bool) {
         self.show_error = show;
     }

--- a/src/component/multi_progress/mod.rs
+++ b/src/component/multi_progress/mod.rs
@@ -425,6 +425,15 @@ impl MultiProgressState {
     }
 
     /// Returns true if there are no items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let state = MultiProgressState::new();
+    /// assert!(state.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()
     }
@@ -605,41 +614,119 @@ impl MultiProgressState {
     }
 
     /// Returns the scroll offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let state = MultiProgressState::new();
+    /// assert_eq!(state.scroll_offset(), 0);
+    /// ```
     pub fn scroll_offset(&self) -> usize {
         self.scroll_offset
     }
 
     /// Sets the scroll offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let mut state = MultiProgressState::new();
+    /// state.add("t1", "Task 1");
+    /// state.add("t2", "Task 2");
+    /// state.set_scroll_offset(1);
+    /// assert_eq!(state.scroll_offset(), 1);
+    /// ```
     pub fn set_scroll_offset(&mut self, offset: usize) {
         self.scroll_offset = offset.min(self.items.len().saturating_sub(1));
     }
 
     /// Returns the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let state = MultiProgressState::new().with_title("Downloads");
+    /// assert_eq!(state.title(), Some("Downloads"));
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
 
     /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let mut state = MultiProgressState::new();
+    /// state.set_title(Some("Tasks".to_string()));
+    /// assert_eq!(state.title(), Some("Tasks"));
+    /// ```
     pub fn set_title(&mut self, title: Option<String>) {
         self.title = title;
     }
 
     /// Returns whether percentages are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let state = MultiProgressState::new();
+    /// assert!(state.show_percentages()); // enabled by default
+    /// ```
     pub fn show_percentages(&self) -> bool {
         self.show_percentages
     }
 
     /// Sets whether to show percentages.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let mut state = MultiProgressState::new();
+    /// state.set_show_percentages(false);
+    /// assert!(!state.show_percentages());
+    /// ```
     pub fn set_show_percentages(&mut self, show: bool) {
         self.show_percentages = show;
     }
 
     /// Returns whether auto-remove is enabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let state = MultiProgressState::new();
+    /// assert!(!state.auto_remove_completed()); // disabled by default
+    /// ```
     pub fn auto_remove_completed(&self) -> bool {
         self.auto_remove_completed
     }
 
     /// Sets whether to auto-remove completed items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let mut state = MultiProgressState::new();
+    /// state.set_auto_remove_completed(true);
+    /// assert!(state.auto_remove_completed());
+    /// ```
     pub fn set_auto_remove_completed(&mut self, auto_remove: bool) {
         self.auto_remove_completed = auto_remove;
     }

--- a/src/component/pane_layout/mod.rs
+++ b/src/component/pane_layout/mod.rs
@@ -374,6 +374,23 @@ impl PaneLayoutState {
     /// Computes the layout rectangles for each pane within the given area.
     ///
     /// Respects min/max size constraints. Returns one `Rect` per pane.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::{PaneConfig, PaneDirection};
+    /// use envision::component::PaneLayoutState;
+    /// use ratatui::prelude::Rect;
+    ///
+    /// let state = PaneLayoutState::new(PaneDirection::Vertical, vec![
+    ///     PaneConfig::new("top").with_proportion(0.5),
+    ///     PaneConfig::new("bottom").with_proportion(0.5),
+    /// ]);
+    /// let rects = state.layout(Rect::new(0, 0, 80, 40));
+    /// assert_eq!(rects.len(), 2);
+    /// assert_eq!(rects[0].height, 20);
+    /// assert_eq!(rects[1].height, 20);
+    /// ```
     pub fn layout(&self, area: Rect) -> Vec<Rect> {
         if self.panes.is_empty() {
             return vec![];
@@ -554,26 +571,91 @@ impl PaneLayoutState {
     }
 
     /// Returns the resize step.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::{PaneConfig, PaneDirection};
+    /// use envision::component::PaneLayoutState;
+    ///
+    /// let state = PaneLayoutState::new(PaneDirection::Horizontal, vec![
+    ///     PaneConfig::new("a"),
+    ///     PaneConfig::new("b"),
+    /// ]);
+    /// assert!((state.resize_step() - 0.05).abs() < f32::EPSILON); // default
+    /// ```
     pub fn resize_step(&self) -> f32 {
         self.resize_step
     }
 
     /// Returns true if the component is focused.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::{PaneConfig, PaneDirection};
+    /// use envision::component::PaneLayoutState;
+    ///
+    /// let mut state = PaneLayoutState::new(PaneDirection::Horizontal, vec![
+    ///     PaneConfig::new("a"),
+    /// ]);
+    /// assert!(!state.is_focused());
+    /// state.set_focused(true);
+    /// assert!(state.is_focused());
+    /// ```
     pub fn is_focused(&self) -> bool {
         self.focused
     }
 
     /// Sets the focus state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::{PaneConfig, PaneDirection};
+    /// use envision::component::PaneLayoutState;
+    ///
+    /// let mut state = PaneLayoutState::new(PaneDirection::Horizontal, vec![
+    ///     PaneConfig::new("a"),
+    /// ]);
+    /// state.set_focused(true);
+    /// assert!(state.is_focused());
+    /// ```
     pub fn set_focused(&mut self, focused: bool) {
         self.focused = focused;
     }
 
     /// Returns true if the component is disabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::{PaneConfig, PaneDirection};
+    /// use envision::component::PaneLayoutState;
+    ///
+    /// let state = PaneLayoutState::new(PaneDirection::Horizontal, vec![
+    ///     PaneConfig::new("a"),
+    /// ]).with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn is_disabled(&self) -> bool {
         self.disabled
     }
 
     /// Sets the disabled state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::{PaneConfig, PaneDirection};
+    /// use envision::component::PaneLayoutState;
+    ///
+    /// let mut state = PaneLayoutState::new(PaneDirection::Horizontal, vec![
+    ///     PaneConfig::new("a"),
+    /// ]);
+    /// state.set_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn set_disabled(&mut self, disabled: bool) {
         self.disabled = disabled;
     }
@@ -581,16 +663,69 @@ impl PaneLayoutState {
     // ---- Instance methods ----
 
     /// Maps an input event to a pane layout message.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::{PaneConfig, PaneDirection};
+    /// use envision::component::{PaneLayoutState, PaneLayoutMessage};
+    /// use envision::input::{Event, KeyCode};
+    ///
+    /// let mut state = PaneLayoutState::new(PaneDirection::Horizontal, vec![
+    ///     PaneConfig::new("left"),
+    ///     PaneConfig::new("right"),
+    /// ]);
+    /// state.set_focused(true);
+    ///
+    /// let msg = state.handle_event(&Event::key(KeyCode::Tab));
+    /// assert_eq!(msg, Some(PaneLayoutMessage::FocusNext));
+    /// ```
     pub fn handle_event(&self, event: &Event) -> Option<PaneLayoutMessage> {
         PaneLayout::handle_event(self, event)
     }
 
     /// Dispatches an event, updating state and returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::{PaneConfig, PaneDirection};
+    /// use envision::component::{PaneLayoutState, PaneLayoutOutput};
+    /// use envision::input::{Event, KeyCode};
+    ///
+    /// let mut state = PaneLayoutState::new(PaneDirection::Horizontal, vec![
+    ///     PaneConfig::new("left"),
+    ///     PaneConfig::new("right"),
+    /// ]);
+    /// state.set_focused(true);
+    ///
+    /// let output = state.dispatch_event(&Event::key(KeyCode::Tab));
+    /// assert_eq!(output, Some(PaneLayoutOutput::FocusChanged {
+    ///     pane_id: "right".to_string(),
+    ///     index: 1,
+    /// }));
+    /// ```
     pub fn dispatch_event(&mut self, event: &Event) -> Option<PaneLayoutOutput> {
         PaneLayout::dispatch_event(self, event)
     }
 
     /// Updates the state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::{PaneConfig, PaneDirection};
+    /// use envision::component::{PaneLayoutState, PaneLayoutMessage, PaneLayoutOutput};
+    ///
+    /// let mut state = PaneLayoutState::new(PaneDirection::Horizontal, vec![
+    ///     PaneConfig::new("left"),
+    ///     PaneConfig::new("right"),
+    /// ]);
+    /// state.set_focused(true);
+    ///
+    /// let output = state.update(PaneLayoutMessage::FocusNext);
+    /// assert_eq!(state.focused_pane_id(), Some("right"));
+    /// ```
     pub fn update(&mut self, msg: PaneLayoutMessage) -> Option<PaneLayoutOutput> {
         PaneLayout::update(self, msg)
     }

--- a/src/component/tab_bar/mod.rs
+++ b/src/component/tab_bar/mod.rs
@@ -628,16 +628,52 @@ impl TabBarState {
     }
 
     /// Returns the maximum tab width, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState};
+    ///
+    /// let state = TabBarState::new(vec![Tab::new("a", "A")]);
+    /// assert_eq!(state.max_tab_width(), None);
+    ///
+    /// let state = state.with_max_tab_width(Some(20));
+    /// assert_eq!(state.max_tab_width(), Some(20));
+    /// ```
     pub fn max_tab_width(&self) -> Option<usize> {
         self.max_tab_width
     }
 
     /// Returns whether the component is disabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState};
+    ///
+    /// let state = TabBarState::new(vec![Tab::new("a", "A")]);
+    /// assert!(!state.is_disabled());
+    ///
+    /// let state = state.with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn is_disabled(&self) -> bool {
         self.disabled
     }
 
     /// Returns whether the component is focused.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState};
+    ///
+    /// let mut state = TabBarState::new(vec![Tab::new("a", "A")]);
+    /// assert!(!state.is_focused());
+    ///
+    /// state.set_focused(true);
+    /// assert!(state.is_focused());
+    /// ```
     pub fn is_focused(&self) -> bool {
         self.focused
     }
@@ -703,11 +739,31 @@ impl TabBarState {
     }
 
     /// Sets the disabled state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState};
+    ///
+    /// let mut state = TabBarState::new(vec![Tab::new("a", "A")]);
+    /// state.set_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn set_disabled(&mut self, disabled: bool) {
         self.disabled = disabled;
     }
 
     /// Sets the focused state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState};
+    ///
+    /// let mut state = TabBarState::new(vec![Tab::new("a", "A")]);
+    /// state.set_focused(true);
+    /// assert!(state.is_focused());
+    /// ```
     pub fn set_focused(&mut self, focused: bool) {
         self.focused = focused;
     }


### PR DESCRIPTION
## Summary

- Add doc tests to public methods on the 5 lowest-coverage components: `tab_bar`, `multi_progress`, `pane_layout`, `loading_list`, and `log_viewer`
- Covers accessors (`max_tab_width`, `is_focused`, `is_disabled`, `resize_step`, `scroll_offset`, `title`, `show_percentages`, `auto_remove_completed`, `show_timestamps`, `show_success`, `show_warning`, `show_error`, `show_indicators`, `len`, `is_empty`, `selected_index`, `scroll_offset`), setters, and instance methods (`handle_event`, `dispatch_event`, `update`, `layout`)
- All requested builders for `EventStreamState` and `LogViewerState` were already present with doc tests from prior work
- All public `Result`-returning methods already had `# Errors` sections from prior work

## Test plan

- [x] `cargo fmt` -- clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo check --no-default-features` -- clean
- [x] `cargo test --all-features --doc` -- 1726 doc tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)