### PR TITLE
Fix feedback: mutable blocks, MultiProgress Selected, missing setters

### DIFF
--- a/src/component/alert_panel/mod.rs
+++ b/src/component/alert_panel/mod.rs
@@ -367,6 +367,21 @@ impl AlertPanelState {
         self.title.as_deref()
     }
 
+    /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::AlertPanelState;
+    ///
+    /// let mut state = AlertPanelState::new();
+    /// state.set_title("System Alerts");
+    /// assert_eq!(state.title(), Some("System Alerts"));
+    /// ```
+    pub fn set_title(&mut self, title: impl Into<String>) {
+        self.title = Some(title.into());
+    }
+
     /// Returns whether sparklines are shown.
     ///
     /// # Example

--- a/src/component/calendar/mod.rs
+++ b/src/component/calendar/mod.rs
@@ -348,6 +348,38 @@ impl CalendarState {
         self.selected_day
     }
 
+    /// Returns the title, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CalendarState;
+    ///
+    /// let state = CalendarState::new(2026, 3).with_title("My Calendar");
+    /// assert_eq!(state.title(), Some("My Calendar"));
+    ///
+    /// let state2 = CalendarState::new(2026, 3);
+    /// assert_eq!(state2.title(), None);
+    /// ```
+    pub fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CalendarState;
+    ///
+    /// let mut state = CalendarState::new(2026, 3);
+    /// state.set_title("Events");
+    /// assert_eq!(state.title(), Some("Events"));
+    /// ```
+    pub fn set_title(&mut self, title: impl Into<String>) {
+        self.title = Some(title.into());
+    }
+
     /// Sets the selected day.
     ///
     /// # Example

--- a/src/component/command_palette/mod.rs
+++ b/src/component/command_palette/mod.rs
@@ -417,6 +417,21 @@ impl CommandPaletteState {
         self.title.as_deref()
     }
 
+    /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{CommandPaletteState, PaletteItem};
+    ///
+    /// let mut state = CommandPaletteState::new(vec![]);
+    /// state.set_title("Actions");
+    /// assert_eq!(state.title(), Some("Actions"));
+    /// ```
+    pub fn set_title(&mut self, title: impl Into<String>) {
+        self.title = Some(title.into());
+    }
+
     /// Returns the placeholder text.
     ///
     /// # Example

--- a/src/component/conversation_view/mod.rs
+++ b/src/component/conversation_view/mod.rs
@@ -374,6 +374,23 @@ impl ConversationViewState {
         &self.messages
     }
 
