### PR TITLE
Add missing setters for all builder-only properties

### DIFF
--- a/src/component/alert_panel/mod.rs
+++ b/src/component/alert_panel/mod.rs
@@ -410,6 +410,36 @@ impl AlertPanelState {
         self.show_thresholds
     }
 
+    /// Sets whether sparklines are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::AlertPanelState;
+    ///
+    /// let mut state = AlertPanelState::new();
+    /// state.set_show_sparklines(false);
+    /// assert!(!state.show_sparklines());
+    /// ```
+    pub fn set_show_sparklines(&mut self, show: bool) {
+        self.show_sparklines = show;
+    }
+
+    /// Sets whether threshold values are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::AlertPanelState;
+    ///
+    /// let mut state = AlertPanelState::new();
+    /// state.set_show_thresholds(true);
+    /// assert!(state.show_thresholds());
+    /// ```
+    pub fn set_show_thresholds(&mut self, show: bool) {
+        self.show_thresholds = show;
+    }
+
     /// Returns true if the panel is focused.
     ///
     /// # Example

--- a/src/component/chart/mod.rs
+++ b/src/component/chart/mod.rs
@@ -475,9 +475,39 @@ impl ChartState {
         self.show_legend
     }
 
+    /// Sets whether to show the legend.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ChartState;
+    ///
+    /// let mut state = ChartState::line(vec![]);
+    /// state.set_show_legend(true);
+    /// assert!(state.show_legend());
+    /// ```
+    pub fn set_show_legend(&mut self, show: bool) {
+        self.show_legend = show;
+    }
+
     /// Returns the maximum display points.
     pub fn max_display_points(&self) -> usize {
         self.max_display_points
+    }
+
+    /// Sets the maximum display points for line charts.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ChartState;
+    ///
+    /// let mut state = ChartState::line(vec![]);
+    /// state.set_max_display_points(200);
+    /// assert_eq!(state.max_display_points(), 200);
+    /// ```
+    pub fn set_max_display_points(&mut self, max: usize) {
+        self.max_display_points = max;
     }
 
     /// Returns the bar width.
@@ -485,9 +515,39 @@ impl ChartState {
         self.bar_width
     }
 
+    /// Sets the bar width.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ChartState;
+    ///
+    /// let mut state = ChartState::bar_vertical(vec![]);
+    /// state.set_bar_width(3);
+    /// assert_eq!(state.bar_width(), 3);
+    /// ```
+    pub fn set_bar_width(&mut self, width: u16) {
+        self.bar_width = width.max(1);
+    }
+
     /// Returns the bar gap.
     pub fn bar_gap(&self) -> u16 {
         self.bar_gap
+    }
+
+    /// Sets the bar gap.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ChartState;
+    ///
+    /// let mut state = ChartState::bar_vertical(vec![]);
+    /// state.set_bar_gap(2);
+    /// assert_eq!(state.bar_gap(), 2);
+    /// ```
+    pub fn set_bar_gap(&mut self, gap: u16) {
+        self.bar_gap = gap;
     }
 
     /// Returns the number of series.

--- a/src/component/chat_view/mod.rs
+++ b/src/component/chat_view/mod.rs
@@ -396,6 +396,36 @@ impl ChatViewState {
         self.input.set_value(value);
     }
 
+    /// Returns the placeholder text for the input field.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ChatViewState;
+    ///
+    /// let state = ChatViewState::new()
+    ///     .with_placeholder("Type here...");
+    /// assert_eq!(state.placeholder(), "Type here...");
+    /// ```
+    pub fn placeholder(&self) -> &str {
+        self.input.placeholder()
+    }
+
+    /// Sets the placeholder text for the input field.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ChatViewState;
+    ///
+    /// let mut state = ChatViewState::new();
+    /// state.set_placeholder("Enter your message...");
+    /// assert_eq!(state.placeholder(), "Enter your message...");
+    /// ```
+    pub fn set_placeholder(&mut self, placeholder: impl Into<String>) {
+        self.input.set_placeholder(placeholder);
+    }
+
     /// Returns the scroll offset.
     ///
     /// # Example

