### PR TITLE
Fix panic safety docs and set_max eviction behavior

### DIFF
--- a/src/component/chat_view/mod.rs
+++ b/src/component/chat_view/mod.rs
@@ -458,8 +458,9 @@ impl ChatViewState {
     /// ```
     pub fn set_max_messages(&mut self, max: usize) {
         self.max_messages = max;
-        while self.messages.len() > self.max_messages {
-            self.messages.remove(0);
+        if self.messages.len() > max {
+            let excess = self.messages.len() - max;
+            self.messages.drain(..excess);
         }
     }
 

--- a/src/component/chat_view/tests.rs
+++ b/src/component/chat_view/tests.rs
@@ -203,6 +203,17 @@ fn test_set_max_messages() {
     assert_eq!(state.messages()[0].content(), "b");
 }
 
+#[test]
+fn test_set_max_messages_no_eviction_when_under_limit() {
+    let mut state = ChatViewState::new();
+    state.push_user("a");
+    state.push_user("b");
+    assert_eq!(state.message_count(), 2);
+
+    state.set_max_messages(10);
+    assert_eq!(state.message_count(), 2);
+}
+
 // =============================================================================
 // Input editing
 // =============================================================================

--- a/src/component/conversation_view/mod.rs
+++ b/src/component/conversation_view/mod.rs
@@ -444,8 +444,9 @@ impl ConversationViewState {
     /// ```
     pub fn set_max_messages(&mut self, max: usize) {
         self.max_messages = max;
-        while self.messages.len() > self.max_messages {
-            self.messages.remove(0);
+        if self.messages.len() > max {
+            let excess = self.messages.len() - max;
+            self.messages.drain(..excess);
         }
     }
 

--- a/src/component/conversation_view/tests.rs
+++ b/src/component/conversation_view/tests.rs
@@ -406,6 +406,17 @@ fn test_set_max_messages() {
 }
 
 #[test]
+fn test_set_max_messages_no_eviction_when_under_limit() {
+    let mut state = ConversationViewState::new();
+    state.push_user("a");
+    state.push_user("b");
+    assert_eq!(state.message_count(), 2);
+
+    state.set_max_messages(10);
+    assert_eq!(state.message_count(), 2);
+}
+
+#[test]
 fn test_last_message_mut() {
     let mut state = ConversationViewState::new();
     state.push_assistant("Starting...");

--- a/src/component/event_stream/state.rs
+++ b/src/component/event_stream/state.rs
@@ -478,8 +478,9 @@ impl EventStreamState {
     /// ```
     pub fn set_max_events(&mut self, max: usize) {
         self.max_events = max;
-        while self.events.len() > self.max_events {
-            self.events.remove(0);
+        if self.events.len() > max {
+            let excess = self.events.len() - max;
+            self.events.drain(..excess);
         }
     }
 

--- a/src/component/event_stream/tests.rs
+++ b/src/component/event_stream/tests.rs
@@ -896,3 +896,30 @@ fn test_search_cursor_navigation() {
     EventStream::update(&mut state, EventStreamMessage::SearchBackspace);
     assert_eq!(state.filter_text(), "b");
 }
+
+#[test]
+fn test_set_max_events_evicts_oldest() {
+    let mut state = EventStreamState::new();
+    state.push_event(EventLevel::Info, "a");
+    state.push_event(EventLevel::Info, "b");
+    state.push_event(EventLevel::Info, "c");
+    state.push_event(EventLevel::Info, "d");
+    state.push_event(EventLevel::Info, "e");
+    assert_eq!(state.events().len(), 5);
+
+    state.set_max_events(2);
+    assert_eq!(state.events().len(), 2);
+    assert_eq!(state.events()[0].message, "d");
+    assert_eq!(state.events()[1].message, "e");
+}
+
+#[test]
+fn test_set_max_events_no_eviction_when_under_limit() {
+    let mut state = EventStreamState::new();
+    state.push_event(EventLevel::Info, "a");
+    state.push_event(EventLevel::Info, "b");
+    assert_eq!(state.events().len(), 2);
+
+    state.set_max_events(10);
+    assert_eq!(state.events().len(), 2);
+}

--- a/src/component/line_input/history.rs
+++ b/src/component/line_input/history.rs
@@ -134,8 +134,9 @@ impl History {
     /// If the current count exceeds the new maximum, oldest entries are removed.
     pub fn set_max_entries(&mut self, max: usize) {
         self.max_entries = max;
-        while self.entries.len() > self.max_entries {
-            self.entries.remove(0);
+        if self.entries.len() > max {
+            let excess = self.entries.len() - max;
+            self.entries.drain(..excess);
         }
     }
 
@@ -262,5 +263,32 @@ mod tests {
         assert!(h.is_browsing());
         h.exit_browse();
         assert!(!h.is_browsing());
+    }
+
+    #[test]
+    fn test_set_max_entries_evicts_oldest() {
+        let mut h = History::new(10);
+        h.push("a".to_string());
+        h.push("b".to_string());
+        h.push("c".to_string());
+        h.push("d".to_string());
+        h.push("e".to_string());
+        assert_eq!(h.count(), 5);
+
+        h.set_max_entries(2);
+        assert_eq!(h.count(), 2);
+        assert_eq!(h.entries()[0], "d");
+        assert_eq!(h.entries()[1], "e");
+    }
+
+    #[test]
+    fn test_set_max_entries_no_eviction_when_under_limit() {
+        let mut h = History::new(10);
+        h.push("a".to_string());
+        h.push("b".to_string());
+        assert_eq!(h.count(), 2);
+
+        h.set_max_entries(10);
+        assert_eq!(h.count(), 2);
     }
 }

--- a/src/component/log_viewer/state.rs
+++ b/src/component/log_viewer/state.rs
@@ -477,8 +477,9 @@ impl LogViewerState {
     /// ```
     pub fn set_max_entries(&mut self, max: usize) {
         self.max_entries = max;
-        while self.entries.len() > self.max_entries {
-            self.entries.remove(0);
+        if self.entries.len() > max {
+            let excess = self.entries.len() - max;
+            self.entries.drain(..excess);
         }
     }
 
@@ -746,8 +747,9 @@ impl LogViewerState {
     /// Sets the maximum search history size.
     pub fn set_max_history(&mut self, max: usize) {
         self.max_history = max;
-        while self.search_history.len() > self.max_history {
-            self.search_history.remove(0);
+        if self.search_history.len() > max {
+            let excess = self.search_history.len() - max;
+            self.search_history.drain(..excess);
         }
     }
 

--- a/src/component/log_viewer/tests.rs
+++ b/src/component/log_viewer/tests.rs
@@ -184,6 +184,45 @@ fn test_set_max_entries_evicts() {
     assert_eq!(state.entries()[0].message(), "b");
 }
 
+#[test]
+fn test_set_max_entries_no_eviction_when_under_limit() {
+    let mut state = LogViewerState::new();
+    state.push_info("a");
+    state.push_info("b");
+    assert_eq!(state.len(), 2);
+
+    state.set_max_entries(10);
+    assert_eq!(state.len(), 2);
+}
+
+#[test]
+fn test_set_max_history_evicts_oldest() {
+    let mut state = LogViewerState::new();
+    state.search_history = vec![
+        "a".to_string(),
+        "b".to_string(),
+        "c".to_string(),
+        "d".to_string(),
+        "e".to_string(),
+    ];
+    assert_eq!(state.search_history().len(), 5);
+
+    state.set_max_history(2);
+    assert_eq!(state.search_history().len(), 2);
+    assert_eq!(state.search_history()[0], "d");
+    assert_eq!(state.search_history()[1], "e");
+}
+
+#[test]
+fn test_set_max_history_no_eviction_when_under_limit() {
+    let mut state = LogViewerState::new();
+    state.search_history = vec!["a".to_string(), "b".to_string()];
+    assert_eq!(state.search_history().len(), 2);
+
+    state.set_max_history(10);
+    assert_eq!(state.search_history().len(), 2);
+}
+
 // =============================================================================
 // Filtering
 // =============================================================================

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -713,6 +713,11 @@ pub trait Focusable: Component {
     /// before rendering. The focus state is set before rendering and
     /// restored after, using `&mut State`.
     ///
+    /// # Panics
+    ///
+    /// If [`view()`](Component::view) panics, the focus state may not be restored.
+    /// This is generally not a concern since panics in view indicate a bug.
+    ///
     /// # Example
     ///
     /// ```rust,ignore
@@ -865,6 +870,11 @@ pub trait Disableable: Component {
     /// This avoids the need to clone state just to change the disabled flag
     /// before rendering. The disabled state is set before rendering and
     /// restored after, using `&mut State`.
+    ///
+    /// # Panics
+    ///
+    /// If [`view()`](Component::view) panics, the disabled state may not be restored.
+    /// This is generally not a concern since panics in view indicate a bug.
     ///
     /// ```rust,ignore
     /// // Render as disabled without permanently changing state:

--- a/src/component/status_log/mod.rs
+++ b/src/component/status_log/mod.rs
@@ -432,6 +432,9 @@ impl StatusLogState {
 
     /// Sets the maximum number of entries.
     ///
+    /// If the current count exceeds the new maximum, the oldest entries are
+    /// removed to bring the count within the limit.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -443,6 +446,10 @@ impl StatusLogState {
     /// ```
     pub fn set_max_entries(&mut self, max: usize) {
         self.max_entries = max;
+        if self.entries.len() > max {
+            let excess = self.entries.len() - max;
+            self.entries.drain(..excess);
+        }
     }
 
     /// Returns whether timestamps are shown.

--- a/src/component/status_log/tests.rs
+++ b/src/component/status_log/tests.rs
@@ -194,6 +194,34 @@ fn test_set_max_entries() {
     assert_eq!(state.max_entries(), 10);
 }
 
+#[test]
+fn test_set_max_entries_evicts_oldest() {
+    let mut state = StatusLogState::new();
+    state.info("a");
+    state.info("b");
+    state.info("c");
+    state.info("d");
+    state.info("e");
+    assert_eq!(state.len(), 5);
+
+    state.set_max_entries(2);
+    assert_eq!(state.len(), 2);
+    // Oldest entries removed, newest kept
+    assert_eq!(state.entries()[0].message(), "d");
+    assert_eq!(state.entries()[1].message(), "e");
+}
+
+#[test]
+fn test_set_max_entries_no_eviction_when_under_limit() {
+    let mut state = StatusLogState::new();
+    state.info("a");
+    state.info("b");
+    assert_eq!(state.len(), 2);
+
+    state.set_max_entries(10);
+    assert_eq!(state.len(), 2);
+}
+
 // ========================================
 // Accessor Tests
 // ========================================

--- a/src/component/terminal_output/tests.rs
+++ b/src/component/terminal_output/tests.rs
@@ -772,3 +772,30 @@ fn test_annotation_focused() {
     assert_eq!(regions.len(), 1);
     assert!(regions[0].annotation.focused);
 }
+
+#[test]
+fn test_set_max_lines_evicts_oldest() {
+    let mut state = TerminalOutputState::new();
+    state.push_line("a");
+    state.push_line("b");
+    state.push_line("c");
+    state.push_line("d");
+    state.push_line("e");
+    assert_eq!(state.line_count(), 5);
+
+    state.set_max_lines(2);
+    assert_eq!(state.line_count(), 2);
+    assert_eq!(state.lines()[0], "d");
+    assert_eq!(state.lines()[1], "e");
+}
+
+#[test]
+fn test_set_max_lines_no_eviction_when_under_limit() {
+    let mut state = TerminalOutputState::new();
+    state.push_line("a");
+    state.push_line("b");
+    assert_eq!(state.line_count(), 2);
+
+    state.set_max_lines(10);
+    assert_eq!(state.line_count(), 2);
+}


### PR DESCRIPTION
## Summary

- Add `# Panics` documentation to `view_with_focus` and `view_with_disabled` in the `Focusable` and `Disableable` traits, noting that focus/disabled state may not be restored if `view()` panics.
- Fix `StatusLogState::set_max_entries` to evict oldest entries when the new maximum is lower than the current count (was the only `set_max_*` method missing eviction logic).
- Replace inefficient `while remove(0)` loops with `drain(..excess)` in `EventStreamState::set_max_events`, `ChatViewState::set_max_messages`, `ConversationViewState::set_max_messages`, `LogViewerState::set_max_entries`, `LogViewerState::set_max_history`, and `LineInputHistory::set_max_entries`.
- Add tests for eviction and no-eviction cases across all `set_max_*` methods.

## Test plan

- [x] All 20 targeted `set_max_*` tests pass (new and existing)
- [x] Full test suite passes: 7123 unit + 1806 doc tests, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo check --no-default-features` passes
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)