+    /// Returns a mutable reference to the messages vector.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ConversationViewState, ConversationMessage, ConversationRole};
+    ///
+    /// let mut state = ConversationViewState::new();
+    /// state.push_user("Hello");
+    /// state.push_assistant("Hi");
+    /// state.messages_mut().retain(|m| m.role() == ConversationRole::User);
+    /// assert_eq!(state.message_count(), 1);
+    /// ```
+    pub fn messages_mut(&mut self) -> &mut Vec<ConversationMessage> {
+        &mut self.messages
+    }
+
     /// Returns the number of messages.
     pub fn message_count(&self) -> usize {
         self.messages.len()

--- a/src/component/conversation_view/tests.rs
+++ b/src/component/conversation_view/tests.rs
@@ -208,6 +208,25 @@ fn test_message_blocks_mut() {
 }
 
 #[test]
+fn test_message_set_blocks() {
+    let mut msg = ConversationMessage::new(ConversationRole::User, "Hello");
+    msg.set_blocks(vec![
+        MessageBlock::text("Replaced"),
+        MessageBlock::code("x = 1", Some("py")),
+    ]);
+    assert_eq!(msg.blocks().len(), 2);
+    assert!(msg.blocks()[0].is_text());
+    assert!(msg.blocks()[1].is_code());
+}
+
+#[test]
+fn test_message_set_blocks_empty() {
+    let mut msg = ConversationMessage::new(ConversationRole::User, "Hello");
+    msg.set_blocks(vec![]);
+    assert!(msg.blocks().is_empty());
+}
+
+#[test]
 fn test_message_text_content() {
     let msg = ConversationMessage::with_blocks(
         ConversationRole::User,
@@ -401,6 +420,25 @@ fn test_last_message_mut() {
 fn test_last_message_mut_empty() {
     let mut state = ConversationViewState::new();
     assert!(state.last_message_mut().is_none());
+}
+
+#[test]
+fn test_messages_mut() {
+    let mut state = ConversationViewState::new();
+    state.push_user("Hello");
+    state.push_assistant("Hi");
+    state.push_system("System msg");
+    state
+        .messages_mut()
+        .retain(|m| m.role() == ConversationRole::User);
+    assert_eq!(state.message_count(), 1);
+    assert_eq!(state.messages()[0].role(), ConversationRole::User);
+}
+
+#[test]
+fn test_messages_mut_empty() {
+    let mut state = ConversationViewState::new();
+    assert!(state.messages_mut().is_empty());
 }
 
 // =============================================================================

--- a/src/component/conversation_view/types.rs
+++ b/src/component/conversation_view/types.rs
@@ -340,8 +340,35 @@ impl ConversationMessage {
     }
 
     /// Returns a mutable reference to the content blocks.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ConversationMessage, ConversationRole, MessageBlock};
+    ///
+    /// let mut msg = ConversationMessage::new(ConversationRole::User, "Hello");
+    /// msg.blocks_mut().push(MessageBlock::text(" world"));
+    /// assert_eq!(msg.blocks().len(), 2);
+    /// ```
     pub fn blocks_mut(&mut self) -> &mut Vec<MessageBlock> {
         &mut self.blocks
+    }
+
+    /// Replace all blocks in this message.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ConversationMessage, ConversationRole, MessageBlock};
+    ///
+    /// let mut msg = ConversationMessage::new(ConversationRole::User, "Hello");
+    /// msg.set_blocks(vec![MessageBlock::text("Replaced"), MessageBlock::code("x = 1", Some("py"))]);
+    /// assert_eq!(msg.blocks().len(), 2);
+    /// assert!(msg.blocks()[0].is_text());
+    /// assert!(msg.blocks()[1].is_code());
+    /// ```
+    pub fn set_blocks(&mut self, blocks: Vec<MessageBlock>) {
+        self.blocks = blocks;
     }
 
     /// Returns the timestamp if set.

--- a/src/component/dependency_graph/mod.rs
+++ b/src/component/dependency_graph/mod.rs
@@ -363,6 +363,21 @@ impl DependencyGraphState {
         self.title.as_deref()
     }
 
+    /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DependencyGraphState;
+    ///
+    /// let mut state = DependencyGraphState::new();
+    /// state.set_title("Service Topology");
+    /// assert_eq!(state.title(), Some("Service Topology"));
+    /// ```
+    pub fn set_title(&mut self, title: impl Into<String>) {
+        self.title = Some(title.into());
+    }
+
     /// Returns the orientation.
     ///
     /// # Example

--- a/src/component/diff_viewer/mod.rs
+++ b/src/component/diff_viewer/mod.rs
@@ -396,6 +396,38 @@ impl DiffViewerState {
 
     // ---- Public accessors ----
 
+    /// Returns the title, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let state = DiffViewerState::new().with_title("My Diff");
+    /// assert_eq!(state.title(), Some("My Diff"));
+    ///
+    /// let state2 = DiffViewerState::new();
+    /// assert_eq!(state2.title(), None);
+    /// ```
+    pub fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let mut state = DiffViewerState::new();
+    /// state.set_title("Code Review");
+    /// assert_eq!(state.title(), Some("Code Review"));
+    /// ```
+    pub fn set_title(&mut self, title: impl Into<String>) {
+        self.title = Some(title.into());
+    }
+
     /// Returns a reference to the diff hunks.
     pub fn hunks(&self) -> &[DiffHunk] {
         &self.hunks

--- a/src/component/event_stream/state.rs
+++ b/src/component/event_stream/state.rs
@@ -448,6 +448,21 @@ impl EventStreamState {
         self.title.as_deref()
     }
 
+    /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let mut state = EventStreamState::new();
+    /// state.set_title("System Events");
+    /// assert_eq!(state.title(), Some("System Events"));
+    /// ```
+    pub fn set_title(&mut self, title: impl Into<String>) {
+        self.title = Some(title.into());
+    }
+
     /// Returns the scroll offset.
     pub fn scroll_offset(&self) -> usize {
         self.scroll.offset()

--- a/src/component/flame_graph/mod.rs
+++ b/src/component/flame_graph/mod.rs
@@ -417,6 +417,21 @@ impl FlameGraphState {
         self.title.as_deref()
     }
 
+    /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::FlameGraphState;
+    ///
+    /// let mut state = FlameGraphState::new();
+    /// state.set_title("CPU Profile");
+    /// assert_eq!(state.title(), Some("CPU Profile"));
+    /// ```
+    pub fn set_title(&mut self, title: impl Into<String>) {
+        self.title = Some(title.into());
+    }
+
     /// Returns true if the component is focused.
     ///
     /// # Example

--- a/src/component/gauge/mod.rs
+++ b/src/component/gauge/mod.rs
@@ -312,6 +312,38 @@ impl GaugeState {
         self
     }
 
+    /// Returns the title, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::GaugeState;
+    ///
+    /// let state = GaugeState::new(50.0, 100.0).with_title("CPU Usage");
+    /// assert_eq!(state.title(), Some("CPU Usage"));
+    ///
+    /// let state2 = GaugeState::new(50.0, 100.0);
+    /// assert_eq!(state2.title(), None);
+    /// ```
+    pub fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::GaugeState;
+    ///
+    /// let mut state = GaugeState::new(50.0, 100.0);
+    /// state.set_title("Memory");
+    /// assert_eq!(state.title(), Some("Memory"));
+    /// ```
+    pub fn set_title(&mut self, title: impl Into<String>) {
+        self.title = Some(title.into());
+    }
+
     /// Returns the current value.
     pub fn value(&self) -> f64 {
         self.value

--- a/src/component/heatmap/mod.rs
+++ b/src/component/heatmap/mod.rs
@@ -578,6 +578,21 @@ impl HeatmapState {
         self.title.as_deref()
     }
 
+    /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HeatmapState;
+    ///
+    /// let mut state = HeatmapState::new(3, 3);
+    /// state.set_title("Error Rates");
+    /// assert_eq!(state.title(), Some("Error Rates"));
+    /// ```
+    pub fn set_title(&mut self, title: impl Into<String>) {
+        self.title = Some(title.into());
+    }
+
     /// Returns whether values are shown in cells.
     pub fn show_values(&self) -> bool {
         self.show_values

--- a/src/component/histogram/mod.rs
+++ b/src/component/histogram/mod.rs
@@ -333,6 +333,21 @@ impl HistogramState {
         self.title.as_deref()
     }
 
+    /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HistogramState;
+    ///
+    /// let mut state = HistogramState::new();
+    /// state.set_title("Response Times");
+    /// assert_eq!(state.title(), Some("Response Times"));
+    /// ```
+    pub fn set_title(&mut self, title: impl Into<String>) {
+        self.title = Some(title.into());
+    }
+
     /// Returns the x-axis label.
     pub fn x_label(&self) -> Option<&str> {
         self.x_label.as_deref()

--- a/src/component/log_correlation/mod.rs
+++ b/src/component/log_correlation/mod.rs
@@ -476,6 +476,21 @@ impl LogCorrelationState {
         self.title.as_deref()
     }
 
+    /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogCorrelationState;
+    ///
+    /// let mut state = LogCorrelationState::new();
+    /// state.set_title("Correlated Logs");
+    /// assert_eq!(state.title(), Some("Correlated Logs"));
+    /// ```
+    pub fn set_title(&mut self, title: impl Into<String>) {
+        self.title = Some(title.into());
+    }
+
     // ---- Mutation ----
 
     /// Adds a new log stream.

--- a/src/component/multi_progress/mod.rs
+++ b/src/component/multi_progress/mod.rs
@@ -229,6 +229,8 @@ pub enum MultiProgressMessage {
     Remove(String),
     /// Clear all items.
     Clear,
+    /// Select the currently focused item.
+    Select,
     /// Scroll up.
     ScrollUp,
     /// Scroll down.
@@ -252,6 +254,8 @@ pub enum MultiProgressOutput {
     Removed(String),
     /// All items were cleared.
     Cleared,
+    /// An item was selected (Enter pressed on item at this index).
+    Selected(usize),
 }
 
 /// State for the MultiProgress component.
@@ -884,6 +888,14 @@ impl Component for MultiProgress {
                 }
             }
 
+            MultiProgressMessage::Select => {
+                if !state.items.is_empty() {
+                    let index = state.scroll_offset.min(state.items.len().saturating_sub(1));
+                    return Some(MultiProgressOutput::Selected(index));
+                }
+                None
+            }
+
             MultiProgressMessage::ScrollUp => {
                 if state.scroll_offset > 0 {
                     state.scroll_offset -= 1;
@@ -918,6 +930,7 @@ impl Component for MultiProgress {
             match key.code {
                 KeyCode::Up | KeyCode::Char('k') => Some(MultiProgressMessage::ScrollUp),
                 KeyCode::Down | KeyCode::Char('j') => Some(MultiProgressMessage::ScrollDown),
+                KeyCode::Enter => Some(MultiProgressMessage::Select),
                 _ => None,
             }
         } else {

--- a/src/component/multi_progress/tests/events.rs
+++ b/src/component/multi_progress/tests/events.rs
@@ -247,9 +247,6 @@ fn test_handle_event_unrecognized_key() {
     let mut state = MultiProgressState::new();
     state.set_focused(true);
 
-    let msg = MultiProgress::handle_event(&state, &Event::key(KeyCode::Enter));
-    assert_eq!(msg, None);
-
     let msg = MultiProgress::handle_event(&state, &Event::key(KeyCode::Tab));
     assert_eq!(msg, None);
 
@@ -283,7 +280,7 @@ fn test_handle_event_instance_unrecognized() {
     let mut state = MultiProgressState::new();
     state.set_focused(true);
 
-    let msg = state.handle_event(&Event::key(KeyCode::Enter));
+    let msg = state.handle_event(&Event::key(KeyCode::Tab));
     assert_eq!(msg, None);
 }
 
@@ -296,7 +293,7 @@ fn test_dispatch_event_unrecognized_returns_none() {
     let mut state = MultiProgressState::new();
     state.set_focused(true);
 
-    let output = MultiProgress::dispatch_event(&mut state, &Event::key(KeyCode::Enter));
+    let output = MultiProgress::dispatch_event(&mut state, &Event::key(KeyCode::Tab));
     assert!(output.is_none());
 }
 
@@ -489,4 +486,112 @@ fn test_update_scroll_to_bottom_ignored_when_disabled() {
 
     MultiProgress::update(&mut state, MultiProgressMessage::ScrollToBottom);
     assert_eq!(state.scroll_offset(), 0);
+}
+
+// ========================================
+// Select (Enter) Tests
+// ========================================
+
+#[test]
+fn test_handle_event_enter_produces_select() {
+    let mut state = MultiProgressState::new();
+    state.set_focused(true);
+
+    let msg = MultiProgress::handle_event(&state, &Event::key(KeyCode::Enter));
+    assert_eq!(msg, Some(MultiProgressMessage::Select));
+}
+
+#[test]
+fn test_update_select_emits_selected_output() {
+    let mut state = MultiProgressState::new();
+    state.add("id1", "Item 1");
+    state.add("id2", "Item 2");
+    state.add("id3", "Item 3");
+    state.set_scroll_offset(1);
+
+    let output = MultiProgress::update(&mut state, MultiProgressMessage::Select);
+    assert_eq!(output, Some(MultiProgressOutput::Selected(1)));
+}
+
+#[test]
+fn test_update_select_first_item() {
+    let mut state = MultiProgressState::new();
+    state.add("id1", "Item 1");
+    state.add("id2", "Item 2");
+
+    let output = MultiProgress::update(&mut state, MultiProgressMessage::Select);
+    assert_eq!(output, Some(MultiProgressOutput::Selected(0)));
+}
+
+#[test]
+fn test_update_select_last_item() {
+    let mut state = MultiProgressState::new();
+    state.add("id1", "Item 1");
+    state.add("id2", "Item 2");
+    state.add("id3", "Item 3");
+    state.set_scroll_offset(2);
+
+    let output = MultiProgress::update(&mut state, MultiProgressMessage::Select);
+    assert_eq!(output, Some(MultiProgressOutput::Selected(2)));
+}
+
+#[test]
+fn test_update_select_empty_returns_none() {
+    let mut state = MultiProgressState::new();
+
+    let output = MultiProgress::update(&mut state, MultiProgressMessage::Select);
+    assert!(output.is_none());
+}
+
+#[test]
+fn test_update_select_ignored_when_disabled() {
+    let mut state = MultiProgressState::new();
+    state.add("id1", "Item 1");
+    state.set_disabled(true);
+
+    let output = MultiProgress::update(&mut state, MultiProgressMessage::Select);
+    assert!(output.is_none());
+}
+
+#[test]
+fn test_dispatch_event_enter_selects_item() {
+    let mut state = MultiProgressState::new();
+    state.set_focused(true);
+    state.add("id1", "Item 1");
+    state.add("id2", "Item 2");
+    state.set_scroll_offset(1);
+
+    let output = MultiProgress::dispatch_event(&mut state, &Event::key(KeyCode::Enter));
+    assert_eq!(output, Some(MultiProgressOutput::Selected(1)));
+}
+
+#[test]
+fn test_instance_handle_event_enter() {
+    let mut state = MultiProgressState::new();
+    state.set_focused(true);
+
+    let msg = state.handle_event(&Event::key(KeyCode::Enter));
+    assert_eq!(msg, Some(MultiProgressMessage::Select));
+}
+
+#[test]
+fn test_instance_dispatch_event_enter() {
+    let mut state = MultiProgressState::new();
+    state.set_focused(true);
+    state.add("id1", "Item 1");
+
+    let output = state.dispatch_event(&Event::key(KeyCode::Enter));
+    assert_eq!(output, Some(MultiProgressOutput::Selected(0)));
+}
+
+#[test]
+fn test_select_clamps_to_last_item() {
+    let mut state = MultiProgressState::new();
+    state.add("id1", "Item 1");
+    // scroll_offset is clamped by set_scroll_offset, but test the Select logic
+    // by directly accessing
+    state.set_scroll_offset(10); // Will be clamped to 0 (last valid index)
+
+    let output = MultiProgress::update(&mut state, MultiProgressMessage::Select);
+    assert_eq!(output, Some(MultiProgressOutput::Selected(0)));
 }

--- a/src/component/pane_layout/mod.rs
+++ b/src/component/pane_layout/mod.rs
@@ -183,6 +183,21 @@ impl PaneConfig {
         self.title.as_deref()
     }
 
+    /// Sets the pane title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::PaneConfig;
+    ///
+    /// let mut pane = PaneConfig::new("sidebar");
+    /// pane.set_title("Files");
+    /// assert_eq!(pane.title(), Some("Files"));
+    /// ```
+    pub fn set_title(&mut self, title: impl Into<String>) {
+        self.title = Some(title.into());
+    }
+
     /// Returns the pane proportion.
     pub fn proportion(&self) -> f32 {
         self.proportion

--- a/src/component/span_tree/mod.rs
+++ b/src/component/span_tree/mod.rs
@@ -374,6 +374,21 @@ impl SpanTreeState {
         self.title.as_deref()
     }
 
+    /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SpanTreeState;
+    ///
+    /// let mut state = SpanTreeState::default();
+    /// state.set_title("Trace View");
+    /// assert_eq!(state.title(), Some("Trace View"));
+    /// ```
+    pub fn set_title(&mut self, title: impl Into<String>) {
+        self.title = Some(title.into());
+    }
+
     /// Returns true if the component is focused.
     ///
     /// # Example

--- a/src/component/sparkline/mod.rs
+++ b/src/component/sparkline/mod.rs
@@ -350,6 +350,21 @@ impl SparklineState {
         self.title.as_deref()
     }
 
+    /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SparklineState;
+    ///
+    /// let mut state = SparklineState::new();
+    /// state.set_title("CPU Usage");
+    /// assert_eq!(state.title(), Some("CPU Usage"));
+    /// ```
+    pub fn set_title(&mut self, title: impl Into<String>) {
+        self.title = Some(title.into());
+    }
+
     /// Returns the render direction.
     pub fn direction(&self) -> &SparklineDirection {
         &self.direction

--- a/src/component/step_indicator/mod.rs
+++ b/src/component/step_indicator/mod.rs
@@ -421,6 +421,22 @@ impl StepIndicatorState {
         self.title.as_deref()
     }
 
+    /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StepIndicatorState;
+    /// use envision::component::step_indicator::Step;
+    ///
+    /// let mut state = StepIndicatorState::new(vec![Step::new("Step 1")]);
+    /// state.set_title("Progress");
+    /// assert_eq!(state.title(), Some("Progress"));
+    /// ```
+    pub fn set_title(&mut self, title: impl Into<String>) {
+        self.title = Some(title.into());
+    }
+
     /// Returns whether descriptions are shown.
     pub fn show_descriptions(&self) -> bool {
         self.show_descriptions

--- a/src/component/styled_text/mod.rs
+++ b/src/component/styled_text/mod.rs
@@ -267,6 +267,21 @@ impl StyledTextState {
         self.title.as_deref()
     }
 
+    /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StyledTextState;
+    ///
+    /// let mut state = StyledTextState::new();
+    /// state.set_title("Preview");
+    /// assert_eq!(state.title(), Some("Preview"));
+    /// ```
+    pub fn set_title(&mut self, title: impl Into<String>) {
+        self.title = Some(title.into());
+    }
+
     /// Returns whether the border is shown.
     ///
     /// # Example

--- a/src/component/timeline/mod.rs
+++ b/src/component/timeline/mod.rs
@@ -437,6 +437,21 @@ impl TimelineState {
         self.title.as_deref()
     }
 
+    /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TimelineState;
+    ///
+    /// let mut state = TimelineState::new();
+    /// state.set_title("Request Timeline");
+    /// assert_eq!(state.title(), Some("Request Timeline"));
+    /// ```
+    pub fn set_title(&mut self, title: impl Into<String>) {
+        self.title = Some(title.into());
+    }
+
     /// Returns whether labels are shown.
     pub fn show_labels(&self) -> bool {
         self.show_labels

--- a/src/component/treemap/mod.rs
+++ b/src/component/treemap/mod.rs
@@ -535,6 +535,21 @@ impl TreemapState {
         self.title.as_deref()
     }
 
+    /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TreemapState;
+    ///
+    /// let mut state = TreemapState::default();
+    /// state.set_title("Disk Usage");
+    /// assert_eq!(state.title(), Some("Disk Usage"));
+    /// ```
+    pub fn set_title(&mut self, title: impl Into<String>) {
+        self.title = Some(title.into());
+    }
+
     /// Returns whether labels are shown.
     pub fn show_labels(&self) -> bool {
         self.show_labels


### PR DESCRIPTION
## Summary

- **Item 1**: Add `ConversationMessage::set_blocks()` to replace all blocks, and `ConversationViewState::messages_mut()` for mutable access to the messages vector
- **Item 3**: Add `MultiProgressOutput::Selected(usize)` variant emitted when Enter is pressed on the focused item, with new `MultiProgressMessage::Select` message and Enter key binding in `handle_event`
- **Item 4**: Systematic audit of all components with `with_title()` -- add `set_title()` to 18 components and `title()` accessor to 3 components (calendar, diff_viewer, gauge) that were missing them

Components updated with `set_title()`: alert_panel, calendar, command_palette, dependency_graph, diff_viewer, event_stream, flame_graph, gauge, heatmap, histogram, log_correlation, pane_layout, span_tree, sparkline, step_indicator, styled_text, timeline, treemap

## Test plan

- [x] All 1750 tests pass (unit + doc + integration + snapshot)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo check --no-default-features` passes
- [x] `cargo fmt` applied
- [x] New unit tests for `set_blocks`, `messages_mut`, `MultiProgress::Select` behavior
- [x] Doc tests for all new public methods

Generated with [Claude Code](https://claude.com/claude-code)