--- a/src/component/command_palette/mod.rs
+++ b/src/component/command_palette/mod.rs
@@ -446,6 +446,21 @@ impl CommandPaletteState {
         &self.placeholder
     }
 
+    /// Sets the placeholder text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{CommandPaletteState, PaletteItem};
+    ///
+    /// let mut state = CommandPaletteState::new(vec![]);
+    /// state.set_placeholder("Search commands...");
+    /// assert_eq!(state.placeholder(), "Search commands...");
+    /// ```
+    pub fn set_placeholder(&mut self, placeholder: impl Into<String>) {
+        self.placeholder = placeholder.into();
+    }
+
     /// Returns the maximum number of visible items.
     ///
     /// # Example
@@ -458,6 +473,21 @@ impl CommandPaletteState {
     /// ```
     pub fn max_visible(&self) -> usize {
         self.max_visible
+    }
+
+    /// Sets the maximum number of visible items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{CommandPaletteState, PaletteItem};
+    ///
+    /// let mut state = CommandPaletteState::new(vec![]);
+    /// state.set_max_visible(20);
+    /// assert_eq!(state.max_visible(), 20);
+    /// ```
+    pub fn set_max_visible(&mut self, max_visible: usize) {
+        self.max_visible = max_visible;
     }
 
     /// Returns the number of items matching the current query.

--- a/src/component/dependency_graph/mod.rs
+++ b/src/component/dependency_graph/mod.rs
@@ -406,6 +406,36 @@ impl DependencyGraphState {
         self.show_edge_labels
     }
 
+    /// Sets the graph orientation.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{DependencyGraphState, GraphOrientation};
+    ///
+    /// let mut state = DependencyGraphState::new();
+    /// state.set_orientation(GraphOrientation::TopToBottom);
+    /// assert_eq!(state.orientation(), &GraphOrientation::TopToBottom);
+    /// ```
+    pub fn set_orientation(&mut self, orientation: GraphOrientation) {
+        self.orientation = orientation;
+    }
+
+    /// Sets whether edge labels are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DependencyGraphState;
+    ///
+    /// let mut state = DependencyGraphState::new();
+    /// state.set_show_edge_labels(true);
+    /// assert!(state.show_edge_labels());
+    /// ```
+    pub fn set_show_edge_labels(&mut self, show: bool) {
+        self.show_edge_labels = show;
+    }
+
     /// Returns whether the component is focused.
     ///
     /// # Example

--- a/src/component/dependency_graph/types.rs
+++ b/src/component/dependency_graph/types.rs
@@ -144,6 +144,22 @@ impl GraphNode {
         self
     }
 
+    /// Sets the override color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::GraphNode;
+    /// use ratatui::style::Color;
+    ///
+    /// let mut node = GraphNode::new("svc", "Service");
+    /// node.set_color(Some(Color::Cyan));
+    /// assert_eq!(node.color, Some(Color::Cyan));
+    /// ```
+    pub fn set_color(&mut self, color: Option<Color>) {
+        self.color = color;
+    }
+
     /// Adds a metadata key-value pair (builder pattern).
     ///
     /// # Example
@@ -245,5 +261,21 @@ impl GraphEdge {
     pub fn with_color(mut self, color: Color) -> Self {
         self.color = Some(color);
         self
+    }
+
+    /// Sets the edge color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::GraphEdge;
+    /// use ratatui::style::Color;
+    ///
+    /// let mut edge = GraphEdge::new("a", "b");
+    /// edge.set_color(Some(Color::Red));
+    /// assert_eq!(edge.color, Some(Color::Red));
+    /// ```
+    pub fn set_color(&mut self, color: Option<Color>) {
+        self.color = color;
     }
 }

--- a/src/component/diff_viewer/mod.rs
+++ b/src/component/diff_viewer/mod.rs
@@ -507,6 +507,107 @@ impl DiffViewerState {
         self.added_count() + self.removed_count()
     }
 
+    /// Returns whether line numbers are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let state = DiffViewerState::new();
+    /// assert!(state.show_line_numbers());
+    /// ```
+    pub fn show_line_numbers(&self) -> bool {
+        self.show_line_numbers
+    }
+
+    /// Sets whether line numbers are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let mut state = DiffViewerState::new();
+    /// state.set_show_line_numbers(false);
+    /// assert!(!state.show_line_numbers());
+    /// ```
+    pub fn set_show_line_numbers(&mut self, show: bool) {
+        self.show_line_numbers = show;
+    }
+
+    /// Returns the number of context lines.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let state = DiffViewerState::new();
+    /// assert_eq!(state.context_lines(), 3);
+    /// ```
+    pub fn context_lines(&self) -> usize {
+        self.context_lines
+    }
+
+    /// Returns the old label, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let state = DiffViewerState::new().with_old_label("original.rs");
+    /// assert_eq!(state.old_label(), Some("original.rs"));
+    /// ```
+    pub fn old_label(&self) -> Option<&str> {
+        self.old_label.as_deref()
+    }
+
+    /// Sets the old label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let mut state = DiffViewerState::new();
+    /// state.set_old_label("original.rs");
+    /// assert_eq!(state.old_label(), Some("original.rs"));
+    /// ```
+    pub fn set_old_label(&mut self, label: impl Into<String>) {
+        self.old_label = Some(label.into());
+    }
+
+    /// Returns the new label, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let state = DiffViewerState::new().with_new_label("modified.rs");
+    /// assert_eq!(state.new_label(), Some("modified.rs"));
+    /// ```
+    pub fn new_label(&self) -> Option<&str> {
+        self.new_label.as_deref()
+    }
+
+    /// Sets the new label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let mut state = DiffViewerState::new();
+    /// state.set_new_label("modified.rs");
+    /// assert_eq!(state.new_label(), Some("modified.rs"));
+    /// ```
+    pub fn set_new_label(&mut self, label: impl Into<String>) {
+        self.new_label = Some(label.into());
+    }
+
     /// Returns the display mode.
     ///
     /// # Example

--- a/src/component/divider/mod.rs
+++ b/src/component/divider/mod.rs
@@ -297,6 +297,22 @@ impl DividerState {
         self.label = label;
     }
 
+    /// Sets the color override.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DividerState;
+    /// use ratatui::style::Color;
+    ///
+    /// let mut state = DividerState::new();
+    /// state.set_color(Some(Color::Red));
+    /// assert_eq!(state.color(), Some(Color::Red));
+    /// ```
+    pub fn set_color(&mut self, color: Option<Color>) {
+        self.color = color;
+    }
+
     /// Sets the orientation.
     ///
     /// # Example

--- a/src/component/event_stream/state.rs
+++ b/src/component/event_stream/state.rs
@@ -463,6 +463,101 @@ impl EventStreamState {
         self.title = Some(title.into());
     }
 
+    /// Sets the maximum number of events to retain.
+    ///
+    /// If the current count exceeds the new maximum, oldest events are removed.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let mut state = EventStreamState::new();
+    /// state.set_max_events(500);
+    /// assert_eq!(state.max_events(), 500);
+    /// ```
+    pub fn set_max_events(&mut self, max: usize) {
+        self.max_events = max;
+        while self.events.len() > self.max_events {
+            self.events.remove(0);
+        }
+    }
+
+    /// Sets whether to show the timestamp column.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let mut state = EventStreamState::new();
+    /// state.set_show_timestamps(false);
+    /// assert!(!state.show_timestamps());
+    /// ```
+    pub fn set_show_timestamps(&mut self, show: bool) {
+        self.show_timestamps = show;
+    }
+
+    /// Sets whether to show the level column.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let mut state = EventStreamState::new();
+    /// state.set_show_level(false);
+    /// assert!(!state.show_level());
+    /// ```
+    pub fn set_show_level(&mut self, show: bool) {
+        self.show_level = show;
+    }
+
+    /// Sets whether to show the source column.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let mut state = EventStreamState::new();
+    /// state.set_show_source(false);
+    /// assert!(!state.show_source());
+    /// ```
+    pub fn set_show_source(&mut self, show: bool) {
+        self.show_source = show;
+    }
+
+    /// Sets whether auto-scroll is enabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let mut state = EventStreamState::new();
+    /// state.set_auto_scroll(false);
+    /// assert!(!state.auto_scroll());
+    /// ```
+    pub fn set_auto_scroll(&mut self, auto_scroll: bool) {
+        self.auto_scroll = auto_scroll;
+    }
+
+    /// Sets the visible column keys.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let mut state = EventStreamState::new();
+    /// state.set_visible_columns(vec!["path".into(), "method".into()]);
+    /// assert_eq!(state.visible_columns().len(), 2);
+    /// ```
+    pub fn set_visible_columns(&mut self, columns: Vec<String>) {
+        self.visible_columns = columns;
+    }
+
     /// Returns the scroll offset.
     pub fn scroll_offset(&self) -> usize {
         self.scroll.offset()

--- a/src/component/file_browser/mod.rs
+++ b/src/component/file_browser/mod.rs
@@ -505,6 +505,21 @@ impl FileBrowserState {
         self.show_hidden
     }
 
+    /// Sets whether hidden files are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::FileBrowserState;
+    ///
+    /// let mut state = FileBrowserState::new("/", vec![]);
+    /// state.set_show_hidden(true);
+    /// assert!(state.show_hidden());
+    /// ```
+    pub fn set_show_hidden(&mut self, show: bool) {
+        self.show_hidden = show;
+    }
+
     /// Returns which sub-area of the file browser currently has internal focus.
     pub(crate) fn internal_focus(&self) -> &FileBrowserFocus {
         &self.internal_focus

--- a/src/component/heatmap/mod.rs
+++ b/src/component/heatmap/mod.rs
@@ -598,6 +598,21 @@ impl HeatmapState {
         self.show_values
     }
 
+    /// Sets whether values are shown in cells.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HeatmapState;
+    ///
+    /// let mut state = HeatmapState::new(3, 3);
+    /// state.set_show_values(true);
+    /// assert!(state.show_values());
+    /// ```
+    pub fn set_show_values(&mut self, show: bool) {
+        self.show_values = show;
+    }
+
     // ---- Instance methods ----
 
     /// Returns true if the component is focused.

--- a/src/component/histogram/mod.rs
+++ b/src/component/histogram/mod.rs
@@ -363,9 +363,40 @@ impl HistogramState {
         self.color
     }
 
+    /// Sets the bar color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HistogramState;
+    /// use ratatui::style::Color;
+    ///
+    /// let mut state = HistogramState::new();
+    /// state.set_color(Some(Color::Blue));
+    /// assert_eq!(state.color(), Some(Color::Blue));
+    /// ```
+    pub fn set_color(&mut self, color: Option<Color>) {
+        self.color = color;
+    }
+
     /// Returns whether count labels are shown on bars.
     pub fn show_counts(&self) -> bool {
         self.show_counts
+    }
+
+    /// Sets whether count labels are shown on bars.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HistogramState;
+    ///
+    /// let mut state = HistogramState::new();
+    /// state.set_show_counts(true);
+    /// assert!(state.show_counts());
+    /// ```
+    pub fn set_show_counts(&mut self, show: bool) {
+        self.show_counts = show;
     }
 
     /// Returns the effective minimum value.

--- a/src/component/line_input/history.rs
+++ b/src/component/line_input/history.rs
@@ -124,6 +124,21 @@ impl History {
         self.entries.len()
     }
 
+    /// Returns the maximum number of entries.
+    pub fn max_entries(&self) -> usize {
+        self.max_entries
+    }
+
+    /// Sets the maximum number of entries.
+    ///
+    /// If the current count exceeds the new maximum, oldest entries are removed.
+    pub fn set_max_entries(&mut self, max: usize) {
+        self.max_entries = max;
+        while self.entries.len() > self.max_entries {
+            self.entries.remove(0);
+        }
+    }
+
     /// Returns the history entries.
     pub fn entries(&self) -> &[String] {
         &self.entries

--- a/src/component/line_input/mod.rs
+++ b/src/component/line_input/mod.rs
@@ -357,6 +357,37 @@ impl LineInputState {
         self.disabled = disabled;
     }
 
+    /// Returns the maximum number of history entries.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LineInputState;
+    ///
+    /// let state = LineInputState::new().with_max_history(50);
+    /// assert_eq!(state.max_history(), 50);
+    /// ```
+    pub fn max_history(&self) -> usize {
+        self.history.max_entries()
+    }
+
+    /// Sets the maximum number of history entries.
+    ///
+    /// If the current count exceeds the new maximum, oldest entries are removed.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LineInputState;
+    ///
+    /// let mut state = LineInputState::new();
+    /// state.set_max_history(50);
+    /// assert_eq!(state.max_history(), 50);
+    /// ```
+    pub fn set_max_history(&mut self, max: usize) {
+        self.history.set_max_entries(max);
+    }
+
     /// Returns the history entries.
     pub fn history_entries(&self) -> &[String] {
         self.history.entries()

--- a/src/component/log_correlation/mod.rs
+++ b/src/component/log_correlation/mod.rs
@@ -185,6 +185,22 @@ impl LogStream {
         self
     }
 
+    /// Sets the header color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogStream;
+    /// use ratatui::prelude::Color;
+    ///
+    /// let mut stream = LogStream::new("API");
+    /// stream.set_color(Color::Cyan);
+    /// assert_eq!(stream.color, Color::Cyan);
+    /// ```
+    pub fn set_color(&mut self, color: Color) {
+        self.color = color;
+    }
+
     /// Appends an entry to the stream (builder pattern).
     ///
     /// # Example

--- a/src/component/number_input/mod.rs
+++ b/src/component/number_input/mod.rs
@@ -335,6 +335,21 @@ impl NumberInputState {
         self.placeholder.as_deref()
     }
 
+    /// Sets the placeholder text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::NumberInputState;
+    ///
+    /// let mut state = NumberInputState::new(0.0);
+    /// state.set_placeholder("Enter a number...");
+    /// assert_eq!(state.placeholder(), Some("Enter a number..."));
+    /// ```
+    pub fn set_placeholder(&mut self, placeholder: impl Into<String>) {
+        self.placeholder = Some(placeholder.into());
+    }
+
     /// Returns the step size.
     pub fn step(&self) -> f64 {
         self.step

--- a/src/component/pane_layout/mod.rs
+++ b/src/component/pane_layout/mod.rs
@@ -208,9 +208,56 @@ impl PaneConfig {
         self.min_size
     }
 
+    /// Sets the minimum size.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::PaneConfig;
+    ///
+    /// let mut pane = PaneConfig::new("sidebar");
+    /// pane.set_min_size(20);
+    /// assert_eq!(pane.min_size(), 20);
+    /// ```
+    pub fn set_min_size(&mut self, min_size: u16) {
+        self.min_size = min_size;
+    }
+
     /// Returns the maximum size.
     pub fn max_size(&self) -> u16 {
         self.max_size
+    }
+
+    /// Sets the maximum size.
+    ///
+    /// A value of 0 means no maximum.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::PaneConfig;
+    ///
+    /// let mut pane = PaneConfig::new("sidebar");
+    /// pane.set_max_size(60);
+    /// assert_eq!(pane.max_size(), 60);
+    /// ```
+    pub fn set_max_size(&mut self, max_size: u16) {
+        self.max_size = max_size;
+    }
+
+    /// Sets the pane proportion.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::PaneConfig;
+    ///
+    /// let mut pane = PaneConfig::new("sidebar");
+    /// pane.set_proportion(0.3);
+    /// assert!((pane.proportion() - 0.3).abs() < f32::EPSILON);
+    /// ```
+    pub fn set_proportion(&mut self, proportion: f32) {
+        self.proportion = proportion;
     }
 }
 

--- a/src/component/progress_bar/mod.rs
+++ b/src/component/progress_bar/mod.rs
@@ -281,6 +281,51 @@ impl ProgressBarState {
         self.show_rate
     }
 
+    /// Sets whether the percentage is shown in the label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressBarState;
+    ///
+    /// let mut state = ProgressBarState::new();
+    /// state.set_show_percentage(true);
+    /// assert!(state.show_percentage());
+    /// ```
+    pub fn set_show_percentage(&mut self, show: bool) {
+        self.show_percentage = show;
+    }
+
+    /// Sets whether the ETA is shown in the label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressBarState;
+    ///
+    /// let mut state = ProgressBarState::new();
+    /// state.set_show_eta(true);
+    /// assert!(state.show_eta());
+    /// ```
+    pub fn set_show_eta(&mut self, show: bool) {
+        self.show_eta = show;
+    }
+
+    /// Sets whether the rate is shown in the label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressBarState;
+    ///
+    /// let mut state = ProgressBarState::new();
+    /// state.set_show_rate(true);
+    /// assert!(state.show_rate());
+    /// ```
+    pub fn set_show_rate(&mut self, show: bool) {
+        self.show_rate = show;
+    }
+
     /// Returns the ETA as a `Duration`, if set.
     pub fn eta(&self) -> Option<Duration> {
         self.eta_millis.map(Duration::from_millis)

--- a/src/component/slider/mod.rs
+++ b/src/component/slider/mod.rs
@@ -321,6 +321,21 @@ impl SliderState {
         self.show_value
     }
 
+    /// Sets whether the value display is enabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SliderState;
+    ///
+    /// let mut state = SliderState::new(0.0, 100.0);
+    /// state.set_show_value(true);
+    /// assert!(state.show_value());
+    /// ```
+    pub fn set_show_value(&mut self, show: bool) {
+        self.show_value = show;
+    }
+
     /// Returns true if the slider is focused.
     pub fn is_focused(&self) -> bool {
         self.focused
@@ -344,6 +359,21 @@ impl SliderState {
     /// Returns the orientation.
     pub fn orientation(&self) -> &SliderOrientation {
         &self.orientation
+    }
+
+    /// Sets the orientation.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SliderState, SliderOrientation};
+    ///
+    /// let mut state = SliderState::new(0.0, 100.0);
+    /// state.set_orientation(SliderOrientation::Vertical);
+    /// assert_eq!(state.orientation(), &SliderOrientation::Vertical);
+    /// ```
+    pub fn set_orientation(&mut self, orientation: SliderOrientation) {
+        self.orientation = orientation;
     }
 
     /// Maps an input event to a slider message.

--- a/src/component/span_tree/types.rs
+++ b/src/component/span_tree/types.rs
@@ -165,6 +165,22 @@ impl SpanNode {
         self.color
     }
 
+    /// Sets the bar color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SpanNode;
+    /// use ratatui::style::Color;
+    ///
+    /// let mut node = SpanNode::new("id", "svc", 0.0, 10.0);
+    /// node.set_color(Color::Red);
+    /// assert_eq!(node.color(), Color::Red);
+    /// ```
+    pub fn set_color(&mut self, color: Color) {
+        self.color = color;
+    }
+
     /// Returns the status text, if set.
     pub fn status(&self) -> Option<&str> {
         self.status.as_deref()

--- a/src/component/sparkline/mod.rs
+++ b/src/component/sparkline/mod.rs
@@ -375,9 +375,40 @@ impl SparklineState {
         self.max_display_points
     }
 
+    /// Sets the maximum number of display points.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SparklineState;
+    ///
+    /// let mut state = SparklineState::new();
+    /// state.set_max_display_points(Some(100));
+    /// assert_eq!(state.max_display_points(), Some(100));
+    /// ```
+    pub fn set_max_display_points(&mut self, max: Option<usize>) {
+        self.max_display_points = max;
+    }
+
     /// Returns the color override, if set.
     pub fn color(&self) -> Option<Color> {
         self.color
+    }
+
+    /// Sets the color override.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SparklineState;
+    /// use ratatui::style::Color;
+    ///
+    /// let mut state = SparklineState::new();
+    /// state.set_color(Some(Color::Green));
+    /// assert_eq!(state.color(), Some(Color::Green));
+    /// ```
+    pub fn set_color(&mut self, color: Option<Color>) {
+        self.color = color;
     }
 
     /// Returns true if the sparkline is disabled.

--- a/src/component/step_indicator/mod.rs
+++ b/src/component/step_indicator/mod.rs
@@ -442,6 +442,38 @@ impl StepIndicatorState {
         self.show_descriptions
     }
 
+    /// Sets whether descriptions are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StepIndicatorState;
+    /// use envision::component::step_indicator::Step;
+    ///
+    /// let mut state = StepIndicatorState::new(vec![Step::new("A"), Step::new("B")]);
+    /// state.set_show_descriptions(true);
+    /// assert!(state.show_descriptions());
+    /// ```
+    pub fn set_show_descriptions(&mut self, show: bool) {
+        self.show_descriptions = show;
+    }
+
+    /// Sets the orientation.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StepIndicatorState;
+    /// use envision::component::step_indicator::{Step, StepOrientation};
+    ///
+    /// let mut state = StepIndicatorState::new(vec![Step::new("A"), Step::new("B")]);
+    /// state.set_orientation(StepOrientation::Vertical);
+    /// assert_eq!(state.orientation(), &StepOrientation::Vertical);
+    /// ```
+    pub fn set_orientation(&mut self, orientation: StepOrientation) {
+        self.orientation = orientation;
+    }
+
     /// Maps an input event to a message.
     pub fn handle_event(&self, event: &Event) -> Option<StepIndicatorMessage> {
         StepIndicator::handle_event(self, event)

--- a/src/component/styled_text/mod.rs
+++ b/src/component/styled_text/mod.rs
@@ -296,6 +296,21 @@ impl StyledTextState {
         self.show_border
     }
 
+    /// Sets whether the border is shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StyledTextState;
+    ///
+    /// let mut state = StyledTextState::new();
+    /// state.set_show_border(false);
+    /// assert!(!state.show_border());
+    /// ```
+    pub fn set_show_border(&mut self, show: bool) {
+        self.show_border = show;
+    }
+
     // ---- Scroll accessors ----
 
     /// Returns the current scroll offset.

--- a/src/component/timeline/mod.rs
+++ b/src/component/timeline/mod.rs
@@ -457,6 +457,21 @@ impl TimelineState {
         self.show_labels
     }
 
+    /// Sets whether labels are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TimelineState;
+    ///
+    /// let mut state = TimelineState::new();
+    /// state.set_show_labels(false);
+    /// assert!(!state.show_labels());
+    /// ```
+    pub fn set_show_labels(&mut self, show: bool) {
+        self.show_labels = show;
+    }
+
     /// Returns the effective lane count (auto-computed if not set).
     pub fn effective_lane_count(&self) -> usize {
         if self.lane_count > 0 {

--- a/src/component/timeline/types.rs
+++ b/src/component/timeline/types.rs
@@ -78,6 +78,22 @@ impl TimelineEvent {
         self.color = color;
         self
     }
+
+    /// Sets the color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TimelineEvent;
+    /// use ratatui::style::Color;
+    ///
+    /// let mut event = TimelineEvent::new("e1", 0.0, "Start");
+    /// event.set_color(Color::Red);
+    /// assert_eq!(event.color, Color::Red);
+    /// ```
+    pub fn set_color(&mut self, color: Color) {
+        self.color = color;
+    }
 }
 
 /// A span (duration) on the timeline.
@@ -162,6 +178,22 @@ impl TimelineSpan {
     pub fn with_color(mut self, color: Color) -> Self {
         self.color = color;
         self
+    }
+
+    /// Sets the color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TimelineSpan;
+    /// use ratatui::style::Color;
+    ///
+    /// let mut span = TimelineSpan::new("s1", 0.0, 100.0, "task");
+    /// span.set_color(Color::Red);
+    /// assert_eq!(span.color, Color::Red);
+    /// ```
+    pub fn set_color(&mut self, color: Color) {
+        self.color = color;
     }
 
     /// Sets the lane (builder pattern).

--- a/src/component/treemap/mod.rs
+++ b/src/component/treemap/mod.rs
@@ -121,6 +121,22 @@ impl TreemapNode {
         self
     }
 
+    /// Sets the color for this node.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TreemapNode;
+    /// use ratatui::style::Color;
+    ///
+    /// let mut node = TreemapNode::new("data", 100.0);
+    /// node.set_color(Color::Red);
+    /// assert_eq!(node.color, Color::Red);
+    /// ```
+    pub fn set_color(&mut self, color: Color) {
+        self.color = color;
+    }
+
     /// Adds a single child node (builder pattern).
     ///
     /// # Example
@@ -555,9 +571,39 @@ impl TreemapState {
         self.show_labels
     }
 
+    /// Sets whether labels are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TreemapState, TreemapNode};
+    ///
+    /// let mut state = TreemapState::new();
+    /// state.set_show_labels(false);
+    /// assert!(!state.show_labels());
+    /// ```
+    pub fn set_show_labels(&mut self, show: bool) {
+        self.show_labels = show;
+    }
+
     /// Returns whether values are shown.
     pub fn show_values(&self) -> bool {
         self.show_values
+    }
+
+    /// Sets whether values are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TreemapState, TreemapNode};
+    ///
+    /// let mut state = TreemapState::new();
+    /// state.set_show_values(true);
+    /// assert!(state.show_values());
+    /// ```
+    pub fn set_show_values(&mut self, show: bool) {
+        self.show_values = show;
     }
 
     /// Returns the selected child index at the current zoom level.


### PR DESCRIPTION
## Summary

- Systematic audit of all components found 50+ missing `set_*()` setter methods where `with_*()` builder methods existed without corresponding runtime setters
- Added setters across 5 audit categories: placeholder, max_*, color, show_*, and orientation
- Every new setter includes a doc test
- 26 files modified across 20+ components, 871 lines added

### Audit 1: placeholder
Added `set_placeholder()` and/or `placeholder()` to ChatView, CommandPalette, NumberInput.

### Audit 2: max_*
Added `set_max_display_points()` to Chart and Sparkline, `set_max_visible()` to CommandPalette, `set_max_history()` to LineInput (plus History internal support), `set_max_size()`/`set_min_size()`/`set_proportion()` to PaneLayout PaneConfig, `set_max_events()` to EventStream. Also added `set_bar_width()`, `set_bar_gap()`, `set_show_legend()` to Chart.

### Audit 3: color
Added `set_color()` to Divider, Histogram, LogCorrelation LogStream, Sparkline, TreemapNode, GraphNode, GraphEdge, SpanNode, TimelineEvent, TimelineSpan.

### Audit 4: show_*
Added `set_show_sparklines()`/`set_show_thresholds()` to AlertPanel, `set_show_edge_labels()` to DependencyGraph, `set_show_line_numbers()`/`set_old_label()`/`set_new_label()` (plus getters) to DiffViewer, `set_show_hidden()` to FileBrowser, `set_show_values()` to Heatmap and Treemap, `set_show_counts()` to Histogram, `set_show_percentage()`/`set_show_eta()`/`set_show_rate()` to ProgressBar, `set_show_value()` to Slider, `set_show_descriptions()` to StepIndicator, `set_show_border()` to StyledText, `set_show_labels()` to Timeline and Treemap, `set_show_timestamps()`/`set_show_level()`/`set_show_source()`/`set_auto_scroll()`/`set_visible_columns()` to EventStream.

### Audit 5: orientation
Added `set_orientation()` to DependencyGraph, Slider, StepIndicator.

## Test plan
- [x] `cargo fmt` -- clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo check --no-default-features` -- clean
- [x] `cargo test --all-features --doc` -- 1806 passed
- [x] `cargo test --all-features` -- all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)