### PR TITLE
Add ViewContext to Component::view() — focus as render parameter

### DIFF
--- a/benches/component_view.rs
+++ b/benches/component_view.rs
@@ -5,6 +5,7 @@
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use envision::backend::CaptureBackend;
+use envision::component::ViewContext;
 use envision::component::{
     Column, Component, SelectableList, SelectableListState, Table, TableRow, TableState, Tree,
     TreeNode, TreeState,
@@ -44,6 +45,7 @@ fn bench_selectable_list_view(c: &mut Criterion) {
                                     frame,
                                     frame.area(),
                                     &theme,
+                                    &ViewContext::default(),
                                 );
                             })
                             .unwrap();
@@ -112,6 +114,7 @@ fn bench_table_view(c: &mut Criterion) {
                                     frame,
                                     frame.area(),
                                     &theme,
+                                    &ViewContext::default(),
                                 );
                             })
                             .unwrap();
@@ -184,6 +187,7 @@ fn bench_tree_view(c: &mut Criterion) {
                                     frame,
                                     frame.area(),
                                     &theme,
+                                    &ViewContext::default(),
                                 );
                             })
                             .unwrap();
@@ -208,7 +212,13 @@ fn bench_tree_view(c: &mut Criterion) {
             b.iter(|| {
                 terminal
                     .draw(|frame| {
-                        Tree::<String>::view(black_box(&state), frame, frame.area(), &theme);
+                        Tree::<String>::view(
+                            black_box(&state),
+                            frame,
+                            frame.area(),
+                            &theme,
+                            &ViewContext::default(),
+                        );
                     })
                     .unwrap();
             });

--- a/examples/accordion.rs
+++ b/examples/accordion.rs
@@ -76,7 +76,13 @@ impl App for AccordionApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        Accordion::view(&state.accordion, frame, chunks[0], &theme);
+        Accordion::view(
+            &state.accordion,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let panel_idx = state
             .accordion

--- a/examples/alert_panel.rs
+++ b/examples/alert_panel.rs
@@ -70,7 +70,13 @@ impl App for AlertPanelApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        AlertPanel::view(&state.panel, frame, chunks[0], &theme);
+        AlertPanel::view(
+            &state.panel,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let selected = state
             .panel

--- a/examples/beautiful_dashboard.rs
+++ b/examples/beautiful_dashboard.rs
@@ -329,10 +329,16 @@ impl App for DashboardApp {
         render_progress(state, frame, main[3], &theme);
 
         // ── Key Hints ──
-        KeyHints::view(&state.hints, frame, main[4], &theme);
+        KeyHints::view(
+            &state.hints,
+            frame,
+            main[4],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // ── Toast overlay (renders on top) ──
-        Toast::view(&state.toasts, frame, area, &theme);
+        Toast::view(&state.toasts, frame, area, &theme, &ViewContext::default());
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {
@@ -438,7 +444,7 @@ fn render_navigation(state: &State, frame: &mut Frame, area: Rect, theme: &Theme
     frame.render_widget(block, area);
 
     // Render menu inside the block
-    Menu::view(&state.menu, frame, inner, theme);
+    Menu::view(&state.menu, frame, inner, theme, &ViewContext::default());
 }
 
 fn render_content(state: &State, frame: &mut Frame, area: Rect, theme: &Theme) {
@@ -474,7 +480,13 @@ fn render_content(state: &State, frame: &mut Frame, area: Rect, theme: &Theme) {
 
     let chart_inner = chart_block.inner(content[0]);
     frame.render_widget(chart_block, content[0]);
-    Chart::view(&state.chart, frame, chart_inner, theme);
+    Chart::view(
+        &state.chart,
+        frame,
+        chart_inner,
+        theme,
+        &ViewContext::default(),
+    );
 
     // ── Metrics Panel ──
     let metrics_focused = state.focus.is_focused(&Panel::Metrics);
@@ -502,7 +514,13 @@ fn render_content(state: &State, frame: &mut Frame, area: Rect, theme: &Theme) {
 
     let metrics_inner = metrics_block.inner(content[1]);
     frame.render_widget(metrics_block, content[1]);
-    MetricsDashboard::view(&state.metrics, frame, metrics_inner, theme);
+    MetricsDashboard::view(
+        &state.metrics,
+        frame,
+        metrics_inner,
+        theme,
+        &ViewContext::default(),
+    );
 }
 
 fn render_progress(state: &State, frame: &mut Frame, area: Rect, theme: &Theme) {
@@ -528,9 +546,27 @@ fn render_progress(state: &State, frame: &mut Frame, area: Rect, theme: &Theme) 
     ])
     .split(inner);
 
-    ProgressBar::view(&state.progress_cpu, frame, cols[0], theme);
-    ProgressBar::view(&state.progress_mem, frame, cols[1], theme);
-    ProgressBar::view(&state.progress_disk, frame, cols[2], theme);
+    ProgressBar::view(
+        &state.progress_cpu,
+        frame,
+        cols[0],
+        theme,
+        &ViewContext::default(),
+    );
+    ProgressBar::view(
+        &state.progress_mem,
+        frame,
+        cols[1],
+        theme,
+        &ViewContext::default(),
+    );
+    ProgressBar::view(
+        &state.progress_disk,
+        frame,
+        cols[2],
+        theme,
+        &ViewContext::default(),
+    );
 }
 
 // =============================================================================

--- a/examples/big_text.rs
+++ b/examples/big_text.rs
@@ -79,16 +79,34 @@ impl App for BigTextApp {
 
         let clock_label = Paragraph::new(" Clock").style(Style::default().fg(Color::DarkGray));
         frame.render_widget(clock_label, chunks[0]);
-        BigText::view(&state.clock, frame, chunks[1], &theme);
+        BigText::view(
+            &state.clock,
+            frame,
+            chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let metric_label =
             Paragraph::new(" Active Users").style(Style::default().fg(Color::DarkGray));
         frame.render_widget(metric_label, chunks[2]);
-        BigText::view(&state.metric, frame, chunks[3], &theme);
+        BigText::view(
+            &state.metric,
+            frame,
+            chunks[3],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let pct_label = Paragraph::new(" Uptime").style(Style::default().fg(Color::DarkGray));
         frame.render_widget(pct_label, chunks[4]);
-        BigText::view(&state.percentage, frame, chunks[5], &theme);
+        BigText::view(
+            &state.percentage,
+            frame,
+            chunks[5],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let footer = Paragraph::new(" BigText dashboard metrics | Esc to quit")
             .style(Style::default().fg(Color::DarkGray))

--- a/examples/box_plot.rs
+++ b/examples/box_plot.rs
@@ -59,7 +59,13 @@ impl App for BoxPlotApp {
     fn view(state: &State, frame: &mut Frame) {
         let theme = Theme::default();
         let area = frame.area();
-        BoxPlot::view(&state.box_plot, frame, area, &theme);
+        BoxPlot::view(
+            &state.box_plot,
+            frame,
+            area,
+            &theme,
+            &ViewContext::default(),
+        );
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {

--- a/examples/breadcrumb.rs
+++ b/examples/breadcrumb.rs
@@ -77,7 +77,13 @@ impl App for BreadcrumbApp {
         ])
         .split(area);
 
-        Breadcrumb::view(&state.breadcrumb, frame, chunks[0], &theme);
+        Breadcrumb::view(
+            &state.breadcrumb,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Show selection history
         let log_lines: Vec<Line> = state

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -113,9 +113,27 @@ impl App for ButtonApp {
         ])
         .split(area);
 
-        Button::view(&state.save, frame, chunks[0], &theme);
-        Button::view(&state.cancel, frame, chunks[1], &theme);
-        Button::view(&state.submit, frame, chunks[2], &theme);
+        Button::view(
+            &state.save,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
+        Button::view(
+            &state.cancel,
+            frame,
+            chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
+        Button::view(
+            &state.submit,
+            frame,
+            chunks[2],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Last pressed info
         let info = match &state.last_pressed {

--- a/examples/calendar.rs
+++ b/examples/calendar.rs
@@ -54,7 +54,13 @@ impl App for CalendarApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        Calendar::view(&state.calendar, frame, chunks[0], &theme);
+        Calendar::view(
+            &state.calendar,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let selected_info = match state.calendar.selected_day() {
             Some(day) => format!(

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -93,7 +93,13 @@ impl App for CanvasApp {
 
     fn view(state: &State, frame: &mut Frame) {
         let theme = Theme::default();
-        Canvas::view(&state.canvas, frame, frame.area(), &theme);
+        Canvas::view(
+            &state.canvas,
+            frame,
+            frame.area(),
+            &theme,
+            &ViewContext::default(),
+        );
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -66,8 +66,20 @@ impl App for ChartApp {
         let chunks =
             Layout::vertical([Constraint::Percentage(50), Constraint::Percentage(50)]).split(area);
 
-        Chart::view(&state.line_chart, frame, chunks[0], &theme);
-        Chart::view(&state.bar_chart, frame, chunks[1], &theme);
+        Chart::view(
+            &state.line_chart,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
+        Chart::view(
+            &state.bar_chart,
+            frame,
+            chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {

--- a/examples/chart_enhanced.rs
+++ b/examples/chart_enhanced.rs
@@ -78,8 +78,20 @@ impl App for ChartEnhancedApp {
         let chunks =
             Layout::vertical([Constraint::Percentage(50), Constraint::Percentage(50)]).split(area);
 
-        Chart::view(&state.area_chart, frame, chunks[0], &theme);
-        Chart::view(&state.scatter_chart, frame, chunks[1], &theme);
+        Chart::view(
+            &state.area_chart,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
+        Chart::view(
+            &state.scatter_chart,
+            frame,
+            chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {

--- a/examples/chat_app.rs
+++ b/examples/chat_app.rs
@@ -88,10 +88,22 @@ impl App for ChatApp {
         let theme = Theme::default();
 
         // Render chat history (using ChatView but without its built-in input)
-        ChatView::view(&state.chat, frame, chunks[0], &theme);
+        ChatView::view(
+            &state.chat,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Render LineInput
-        LineInput::view(&state.input, frame, chunks[1], &theme);
+        LineInput::view(
+            &state.input,
+            frame,
+            chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Status bar
         let status = Paragraph::new(format!(

--- a/examples/chat_markdown_demo.rs
+++ b/examples/chat_markdown_demo.rs
@@ -301,10 +301,22 @@ impl App for ChatMarkdownApp {
         frame.render_widget(header, chunks[0]);
 
         // Chat messages
-        ChatView::view(&state.chat, frame, chunks[1], &theme);
+        ChatView::view(
+            &state.chat,
+            frame,
+            chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Input (multi-line)
-        TextArea::view(&state.input, frame, chunks[2], &theme);
+        TextArea::view(
+            &state.input,
+            frame,
+            chunks[2],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Status bar
         let status = Paragraph::new(Line::from(vec![

--- a/examples/chat_view.rs
+++ b/examples/chat_view.rs
@@ -63,7 +63,13 @@ impl App for ChatViewApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        ChatView::view(&state.chat, frame, chunks[0], &theme);
+        ChatView::view(
+            &state.chat,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let status = format!(
             " Messages: {} | Ctrl+Enter: send, Tab: toggle focus, Esc: quit",

--- a/examples/checkbox.rs
+++ b/examples/checkbox.rs
@@ -110,9 +110,27 @@ impl App for CheckboxApp {
         ])
         .split(area);
 
-        Checkbox::view(&state.notifications, frame, chunks[0], &theme);
-        Checkbox::view(&state.dark_mode, frame, chunks[1], &theme);
-        Checkbox::view(&state.auto_save, frame, chunks[2], &theme);
+        Checkbox::view(
+            &state.notifications,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
+        Checkbox::view(
+            &state.dark_mode,
+            frame,
+            chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
+        Checkbox::view(
+            &state.auto_save,
+            frame,
+            chunks[2],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Summary
         let summary = format!(

--- a/examples/code_block.rs
+++ b/examples/code_block.rs
@@ -96,7 +96,13 @@ fn main() {
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
         let theme = Theme::default();
-        CodeBlock::view(&state.code, frame, chunks[0], &theme);
+        CodeBlock::view(
+            &state.code,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let status = Paragraph::new(format!(
             " Line {} | {}/{} | Up/Down/PgUp/PgDn/Home/End | l=line nums | Esc=quit",

--- a/examples/collapsible.rs
+++ b/examples/collapsible.rs
@@ -50,7 +50,13 @@ impl App for CollapsibleApp {
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
         // Render the collapsible header and border
-        Collapsible::view(&state.collapsible, frame, chunks[0], &theme);
+        Collapsible::view(
+            &state.collapsible,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Render content inside the content area when expanded
         let content_area = state.collapsible.content_area(chunks[0]);

--- a/examples/command_palette.rs
+++ b/examples/command_palette.rs
@@ -126,7 +126,13 @@ impl App for CommandPaletteApp {
         .split(area);
 
         // Main area: render the command palette overlay
-        CommandPalette::view(&state.palette, frame, chunks[0], &theme);
+        CommandPalette::view(
+            &state.palette,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Show selection history
         let log_lines: Vec<Line> = state

--- a/examples/component_showcase.rs
+++ b/examples/component_showcase.rs
@@ -459,10 +459,22 @@ impl App for ShowcaseApp {
         .split(area);
 
         // Menu bar
-        envision::component::Menu::view(&state.menu, frame, main_chunks[0], &theme);
+        envision::component::Menu::view(
+            &state.menu,
+            frame,
+            main_chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Tabs
-        Tabs::view(&state.tabs, frame, main_chunks[1], &theme);
+        Tabs::view(
+            &state.tabs,
+            frame,
+            main_chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Content panel based on selected tab
         let content_area = main_chunks[2];
@@ -497,7 +509,13 @@ impl App for ShowcaseApp {
         // Dialog overlay (rendered last, on top)
         if state.dialog.is_visible() {
             let dialog_area = centered_rect(40, 8, area);
-            Dialog::view(&state.dialog, frame, dialog_area, &theme);
+            Dialog::view(
+                &state.dialog,
+                frame,
+                dialog_area,
+                &theme,
+                &ViewContext::default(),
+            );
         }
     }
 
@@ -569,10 +587,34 @@ fn render_form_panel(state: &State, frame: &mut Frame, area: Rect, theme: &Theme
     ])
     .split(inner);
 
-    envision::component::InputField::view(&state.input, frame, chunks[0], theme);
-    envision::component::Checkbox::view(&state.checkbox, frame, chunks[1], theme);
-    envision::component::RadioGroup::view(&state.radio, frame, chunks[2], theme);
-    envision::component::Button::view(&state.submit_button, frame, chunks[3], theme);
+    envision::component::InputField::view(
+        &state.input,
+        frame,
+        chunks[0],
+        theme,
+        &ViewContext::default(),
+    );
+    envision::component::Checkbox::view(
+        &state.checkbox,
+        frame,
+        chunks[1],
+        theme,
+        &ViewContext::default(),
+    );
+    envision::component::RadioGroup::view(
+        &state.radio,
+        frame,
+        chunks[2],
+        theme,
+        &ViewContext::default(),
+    );
+    envision::component::Button::view(
+        &state.submit_button,
+        frame,
+        chunks[3],
+        theme,
+        &ViewContext::default(),
+    );
 }
 
 fn render_data_panel(state: &State, frame: &mut Frame, area: Rect, theme: &Theme) {
@@ -593,10 +635,22 @@ fn render_data_panel(state: &State, frame: &mut Frame, area: Rect, theme: &Theme
         .title("Users");
     let list_inner = list_block.inner(chunks[0]);
     frame.render_widget(list_block, chunks[0]);
-    envision::component::SelectableList::view(&state.list, frame, list_inner, theme);
+    envision::component::SelectableList::view(
+        &state.list,
+        frame,
+        list_inner,
+        theme,
+        &ViewContext::default(),
+    );
 
     // Table
-    Table::view(&state.table, frame, chunks[1], theme);
+    Table::view(
+        &state.table,
+        frame,
+        chunks[1],
+        theme,
+        &ViewContext::default(),
+    );
 }
 
 fn render_status_panel(state: &State, frame: &mut Frame, area: Rect, theme: &Theme) {
@@ -614,9 +668,27 @@ fn render_status_panel(state: &State, frame: &mut Frame, area: Rect, theme: &The
     ])
     .split(inner);
 
-    envision::component::ProgressBar::view(&state.progress, frame, chunks[0], theme);
-    Spinner::view(&state.spinner, frame, chunks[1], theme);
-    Toast::view(&state.toast, frame, chunks[2], theme);
+    envision::component::ProgressBar::view(
+        &state.progress,
+        frame,
+        chunks[0],
+        theme,
+        &ViewContext::default(),
+    );
+    Spinner::view(
+        &state.spinner,
+        frame,
+        chunks[1],
+        theme,
+        &ViewContext::default(),
+    );
+    Toast::view(
+        &state.toast,
+        frame,
+        chunks[2],
+        theme,
+        &ViewContext::default(),
+    );
 }
 
 fn render_viz_panel(state: &State, frame: &mut Frame, area: Rect, theme: &Theme) {
@@ -639,20 +711,56 @@ fn render_viz_panel(state: &State, frame: &mut Frame, area: Rect, theme: &Theme)
     // Row 1: Sparkline (left) + Gauge (right)
     let top_cols =
         Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)]).split(rows[0]);
-    Sparkline::view(&state.sparkline, frame, top_cols[0], theme);
-    Gauge::view(&state.gauge, frame, top_cols[1], theme);
+    Sparkline::view(
+        &state.sparkline,
+        frame,
+        top_cols[0],
+        theme,
+        &ViewContext::default(),
+    );
+    Gauge::view(
+        &state.gauge,
+        frame,
+        top_cols[1],
+        theme,
+        &ViewContext::default(),
+    );
 
     // Row 2: Heatmap (full width)
-    Heatmap::view(&state.heatmap, frame, rows[1], theme);
+    Heatmap::view(
+        &state.heatmap,
+        frame,
+        rows[1],
+        theme,
+        &ViewContext::default(),
+    );
 
     // Row 3: Timeline (full width)
-    Timeline::view(&state.timeline, frame, rows[2], theme);
+    Timeline::view(
+        &state.timeline,
+        frame,
+        rows[2],
+        theme,
+        &ViewContext::default(),
+    );
 
     // Row 4: CommandPalette (left) + CodeBlock (right)
     let bottom_cols =
         Layout::horizontal([Constraint::Percentage(40), Constraint::Percentage(60)]).split(rows[3]);
-    CommandPalette::view(&state.command_palette, frame, bottom_cols[0], theme);
-    CodeBlock::view(&state.code_block, frame, bottom_cols[1], theme);
+    CommandPalette::view(
+        &state.command_palette,
+        frame,
+        bottom_cols[0],
+        theme,
+        &ViewContext::default(),
+    );
+    CodeBlock::view(
+        &state.code_block,
+        frame,
+        bottom_cols[1],
+        theme,
+        &ViewContext::default(),
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/examples/confirm_dialog.rs
+++ b/examples/confirm_dialog.rs
@@ -116,7 +116,7 @@ impl App for ConfirmDialogApp {
 
         // Overlay dialog when visible
         if ConfirmDialog::is_visible(&state.dialog) {
-            ConfirmDialog::view(&state.dialog, frame, area, &theme);
+            ConfirmDialog::view(&state.dialog, frame, area, &theme, &ViewContext::default());
         }
 
         let status = " d: delete dialog | s: save dialog | q: quit";

--- a/examples/conversation_view.rs
+++ b/examples/conversation_view.rs
@@ -149,7 +149,13 @@ impl App for ConversationApp {
 
     fn view(state: &State, frame: &mut Frame) {
         let theme = Theme::default();
-        ConversationView::view(&state.conversation, frame, frame.area(), &theme);
+        ConversationView::view(
+            &state.conversation,
+            frame,
+            frame.area(),
+            &theme,
+            &ViewContext::default(),
+        );
     }
 
     fn handle_event_with_state(state: &Self::State, event: &Event) -> Option<Msg> {

--- a/examples/dashboard_demo.rs
+++ b/examples/dashboard_demo.rs
@@ -347,17 +347,41 @@ impl App for DashboardApp {
             Layout::vertical([Constraint::Percentage(50), Constraint::Percentage(50)])
                 .split(content_chunks[0]);
 
-        Chart::view(&state.chart, frame, left_chunks[0], &theme);
-        MultiProgress::view(&state.multi_progress, frame, left_chunks[1], &theme);
+        Chart::view(
+            &state.chart,
+            frame,
+            left_chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
+        MultiProgress::view(
+            &state.multi_progress,
+            frame,
+            left_chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Right column: status log
-        StatusLog::view(&state.status_log, frame, content_chunks[1], &theme);
+        StatusLog::view(
+            &state.status_log,
+            frame,
+            content_chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Toast overlay (renders on top of everything)
-        Toast::view(&state.toasts, frame, area, &theme);
+        Toast::view(&state.toasts, frame, area, &theme, &ViewContext::default());
 
         // Status bar
-        StatusBar::view(&state.status_bar, frame, main_chunks[2], &theme);
+        StatusBar::view(
+            &state.status_bar,
+            frame,
+            main_chunks[2],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Key hints
         render_key_hints(frame, main_chunks[3], &theme);

--- a/examples/data_grid.rs
+++ b/examples/data_grid.rs
@@ -91,7 +91,13 @@ impl App for DataGridApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        DataGrid::view(&state.grid, frame, chunks[0], &theme);
+        DataGrid::view(
+            &state.grid,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let selected = state
             .grid

--- a/examples/dependency_graph.rs
+++ b/examples/dependency_graph.rs
@@ -96,7 +96,13 @@ impl App for DependencyGraphApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        DependencyGraph::view(&state.graph, frame, chunks[0], &theme);
+        DependencyGraph::view(
+            &state.graph,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let selected_info = state
             .graph

--- a/examples/dialog.rs
+++ b/examples/dialog.rs
@@ -86,7 +86,7 @@ impl App for DialogApp {
         frame.render_widget(content, chunks[0]);
 
         if Dialog::is_visible(&state.dialog) {
-            Dialog::view(&state.dialog, frame, area, &theme);
+            Dialog::view(&state.dialog, frame, area, &theme, &ViewContext::default());
         }
 
         let status = " d: show dialog, q: quit";

--- a/examples/diff_viewer.rs
+++ b/examples/diff_viewer.rs
@@ -78,7 +78,13 @@ fn main() {
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
         let theme = Theme::default();
-        DiffViewer::view(&state.viewer, frame, chunks[0], &theme);
+        DiffViewer::view(
+            &state.viewer,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let mode_str = match state.viewer.mode() {
             DiffMode::Unified => "Unified",

--- a/examples/divider.rs
+++ b/examples/divider.rs
@@ -60,8 +60,20 @@ impl App for DividerApp {
         ])
         .split(area);
 
-        Divider::view(&state.horizontal, frame, main_chunks[0], &theme);
-        Divider::view(&state.horizontal_labeled, frame, main_chunks[2], &theme);
+        Divider::view(
+            &state.horizontal,
+            frame,
+            main_chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
+        Divider::view(
+            &state.horizontal_labeled,
+            frame,
+            main_chunks[2],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Bottom section: vertical dividers side by side
         let vertical_chunks = Layout::horizontal([
@@ -72,8 +84,20 @@ impl App for DividerApp {
         ])
         .split(main_chunks[4]);
 
-        Divider::view(&state.vertical, frame, vertical_chunks[0], &theme);
-        Divider::view(&state.vertical_labeled, frame, vertical_chunks[2], &theme);
+        Divider::view(
+            &state.vertical,
+            frame,
+            vertical_chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
+        Divider::view(
+            &state.vertical_labeled,
+            frame,
+            vertical_chunks[2],
+            &theme,
+            &ViewContext::default(),
+        );
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {

--- a/examples/dropdown.rs
+++ b/examples/dropdown.rs
@@ -61,7 +61,13 @@ impl App for DropdownApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Length(3), Constraint::Min(0)]).split(area);
 
-        Dropdown::view(&state.language, frame, chunks[0], &theme);
+        Dropdown::view(
+            &state.language,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let selected = state.language.selected_value().unwrap_or("None");
         let status = format!(" Selected: {}", selected);

--- a/examples/event_stream.rs
+++ b/examples/event_stream.rs
@@ -166,7 +166,13 @@ impl App for EventStreamApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        EventStream::view(&state.stream, frame, chunks[0], &theme);
+        EventStream::view(
+            &state.stream,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let visible = state.stream.visible_events().len();
         let total = state.stream.event_count();

--- a/examples/file_browser.rs
+++ b/examples/file_browser.rs
@@ -73,7 +73,13 @@ impl App for FileBrowserApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        FileBrowser::view(&state.browser, frame, chunks[0], &theme);
+        FileBrowser::view(
+            &state.browser,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let selected = state
             .browser

--- a/examples/flame_graph.rs
+++ b/examples/flame_graph.rs
@@ -79,7 +79,13 @@ impl App for FlameGraphApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        FlameGraph::view(&state.graph, frame, chunks[0], &theme);
+        FlameGraph::view(
+            &state.graph,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let selected = state
             .graph

--- a/examples/form.rs
+++ b/examples/form.rs
@@ -89,7 +89,13 @@ impl App for FormApp {
             );
             frame.render_widget(widget, chunks[0]);
         } else {
-            Form::view(&state.form, frame, chunks[0], &theme);
+            Form::view(
+                &state.form,
+                frame,
+                chunks[0],
+                &theme,
+                &ViewContext::default(),
+            );
         }
 
         let status =

--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -91,10 +91,34 @@ impl App for GaugeApp {
         ])
         .split(area);
 
-        Gauge::view(&state.cpu, frame, chunks[0], &theme);
-        Gauge::view(&state.memory, frame, chunks[1], &theme);
-        Gauge::view(&state.disk, frame, chunks[2], &theme);
-        Gauge::view(&state.network, frame, chunks[3], &theme);
+        Gauge::view(
+            &state.cpu,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
+        Gauge::view(
+            &state.memory,
+            frame,
+            chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
+        Gauge::view(
+            &state.disk,
+            frame,
+            chunks[2],
+            &theme,
+            &ViewContext::default(),
+        );
+        Gauge::view(
+            &state.network,
+            frame,
+            chunks[3],
+            &theme,
+            &ViewContext::default(),
+        );
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {

--- a/examples/heatmap.rs
+++ b/examples/heatmap.rs
@@ -65,7 +65,7 @@ impl App for HeatmapApp {
     fn view(state: &State, frame: &mut Frame) {
         let theme = Theme::default();
         let area = frame.area();
-        Heatmap::view(&state.heatmap, frame, area, &theme);
+        Heatmap::view(&state.heatmap, frame, area, &theme, &ViewContext::default());
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {

--- a/examples/help_panel.rs
+++ b/examples/help_panel.rs
@@ -95,7 +95,13 @@ impl App for HelpPanelApp {
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
         let theme = Theme::default();
-        HelpPanel::view(&state.help, frame, chunks[0], &theme);
+        HelpPanel::view(
+            &state.help,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let status = Paragraph::new(format!(
             " Scroll: {} | Up/Down | PgUp/PgDn | Home/End | Esc quit",

--- a/examples/histogram.rs
+++ b/examples/histogram.rs
@@ -54,7 +54,13 @@ impl App for HistogramApp {
     fn view(state: &State, frame: &mut Frame) {
         let theme = Theme::default();
         let area = frame.area();
-        Histogram::view(&state.histogram, frame, area, &theme);
+        Histogram::view(
+            &state.histogram,
+            frame,
+            area,
+            &theme,
+            &ViewContext::default(),
+        );
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {

--- a/examples/input_field.rs
+++ b/examples/input_field.rs
@@ -67,7 +67,13 @@ impl App for InputFieldApp {
         ])
         .split(area);
 
-        InputField::view(&state.input, frame, chunks[0], &theme);
+        InputField::view(
+            &state.input,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Show submitted values
         let submitted_text = if state.submitted.is_empty() {

--- a/examples/key_hints.rs
+++ b/examples/key_hints.rs
@@ -98,7 +98,13 @@ impl App for KeyHintsApp {
         frame.render_widget(widget, chunks[0]);
 
         // Key hints bar at the bottom
-        KeyHints::view(&state.hints, frame, chunks[1], &theme);
+        KeyHints::view(
+            &state.hints,
+            frame,
+            chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {

--- a/examples/line_input.rs
+++ b/examples/line_input.rs
@@ -64,7 +64,13 @@ impl App for LineInputApp {
         .split(area);
 
         let theme = Theme::default();
-        LineInput::view(&state.input, frame, chunks[0], &theme);
+        LineInput::view(
+            &state.input,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Show submissions log
         let log_lines: Vec<Line> = state

--- a/examples/loading_list.rs
+++ b/examples/loading_list.rs
@@ -73,7 +73,13 @@ impl App for LoadingListApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        LoadingList::view(&state.list, frame, chunks[0], &theme);
+        LoadingList::view(
+            &state.list,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let selected = state
             .list

--- a/examples/log_correlation.rs
+++ b/examples/log_correlation.rs
@@ -143,7 +143,13 @@ impl App for LogCorrelationApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        LogCorrelation::view(&state.correlation, frame, chunks[0], &theme);
+        LogCorrelation::view(
+            &state.correlation,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let status = " Tab: switch stream | j/k: scroll | s: toggle sync | q: quit";
         frame.render_widget(

--- a/examples/log_viewer.rs
+++ b/examples/log_viewer.rs
@@ -71,7 +71,13 @@ impl App for LogViewerApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        LogViewer::view(&state.viewer, frame, chunks[0], &theme);
+        LogViewer::view(
+            &state.viewer,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let visible = state.viewer.visible_entries().len();
         let follow = if state.viewer.follow() { "ON" } else { "OFF" };

--- a/examples/markdown_renderer.rs
+++ b/examples/markdown_renderer.rs
@@ -104,7 +104,13 @@ impl App for MarkdownRendererApp {
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
         let theme = Theme::default();
-        MarkdownRenderer::view(&state.renderer, frame, chunks[0], &theme);
+        MarkdownRenderer::view(
+            &state.renderer,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let mode = if state.renderer.show_source() {
             "source"

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -69,7 +69,13 @@ impl App for MenuApp {
         ])
         .split(area);
 
-        Menu::view(&state.menu, frame, chunks[0], &theme);
+        Menu::view(
+            &state.menu,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let selected_text = state.last_selected.as_deref().unwrap_or("None");
         let content =

--- a/examples/metrics_dashboard.rs
+++ b/examples/metrics_dashboard.rs
@@ -60,7 +60,13 @@ impl App for MetricsDashboardApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        MetricsDashboard::view(&state.dashboard, frame, chunks[0], &theme);
+        MetricsDashboard::view(
+            &state.dashboard,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let selected = state
             .dashboard

--- a/examples/multi_progress.rs
+++ b/examples/multi_progress.rs
@@ -55,7 +55,13 @@ impl App for MultiProgressApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        MultiProgress::view(&state.progress, frame, chunks[0], &theme);
+        MultiProgress::view(
+            &state.progress,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let completed = state.progress.completed_count();
         let total = state.progress.len();

--- a/examples/number_input.rs
+++ b/examples/number_input.rs
@@ -119,9 +119,27 @@ impl App for NumberInputApp {
         ])
         .split(area);
 
-        NumberInput::view(&state.quantity, frame, chunks[0], &theme);
-        NumberInput::view(&state.price, frame, chunks[1], &theme);
-        NumberInput::view(&state.temperature, frame, chunks[2], &theme);
+        NumberInput::view(
+            &state.quantity,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
+        NumberInput::view(
+            &state.price,
+            frame,
+            chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
+        NumberInput::view(
+            &state.temperature,
+            frame,
+            chunks[2],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let status = format!(
             " Qty: {} | Price: {} | Temp: {} | Tab: navigate, Enter: edit, q: quit",

--- a/examples/paginator.rs
+++ b/examples/paginator.rs
@@ -92,25 +92,49 @@ impl App for PaginatorApp {
             ratatui::widgets::Paragraph::new("PageOfTotal:").style(theme.info_style()),
             chunks[0],
         );
-        Paginator::view(&state.page_of_total, frame, chunks[1], &theme);
+        Paginator::view(
+            &state.page_of_total,
+            frame,
+            chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
 
         frame.render_widget(
             ratatui::widgets::Paragraph::new("RangeOfTotal:").style(theme.info_style()),
             chunks[3],
         );
-        Paginator::view(&state.range_of_total, frame, chunks[4], &theme);
+        Paginator::view(
+            &state.range_of_total,
+            frame,
+            chunks[4],
+            &theme,
+            &ViewContext::default(),
+        );
 
         frame.render_widget(
             ratatui::widgets::Paragraph::new("Dots:").style(theme.info_style()),
             chunks[6],
         );
-        Paginator::view(&state.dots, frame, chunks[7], &theme);
+        Paginator::view(
+            &state.dots,
+            frame,
+            chunks[7],
+            &theme,
+            &ViewContext::default(),
+        );
 
         frame.render_widget(
             ratatui::widgets::Paragraph::new("Compact:").style(theme.info_style()),
             chunks[9],
         );
-        Paginator::view(&state.compact, frame, chunks[10], &theme);
+        Paginator::view(
+            &state.compact,
+            frame,
+            chunks[10],
+            &theme,
+            &ViewContext::default(),
+        );
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {

--- a/examples/pane_layout.rs
+++ b/examples/pane_layout.rs
@@ -75,7 +75,13 @@ impl App for PaneLayoutApp {
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
         // Render pane borders
-        PaneLayout::view(&state.layout, frame, chunks[0], &theme);
+        PaneLayout::view(
+            &state.layout,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Render content in each pane
         let rects = state.layout.layout(chunks[0]);

--- a/examples/production_app.rs
+++ b/examples/production_app.rs
@@ -208,7 +208,13 @@ impl App for ProcessorApp {
             .padding(Padding::horizontal(1));
         let progress_inner = progress_block.inner(sections[1]);
         frame.render_widget(progress_block, sections[1]);
-        ProgressBar::view(&state.progress, frame, progress_inner, &theme);
+        ProgressBar::view(
+            &state.progress,
+            frame,
+            progress_inner,
+            &theme,
+            &ViewContext::default(),
+        );
 
         // -- Current file indicator --
         let current_text = match &state.current_file {
@@ -232,7 +238,13 @@ impl App for ProcessorApp {
         frame.render_widget(current, sections[2]);
 
         // -- Status log --
-        StatusLog::view(&state.log, frame, sections[3], &theme);
+        StatusLog::view(
+            &state.log,
+            frame,
+            sections[3],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // -- Bottom status bar --
         let status = Line::from(vec![

--- a/examples/progress_bar.rs
+++ b/examples/progress_bar.rs
@@ -68,9 +68,27 @@ impl App for ProgressBarApp {
         ])
         .split(area);
 
-        ProgressBar::view(&state.download, frame, chunks[0], &theme);
-        ProgressBar::view(&state.install, frame, chunks[1], &theme);
-        ProgressBar::view(&state.verify, frame, chunks[2], &theme);
+        ProgressBar::view(
+            &state.download,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
+        ProgressBar::view(
+            &state.install,
+            frame,
+            chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
+        ProgressBar::view(
+            &state.verify,
+            frame,
+            chunks[2],
+            &theme,
+            &ViewContext::default(),
+        );
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {

--- a/examples/radio_group.rs
+++ b/examples/radio_group.rs
@@ -60,7 +60,13 @@ impl App for RadioGroupApp {
         ])
         .split(area);
 
-        RadioGroup::<String>::view(&state.size, frame, chunks[0], &theme);
+        RadioGroup::<String>::view(
+            &state.size,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let selected = state
             .size

--- a/examples/scroll_view.rs
+++ b/examples/scroll_view.rs
@@ -60,7 +60,13 @@ impl App for ScrollViewApp {
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
         // Render the scroll view (border + scrollbar)
-        ScrollView::view(&state.scroll_view, frame, chunks[0], &theme);
+        ScrollView::view(
+            &state.scroll_view,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Render content inside the content area
         let content_area = state.scroll_view.content_area(chunks[0]);

--- a/examples/scrollable_text.rs
+++ b/examples/scrollable_text.rs
@@ -63,7 +63,13 @@ impl App for ScrollableTextApp {
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
         let theme = Theme::default();
-        ScrollableText::view(&state.text, frame, chunks[0], &theme);
+        ScrollableText::view(
+            &state.text,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let status = Paragraph::new(format!(
             " Scroll offset: {} | Up/Down scroll | PgUp/PgDn page | Home/End | Esc quit",

--- a/examples/searchable_list.rs
+++ b/examples/searchable_list.rs
@@ -82,7 +82,13 @@ impl App for SearchableListApp {
         ])
         .split(area);
 
-        SearchableList::view(&state.list, frame, chunks[0], &theme);
+        SearchableList::view(
+            &state.list,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Show selection history
         let log_lines: Vec<Line> = state

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -95,8 +95,20 @@ impl App for SelectApp {
         ])
         .split(area);
 
-        Select::view(&state.color, frame, chunks[0], &theme);
-        Select::view(&state.size, frame, chunks[1], &theme);
+        Select::view(
+            &state.color,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
+        Select::view(
+            &state.size,
+            frame,
+            chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Summary
         let color_val = state.color.selected_value().unwrap_or("none");

--- a/examples/selectable_list.rs
+++ b/examples/selectable_list.rs
@@ -58,7 +58,13 @@ impl App for SelectableListApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        SelectableList::<String>::view(&state.list, frame, chunks[0], &theme);
+        SelectableList::<String>::view(
+            &state.list,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let selected = state
             .list

--- a/examples/slider.rs
+++ b/examples/slider.rs
@@ -130,10 +130,34 @@ impl App for SliderApp {
         ])
         .split(area);
 
-        Slider::view(&state.volume, frame, chunks[0], &theme);
-        Slider::view(&state.brightness, frame, chunks[1], &theme);
-        Slider::view(&state.temperature, frame, chunks[2], &theme);
-        Slider::view(&state.vertical, frame, chunks[3], &theme);
+        Slider::view(
+            &state.volume,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
+        Slider::view(
+            &state.brightness,
+            frame,
+            chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
+        Slider::view(
+            &state.temperature,
+            frame,
+            chunks[2],
+            &theme,
+            &ViewContext::default(),
+        );
+        Slider::view(
+            &state.vertical,
+            frame,
+            chunks[3],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let status = format!(
             " Vol: {} | Bright: {} | Temp: {} | Level: {} | Tab: navigate, q: quit",

--- a/examples/span_tree.rs
+++ b/examples/span_tree.rs
@@ -82,7 +82,13 @@ impl App for SpanTreeApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        SpanTree::view(&state.tree, frame, chunks[0], &theme);
+        SpanTree::view(
+            &state.tree,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let selected = state
             .tree

--- a/examples/sparkline.rs
+++ b/examples/sparkline.rs
@@ -61,10 +61,34 @@ impl App for SparklineApp {
         ])
         .split(area);
 
-        Sparkline::view(&state.basic, frame, chunks[0], &theme);
-        Sparkline::view(&state.titled, frame, chunks[1], &theme);
-        Sparkline::view(&state.rtl, frame, chunks[2], &theme);
-        Sparkline::view(&state.limited, frame, chunks[3], &theme);
+        Sparkline::view(
+            &state.basic,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
+        Sparkline::view(
+            &state.titled,
+            frame,
+            chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
+        Sparkline::view(
+            &state.rtl,
+            frame,
+            chunks[2],
+            &theme,
+            &ViewContext::default(),
+        );
+        Sparkline::view(
+            &state.limited,
+            frame,
+            chunks[3],
+            &theme,
+            &ViewContext::default(),
+        );
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {

--- a/examples/spinner.rs
+++ b/examples/spinner.rs
@@ -70,10 +70,34 @@ impl App for SpinnerApp {
         ])
         .split(area);
 
-        Spinner::view(&state.dots, frame, chunks[0], &theme);
-        Spinner::view(&state.line, frame, chunks[1], &theme);
-        Spinner::view(&state.circle, frame, chunks[2], &theme);
-        Spinner::view(&state.stopped, frame, chunks[3], &theme);
+        Spinner::view(
+            &state.dots,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
+        Spinner::view(
+            &state.line,
+            frame,
+            chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
+        Spinner::view(
+            &state.circle,
+            frame,
+            chunks[2],
+            &theme,
+            &ViewContext::default(),
+        );
+        Spinner::view(
+            &state.stopped,
+            frame,
+            chunks[3],
+            &theme,
+            &ViewContext::default(),
+        );
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {

--- a/examples/split_panel.rs
+++ b/examples/split_panel.rs
@@ -53,7 +53,13 @@ impl App for SplitPanelApp {
 
         // Render the split panel borders
         let theme = Theme::default();
-        SplitPanel::view(&state.split, frame, chunks[0], &theme);
+        SplitPanel::view(
+            &state.split,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Render content inside each pane
         let (first_area, second_area) = state.split.layout(chunks[0]);

--- a/examples/status_bar.rs
+++ b/examples/status_bar.rs
@@ -102,7 +102,13 @@ impl App for StatusBarApp {
         frame.render_widget(widget, chunks[0]);
 
         // Status bar
-        StatusBar::view(&state.status, frame, chunks[1], &theme);
+        StatusBar::view(
+            &state.status,
+            frame,
+            chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Help line
         frame.render_widget(

--- a/examples/status_log.rs
+++ b/examples/status_log.rs
@@ -58,7 +58,13 @@ impl App for StatusLogApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        StatusLog::view(&state.log, frame, chunks[0], &theme);
+        StatusLog::view(
+            &state.log,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let status = format!(" Entries: {} | Up/Down: scroll, q: quit", state.log.len());
         frame.render_widget(

--- a/examples/step_indicator.rs
+++ b/examples/step_indicator.rs
@@ -89,7 +89,13 @@ impl App for StepIndicatorApp {
         ])
         .split(area);
 
-        StepIndicator::view(&state.pipeline, frame, chunks[0], &theme);
+        StepIndicator::view(
+            &state.pipeline,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Info panel
         let active = state

--- a/examples/styled_text.rs
+++ b/examples/styled_text.rs
@@ -134,7 +134,13 @@ impl App for StyledTextApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        StyledText::view(&state.text, frame, chunks[0], &theme);
+        StyledText::view(
+            &state.text,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let status = format!(
             " Scroll: {} | Up/Down: scroll | PgUp/PgDn: page | Home/End: jump | q: quit",

--- a/examples/styling_showcase.rs
+++ b/examples/styling_showcase.rs
@@ -305,7 +305,13 @@ impl App for StylingShowcaseApp {
         render_style_palette(state, frame, panels[0], &theme);
 
         // Right panel: Rich Text
-        StyledText::view(&state.styled_text, frame, panels[1], &theme);
+        StyledText::view(
+            &state.styled_text,
+            frame,
+            panels[1],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Footer — key hints
         render_footer(frame, main_chunks[2], &theme);

--- a/examples/switch.rs
+++ b/examples/switch.rs
@@ -131,10 +131,34 @@ impl App for SwitchApp {
         frame.render_widget(title, chunks[0]);
 
         // Switches
-        Switch::view(&state.wifi, frame, chunks[1], &theme);
-        Switch::view(&state.bluetooth, frame, chunks[2], &theme);
-        Switch::view(&state.dark_mode, frame, chunks[3], &theme);
-        Switch::view(&state.notifications, frame, chunks[4], &theme);
+        Switch::view(
+            &state.wifi,
+            frame,
+            chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
+        Switch::view(
+            &state.bluetooth,
+            frame,
+            chunks[2],
+            &theme,
+            &ViewContext::default(),
+        );
+        Switch::view(
+            &state.dark_mode,
+            frame,
+            chunks[3],
+            &theme,
+            &ViewContext::default(),
+        );
+        Switch::view(
+            &state.notifications,
+            frame,
+            chunks[4],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Summary
         let summary = format!(

--- a/examples/tab_bar.rs
+++ b/examples/tab_bar.rs
@@ -83,7 +83,13 @@ impl App for TabBarApp {
         ])
         .split(area);
 
-        TabBar::view(&state.tab_bar, frame, chunks[0], &theme);
+        TabBar::view(
+            &state.tab_bar,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let tab_name = state
             .tab_bar

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -97,7 +97,13 @@ impl App for TableApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        Table::<Language>::view(&state.table, frame, chunks[0], &theme);
+        Table::<Language>::view(
+            &state.table,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let selected = state
             .table

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -59,7 +59,13 @@ impl App for TabsApp {
         ])
         .split(area);
 
-        Tabs::<String>::view(&state.tabs, frame, chunks[0], &theme);
+        Tabs::<String>::view(
+            &state.tabs,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let tab_name = state
             .tabs

--- a/examples/terminal_output.rs
+++ b/examples/terminal_output.rs
@@ -78,7 +78,13 @@ impl App for TerminalOutputApp {
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
         let theme = Theme::default();
-        TerminalOutput::view(&state.output, frame, chunks[0], &theme);
+        TerminalOutput::view(
+            &state.output,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let status = Paragraph::new(
             " Lines: {} | a: auto-scroll | n: line nums | Up/Down/PgUp/PgDn | Esc quit"

--- a/examples/text_area.rs
+++ b/examples/text_area.rs
@@ -50,7 +50,13 @@ impl App for TextAreaApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        TextArea::view(&state.editor, frame, chunks[0], &theme);
+        TextArea::view(
+            &state.editor,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let (row, col) = state.editor.cursor_position();
         let lines = state.editor.line_count();

--- a/examples/themed_app.rs
+++ b/examples/themed_app.rs
@@ -213,6 +213,7 @@ impl App for ThemedApp {
             frame,
             button_checkbox_chunks[0],
             &theme,
+            &ViewContext::default(),
         );
 
         // Render checkbox using Component trait
@@ -221,10 +222,17 @@ impl App for ThemedApp {
             frame,
             button_checkbox_chunks[1],
             &theme,
+            &ViewContext::default(),
         );
 
         // Progress bar
-        ProgressBar::view(&state.progress_state, frame, chunks[3], &theme);
+        ProgressBar::view(
+            &state.progress_state,
+            frame,
+            chunks[3],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Selectable list with block wrapper
         let list_area = chunks[4];
@@ -239,7 +247,13 @@ impl App for ThemedApp {
             .title("Items");
         let inner_area = list_block.inner(list_area);
         frame.render_widget(list_block, list_area);
-        SelectableList::view(&state.list_state, frame, inner_area, &theme);
+        SelectableList::view(
+            &state.list_state,
+            frame,
+            inner_area,
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Controls help
         let controls = Paragraph::new(Line::from(vec![

--- a/examples/timeline.rs
+++ b/examples/timeline.rs
@@ -79,7 +79,13 @@ impl App for TimelineApp {
 
     fn view(state: &State, frame: &mut Frame) {
         let theme = Theme::default();
-        Timeline::view(&state.timeline, frame, frame.area(), &theme);
+        Timeline::view(
+            &state.timeline,
+            frame,
+            frame.area(),
+            &theme,
+            &ViewContext::default(),
+        );
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {

--- a/examples/title_card.rs
+++ b/examples/title_card.rs
@@ -83,9 +83,27 @@ impl App for TitleCardApp {
 
         let theme = Theme::default();
 
-        TitleCard::view(&state.plain, frame, chunks[0], &theme);
-        TitleCard::view(&state.decorated, frame, chunks[1], &theme);
-        TitleCard::view(&state.styled, frame, chunks[2], &theme);
+        TitleCard::view(
+            &state.plain,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
+        TitleCard::view(
+            &state.decorated,
+            frame,
+            chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
+        TitleCard::view(
+            &state.styled,
+            frame,
+            chunks[2],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let footer = Paragraph::new(" TitleCard configurations | Esc to quit")
             .style(Style::default().fg(Color::DarkGray))

--- a/examples/toast.rs
+++ b/examples/toast.rs
@@ -68,7 +68,7 @@ impl App for ToastApp {
                 );
         frame.render_widget(content, chunks[0]);
 
-        Toast::view(&state.toasts, frame, area, &theme);
+        Toast::view(&state.toasts, frame, area, &theme, &ViewContext::default());
 
         let status = " s: success, w: warning, e: error, q: quit";
         frame.render_widget(

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -69,7 +69,13 @@ impl App for TreeApp {
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        Tree::view(&state.tree, frame, chunks[0], &theme);
+        Tree::view(
+            &state.tree,
+            frame,
+            chunks[0],
+            &theme,
+            &ViewContext::default(),
+        );
 
         let selected = state
             .tree

--- a/examples/treemap.rs
+++ b/examples/treemap.rs
@@ -85,7 +85,7 @@ impl App for TreemapApp {
     fn view(state: &State, frame: &mut Frame) {
         let theme = Theme::default();
         let area = frame.area();
-        Treemap::view(&state.treemap, frame, area, &theme);
+        Treemap::view(&state.treemap, frame, area, &theme, &ViewContext::default());
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {

--- a/examples/usage_display.rs
+++ b/examples/usage_display.rs
@@ -80,17 +80,35 @@ impl App for UsageDisplayApp {
         frame.render_widget(title, chunks[0]);
 
         // Horizontal layout
-        UsageDisplay::view(&state.horizontal, frame, chunks[1], &theme);
+        UsageDisplay::view(
+            &state.horizontal,
+            frame,
+            chunks[1],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Vertical layout
-        UsageDisplay::view(&state.vertical, frame, chunks[2], &theme);
+        UsageDisplay::view(
+            &state.vertical,
+            frame,
+            chunks[2],
+            &theme,
+            &ViewContext::default(),
+        );
 
         // Spacer line
         let spacer = ratatui::widgets::Paragraph::new("");
         frame.render_widget(spacer, chunks[3]);
 
         // Grid layout
-        UsageDisplay::view(&state.grid, frame, chunks[4], &theme);
+        UsageDisplay::view(
+            &state.grid,
+            frame,
+            chunks[4],
+            &theme,
+            &ViewContext::default(),
+        );
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {

--- a/src/component/accordion/mod.rs
+++ b/src/component/accordion/mod.rs
@@ -37,7 +37,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -705,7 +705,7 @@ impl Component for Accordion {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if state.panels.is_empty() {
             return;
         }

--- a/src/component/accordion/tests.rs
+++ b/src/component/accordion/tests.rs
@@ -467,7 +467,7 @@ fn test_view_empty() {
 
     terminal
         .draw(|frame| {
-            Accordion::view(&state, frame, frame.area(), &theme);
+            Accordion::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -481,7 +481,7 @@ fn test_view_collapsed() {
 
     terminal
         .draw(|frame| {
-            Accordion::view(&state, frame, frame.area(), &theme);
+            Accordion::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -497,7 +497,7 @@ fn test_view_expanded() {
 
     terminal
         .draw(|frame| {
-            Accordion::view(&state, frame, frame.area(), &theme);
+            Accordion::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -514,7 +514,7 @@ fn test_view_mixed() {
 
     terminal
         .draw(|frame| {
-            Accordion::view(&state, frame, frame.area(), &theme);
+            Accordion::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -529,7 +529,7 @@ fn test_view_focused_highlight() {
 
     terminal
         .draw(|frame| {
-            Accordion::view(&state, frame, frame.area(), &theme);
+            Accordion::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -547,7 +547,7 @@ fn test_view_long_content() {
 
     terminal
         .draw(|frame| {
-            Accordion::view(&state, frame, frame.area(), &theme);
+            Accordion::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -796,7 +796,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Accordion::view(&state, frame, frame.area(), &theme);
+                Accordion::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/alert_panel/mod.rs
+++ b/src/component/alert_panel/mod.rs
@@ -45,7 +45,7 @@ use std::marker::PhantomData;
 
 use ratatui::prelude::*;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -943,7 +943,7 @@ impl Component for AlertPanel {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         render::render_alert_panel(state, frame, area, theme);
     }
 }

--- a/src/component/alert_panel/snapshot_tests.rs
+++ b/src/component/alert_panel/snapshot_tests.rs
@@ -28,7 +28,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(80, 25);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme);
+            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -43,7 +43,7 @@ fn test_snapshot_with_metrics() {
     let (mut terminal, theme) = test_utils::setup_render(80, 25);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme);
+            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -59,7 +59,7 @@ fn test_snapshot_focused() {
     let (mut terminal, theme) = test_utils::setup_render(80, 25);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme);
+            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -74,7 +74,7 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(80, 25);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme);
+            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -96,7 +96,7 @@ fn test_snapshot_all_ok() {
     let (mut terminal, theme) = test_utils::setup_render(80, 15);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme);
+            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -118,7 +118,7 @@ fn test_snapshot_all_critical() {
     let (mut terminal, theme) = test_utils::setup_render(80, 15);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme);
+            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -143,7 +143,7 @@ fn test_snapshot_with_sparklines() {
     let (mut terminal, theme) = test_utils::setup_render(80, 15);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme);
+            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -163,7 +163,7 @@ fn test_snapshot_single_metric() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme);
+            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -185,7 +185,7 @@ fn test_snapshot_with_thresholds() {
     let (mut terminal, theme) = test_utils::setup_render(80, 15);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme);
+            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/alert_panel/tests.rs
+++ b/src/component/alert_panel/tests.rs
@@ -694,7 +694,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme);
+            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -705,7 +705,7 @@ fn test_render_with_metrics() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme);
+            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -718,7 +718,7 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme);
+            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -729,7 +729,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(60, 2);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme);
+            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -746,7 +746,7 @@ fn test_render_with_history() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme);
+            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -908,7 +908,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                AlertPanel::view(&state, frame, frame.area(), &theme);
+                AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/big_text/mod.rs
+++ b/src/component/big_text/mod.rs
@@ -24,7 +24,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, Disableable};
+use super::{Component, Disableable, ViewContext};
 use crate::theme::Theme;
 
 /// Returns the 3-row block representation of a character.
@@ -469,7 +469,7 @@ impl Component for BigText {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,

--- a/src/component/big_text/tests.rs
+++ b/src/component/big_text/tests.rs
@@ -320,7 +320,7 @@ fn test_empty_text() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme);
+            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -332,7 +332,7 @@ fn test_unsupported_characters() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme);
+            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -345,7 +345,7 @@ fn test_zero_height_area() {
     terminal
         .draw(|frame| {
             let area = Rect::new(0, 0, 40, 0);
-            BigText::view(&state, frame, area, &theme);
+            BigText::view(&state, frame, area, &theme, &ViewContext::default());
         })
         .unwrap();
     // Should not panic
@@ -358,7 +358,7 @@ fn test_zero_width_area() {
     terminal
         .draw(|frame| {
             let area = Rect::new(0, 0, 0, 5);
-            BigText::view(&state, frame, area, &theme);
+            BigText::view(&state, frame, area, &theme, &ViewContext::default());
         })
         .unwrap();
     // Should not panic
@@ -374,7 +374,7 @@ fn test_view_digits() {
     let (mut terminal, theme) = test_utils::setup_render(60, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme);
+            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -386,7 +386,7 @@ fn test_view_clock() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme);
+            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -398,7 +398,7 @@ fn test_view_percentage() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme);
+            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -410,7 +410,7 @@ fn test_view_with_color() {
     let (mut terminal, theme) = test_utils::setup_render(30, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme);
+            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -422,7 +422,7 @@ fn test_view_left_aligned() {
     let (mut terminal, theme) = test_utils::setup_render(30, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme);
+            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -434,7 +434,7 @@ fn test_view_right_aligned() {
     let (mut terminal, theme) = test_utils::setup_render(30, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme);
+            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -446,7 +446,7 @@ fn test_view_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(30, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme);
+            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -458,7 +458,7 @@ fn test_view_letters() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme);
+            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -471,7 +471,7 @@ fn test_view_lowercase_converted() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme);
+            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -483,7 +483,7 @@ fn test_view_single_char() {
     let (mut terminal, theme) = test_utils::setup_render(20, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme);
+            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -495,7 +495,7 @@ fn test_view_dash() {
     let (mut terminal, theme) = test_utils::setup_render(30, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme);
+            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -507,7 +507,7 @@ fn test_view_date() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme);
+            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -525,7 +525,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                BigText::view(&state, frame, frame.area(), &theme);
+                BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -544,7 +544,7 @@ fn test_annotation_disabled() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                BigText::view(&state, frame, frame.area(), &theme);
+                BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/box_plot/mod.rs
+++ b/src/component/box_plot/mod.rs
@@ -24,7 +24,7 @@ use std::marker::PhantomData;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -738,7 +738,7 @@ impl Component for BoxPlot {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if area.height < 3 || area.width < 3 {
             return;
         }

--- a/src/component/box_plot/snapshot_tests.rs
+++ b/src/component/box_plot/snapshot_tests.rs
@@ -11,7 +11,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme);
+            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -24,7 +24,7 @@ fn test_snapshot_single_vertical() {
     let (mut terminal, theme) = test_utils::setup_render(40, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme);
+            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -41,7 +41,7 @@ fn test_snapshot_multiple_vertical() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme);
+            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -58,7 +58,7 @@ fn test_snapshot_horizontal() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme);
+            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -74,7 +74,7 @@ fn test_snapshot_with_outliers() {
     let (mut terminal, theme) = test_utils::setup_render(40, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme);
+            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -90,7 +90,7 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme);
+            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -108,7 +108,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                BoxPlot::view(&state, frame, frame.area(), &theme);
+                BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -124,7 +124,7 @@ fn test_annotation_with_focus() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                BoxPlot::view(&state, frame, frame.area(), &theme);
+                BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -141,7 +141,7 @@ fn test_annotation_with_disabled() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                BoxPlot::view(&state, frame, frame.area(), &theme);
+                BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/box_plot/tests.rs
+++ b/src/component/box_plot/tests.rs
@@ -744,7 +744,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme);
+            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -758,7 +758,7 @@ fn test_render_single_dataset() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme);
+            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -774,7 +774,7 @@ fn test_render_multiple_datasets() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme);
+            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -788,7 +788,7 @@ fn test_render_with_outliers() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme);
+            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -803,7 +803,7 @@ fn test_render_without_outliers() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme);
+            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -816,7 +816,7 @@ fn test_render_focused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme);
+            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -828,7 +828,7 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme);
+            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -839,7 +839,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(60, 2);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme);
+            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -850,7 +850,7 @@ fn test_render_very_small_width() {
     let (mut terminal, theme) = test_utils::setup_render(4, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme);
+            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -869,7 +869,7 @@ fn test_render_horizontal_single() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme);
+            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -884,7 +884,7 @@ fn test_render_horizontal_multiple() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme);
+            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -899,7 +899,7 @@ fn test_render_horizontal_with_outliers() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme);
+            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -912,7 +912,7 @@ fn test_render_horizontal_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme);
+            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -930,7 +930,7 @@ fn test_render_zero_range() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme);
+            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }

--- a/src/component/breadcrumb/mod.rs
+++ b/src/component/breadcrumb/mod.rs
@@ -38,7 +38,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -583,7 +583,7 @@ impl Component for Breadcrumb {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if state.segments.is_empty() {
             return;
         }

--- a/src/component/breadcrumb/tests.rs
+++ b/src/component/breadcrumb/tests.rs
@@ -448,7 +448,7 @@ fn test_view_empty() {
 
     terminal
         .draw(|frame| {
-            Breadcrumb::view(&state, frame, frame.area(), &theme);
+            Breadcrumb::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -463,7 +463,7 @@ fn test_view_single() {
 
     terminal
         .draw(|frame| {
-            Breadcrumb::view(&state, frame, frame.area(), &theme);
+            Breadcrumb::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -478,7 +478,7 @@ fn test_view_multiple() {
 
     terminal
         .draw(|frame| {
-            Breadcrumb::view(&state, frame, frame.area(), &theme);
+            Breadcrumb::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -495,7 +495,7 @@ fn test_view_focused_highlight() {
 
     terminal
         .draw(|frame| {
-            Breadcrumb::view(&state, frame, frame.area(), &theme);
+            Breadcrumb::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -512,7 +512,7 @@ fn test_view_truncated() {
 
     terminal
         .draw(|frame| {
-            Breadcrumb::view(&state, frame, frame.area(), &theme);
+            Breadcrumb::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -528,7 +528,7 @@ fn test_view_custom_separator() {
 
     terminal
         .draw(|frame| {
-            Breadcrumb::view(&state, frame, frame.area(), &theme);
+            Breadcrumb::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -544,7 +544,7 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Breadcrumb::view(&state, frame, frame.area(), &theme);
+            Breadcrumb::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -804,7 +804,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Breadcrumb::view(&state, frame, frame.area(), &theme);
+                Breadcrumb::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/button/mod.rs
+++ b/src/component/button/mod.rs
@@ -32,7 +32,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -320,7 +320,7 @@ impl Component for Button {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         let style = if state.disabled {
             theme.disabled_style()
         } else if state.focused {

--- a/src/component/button/tests.rs
+++ b/src/component/button/tests.rs
@@ -49,7 +49,7 @@ fn test_view() {
 
     terminal
         .draw(|frame| {
-            Button::view(&state, frame, frame.area(), &theme);
+            Button::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -64,7 +64,7 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            Button::view(&state, frame, frame.area(), &theme);
+            Button::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -79,7 +79,7 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Button::view(&state, frame, frame.area(), &theme);
+            Button::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -177,7 +177,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Button::view(&state, frame, frame.area(), &theme);
+                Button::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -198,7 +198,7 @@ fn test_annotation_focused() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Button::view(&state, frame, frame.area(), &theme);
+                Button::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/calendar/mod.rs
+++ b/src/component/calendar/mod.rs
@@ -44,7 +44,7 @@ use std::collections::HashMap;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -819,7 +819,7 @@ impl Component for Calendar {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if area.height == 0 || area.width == 0 {
             return;
         }

--- a/src/component/calendar/view_tests.rs
+++ b/src/component/calendar/view_tests.rs
@@ -8,7 +8,7 @@ fn test_view_march_2026() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(34, 12);
     terminal
         .draw(|frame| {
-            Calendar::view(&state, frame, frame.area(), &theme);
+            Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -20,7 +20,7 @@ fn test_view_with_selected_day() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(34, 12);
     terminal
         .draw(|frame| {
-            Calendar::view(&state, frame, frame.area(), &theme);
+            Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -35,7 +35,7 @@ fn test_view_with_events() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(34, 12);
     terminal
         .draw(|frame| {
-            Calendar::view(&state, frame, frame.area(), &theme);
+            Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -47,7 +47,7 @@ fn test_view_with_title() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 12);
     terminal
         .draw(|frame| {
-            Calendar::view(&state, frame, frame.area(), &theme);
+            Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -60,7 +60,7 @@ fn test_view_focused() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(34, 12);
     terminal
         .draw(|frame| {
-            Calendar::view(&state, frame, frame.area(), &theme);
+            Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -74,7 +74,7 @@ fn test_view_disabled() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(34, 12);
     terminal
         .draw(|frame| {
-            Calendar::view(&state, frame, frame.area(), &theme);
+            Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -86,7 +86,7 @@ fn test_view_february_leap_year() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(34, 12);
     terminal
         .draw(|frame| {
-            Calendar::view(&state, frame, frame.area(), &theme);
+            Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -98,7 +98,7 @@ fn test_view_february_non_leap_year() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(34, 12);
     terminal
         .draw(|frame| {
-            Calendar::view(&state, frame, frame.area(), &theme);
+            Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -110,7 +110,13 @@ fn test_view_zero_area() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(34, 12);
     terminal
         .draw(|frame| {
-            Calendar::view(&state, frame, Rect::new(0, 0, 0, 0), &theme);
+            Calendar::view(
+                &state,
+                frame,
+                Rect::new(0, 0, 0, 0),
+                &theme,
+                &ViewContext::default(),
+            );
         })
         .unwrap();
     // Should not panic
@@ -122,7 +128,7 @@ fn test_view_narrow_area() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(10, 5);
     terminal
         .draw(|frame| {
-            Calendar::view(&state, frame, frame.area(), &theme);
+            Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -139,7 +145,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Calendar::view(&state, frame, frame.area(), &theme);
+                Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -161,7 +167,7 @@ fn test_annotation_reflects_state() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Calendar::view(&state, frame, frame.area(), &theme);
+                Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/canvas/mod.rs
+++ b/src/component/canvas/mod.rs
@@ -36,7 +36,7 @@ use ratatui::widgets::canvas::{
 };
 use ratatui::widgets::{Block, Borders};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::theme::Theme;
 
 /// A drawable shape on the canvas.
@@ -615,7 +615,7 @@ impl Component for Canvas {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if area.height < 2 || area.width < 2 {
             return;
         }

--- a/src/component/canvas/tests.rs
+++ b/src/component/canvas/tests.rs
@@ -545,7 +545,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Canvas::view(&state, frame, frame.area(), &theme);
+            Canvas::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -556,7 +556,7 @@ fn test_render_with_title() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            Canvas::view(&state, frame, frame.area(), &theme);
+            Canvas::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -590,7 +590,7 @@ fn test_render_with_shapes() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Canvas::view(&state, frame, frame.area(), &theme);
+            Canvas::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -604,7 +604,7 @@ fn test_render_focused() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            Canvas::view(&state, frame, frame.area(), &theme);
+            Canvas::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -625,7 +625,7 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            Canvas::view(&state, frame, frame.area(), &theme);
+            Canvas::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -638,7 +638,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(5, 2);
     terminal
         .draw(|frame| {
-            Canvas::view(&state, frame, frame.area(), &theme);
+            Canvas::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -649,7 +649,7 @@ fn test_render_tiny_area_no_panic() {
     let (mut terminal, theme) = test_utils::setup_render(1, 1);
     terminal
         .draw(|frame| {
-            Canvas::view(&state, frame, frame.area(), &theme);
+            Canvas::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -665,7 +665,7 @@ fn test_render_with_points() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            Canvas::view(&state, frame, frame.area(), &theme);
+            Canvas::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -685,7 +685,7 @@ fn test_render_with_label() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            Canvas::view(&state, frame, frame.area(), &theme);
+            Canvas::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -704,7 +704,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Canvas::view(&state, frame, frame.area(), &theme);
+                Canvas::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/chart/enhancement_tests.rs
+++ b/src/component/chart/enhancement_tests.rs
@@ -211,7 +211,7 @@ fn test_render_area_chart() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -228,7 +228,7 @@ fn test_render_area_chart_with_labels() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -239,7 +239,7 @@ fn test_render_area_chart_multi_series() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -257,7 +257,7 @@ fn test_render_scatter_chart() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -268,7 +268,7 @@ fn test_render_scatter_chart_multi_series() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -288,7 +288,7 @@ fn test_render_area_chart_with_thresholds() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -304,7 +304,7 @@ fn test_render_scatter_with_thresholds() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -320,7 +320,7 @@ fn test_render_area_chart_with_y_range() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -335,7 +335,7 @@ fn test_render_empty_area_chart() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -346,7 +346,7 @@ fn test_render_empty_scatter_chart() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -384,7 +384,7 @@ fn test_area_chart_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -396,7 +396,7 @@ fn test_scatter_chart_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }

--- a/src/component/chart/mod.rs
+++ b/src/component/chart/mod.rs
@@ -25,7 +25,7 @@ use std::marker::PhantomData;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use super::{Component, Disableable};
+use super::{Component, Disableable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -827,7 +827,7 @@ impl Component for Chart {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if area.height < 3 || area.width < 3 {
             return;
         }

--- a/src/component/chart/snapshot_tests.rs
+++ b/src/component/chart/snapshot_tests.rs
@@ -18,7 +18,7 @@ fn test_snapshot_default_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -33,7 +33,7 @@ fn test_snapshot_populated_line_chart() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -46,7 +46,7 @@ fn test_snapshot_focused_line_chart() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -62,7 +62,7 @@ fn test_snapshot_bar_vertical() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -76,7 +76,7 @@ fn test_snapshot_bar_horizontal() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -91,7 +91,7 @@ fn test_snapshot_single_series() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -111,7 +111,7 @@ fn test_snapshot_area_chart() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -127,7 +127,7 @@ fn test_snapshot_scatter_chart() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -145,7 +145,7 @@ fn test_snapshot_area_chart_with_thresholds() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -162,7 +162,7 @@ fn test_snapshot_area_chart_with_y_range() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -174,7 +174,7 @@ fn test_snapshot_multi_series_area() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -186,7 +186,7 @@ fn test_snapshot_multi_series_scatter() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/chart/tests.rs
+++ b/src/component/chart/tests.rs
@@ -440,7 +440,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -451,7 +451,7 @@ fn test_render_line_chart() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -465,7 +465,7 @@ fn test_render_line_chart_with_labels() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -479,7 +479,7 @@ fn test_render_bar_vertical() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -490,7 +490,7 @@ fn test_render_bar_horizontal() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -501,7 +501,7 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -512,7 +512,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(60, 2);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -523,7 +523,7 @@ fn test_render_single_series_no_legend() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -570,7 +570,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Chart::view(&state, frame, frame.area(), &theme);
+                Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/chat_view/component_impl.rs
+++ b/src/component/chat_view/component_impl.rs
@@ -4,7 +4,7 @@ use ratatui::prelude::*;
 
 use super::message::Focus;
 use super::render_helpers;
-use super::{ChatView, ChatViewMessage, ChatViewOutput, ChatViewState};
+use super::{ChatView, ChatViewMessage, ChatViewOutput, ChatViewState, ViewContext};
 use crate::component::{Component, Disableable, Focusable, TextAreaMessage, TextAreaOutput};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::theme::Theme;
@@ -206,7 +206,7 @@ impl Component for ChatView {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if area.height < 4 {
             return;
         }

--- a/src/component/chat_view/mod.rs
+++ b/src/component/chat_view/mod.rs
@@ -39,7 +39,7 @@ use std::marker::PhantomData;
 
 use ratatui::prelude::*;
 
-use super::{Component, TextAreaState};
+use super::{Component, TextAreaState, ViewContext};
 use crate::input::Event;
 use crate::scroll::ScrollState;
 

--- a/src/component/chat_view/snapshot_tests.rs
+++ b/src/component/chat_view/snapshot_tests.rs
@@ -18,7 +18,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ChatView::view(&state, frame, frame.area(), &theme);
+            ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -31,7 +31,7 @@ fn test_snapshot_single_user_message() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ChatView::view(&state, frame, frame.area(), &theme);
+            ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -46,7 +46,7 @@ fn test_snapshot_multi_role() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ChatView::view(&state, frame, frame.area(), &theme);
+            ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -63,7 +63,7 @@ fn test_snapshot_focused_input() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ChatView::view(&state, frame, frame.area(), &theme);
+            ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -78,7 +78,7 @@ fn test_snapshot_focused_history() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ChatView::view(&state, frame, frame.area(), &theme);
+            ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -92,7 +92,7 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ChatView::view(&state, frame, frame.area(), &theme);
+            ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -107,7 +107,7 @@ fn test_snapshot_with_timestamps() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ChatView::view(&state, frame, frame.area(), &theme);
+            ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/chat_view/tests.rs
+++ b/src/component/chat_view/tests.rs
@@ -628,7 +628,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ChatView::view(&state, frame, frame.area(), &theme);
+            ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -639,7 +639,7 @@ fn test_render_with_messages() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ChatView::view(&state, frame, frame.area(), &theme);
+            ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -650,7 +650,7 @@ fn test_render_focused_input() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ChatView::view(&state, frame, frame.area(), &theme);
+            ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -662,7 +662,7 @@ fn test_render_focused_history() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ChatView::view(&state, frame, frame.area(), &theme);
+            ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -673,7 +673,7 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ChatView::view(&state, frame, frame.area(), &theme);
+            ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -686,7 +686,7 @@ fn test_render_with_timestamps() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ChatView::view(&state, frame, frame.area(), &theme);
+            ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -697,7 +697,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(60, 3);
     terminal
         .draw(|frame| {
-            ChatView::view(&state, frame, frame.area(), &theme);
+            ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -713,7 +713,7 @@ fn test_render_with_input_text() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ChatView::view(&state, frame, frame.area(), &theme);
+            ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -923,7 +923,7 @@ fn test_render_with_custom_role_styles() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ChatView::view(&state, frame, frame.area(), &theme);
+            ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     // Just verify it renders without panicking
@@ -939,7 +939,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                ChatView::view(&state, frame, frame.area(), &theme);
+                ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/checkbox/mod.rs
+++ b/src/component/checkbox/mod.rs
@@ -35,7 +35,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -335,7 +335,7 @@ impl Component for Checkbox {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         let check_mark = if state.checked { "x" } else { " " };
         let text = format!("[{}] {}", check_mark, state.label);
 

--- a/src/component/checkbox/tests.rs
+++ b/src/component/checkbox/tests.rs
@@ -83,7 +83,7 @@ fn test_view_unchecked() {
 
     terminal
         .draw(|frame| {
-            Checkbox::view(&state, frame, frame.area(), &theme);
+            Checkbox::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -97,7 +97,7 @@ fn test_view_checked() {
 
     terminal
         .draw(|frame| {
-            Checkbox::view(&state, frame, frame.area(), &theme);
+            Checkbox::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -112,7 +112,7 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            Checkbox::view(&state, frame, frame.area(), &theme);
+            Checkbox::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -127,7 +127,7 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Checkbox::view(&state, frame, frame.area(), &theme);
+            Checkbox::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -264,7 +264,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Checkbox::view(&state, frame, frame.area(), &theme);
+                Checkbox::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -284,7 +284,7 @@ fn test_annotation_checked() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Checkbox::view(&state, frame, frame.area(), &theme);
+                Checkbox::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/code_block/mod.rs
+++ b/src/component/code_block/mod.rs
@@ -42,7 +42,7 @@ use std::collections::HashSet;
 use ratatui::prelude::*;
 
 use self::highlight::Language;
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
@@ -498,7 +498,7 @@ impl Component for CodeBlock {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         render::render(state, frame, area, theme);
     }
 }

--- a/src/component/code_block/tests.rs
+++ b/src/component/code_block/tests.rs
@@ -555,7 +555,7 @@ fn test_view_empty() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme);
+            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -570,7 +570,7 @@ fn test_view_with_rust_code() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme);
+            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -585,7 +585,7 @@ fn test_view_with_line_numbers() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme);
+            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -601,7 +601,7 @@ fn test_view_focused() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme);
+            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -616,7 +616,7 @@ fn test_view_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme);
+            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -633,7 +633,7 @@ fn test_view_scrolled() {
     let (mut terminal, theme) = test_utils::setup_render(50, 8);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme);
+            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -648,7 +648,7 @@ fn test_view_with_highlight_lines() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme);
+            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -664,7 +664,7 @@ fn test_view_python_code() {
     let (mut terminal, theme) = test_utils::setup_render(60, 8);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme);
+            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -682,7 +682,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                CodeBlock::view(&state, frame, frame.area(), &theme);
+                CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -702,7 +702,7 @@ fn test_annotation_focused() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                CodeBlock::view(&state, frame, frame.area(), &theme);
+                CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -721,7 +721,7 @@ fn test_zero_size_render() {
     let (mut terminal, theme) = test_utils::setup_render(3, 3);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme);
+            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     // Should not panic
@@ -733,7 +733,7 @@ fn test_single_line_render() {
     let (mut terminal, theme) = test_utils::setup_render(30, 5);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme);
+            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -746,7 +746,7 @@ fn test_scroll_beyond_content() {
     let (mut terminal, theme) = test_utils::setup_render(30, 5);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme);
+            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     // Should not panic; scroll is clamped during render

--- a/src/component/collapsible/mod.rs
+++ b/src/component/collapsible/mod.rs
@@ -37,7 +37,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use super::{Component, Disableable, Focusable, Toggleable};
+use super::{Component, Disableable, Focusable, Toggleable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -554,7 +554,7 @@ impl Component for Collapsible {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if area.height == 0 || area.width == 0 {
             return;
         }

--- a/src/component/collapsible/tests.rs
+++ b/src/component/collapsible/tests.rs
@@ -612,7 +612,7 @@ fn test_view_expanded() {
 
     terminal
         .draw(|frame| {
-            Collapsible::view(&state, frame, frame.area(), &theme);
+            Collapsible::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -626,7 +626,7 @@ fn test_view_collapsed() {
 
     terminal
         .draw(|frame| {
-            Collapsible::view(&state, frame, frame.area(), &theme);
+            Collapsible::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -641,7 +641,7 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            Collapsible::view(&state, frame, frame.area(), &theme);
+            Collapsible::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -655,7 +655,7 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Collapsible::view(&state, frame, frame.area(), &theme);
+            Collapsible::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -670,7 +670,7 @@ fn test_view_focused_collapsed() {
 
     terminal
         .draw(|frame| {
-            Collapsible::view(&state, frame, frame.area(), &theme);
+            Collapsible::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -685,7 +685,7 @@ fn test_view_zero_area() {
     terminal
         .draw(|frame| {
             let zero_area = Rect::new(0, 0, 0, 0);
-            Collapsible::view(&state, frame, zero_area, &theme);
+            Collapsible::view(&state, frame, zero_area, &theme, &ViewContext::default());
         })
         .unwrap();
     // Should not panic
@@ -699,7 +699,7 @@ fn test_view_height_one() {
     terminal
         .draw(|frame| {
             let area = Rect::new(0, 0, 40, 1);
-            Collapsible::view(&state, frame, area, &theme);
+            Collapsible::view(&state, frame, area, &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -717,7 +717,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Collapsible::view(&state, frame, frame.area(), &theme);
+                Collapsible::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -742,7 +742,7 @@ fn test_annotation_reflects_state() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Collapsible::view(&state, frame, frame.area(), &theme);
+                Collapsible::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/command_palette/mod.rs
+++ b/src/component/command_palette/mod.rs
@@ -41,7 +41,7 @@ pub use item::{fuzzy_score, PaletteItem};
 
 use ratatui::prelude::*;
 
-use super::{Component, Disableable, Focusable, Toggleable};
+use super::{Component, Disableable, Focusable, Toggleable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
@@ -867,7 +867,7 @@ impl Component for CommandPalette {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         render::render_command_palette(state, frame, area, theme);
     }
 }

--- a/src/component/command_palette/snapshot_tests.rs
+++ b/src/component/command_palette/snapshot_tests.rs
@@ -24,7 +24,7 @@ fn test_snapshot_visible_default() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme);
+            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -37,7 +37,7 @@ fn test_snapshot_with_query() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme);
+            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -51,7 +51,7 @@ fn test_snapshot_with_selection() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme);
+            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -67,7 +67,7 @@ fn test_snapshot_no_matches() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme);
+            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -79,7 +79,7 @@ fn test_snapshot_hidden() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme);
+            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -95,7 +95,7 @@ fn test_snapshot_custom_title_and_placeholder() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme);
+            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -109,7 +109,7 @@ fn test_snapshot_empty_items() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme);
+            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -131,7 +131,7 @@ fn test_snapshot_with_descriptions() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme);
+            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/command_palette/tests.rs
+++ b/src/component/command_palette/tests.rs
@@ -697,7 +697,7 @@ fn test_render_hidden_is_noop() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme);
+            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     // Should render nothing (blank)
@@ -709,7 +709,7 @@ fn test_render_visible() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme);
+            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -721,7 +721,7 @@ fn test_render_with_query() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme);
+            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -733,7 +733,7 @@ fn test_render_with_selection() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme);
+            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -748,7 +748,7 @@ fn test_render_no_matches() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme);
+            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -761,7 +761,7 @@ fn test_render_empty_items() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme);
+            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -840,7 +840,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                CommandPalette::view(&state, frame, frame.area(), &theme);
+                CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/confirm_dialog/mod.rs
+++ b/src/component/confirm_dialog/mod.rs
@@ -31,7 +31,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
-use super::{Component, Focusable, Toggleable};
+use super::{Component, Focusable, Toggleable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -672,7 +672,7 @@ impl Component for ConfirmDialog {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if !state.visible {
             return;
         }

--- a/src/component/confirm_dialog/tests.rs
+++ b/src/component/confirm_dialog/tests.rs
@@ -400,7 +400,7 @@ fn test_view_not_visible() {
 
     terminal
         .draw(|frame| {
-            ConfirmDialog::view(&state, frame, frame.area(), &theme);
+            ConfirmDialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -418,7 +418,7 @@ fn test_view_ok_dialog() {
 
     terminal
         .draw(|frame| {
-            ConfirmDialog::view(&state, frame, frame.area(), &theme);
+            ConfirmDialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -434,7 +434,7 @@ fn test_view_yes_no_dialog() {
 
     terminal
         .draw(|frame| {
-            ConfirmDialog::view(&state, frame, frame.area(), &theme);
+            ConfirmDialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -454,7 +454,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                ConfirmDialog::view(&state, frame, frame.area(), &theme);
+                ConfirmDialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/conversation_view/mod.rs
+++ b/src/component/conversation_view/mod.rs
@@ -45,7 +45,7 @@ use std::marker::PhantomData;
 
 use ratatui::prelude::*;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
@@ -801,7 +801,7 @@ impl Component for ConversationView {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if area.height < 3 || area.width < 5 {
             return;
         }

--- a/src/component/conversation_view/render_tests.rs
+++ b/src/component/conversation_view/render_tests.rs
@@ -26,7 +26,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -37,7 +37,7 @@ fn test_render_with_messages() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -48,7 +48,7 @@ fn test_render_focused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -59,7 +59,7 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -70,7 +70,7 @@ fn test_render_with_title() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -87,7 +87,7 @@ fn test_render_with_timestamps() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -100,7 +100,7 @@ fn test_render_without_role_labels() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -118,7 +118,7 @@ fn test_render_code_block() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -136,7 +136,7 @@ fn test_render_tool_use_block() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -154,7 +154,7 @@ fn test_render_thinking_block() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -169,7 +169,7 @@ fn test_render_error_block() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -183,7 +183,7 @@ fn test_render_streaming_message() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -202,7 +202,7 @@ fn test_render_collapsed_thinking() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -218,7 +218,7 @@ fn test_render_collapsed_tool_use() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -229,7 +229,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(60, 4);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -240,7 +240,7 @@ fn test_render_tiny_area_no_panic() {
     let (mut terminal, theme) = test_utils::setup_render(4, 2);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -261,7 +261,7 @@ fn test_render_mixed_blocks() {
     let (mut terminal, theme) = test_utils::setup_render(60, 30);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -280,7 +280,7 @@ fn test_render_empty_code_block() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -295,7 +295,7 @@ fn test_render_empty_tool_input() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -310,7 +310,7 @@ fn test_render_empty_text_block() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -327,7 +327,13 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                ConversationView::view(&state, frame, frame.area(), &theme);
+                ConversationView::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::default(),
+                );
             })
             .unwrap();
     });

--- a/src/component/conversation_view/snapshot_tests.rs
+++ b/src/component/conversation_view/snapshot_tests.rs
@@ -18,7 +18,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -33,7 +33,7 @@ fn test_snapshot_with_messages() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -53,7 +53,7 @@ fn test_snapshot_with_code_block() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -67,7 +67,7 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -80,7 +80,7 @@ fn test_snapshot_with_title() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -96,7 +96,7 @@ fn test_snapshot_multiple_roles() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/data_grid/mod.rs
+++ b/src/component/data_grid/mod.rs
@@ -47,6 +47,7 @@ use ratatui::widgets::{Block, Borders, Row, Table as RatatuiTable};
 
 use super::{
     Column, Component, Disableable, Focusable, InputFieldMessage, InputFieldState, TableRow,
+    ViewContext,
 };
 use crate::input::{Event, KeyCode};
 use crate::scroll::ScrollState;
@@ -753,7 +754,7 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if state.columns.is_empty() {
             return;
         }

--- a/src/component/data_grid/snapshot_tests.rs
+++ b/src/component/data_grid/snapshot_tests.rs
@@ -47,7 +47,7 @@ fn test_snapshot_default_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            DataGrid::view(&state, frame, frame.area(), &theme);
+            DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -59,7 +59,7 @@ fn test_snapshot_populated() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            DataGrid::view(&state, frame, frame.area(), &theme);
+            DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -72,7 +72,7 @@ fn test_snapshot_focused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            DataGrid::view(&state, frame, frame.area(), &theme);
+            DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -86,7 +86,7 @@ fn test_snapshot_focused_second_column() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            DataGrid::view(&state, frame, frame.area(), &theme);
+            DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -100,7 +100,7 @@ fn test_snapshot_editing() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            DataGrid::view(&state, frame, frame.area(), &theme);
+            DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/data_grid/tests.rs
+++ b/src/component/data_grid/tests.rs
@@ -534,7 +534,7 @@ fn test_render_unfocused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            DataGrid::view(&state, frame, frame.area(), &theme);
+            DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -545,7 +545,7 @@ fn test_render_focused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            DataGrid::view(&state, frame, frame.area(), &theme);
+            DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -557,7 +557,7 @@ fn test_render_editing() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            DataGrid::view(&state, frame, frame.area(), &theme);
+            DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -568,7 +568,7 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            DataGrid::view(&state, frame, frame.area(), &theme);
+            DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -579,7 +579,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            DataGrid::view(&state, frame, frame.area(), &theme);
+            DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -644,7 +644,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                DataGrid::view(&state, frame, frame.area(), &theme);
+                DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/dependency_graph/mod.rs
+++ b/src/component/dependency_graph/mod.rs
@@ -31,7 +31,7 @@
 
 use ratatui::prelude::*;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -942,7 +942,7 @@ impl Component for DependencyGraph {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         render::render_dependency_graph(state, frame, area, theme);
     }
 }

--- a/src/component/dependency_graph/snapshot_tests.rs
+++ b/src/component/dependency_graph/snapshot_tests.rs
@@ -7,7 +7,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 10);
     terminal
         .draw(|frame| {
-            DependencyGraph::view(&state, frame, frame.area(), &theme);
+            DependencyGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -21,7 +21,7 @@ fn test_snapshot_single_node() {
     let (mut terminal, theme) = test_utils::setup_render(60, 10);
     terminal
         .draw(|frame| {
-            DependencyGraph::view(&state, frame, frame.area(), &theme);
+            DependencyGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -39,7 +39,7 @@ fn test_snapshot_simple_graph() {
     let (mut terminal, theme) = test_utils::setup_render(80, 16);
     terminal
         .draw(|frame| {
-            DependencyGraph::view(&state, frame, frame.area(), &theme);
+            DependencyGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -57,7 +57,7 @@ fn test_snapshot_with_selection() {
     let (mut terminal, theme) = test_utils::setup_render(80, 12);
     terminal
         .draw(|frame| {
-            DependencyGraph::view(&state, frame, frame.area(), &theme);
+            DependencyGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -77,7 +77,7 @@ fn test_snapshot_with_statuses() {
     let (mut terminal, theme) = test_utils::setup_render(80, 16);
     terminal
         .draw(|frame| {
-            DependencyGraph::view(&state, frame, frame.area(), &theme);
+            DependencyGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -94,7 +94,7 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(80, 12);
     terminal
         .draw(|frame| {
-            DependencyGraph::view(&state, frame, frame.area(), &theme);
+            DependencyGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -111,7 +111,7 @@ fn test_snapshot_top_to_bottom() {
     let (mut terminal, theme) = test_utils::setup_render(60, 16);
     terminal
         .draw(|frame| {
-            DependencyGraph::view(&state, frame, frame.area(), &theme);
+            DependencyGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/dialog/mod.rs
+++ b/src/component/dialog/mod.rs
@@ -27,7 +27,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
-use super::{Component, Disableable, Focusable, Toggleable};
+use super::{Component, Disableable, Focusable, Toggleable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -642,7 +642,7 @@ impl Component for Dialog {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if !state.visible {
             return;
         }

--- a/src/component/dialog/tests.rs
+++ b/src/component/dialog/tests.rs
@@ -306,7 +306,7 @@ fn test_view_when_hidden() {
 
     terminal
         .draw(|frame| {
-            Dialog::view(&state, frame, frame.area(), &theme);
+            Dialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -325,7 +325,7 @@ fn test_view_renders() {
 
     terminal
         .draw(|frame| {
-            Dialog::view(&state, frame, frame.area(), &theme);
+            Dialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -340,7 +340,7 @@ fn test_view_title() {
 
     terminal
         .draw(|frame| {
-            Dialog::view(&state, frame, frame.area(), &theme);
+            Dialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -355,7 +355,7 @@ fn test_view_message() {
 
     terminal
         .draw(|frame| {
-            Dialog::view(&state, frame, frame.area(), &theme);
+            Dialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -370,7 +370,7 @@ fn test_view_buttons() {
 
     terminal
         .draw(|frame| {
-            Dialog::view(&state, frame, frame.area(), &theme);
+            Dialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -386,7 +386,7 @@ fn test_view_focused_button() {
 
     terminal
         .draw(|frame| {
-            Dialog::view(&state, frame, frame.area(), &theme);
+            Dialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -401,7 +401,7 @@ fn test_view_primary_button() {
 
     terminal
         .draw(|frame| {
-            Dialog::view(&state, frame, frame.area(), &theme);
+            Dialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -416,7 +416,7 @@ fn test_view_multiline_message() {
 
     terminal
         .draw(|frame| {
-            Dialog::view(&state, frame, frame.area(), &theme);
+            Dialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -727,7 +727,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Dialog::view(&state, frame, frame.area(), &theme);
+                Dialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/diff_viewer/mod.rs
+++ b/src/component/diff_viewer/mod.rs
@@ -40,7 +40,7 @@ mod render;
 
 use ratatui::prelude::*;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
@@ -956,7 +956,7 @@ impl Component for DiffViewer {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         render::render(state, frame, area, theme);
     }
 }

--- a/src/component/diff_viewer/tests.rs
+++ b/src/component/diff_viewer/tests.rs
@@ -715,7 +715,7 @@ fn test_view_unified_empty() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            DiffViewer::view(&state, frame, frame.area(), &theme);
+            DiffViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -727,7 +727,7 @@ fn test_view_unified_with_diff() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            DiffViewer::view(&state, frame, frame.area(), &theme);
+            DiffViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -740,7 +740,7 @@ fn test_view_unified_focused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            DiffViewer::view(&state, frame, frame.area(), &theme);
+            DiffViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -754,7 +754,7 @@ fn test_view_unified_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            DiffViewer::view(&state, frame, frame.area(), &theme);
+            DiffViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -769,7 +769,7 @@ fn test_view_side_by_side() {
     let (mut terminal, theme) = test_utils::setup_render(80, 12);
     terminal
         .draw(|frame| {
-            DiffViewer::view(&state, frame, frame.area(), &theme);
+            DiffViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -781,7 +781,7 @@ fn test_view_with_line_numbers() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            DiffViewer::view(&state, frame, frame.area(), &theme);
+            DiffViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -793,7 +793,7 @@ fn test_view_without_line_numbers() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            DiffViewer::view(&state, frame, frame.area(), &theme);
+            DiffViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -812,7 +812,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                DiffViewer::view(&state, frame, frame.area(), &theme);
+                DiffViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/divider/mod.rs
+++ b/src/component/divider/mod.rs
@@ -25,7 +25,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, Disableable};
+use super::{Component, Disableable, ViewContext};
 use crate::input::Event;
 use crate::theme::Theme;
 
@@ -440,7 +440,7 @@ impl Component for Divider {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,

--- a/src/component/divider/tests.rs
+++ b/src/component/divider/tests.rs
@@ -231,7 +231,7 @@ fn test_view_horizontal_no_label() {
 
     terminal
         .draw(|frame| {
-            Divider::view(&state, frame, frame.area(), &theme);
+            Divider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -245,7 +245,7 @@ fn test_view_horizontal_with_label() {
 
     terminal
         .draw(|frame| {
-            Divider::view(&state, frame, frame.area(), &theme);
+            Divider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -259,7 +259,7 @@ fn test_view_vertical() {
 
     terminal
         .draw(|frame| {
-            Divider::view(&state, frame, frame.area(), &theme);
+            Divider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -273,7 +273,7 @@ fn test_view_vertical_with_label() {
 
     terminal
         .draw(|frame| {
-            Divider::view(&state, frame, frame.area(), &theme);
+            Divider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -289,7 +289,7 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Divider::view(&state, frame, frame.area(), &theme);
+            Divider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -304,7 +304,7 @@ fn test_view_zero_width() {
     terminal
         .draw(|frame| {
             let area = Rect::new(0, 0, 0, 3);
-            Divider::view(&state, frame, area, &theme);
+            Divider::view(&state, frame, area, &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -319,7 +319,7 @@ fn test_view_zero_height() {
     terminal
         .draw(|frame| {
             let area = Rect::new(0, 0, 40, 0);
-            Divider::view(&state, frame, area, &theme);
+            Divider::view(&state, frame, area, &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -333,7 +333,7 @@ fn test_view_narrow_with_long_label() {
 
     terminal
         .draw(|frame| {
-            Divider::view(&state, frame, frame.area(), &theme);
+            Divider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -352,7 +352,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Divider::view(&state, frame, frame.area(), &theme);
+                Divider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -373,7 +373,7 @@ fn test_annotation_emitted_no_label() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Divider::view(&state, frame, frame.area(), &theme);
+                Divider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -394,7 +394,7 @@ fn test_annotation_disabled() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Divider::view(&state, frame, frame.area(), &theme);
+                Divider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/dropdown/mod.rs
+++ b/src/component/dropdown/mod.rs
@@ -34,7 +34,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::theme::Theme;
 
@@ -810,7 +810,7 @@ impl Component for Dropdown {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             let mut ann = crate::annotation::Annotation::dropdown("dropdown")
                 .with_focus(state.focused)

--- a/src/component/dropdown/tests.rs
+++ b/src/component/dropdown/tests.rs
@@ -454,7 +454,7 @@ fn test_view_closed_empty() {
 
     terminal
         .draw(|frame| {
-            Dropdown::view(&state, frame, frame.area(), &theme);
+            Dropdown::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -469,7 +469,7 @@ fn test_view_closed_with_selection() {
 
     terminal
         .draw(|frame| {
-            Dropdown::view(&state, frame, frame.area(), &theme);
+            Dropdown::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -485,7 +485,7 @@ fn test_view_open_no_filter() {
 
     terminal
         .draw(|frame| {
-            Dropdown::view(&state, frame, frame.area(), &theme);
+            Dropdown::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -502,7 +502,7 @@ fn test_view_open_with_filter() {
 
     terminal
         .draw(|frame| {
-            Dropdown::view(&state, frame, frame.area(), &theme);
+            Dropdown::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -519,7 +519,7 @@ fn test_view_highlight() {
 
     terminal
         .draw(|frame| {
-            Dropdown::view(&state, frame, frame.area(), &theme);
+            Dropdown::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -536,7 +536,7 @@ fn test_view_no_matches() {
 
     terminal
         .draw(|frame| {
-            Dropdown::view(&state, frame, frame.area(), &theme);
+            Dropdown::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -552,7 +552,7 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            Dropdown::view(&state, frame, frame.area(), &theme);
+            Dropdown::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -833,7 +833,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Dropdown::view(&state, frame, frame.area(), &theme);
+                Dropdown::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/event_stream/event_tests.rs
+++ b/src/component/event_stream/event_tests.rs
@@ -249,7 +249,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(70, 15);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme);
+            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -260,7 +260,7 @@ fn test_render_with_events() {
     let (mut terminal, theme) = test_utils::setup_render(70, 15);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme);
+            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -271,7 +271,7 @@ fn test_render_focused() {
     let (mut terminal, theme) = test_utils::setup_render(70, 15);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme);
+            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -282,7 +282,7 @@ fn test_render_with_sources() {
     let (mut terminal, theme) = test_utils::setup_render(80, 15);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme);
+            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -293,7 +293,7 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(70, 15);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme);
+            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -306,7 +306,7 @@ fn test_render_with_title() {
     let (mut terminal, theme) = test_utils::setup_render(70, 15);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme);
+            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -318,7 +318,7 @@ fn test_render_filtered() {
     let (mut terminal, theme) = test_utils::setup_render(80, 15);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme);
+            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -329,7 +329,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(70, 2);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme);
+            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -343,7 +343,7 @@ fn test_render_search_focused() {
     let (mut terminal, theme) = test_utils::setup_render(70, 15);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme);
+            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -358,7 +358,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                EventStream::view(&state, frame, frame.area(), &theme);
+                EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/event_stream/mod.rs
+++ b/src/component/event_stream/mod.rs
@@ -38,7 +38,7 @@ use std::marker::PhantomData;
 
 use ratatui::prelude::*;
 
-use super::{Component, Disableable, Focusable, InputFieldMessage};
+use super::{Component, Disableable, Focusable, InputFieldMessage, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::theme::Theme;
 
@@ -382,7 +382,7 @@ impl Component for EventStream {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         render::render_event_stream(state, frame, area, theme);
     }
 }

--- a/src/component/event_stream/snapshot_tests.rs
+++ b/src/component/event_stream/snapshot_tests.rs
@@ -49,7 +49,7 @@ fn test_snapshot_default_empty() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme);
+            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -61,7 +61,7 @@ fn test_snapshot_populated() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme);
+            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -74,7 +74,7 @@ fn test_snapshot_focused() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme);
+            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -89,7 +89,7 @@ fn test_snapshot_with_title() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme);
+            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -101,7 +101,7 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme);
+            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -114,7 +114,7 @@ fn test_snapshot_filtered() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme);
+            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -131,7 +131,7 @@ fn test_snapshot_search_active() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme);
+            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/file_browser/mod.rs
+++ b/src/component/file_browser/mod.rs
@@ -38,7 +38,7 @@ use std::sync::Arc;
 use ratatui::prelude::*;
 use ratatui::widgets::ListState;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::theme::Theme;
 use types::FileBrowserFocus;
@@ -968,7 +968,7 @@ impl Component for FileBrowser {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         view::render(state, frame, area, theme);
     }
 }

--- a/src/component/file_browser/snapshot_tests.rs
+++ b/src/component/file_browser/snapshot_tests.rs
@@ -28,7 +28,7 @@ fn test_render_basic() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            FileBrowser::view(&state, frame, frame.area(), &theme);
+            FileBrowser::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -40,7 +40,7 @@ fn test_render_unfocused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            FileBrowser::view(&state, frame, frame.area(), &theme);
+            FileBrowser::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -53,7 +53,7 @@ fn test_render_with_filter() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            FileBrowser::view(&state, frame, frame.area(), &theme);
+            FileBrowser::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -66,7 +66,7 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            FileBrowser::view(&state, frame, frame.area(), &theme);
+            FileBrowser::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -80,7 +80,7 @@ fn test_render_with_selection_markers() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            FileBrowser::view(&state, frame, frame.area(), &theme);
+            FileBrowser::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -93,7 +93,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 8);
     terminal
         .draw(|frame| {
-            FileBrowser::view(&state, frame, frame.area(), &theme);
+            FileBrowser::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -110,7 +110,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                FileBrowser::view(&state, frame, frame.area(), &theme);
+                FileBrowser::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/flame_graph/mod.rs
+++ b/src/component/flame_graph/mod.rs
@@ -34,7 +34,7 @@
 
 use ratatui::prelude::*;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -969,7 +969,7 @@ impl Component for FlameGraph {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         render::render_flame_graph(state, frame, area, theme);
     }
 }

--- a/src/component/flame_graph/snapshot_tests.rs
+++ b/src/component/flame_graph/snapshot_tests.rs
@@ -8,7 +8,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 10);
     terminal
         .draw(|frame| {
-            FlameGraph::view(&state, frame, frame.area(), &theme);
+            FlameGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -20,7 +20,7 @@ fn test_snapshot_single_frame() {
     let (mut terminal, theme) = test_utils::setup_render(60, 8);
     terminal
         .draw(|frame| {
-            FlameGraph::view(&state, frame, frame.area(), &theme);
+            FlameGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -41,7 +41,7 @@ fn test_snapshot_simple_tree() {
     let (mut terminal, theme) = test_utils::setup_render(60, 10);
     terminal
         .draw(|frame| {
-            FlameGraph::view(&state, frame, frame.area(), &theme);
+            FlameGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -60,7 +60,7 @@ fn test_snapshot_focused_with_selection() {
     let (mut terminal, theme) = test_utils::setup_render(60, 8);
     terminal
         .draw(|frame| {
-            FlameGraph::view(&state, frame, frame.area(), &theme);
+            FlameGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -84,7 +84,7 @@ fn test_snapshot_zoomed() {
     let (mut terminal, theme) = test_utils::setup_render(60, 8);
     terminal
         .draw(|frame| {
-            FlameGraph::view(&state, frame, frame.area(), &theme);
+            FlameGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -99,7 +99,7 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 8);
     terminal
         .draw(|frame| {
-            FlameGraph::view(&state, frame, frame.area(), &theme);
+            FlameGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -121,7 +121,7 @@ fn test_snapshot_with_search() {
     let (mut terminal, theme) = test_utils::setup_render(60, 10);
     terminal
         .draw(|frame| {
-            FlameGraph::view(&state, frame, frame.area(), &theme);
+            FlameGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -148,7 +148,7 @@ fn test_snapshot_deep_nesting() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            FlameGraph::view(&state, frame, frame.area(), &theme);
+            FlameGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/form/mod.rs
+++ b/src/component/form/mod.rs
@@ -45,7 +45,7 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 
 use super::{
     Checkbox, CheckboxMessage, CheckboxState, Component, Disableable, Focusable, InputField,
-    InputFieldMessage, InputFieldState, Select, SelectMessage, SelectState,
+    InputFieldMessage, InputFieldState, Select, SelectMessage, SelectState, ViewContext,
 };
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
@@ -792,7 +792,7 @@ impl Component for Form {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if state.fields.is_empty() {
             return;
         }

--- a/src/component/form/snapshot_tests.rs
+++ b/src/component/form/snapshot_tests.rs
@@ -19,7 +19,7 @@ fn test_snapshot_default_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Form::view(&state, frame, frame.area(), &theme);
+            Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -39,7 +39,7 @@ fn test_snapshot_populated() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Form::view(&state, frame, frame.area(), &theme);
+            Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -52,7 +52,7 @@ fn test_snapshot_focused_text_field() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Form::view(&state, frame, frame.area(), &theme);
+            Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -66,7 +66,7 @@ fn test_snapshot_focused_checkbox() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Form::view(&state, frame, frame.area(), &theme);
+            Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -81,7 +81,7 @@ fn test_snapshot_focused_select() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Form::view(&state, frame, frame.area(), &theme);
+            Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -93,7 +93,7 @@ fn test_snapshot_unfocused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Form::view(&state, frame, frame.area(), &theme);
+            Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -108,7 +108,7 @@ fn test_snapshot_with_placeholder() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Form::view(&state, frame, frame.area(), &theme);
+            Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/form/tests.rs
+++ b/src/component/form/tests.rs
@@ -561,7 +561,7 @@ fn test_render_unfocused() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            Form::view(&state, frame, frame.area(), &theme);
+            Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -572,7 +572,7 @@ fn test_render_focused() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            Form::view(&state, frame, frame.area(), &theme);
+            Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -586,7 +586,7 @@ fn test_render_with_values() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            Form::view(&state, frame, frame.area(), &theme);
+            Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -597,7 +597,7 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            Form::view(&state, frame, frame.area(), &theme);
+            Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -608,7 +608,7 @@ fn test_render_empty_form() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            Form::view(&state, frame, frame.area(), &theme);
+            Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -686,7 +686,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Form::view(&state, frame, frame.area(), &theme);
+                Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/gauge/mod.rs
+++ b/src/component/gauge/mod.rs
@@ -40,7 +40,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Gauge as RatatuiGauge, LineGauge};
 
-use super::{Component, Disableable};
+use super::{Component, Disableable, ViewContext};
 use crate::theme::Theme;
 
 /// The visual variant of the gauge.
@@ -590,7 +590,7 @@ impl Component for Gauge {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         let label_text = state.label_text();
 
         match state.variant {

--- a/src/component/gauge/tests.rs
+++ b/src/component/gauge/tests.rs
@@ -518,7 +518,7 @@ fn test_view_full_gauge() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme);
+            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -532,7 +532,7 @@ fn test_view_full_gauge_with_title() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme);
+            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -548,7 +548,7 @@ fn test_view_full_gauge_with_units() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme);
+            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -562,7 +562,7 @@ fn test_view_line_gauge() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme);
+            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -578,7 +578,7 @@ fn test_view_line_gauge_with_title() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme);
+            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -592,7 +592,7 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme);
+            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -606,7 +606,7 @@ fn test_view_green_zone() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme);
+            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -620,7 +620,7 @@ fn test_view_yellow_zone() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme);
+            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -634,7 +634,7 @@ fn test_view_red_zone() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme);
+            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -648,7 +648,7 @@ fn test_view_zero_percent() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme);
+            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -662,7 +662,7 @@ fn test_view_full_percent() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme);
+            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -681,7 +681,7 @@ fn test_annotation_emitted_full() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Gauge::view(&state, frame, frame.area(), &theme);
+                Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -699,7 +699,7 @@ fn test_annotation_emitted_line() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Gauge::view(&state, frame, frame.area(), &theme);
+                Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/heatmap/mod.rs
+++ b/src/component/heatmap/mod.rs
@@ -28,7 +28,7 @@ use std::marker::PhantomData;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -874,7 +874,7 @@ impl Component for Heatmap {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if area.height < 3 || area.width < 3 {
             return;
         }

--- a/src/component/heatmap/snapshot_tests.rs
+++ b/src/component/heatmap/snapshot_tests.rs
@@ -7,7 +7,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme);
+            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -19,7 +19,7 @@ fn test_snapshot_small_grid() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme);
+            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -34,7 +34,7 @@ fn test_snapshot_with_labels() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme);
+            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -48,7 +48,7 @@ fn test_snapshot_with_values() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme);
+            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -62,7 +62,7 @@ fn test_snapshot_focused() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme);
+            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -77,7 +77,7 @@ fn test_snapshot_focused_with_selection() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme);
+            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -91,7 +91,7 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme);
+            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -105,7 +105,7 @@ fn test_snapshot_blue_to_red_scale() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme);
+            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -117,7 +117,7 @@ fn test_snapshot_1x1_grid() {
     let (mut terminal, theme) = test_utils::setup_render(20, 6);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme);
+            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/heatmap/tests.rs
+++ b/src/component/heatmap/tests.rs
@@ -671,7 +671,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme);
+            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -682,7 +682,7 @@ fn test_render_small_grid() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme);
+            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -696,7 +696,7 @@ fn test_render_with_labels() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme);
+            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -709,7 +709,7 @@ fn test_render_with_values() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme);
+            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -720,7 +720,7 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme);
+            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -735,7 +735,7 @@ fn test_render_focused_with_selection() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme);
+            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -746,7 +746,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(5, 2);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme);
+            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -820,7 +820,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Heatmap::view(&state, frame, frame.area(), &theme);
+                Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/help_panel/mod.rs
+++ b/src/component/help_panel/mod.rs
@@ -37,7 +37,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
-use super::{Component, Disableable, Focusable, Toggleable};
+use super::{Component, Disableable, Focusable, Toggleable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
@@ -679,7 +679,7 @@ impl Component for HelpPanel {
         None // Display-only, no output
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,

--- a/src/component/help_panel/tests.rs
+++ b/src/component/help_panel/tests.rs
@@ -563,7 +563,7 @@ fn test_view_empty() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            HelpPanel::view(&state, frame, frame.area(), &theme);
+            HelpPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -575,7 +575,7 @@ fn test_view_with_groups() {
     let (mut terminal, theme) = test_utils::setup_render(40, 16);
     terminal
         .draw(|frame| {
-            HelpPanel::view(&state, frame, frame.area(), &theme);
+            HelpPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -587,7 +587,7 @@ fn test_view_focused() {
     let (mut terminal, theme) = test_utils::setup_render(40, 16);
     terminal
         .draw(|frame| {
-            HelpPanel::view(&state, frame, frame.area(), &theme);
+            HelpPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -602,7 +602,7 @@ fn test_view_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 16);
     terminal
         .draw(|frame| {
-            HelpPanel::view(&state, frame, frame.area(), &theme);
+            HelpPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -618,7 +618,7 @@ fn test_view_scrolled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            HelpPanel::view(&state, frame, frame.area(), &theme);
+            HelpPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -636,7 +636,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                HelpPanel::view(&state, frame, frame.area(), &theme);
+                HelpPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -655,7 +655,7 @@ fn test_annotation_focused() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                HelpPanel::view(&state, frame, frame.area(), &theme);
+                HelpPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/histogram/mod.rs
+++ b/src/component/histogram/mod.rs
@@ -19,7 +19,7 @@ use std::marker::PhantomData;
 use ratatui::prelude::*;
 use ratatui::widgets::{Bar, BarChart, BarGroup, Block, Borders};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::Event;
 use crate::theme::Theme;
 
@@ -651,7 +651,7 @@ impl Component for Histogram {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if area.height < 3 || area.width < 3 {
             return;
         }

--- a/src/component/histogram/tests.rs
+++ b/src/component/histogram/tests.rs
@@ -456,7 +456,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme);
+            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -470,7 +470,7 @@ fn test_render_with_data() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme);
+            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -485,7 +485,7 @@ fn test_render_with_labels() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme);
+            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -498,7 +498,7 @@ fn test_render_with_show_counts() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme);
+            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -511,7 +511,7 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme);
+            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -524,7 +524,7 @@ fn test_render_focused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme);
+            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -535,7 +535,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(60, 2);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme);
+            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -548,7 +548,7 @@ fn test_render_with_color() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme);
+            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -563,7 +563,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme);
+            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -578,7 +578,7 @@ fn test_snapshot_with_data() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme);
+            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -592,7 +592,7 @@ fn test_snapshot_with_title() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme);
+            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -607,7 +607,7 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme);
+            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -625,7 +625,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Histogram::view(&state, frame, frame.area(), &theme);
+                Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/input_field/mod.rs
+++ b/src/component/input_field/mod.rs
@@ -30,7 +30,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 use unicode_width::UnicodeWidthStr;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::theme::Theme;
 use crate::undo::{EditKind, UndoStack};
@@ -784,7 +784,7 @@ impl Component for InputField {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,

--- a/src/component/input_field/tests.rs
+++ b/src/component/input_field/tests.rs
@@ -260,7 +260,7 @@ fn test_view() {
 
     terminal
         .draw(|frame| {
-            InputField::view(&state, frame, frame.area(), &theme);
+            InputField::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -274,7 +274,7 @@ fn test_view_unfocused() {
 
     terminal
         .draw(|frame| {
-            InputField::view(&state, frame, frame.area(), &theme);
+            InputField::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -289,7 +289,7 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            InputField::view(&state, frame, frame.area(), &theme);
+            InputField::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -304,7 +304,7 @@ fn test_view_placeholder() {
 
     terminal
         .draw(|frame| {
-            InputField::view(&state, frame, frame.area(), &theme);
+            InputField::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -698,7 +698,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                InputField::view(&state, frame, frame.area(), &theme);
+                InputField::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/key_hints/mod.rs
+++ b/src/component/key_hints/mod.rs
@@ -27,7 +27,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, Disableable};
+use super::{Component, Disableable, ViewContext};
 use crate::theme::Theme;
 
 /// Layout style for key hints display.
@@ -521,7 +521,7 @@ impl Component for KeyHints {
         None // Display-only, no output
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if state.hints.is_empty() || area.width == 0 || area.height == 0 {
             return;
         }

--- a/src/component/key_hints/tests.rs
+++ b/src/component/key_hints/tests.rs
@@ -287,7 +287,7 @@ fn test_view_empty() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(80, 1);
 
     terminal
-        .draw(|frame| KeyHints::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| KeyHints::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -299,7 +299,7 @@ fn test_view_single_hint() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(80, 1);
 
     terminal
-        .draw(|frame| KeyHints::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| KeyHints::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -315,7 +315,7 @@ fn test_view_multiple_hints() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(80, 1);
 
     terminal
-        .draw(|frame| KeyHints::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| KeyHints::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -331,7 +331,7 @@ fn test_view_disabled_hints_hidden() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(80, 1);
 
     terminal
-        .draw(|frame| KeyHints::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| KeyHints::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -347,7 +347,7 @@ fn test_view_inline_layout() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(80, 1);
 
     terminal
-        .draw(|frame| KeyHints::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| KeyHints::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -435,7 +435,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                KeyHints::view(&state, frame, frame.area(), &theme);
+                KeyHints::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/line_input/mod.rs
+++ b/src/component/line_input/mod.rs
@@ -38,7 +38,7 @@ mod tests;
 
 use ratatui::prelude::*;
 
-use crate::component::{Component, Disableable, Focusable};
+use crate::component::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::theme::Theme;
 use crate::undo::{EditKind, UndoStack};
@@ -993,7 +993,7 @@ impl Component for LineInput {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         view_helpers::render(state, frame, area, theme);
     }
 }

--- a/src/component/line_input/tests.rs
+++ b/src/component/line_input/tests.rs
@@ -663,7 +663,7 @@ fn test_snapshot_focused() {
     state.set_focused(true);
     terminal
         .draw(|frame| {
-            LineInput::view(&state, frame, frame.area(), &theme);
+            LineInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -675,7 +675,7 @@ fn test_snapshot_unfocused() {
     let state = LineInputState::with_value("hello");
     terminal
         .draw(|frame| {
-            LineInput::view(&state, frame, frame.area(), &theme);
+            LineInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -687,7 +687,7 @@ fn test_snapshot_disabled() {
     let state = LineInputState::with_value("hello").with_disabled(true);
     terminal
         .draw(|frame| {
-            LineInput::view(&state, frame, frame.area(), &theme);
+            LineInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -699,7 +699,7 @@ fn test_snapshot_placeholder() {
     let state = LineInputState::new().with_placeholder("Type here...");
     terminal
         .draw(|frame| {
-            LineInput::view(&state, frame, frame.area(), &theme);
+            LineInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -712,7 +712,7 @@ fn test_snapshot_wrapped() {
     state.set_focused(true);
     terminal
         .draw(|frame| {
-            LineInput::view(&state, frame, frame.area(), &theme);
+            LineInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -725,7 +725,7 @@ fn test_snapshot_wide_chars() {
     state.set_focused(true);
     terminal
         .draw(|frame| {
-            LineInput::view(&state, frame, frame.area(), &theme);
+            LineInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -740,7 +740,7 @@ fn test_snapshot_selection() {
     state.selection_anchor = Some(5);
     terminal
         .draw(|frame| {
-            LineInput::view(&state, frame, frame.area(), &theme);
+            LineInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -876,7 +876,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                LineInput::view(&state, frame, frame.area(), &theme);
+                LineInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/loading_list/mod.rs
+++ b/src/component/loading_list/mod.rs
@@ -38,7 +38,7 @@
 
 use ratatui::prelude::*;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
@@ -1017,7 +1017,7 @@ impl<T: Clone> Component for LoadingList<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         render::render_loading_list(state, frame, area, theme);
     }
 }

--- a/src/component/loading_list/snapshot_tests.rs
+++ b/src/component/loading_list/snapshot_tests.rs
@@ -34,7 +34,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme);
+            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -47,7 +47,7 @@ fn test_snapshot_with_items() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme);
+            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -60,7 +60,7 @@ fn test_snapshot_with_selected() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme);
+            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -74,7 +74,7 @@ fn test_snapshot_with_loading_item() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme);
+            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -88,7 +88,7 @@ fn test_snapshot_with_error_item() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme);
+            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -104,7 +104,7 @@ fn test_snapshot_mixed_states() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme);
+            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -117,7 +117,7 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme);
+            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/loading_list/tests/component.rs
+++ b/src/component/loading_list/tests/component.rs
@@ -797,7 +797,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                LoadingList::view(&state, frame, frame.area(), &theme);
+                LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/loading_list/tests/view.rs
+++ b/src/component/loading_list/tests/view.rs
@@ -11,7 +11,9 @@ fn test_view_empty() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| LoadingList::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -26,7 +28,9 @@ fn test_view_with_items() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| LoadingList::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -40,7 +44,9 @@ fn test_view_with_title() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| LoadingList::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -55,7 +61,9 @@ fn test_view_with_error() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| LoadingList::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -70,14 +78,26 @@ fn test_view_zero_size_area() {
     // Test with zero width
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, Rect::new(0, 0, 0, 10), &theme);
+            LoadingList::view(
+                &state,
+                frame,
+                Rect::new(0, 0, 0, 10),
+                &theme,
+                &ViewContext::default(),
+            );
         })
         .unwrap();
 
     // Test with zero height
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, Rect::new(0, 0, 60, 0), &Theme::default());
+            LoadingList::view(
+                &state,
+                frame,
+                Rect::new(0, 0, 60, 0),
+                &Theme::default(),
+                &ViewContext::default(),
+            );
         })
         .unwrap();
 }
@@ -91,7 +111,9 @@ fn test_view_without_indicators() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| LoadingList::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -106,7 +128,9 @@ fn test_view_without_indicators_with_error() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| LoadingList::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -126,7 +150,9 @@ fn test_view_focused() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| LoadingList::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -141,7 +167,9 @@ fn test_view_with_loading_item() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| LoadingList::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -158,7 +186,9 @@ fn test_view_with_mixed_states() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| LoadingList::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -175,7 +205,9 @@ fn test_view_single_item() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| LoadingList::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -190,7 +222,9 @@ fn test_view_disabled() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| LoadingList::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -205,7 +239,9 @@ fn test_view_with_title_and_selection() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| LoadingList::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/log_correlation/mod.rs
+++ b/src/component/log_correlation/mod.rs
@@ -40,7 +40,7 @@ use std::marker::PhantomData;
 
 use ratatui::prelude::*;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
@@ -820,7 +820,7 @@ impl Component for LogCorrelation {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         render::render(state, frame, area, theme);
     }
 }

--- a/src/component/log_correlation/snapshot_tests.rs
+++ b/src/component/log_correlation/snapshot_tests.rs
@@ -67,7 +67,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme);
+            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -79,7 +79,7 @@ fn test_snapshot_two_streams() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme);
+            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -92,7 +92,7 @@ fn test_snapshot_focused() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme);
+            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -113,7 +113,7 @@ fn test_snapshot_with_title() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme);
+            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -125,7 +125,7 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme);
+            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -138,7 +138,7 @@ fn test_snapshot_with_filter() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme);
+            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/log_correlation/tests.rs
+++ b/src/component/log_correlation/tests.rs
@@ -753,7 +753,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme);
+            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -764,7 +764,7 @@ fn test_render_two_streams() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme);
+            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -775,7 +775,7 @@ fn test_render_focused() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme);
+            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -786,7 +786,7 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme);
+            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -810,7 +810,7 @@ fn test_render_with_title() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme);
+            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -822,7 +822,7 @@ fn test_render_with_filter() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme);
+            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -833,7 +833,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(80, 2);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme);
+            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -844,7 +844,7 @@ fn test_render_narrow_area() {
     let (mut terminal, theme) = test_utils::setup_render(20, 10);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme);
+            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -958,7 +958,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                LogCorrelation::view(&state, frame, frame.area(), &theme);
+                LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/log_viewer/enhancement_tests.rs
+++ b/src/component/log_viewer/enhancement_tests.rs
@@ -590,7 +590,7 @@ fn test_render_with_follow() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme);
+            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -602,7 +602,7 @@ fn test_render_without_follow() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme);
+            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -614,7 +614,7 @@ fn test_render_with_regex() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme);
+            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }

--- a/src/component/log_viewer/mod.rs
+++ b/src/component/log_viewer/mod.rs
@@ -45,7 +45,7 @@ use ratatui::prelude::*;
 
 use super::{
     Component, Disableable, Focusable, InputFieldMessage, InputFieldState, StatusLogEntry,
-    StatusLogLevel,
+    StatusLogLevel, ViewContext,
 };
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::theme::Theme;
@@ -451,7 +451,7 @@ impl Component for LogViewer {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if area.height < 3 {
             return;
         }

--- a/src/component/log_viewer/snapshot_tests.rs
+++ b/src/component/log_viewer/snapshot_tests.rs
@@ -20,7 +20,7 @@ fn test_snapshot_default_empty() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme);
+            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -32,7 +32,7 @@ fn test_snapshot_populated() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme);
+            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -45,7 +45,7 @@ fn test_snapshot_focused() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme);
+            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -60,7 +60,7 @@ fn test_snapshot_with_title() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme);
+            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -75,7 +75,7 @@ fn test_snapshot_with_timestamps() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme);
+            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -92,7 +92,7 @@ fn test_snapshot_search_active() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme);
+            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/log_viewer/tests.rs
+++ b/src/component/log_viewer/tests.rs
@@ -759,7 +759,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme);
+            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -770,7 +770,7 @@ fn test_render_with_entries() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme);
+            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -781,7 +781,7 @@ fn test_render_focused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme);
+            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -795,7 +795,7 @@ fn test_render_search_focused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme);
+            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -806,7 +806,7 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme);
+            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -819,7 +819,7 @@ fn test_render_with_title() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme);
+            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -832,7 +832,7 @@ fn test_render_with_timestamps() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme);
+            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -843,7 +843,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(60, 2);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme);
+            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -967,7 +967,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                LogViewer::view(&state, frame, frame.area(), &theme);
+                LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/markdown_renderer/mod.rs
+++ b/src/component/markdown_renderer/mod.rs
@@ -36,7 +36,7 @@ pub mod render;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
@@ -472,7 +472,7 @@ impl Component for MarkdownRenderer {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,

--- a/src/component/markdown_renderer/tests.rs
+++ b/src/component/markdown_renderer/tests.rs
@@ -389,7 +389,7 @@ fn test_view_empty() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            MarkdownRenderer::view(&state, frame, frame.area(), &theme);
+            MarkdownRenderer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -401,7 +401,7 @@ fn test_view_with_heading() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            MarkdownRenderer::view(&state, frame, frame.area(), &theme);
+            MarkdownRenderer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -414,7 +414,7 @@ fn test_view_with_paragraph() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            MarkdownRenderer::view(&state, frame, frame.area(), &theme);
+            MarkdownRenderer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -427,7 +427,7 @@ fn test_view_with_code_block() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            MarkdownRenderer::view(&state, frame, frame.area(), &theme);
+            MarkdownRenderer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -439,7 +439,7 @@ fn test_view_with_list() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            MarkdownRenderer::view(&state, frame, frame.area(), &theme);
+            MarkdownRenderer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -451,7 +451,7 @@ fn test_view_focused() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            MarkdownRenderer::view(&state, frame, frame.area(), &theme);
+            MarkdownRenderer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -465,7 +465,7 @@ fn test_view_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            MarkdownRenderer::view(&state, frame, frame.area(), &theme);
+            MarkdownRenderer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -479,7 +479,7 @@ fn test_view_with_title() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            MarkdownRenderer::view(&state, frame, frame.area(), &theme);
+            MarkdownRenderer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -494,7 +494,7 @@ fn test_view_source_mode() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            MarkdownRenderer::view(&state, frame, frame.area(), &theme);
+            MarkdownRenderer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -512,7 +512,13 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                MarkdownRenderer::view(&state, frame, frame.area(), &theme);
+                MarkdownRenderer::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::default(),
+                );
             })
             .unwrap();
     });

--- a/src/component/menu/mod.rs
+++ b/src/component/menu/mod.rs
@@ -28,7 +28,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -499,7 +499,7 @@ impl Component for Menu {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         let mut menu_text = String::new();
 
         for (idx, item) in state.items.iter().enumerate() {

--- a/src/component/menu/tests.rs
+++ b/src/component/menu/tests.rs
@@ -319,7 +319,7 @@ fn test_view() {
 
     terminal
         .draw(|frame| {
-            Menu::view(&state, frame, frame.area(), &theme);
+            Menu::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -335,7 +335,7 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            Menu::view(&state, frame, frame.area(), &theme);
+            Menu::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -356,7 +356,7 @@ fn test_view_selected() {
 
     terminal
         .draw(|frame| {
-            Menu::view(&state, frame, frame.area(), &theme);
+            Menu::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -371,7 +371,7 @@ fn test_view_empty() {
 
     terminal
         .draw(|frame| {
-            Menu::view(&state, frame, frame.area(), &theme);
+            Menu::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -661,7 +661,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Menu::view(&state, frame, frame.area(), &theme);
+                Menu::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/metrics_dashboard/mod.rs
+++ b/src/component/metrics_dashboard/mod.rs
@@ -36,7 +36,7 @@ use std::marker::PhantomData;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Sparkline};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -700,7 +700,7 @@ impl Component for MetricsDashboard {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if state.widgets.is_empty() || area.height < 3 || area.width < 3 {
             return;
         }

--- a/src/component/metrics_dashboard/snapshot_tests.rs
+++ b/src/component/metrics_dashboard/snapshot_tests.rs
@@ -22,7 +22,7 @@ fn test_snapshot_default_empty() {
     let (mut terminal, theme) = test_utils::setup_render(80, 25);
     terminal
         .draw(|frame| {
-            MetricsDashboard::view(&state, frame, frame.area(), &theme);
+            MetricsDashboard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -34,7 +34,7 @@ fn test_snapshot_populated() {
     let (mut terminal, theme) = test_utils::setup_render(80, 25);
     terminal
         .draw(|frame| {
-            MetricsDashboard::view(&state, frame, frame.area(), &theme);
+            MetricsDashboard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -47,7 +47,7 @@ fn test_snapshot_focused() {
     let (mut terminal, theme) = test_utils::setup_render(80, 25);
     terminal
         .draw(|frame| {
-            MetricsDashboard::view(&state, frame, frame.area(), &theme);
+            MetricsDashboard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -61,7 +61,7 @@ fn test_snapshot_focused_second_widget() {
     let (mut terminal, theme) = test_utils::setup_render(80, 25);
     terminal
         .draw(|frame| {
-            MetricsDashboard::view(&state, frame, frame.area(), &theme);
+            MetricsDashboard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -81,7 +81,7 @@ fn test_snapshot_two_columns() {
     let (mut terminal, theme) = test_utils::setup_render(80, 25);
     terminal
         .draw(|frame| {
-            MetricsDashboard::view(&state, frame, frame.area(), &theme);
+            MetricsDashboard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -102,7 +102,7 @@ fn test_snapshot_with_sparkline_history() {
     let (mut terminal, theme) = test_utils::setup_render(80, 25);
     terminal
         .draw(|frame| {
-            MetricsDashboard::view(&state, frame, frame.area(), &theme);
+            MetricsDashboard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/metrics_dashboard/tests.rs
+++ b/src/component/metrics_dashboard/tests.rs
@@ -520,7 +520,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            MetricsDashboard::view(&state, frame, frame.area(), &theme);
+            MetricsDashboard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -531,7 +531,7 @@ fn test_render_with_widgets() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            MetricsDashboard::view(&state, frame, frame.area(), &theme);
+            MetricsDashboard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -542,7 +542,7 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            MetricsDashboard::view(&state, frame, frame.area(), &theme);
+            MetricsDashboard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -557,7 +557,7 @@ fn test_render_with_history() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            MetricsDashboard::view(&state, frame, frame.area(), &theme);
+            MetricsDashboard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -568,7 +568,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(60, 2);
     terminal
         .draw(|frame| {
-            MetricsDashboard::view(&state, frame, frame.area(), &theme);
+            MetricsDashboard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -653,7 +653,13 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                MetricsDashboard::view(&state, frame, frame.area(), &theme);
+                MetricsDashboard::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::default(),
+                );
             })
             .unwrap();
     });

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -34,7 +34,7 @@
 //! # Example
 //!
 //! ```rust
-//! use envision::component::{Component, Focusable};
+//! use envision::component::{Component, Focusable, ViewContext};
 //! use envision::theme::Theme;
 //! use ratatui::prelude::*;
 //!
@@ -74,7 +74,7 @@
 //!         Some(CounterOutput::ValueChanged(state.value))
 //!     }
 //!
-//!     fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+//!     fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
 //!         let style = if state.focused {
 //!             theme.focused_style()
 //!         } else {
@@ -505,6 +505,54 @@ pub use markdown_renderer::{MarkdownRenderer, MarkdownRendererMessage, MarkdownR
 // Always available
 pub use focus_manager::FocusManager;
 
+/// Render-time context passed to [`Component::view`].
+///
+/// `ViewContext` carries information that the parent determines at render
+/// time, such as whether a component is focused or disabled. This separates
+/// render-time concerns from persistent component state, allowing parents
+/// to control visual appearance without mutating component state.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::component::ViewContext;
+///
+/// // Default: unfocused, enabled
+/// let ctx = ViewContext::default();
+///
+/// // Focused component
+/// let ctx = ViewContext::new().focused(true);
+///
+/// // Disabled and focused
+/// let ctx = ViewContext::new().focused(true).disabled(true);
+/// ```
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ViewContext {
+    /// Whether this component currently has keyboard focus.
+    pub focused: bool,
+    /// Whether this component is currently disabled.
+    pub disabled: bool,
+}
+
+impl ViewContext {
+    /// Creates a new default ViewContext (unfocused, enabled).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the focused state (builder pattern).
+    pub fn focused(mut self, focused: bool) -> Self {
+        self.focused = focused;
+        self
+    }
+
+    /// Sets the disabled state (builder pattern).
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+}
+
 /// A composable UI component with its own state and message handling.
 ///
 /// Components are the building blocks of complex TUI applications. Each
@@ -566,7 +614,7 @@ pub trait Component: Sized {
     /// The `theme` parameter provides the color scheme to use for rendering.
     /// Use [`Theme::default()`] for the standard color scheme, or
     /// [`Theme::nord()`] for the Nord color palette.
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme);
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext);
 
     /// Renders the component with optional tracing instrumentation.
     ///
@@ -574,7 +622,13 @@ pub trait Component: Sized {
     /// around the [`view`](Component::view) call with the component type name
     /// and render area dimensions. When the feature is disabled, this is
     /// identical to calling `view` directly.
-    fn traced_view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn traced_view(
+        state: &Self::State,
+        frame: &mut Frame,
+        area: Rect,
+        theme: &Theme,
+        ctx: &ViewContext,
+    ) {
         #[cfg(feature = "tracing")]
         let _span = tracing::trace_span!(
             "component_view",
@@ -585,7 +639,7 @@ pub trait Component: Sized {
             area.height = area.height,
         )
         .entered();
-        Self::view(state, frame, area, theme);
+        Self::view(state, frame, area, theme, ctx);
     }
 
     /// Maps an input event to a component message.
@@ -650,7 +704,7 @@ pub trait Component: Sized {
 /// # Example
 ///
 /// ```rust
-/// use envision::component::{Component, Focusable};
+/// use envision::component::{Component, Focusable, ViewContext};
 /// use envision::theme::Theme;
 /// use ratatui::prelude::*;
 ///
@@ -673,7 +727,7 @@ pub trait Component: Sized {
 /// #     type Output = TextInputOutput;
 /// #     fn init() -> Self::State { TextInputState::default() }
 /// #     fn update(_: &mut Self::State, _: Self::Message) -> Option<Self::Output> { None }
-/// #     fn view(_: &Self::State, _: &mut Frame, _: Rect, _: &Theme) {}
+/// #     fn view(_: &Self::State, _: &mut Frame, _: Rect, _: &Theme, _: &ViewContext) {}
 /// # }
 /// #
 /// impl Focusable for TextInput {
@@ -741,7 +795,8 @@ pub trait Focusable: Component {
     ) {
         let was_focused = Self::is_focused(state);
         Self::set_focused(state, focused);
-        Self::view(state, frame, area, theme);
+        let ctx = ViewContext::new().focused(focused);
+        Self::view(state, frame, area, theme, &ctx);
         Self::set_focused(state, was_focused);
     }
 }
@@ -755,7 +810,7 @@ pub trait Focusable: Component {
 /// # Example
 ///
 /// ```rust
-/// use envision::component::{Component, Toggleable};
+/// use envision::component::{Component, Toggleable, ViewContext};
 /// use envision::theme::Theme;
 /// use ratatui::prelude::*;
 ///
@@ -778,7 +833,7 @@ pub trait Focusable: Component {
 /// #     type Output = HelpPanelOutput;
 /// #     fn init() -> Self::State { HelpPanelState { visible: false, content: String::new() } }
 /// #     fn update(_: &mut Self::State, _: Self::Message) -> Option<Self::Output> { None }
-/// #     fn view(_: &Self::State, _: &mut Frame, _: Rect, _: &Theme) {}
+/// #     fn view(_: &Self::State, _: &mut Frame, _: Rect, _: &Theme, _: &ViewContext) {}
 /// # }
 /// #
 /// impl Toggleable for HelpPanel {
@@ -902,7 +957,8 @@ pub trait Disableable: Component {
     ) {
         let was_disabled = Self::is_disabled(state);
         Self::set_disabled(state, disabled);
-        Self::view(state, frame, area, theme);
+        let ctx = ViewContext::new().disabled(disabled);
+        Self::view(state, frame, area, theme, &ctx);
         Self::set_disabled(state, was_disabled);
     }
 }

--- a/src/component/multi_progress/mod.rs
+++ b/src/component/multi_progress/mod.rs
@@ -31,7 +31,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -990,7 +990,7 @@ impl Component for MultiProgress {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if area.width == 0 || area.height == 0 {
             return;
         }

--- a/src/component/multi_progress/snapshot_tests.rs
+++ b/src/component/multi_progress/snapshot_tests.rs
@@ -11,7 +11,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme);
+            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -26,7 +26,7 @@ fn test_snapshot_with_items() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme);
+            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -54,7 +54,7 @@ fn test_snapshot_active_progress() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme);
+            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -84,7 +84,7 @@ fn test_snapshot_completed_and_failed() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme);
+            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -98,7 +98,7 @@ fn test_snapshot_without_percentages() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme);
+            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -113,7 +113,7 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme);
+            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/multi_progress/tests/component.rs
+++ b/src/component/multi_progress/tests/component.rs
@@ -240,7 +240,9 @@ fn test_view_empty() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| MultiProgress::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -263,7 +265,9 @@ fn test_view_with_items() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| MultiProgress::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -275,7 +279,9 @@ fn test_view_with_title() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| MultiProgress::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -297,7 +303,9 @@ fn test_view_failed_item() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| MultiProgress::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -316,7 +324,9 @@ fn test_view_completed_item() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| MultiProgress::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -335,14 +345,26 @@ fn test_view_zero_size_area() {
     // Test with zero width
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, Rect::new(0, 0, 0, 10), &theme);
+            MultiProgress::view(
+                &state,
+                frame,
+                Rect::new(0, 0, 0, 10),
+                &theme,
+                &ViewContext::default(),
+            );
         })
         .unwrap();
 
     // Test with zero height
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, Rect::new(0, 0, 60, 0), &Theme::default());
+            MultiProgress::view(
+                &state,
+                frame,
+                Rect::new(0, 0, 60, 0),
+                &Theme::default(),
+                &ViewContext::default(),
+            );
         })
         .unwrap();
 }
@@ -355,7 +377,9 @@ fn test_view_without_percentages() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| MultiProgress::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -377,7 +401,9 @@ fn test_view_failed_without_message() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| MultiProgress::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -560,7 +586,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                MultiProgress::view(&state, frame, frame.area(), &theme);
+                MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/multi_progress/tests/workflow.rs
+++ b/src/component/multi_progress/tests/workflow.rs
@@ -400,7 +400,9 @@ fn test_view_multiple_items_mixed_states() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| MultiProgress::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -425,7 +427,9 @@ fn test_view_disabled_state() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| MultiProgress::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -447,7 +451,9 @@ fn test_view_single_item_full_progress() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| MultiProgress::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/number_input/mod.rs
+++ b/src/component/number_input/mod.rs
@@ -34,7 +34,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -630,7 +630,7 @@ impl Component for NumberInput {
     }
 
     #[allow(clippy::cast_possible_truncation)]
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if area.width == 0 || area.height == 0 {
             return;
         }

--- a/src/component/number_input/view_tests.rs
+++ b/src/component/number_input/view_tests.rs
@@ -11,7 +11,7 @@ fn test_view_normal() {
 
     terminal
         .draw(|frame| {
-            NumberInput::view(&state, frame, frame.area(), &theme);
+            NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -26,7 +26,7 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            NumberInput::view(&state, frame, frame.area(), &theme);
+            NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -40,7 +40,7 @@ fn test_view_with_label() {
 
     terminal
         .draw(|frame| {
-            NumberInput::view(&state, frame, frame.area(), &theme);
+            NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -56,7 +56,7 @@ fn test_view_editing() {
 
     terminal
         .draw(|frame| {
-            NumberInput::view(&state, frame, frame.area(), &theme);
+            NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -72,7 +72,7 @@ fn test_view_editing_with_label() {
 
     terminal
         .draw(|frame| {
-            NumberInput::view(&state, frame, frame.area(), &theme);
+            NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -86,7 +86,7 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            NumberInput::view(&state, frame, frame.area(), &theme);
+            NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -100,7 +100,7 @@ fn test_view_negative_value() {
 
     terminal
         .draw(|frame| {
-            NumberInput::view(&state, frame, frame.area(), &theme);
+            NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -114,7 +114,7 @@ fn test_view_float_precision() {
 
     terminal
         .draw(|frame| {
-            NumberInput::view(&state, frame, frame.area(), &theme);
+            NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -129,7 +129,7 @@ fn test_view_zero_area() {
     // Should not panic
     terminal
         .draw(|frame| {
-            NumberInput::view(&state, frame, frame.area(), &theme);
+            NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -146,7 +146,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                NumberInput::view(&state, frame, frame.area(), &theme);
+                NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -166,7 +166,7 @@ fn test_annotation_focused() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                NumberInput::view(&state, frame, frame.area(), &theme);
+                NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -183,7 +183,7 @@ fn test_annotation_disabled() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                NumberInput::view(&state, frame, frame.area(), &theme);
+                NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/paginator/mod.rs
+++ b/src/component/paginator/mod.rs
@@ -40,7 +40,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -605,7 +605,7 @@ impl Component for Paginator {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,

--- a/src/component/paginator/tests.rs
+++ b/src/component/paginator/tests.rs
@@ -567,7 +567,7 @@ fn test_view_page_of_total_first_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme);
+            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -579,7 +579,7 @@ fn test_view_page_of_total_middle_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme);
+            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -591,7 +591,7 @@ fn test_view_page_of_total_last_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme);
+            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -607,7 +607,7 @@ fn test_view_range_of_total_first_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme);
+            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -621,7 +621,7 @@ fn test_view_range_of_total_middle_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme);
+            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -635,7 +635,7 @@ fn test_view_range_of_total_last_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme);
+            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -647,7 +647,7 @@ fn test_view_range_of_total_zero_items() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme);
+            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -663,7 +663,7 @@ fn test_view_dots_first_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme);
+            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -677,7 +677,7 @@ fn test_view_dots_middle_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme);
+            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -691,7 +691,7 @@ fn test_view_dots_last_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme);
+            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -703,7 +703,7 @@ fn test_view_dots_single_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme);
+            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -717,7 +717,7 @@ fn test_view_dots_many_pages() {
     let (mut terminal, theme) = test_utils::setup_render(50, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme);
+            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -733,7 +733,7 @@ fn test_view_compact_first_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme);
+            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -747,7 +747,7 @@ fn test_view_compact_middle_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme);
+            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -761,7 +761,7 @@ fn test_view_compact_last_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme);
+            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -777,7 +777,7 @@ fn test_view_focused() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme);
+            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -789,7 +789,7 @@ fn test_view_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme);
+            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -807,7 +807,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Paginator::view(&state, frame, frame.area(), &theme);
+                Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -827,7 +827,7 @@ fn test_annotation_focused() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Paginator::view(&state, frame, frame.area(), &theme);
+                Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/pane_layout/mod.rs
+++ b/src/component/pane_layout/mod.rs
@@ -41,7 +41,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
-use super::{Component, Focusable};
+use super::{Component, Focusable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::theme::Theme;
 
@@ -1058,7 +1058,7 @@ impl Component for PaneLayout {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,

--- a/src/component/pane_layout/tests.rs
+++ b/src/component/pane_layout/tests.rs
@@ -688,7 +688,7 @@ fn test_view_two_panes_horizontal() {
 
     terminal
         .draw(|frame| {
-            PaneLayout::view(&state, frame, frame.area(), &theme);
+            PaneLayout::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -707,7 +707,7 @@ fn test_view_two_panes_vertical() {
 
     terminal
         .draw(|frame| {
-            PaneLayout::view(&state, frame, frame.area(), &theme);
+            PaneLayout::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -729,7 +729,7 @@ fn test_view_three_panes_focused() {
 
     terminal
         .draw(|frame| {
-            PaneLayout::view(&state, frame, frame.area(), &theme);
+            PaneLayout::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -744,7 +744,7 @@ fn test_view_empty_panes() {
 
     terminal
         .draw(|frame| {
-            PaneLayout::view(&state, frame, frame.area(), &theme);
+            PaneLayout::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -764,7 +764,7 @@ fn test_annotation_emission() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                PaneLayout::view(&state, frame, frame.area(), &theme);
+                PaneLayout::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/progress_bar/mod.rs
+++ b/src/component/progress_bar/mod.rs
@@ -37,7 +37,7 @@ use std::time::Duration;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Gauge};
 
-use super::{Component, Disableable};
+use super::{Component, Disableable, ViewContext};
 use crate::theme::Theme;
 
 /// Messages that can be sent to a ProgressBar.
@@ -476,7 +476,7 @@ impl Component for ProgressBar {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         let label = build_label(state);
 
         let gauge = Gauge::default()

--- a/src/component/progress_bar/tests.rs
+++ b/src/component/progress_bar/tests.rs
@@ -195,7 +195,7 @@ fn test_view_zero_progress() {
 
     terminal
         .draw(|frame| {
-            ProgressBar::view(&state, frame, frame.area(), &theme);
+            ProgressBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -209,7 +209,7 @@ fn test_view_half_progress() {
 
     terminal
         .draw(|frame| {
-            ProgressBar::view(&state, frame, frame.area(), &theme);
+            ProgressBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -223,7 +223,7 @@ fn test_view_full_progress() {
 
     terminal
         .draw(|frame| {
-            ProgressBar::view(&state, frame, frame.area(), &theme);
+            ProgressBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -238,7 +238,7 @@ fn test_view_renders() {
 
     terminal
         .draw(|frame| {
-            ProgressBar::view(&state, frame, frame.area(), &theme);
+            ProgressBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -252,7 +252,7 @@ fn test_view_without_label() {
 
     terminal
         .draw(|frame| {
-            ProgressBar::view(&state, frame, frame.area(), &theme);
+            ProgressBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -546,7 +546,7 @@ fn test_view_with_eta_and_rate() {
 
     terminal
         .draw(|frame| {
-            ProgressBar::view(&state, frame, frame.area(), &theme);
+            ProgressBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -564,7 +564,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                ProgressBar::view(&state, frame, frame.area(), &theme);
+                ProgressBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/radio_group/mod.rs
+++ b/src/component/radio_group/mod.rs
@@ -37,7 +37,7 @@ use std::marker::PhantomData;
 use ratatui::prelude::*;
 use ratatui::widgets::{List, ListItem};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -389,7 +389,7 @@ impl<T: Clone + std::fmt::Display + 'static> Component for RadioGroup<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         let items: Vec<ListItem> = state
             .options
             .iter()

--- a/src/component/radio_group/tests.rs
+++ b/src/component/radio_group/tests.rs
@@ -177,7 +177,7 @@ fn test_view_renders_indicators() {
 
     terminal
         .draw(|frame| {
-            RadioGroup::<&str>::view(&state, frame, frame.area(), &theme);
+            RadioGroup::<&str>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -192,7 +192,7 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            RadioGroup::<&str>::view(&state, frame, frame.area(), &theme);
+            RadioGroup::<&str>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -223,7 +223,7 @@ fn test_view_unfocused() {
 
     terminal
         .draw(|frame| {
-            RadioGroup::<&str>::view(&state, frame, frame.area(), &theme);
+            RadioGroup::<&str>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -239,7 +239,7 @@ fn test_view_focused_not_selected() {
 
     terminal
         .draw(|frame| {
-            RadioGroup::<&str>::view(&state, frame, frame.area(), &theme);
+            RadioGroup::<&str>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -505,7 +505,13 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                RadioGroup::<String>::view(&state, frame, frame.area(), &theme);
+                RadioGroup::<String>::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::default(),
+                );
             })
             .unwrap();
     });

--- a/src/component/router/mod.rs
+++ b/src/component/router/mod.rs
@@ -57,6 +57,7 @@
 use ratatui::prelude::*;
 
 use super::Component;
+use super::ViewContext;
 use crate::theme::Theme;
 
 /// Navigation mode for screen transitions.
@@ -377,7 +378,13 @@ impl<S: Clone + PartialEq> Router<S> {
     ///
     /// Router is state-only, so this is a no-op. The parent application
     /// should render based on `state.current()`.
-    pub fn view(_state: &RouterState<S>, _frame: &mut Frame, _area: Rect, _theme: &Theme) {
+    pub fn view(
+        _state: &RouterState<S>,
+        _frame: &mut Frame,
+        _area: Rect,
+        _theme: &Theme,
+        _ctx: &ViewContext,
+    ) {
         // Router is state-only - no view implementation.
         // The parent application should render based on state.current()
     }
@@ -396,8 +403,8 @@ impl<S: Clone + PartialEq + Default> Component for Router<S> {
         Router::update(state, msg)
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
-        Router::view(state, frame, area, theme)
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+        Router::view(state, frame, area, theme, &ViewContext::default())
     }
 }
 

--- a/src/component/router/snapshot_tests.rs
+++ b/src/component/router/snapshot_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::component::test_utils;
+use crate::component::ViewContext;
 
 /// Router is a state-only component with no visual output.
 /// These tests verify that `Router::view()` is a no-op and
@@ -23,7 +24,7 @@ fn test_snapshot_initial_screen() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Router::view(&state, frame, frame.area(), &theme);
+            Router::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     // Router renders nothing -- the output should be blank
@@ -41,7 +42,7 @@ fn test_snapshot_after_navigation() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Router::view(&state, frame, frame.area(), &theme);
+            Router::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     // Router renders nothing -- the output should be blank
@@ -58,7 +59,7 @@ fn test_snapshot_after_back() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Router::view(&state, frame, frame.area(), &theme);
+            Router::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/router/tests.rs
+++ b/src/component/router/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::component::ViewContext;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 enum TestScreen {
@@ -303,7 +304,7 @@ fn test_view_is_noop() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(80, 24);
 
     terminal
-        .draw(|frame| Router::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| Router::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
 
     // View should do nothing - output should be empty

--- a/src/component/scroll_view/mod.rs
+++ b/src/component/scroll_view/mod.rs
@@ -34,7 +34,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
@@ -645,7 +645,7 @@ impl Component for ScrollView {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if area.width == 0 || area.height == 0 {
             return;
         }

--- a/src/component/scroll_view/tests.rs
+++ b/src/component/scroll_view/tests.rs
@@ -658,7 +658,7 @@ fn test_view_empty() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollView::view(&state, frame, frame.area(), &theme);
+            ScrollView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -670,7 +670,7 @@ fn test_view_with_title() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollView::view(&state, frame, frame.area(), &theme);
+            ScrollView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -682,7 +682,7 @@ fn test_view_focused() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollView::view(&state, frame, frame.area(), &theme);
+            ScrollView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -696,7 +696,7 @@ fn test_view_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollView::view(&state, frame, frame.area(), &theme);
+            ScrollView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -711,7 +711,7 @@ fn test_view_with_scrollbar() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollView::view(&state, frame, frame.area(), &theme);
+            ScrollView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -725,7 +725,7 @@ fn test_view_no_scrollbar_when_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollView::view(&state, frame, frame.area(), &theme);
+            ScrollView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -737,7 +737,7 @@ fn test_view_no_scrollbar_when_content_fits() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollView::view(&state, frame, frame.area(), &theme);
+            ScrollView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -750,7 +750,7 @@ fn test_view_zero_area() {
     terminal
         .draw(|frame| {
             let zero_area = Rect::new(0, 0, 0, 0);
-            ScrollView::view(&state, frame, zero_area, &theme);
+            ScrollView::view(&state, frame, zero_area, &theme, &ViewContext::default());
         })
         .unwrap();
     // Should not panic
@@ -763,7 +763,7 @@ fn test_view_minimal_area() {
     terminal
         .draw(|frame| {
             let small_area = Rect::new(0, 0, 3, 3);
-            ScrollView::view(&state, frame, small_area, &theme);
+            ScrollView::view(&state, frame, small_area, &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -782,7 +782,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                ScrollView::view(&state, frame, frame.area(), &theme);
+                ScrollView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -804,7 +804,7 @@ fn test_annotation_reflects_focus_and_disabled() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                ScrollView::view(&state, frame, frame.area(), &theme);
+                ScrollView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/scrollable_text/mod.rs
+++ b/src/component/scrollable_text/mod.rs
@@ -30,7 +30,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
@@ -386,7 +386,7 @@ impl Component for ScrollableText {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,

--- a/src/component/scrollable_text/tests.rs
+++ b/src/component/scrollable_text/tests.rs
@@ -369,7 +369,7 @@ fn test_view_empty() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollableText::view(&state, frame, frame.area(), &theme);
+            ScrollableText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -382,7 +382,7 @@ fn test_view_with_content() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollableText::view(&state, frame, frame.area(), &theme);
+            ScrollableText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -396,7 +396,7 @@ fn test_view_scrolled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 6);
     terminal
         .draw(|frame| {
-            ScrollableText::view(&state, frame, frame.area(), &theme);
+            ScrollableText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -408,7 +408,7 @@ fn test_view_focused() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollableText::view(&state, frame, frame.area(), &theme);
+            ScrollableText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -422,7 +422,7 @@ fn test_view_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollableText::view(&state, frame, frame.area(), &theme);
+            ScrollableText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -438,7 +438,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                ScrollableText::view(&state, frame, frame.area(), &theme);
+                ScrollableText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/searchable_list/mod.rs
+++ b/src/component/searchable_list/mod.rs
@@ -43,7 +43,7 @@ use std::sync::Arc;
 use ratatui::prelude::*;
 use ratatui::widgets::ListState;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
@@ -1030,7 +1030,7 @@ impl<T: Clone + Display + 'static> Component for SearchableList<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         render::render_searchable_list(state, frame, area, theme);
     }
 }

--- a/src/component/searchable_list/snapshot_tests.rs
+++ b/src/component/searchable_list/snapshot_tests.rs
@@ -21,7 +21,7 @@ fn test_snapshot_default_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme);
+            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -33,7 +33,7 @@ fn test_snapshot_populated() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme);
+            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -46,7 +46,7 @@ fn test_snapshot_focused_filter() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme);
+            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -60,7 +60,7 @@ fn test_snapshot_focused_list() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme);
+            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -74,7 +74,7 @@ fn test_snapshot_filtered() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme);
+            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -91,7 +91,7 @@ fn test_snapshot_no_matches() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme);
+            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -103,7 +103,7 @@ fn test_snapshot_custom_placeholder() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme);
+            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/searchable_list/tests.rs
+++ b/src/component/searchable_list/tests.rs
@@ -616,7 +616,7 @@ fn test_render_unfocused() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme);
+            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -628,7 +628,7 @@ fn test_render_focused_filter() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme);
+            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -641,7 +641,7 @@ fn test_render_focused_list() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme);
+            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -657,7 +657,7 @@ fn test_render_with_filter() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme);
+            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -669,7 +669,7 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme);
+            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -680,7 +680,7 @@ fn test_render_empty_list() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme);
+            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -929,7 +929,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                SearchableList::view(&state, frame, frame.area(), &theme);
+                SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/select/mod.rs
+++ b/src/component/select/mod.rs
@@ -31,7 +31,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -639,7 +639,7 @@ impl Component for Select {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             let mut ann = crate::annotation::Annotation::new(crate::annotation::WidgetType::Select)
                 .with_id("select")

--- a/src/component/select/tests.rs
+++ b/src/component/select/tests.rs
@@ -195,7 +195,7 @@ fn test_view_closed() {
 
     terminal
         .draw(|frame| {
-            Select::view(&state, frame, frame.area(), &theme);
+            Select::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -211,7 +211,7 @@ fn test_view_open() {
 
     terminal
         .draw(|frame| {
-            Select::view(&state, frame, frame.area(), &theme);
+            Select::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -226,7 +226,7 @@ fn test_view_with_selection() {
 
     terminal
         .draw(|frame| {
-            Select::view(&state, frame, frame.area(), &theme);
+            Select::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -242,7 +242,7 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            Select::view(&state, frame, frame.area(), &theme);
+            Select::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -468,7 +468,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Select::view(&state, frame, frame.area(), &theme);
+                Select::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/selectable_list/mod.rs
+++ b/src/component/selectable_list/mod.rs
@@ -30,7 +30,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
@@ -698,7 +698,7 @@ impl<T: Clone + std::fmt::Display + 'static> Component for SelectableList<T> {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             let mut ann = crate::annotation::Annotation::list("selectable_list")
                 .with_focus(state.focused)

--- a/src/component/selectable_list/tests.rs
+++ b/src/component/selectable_list/tests.rs
@@ -259,7 +259,13 @@ fn test_view() {
 
     terminal
         .draw(|frame| {
-            SelectableList::<&str>::view(&state, frame, frame.area(), &theme);
+            SelectableList::<&str>::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::default(),
+            );
         })
         .unwrap();
 
@@ -274,7 +280,13 @@ fn test_view_unfocused() {
 
     terminal
         .draw(|frame| {
-            SelectableList::<&str>::view(&state, frame, frame.area(), &theme);
+            SelectableList::<&str>::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::default(),
+            );
         })
         .unwrap();
 
@@ -714,7 +726,13 @@ fn test_filter_view() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            SelectableList::<String>::view(&state, frame, frame.area(), &theme);
+            SelectableList::<String>::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::default(),
+            );
         })
         .unwrap();
 
@@ -810,7 +828,13 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                SelectableList::<String>::view(&state, frame, frame.area(), &theme);
+                SelectableList::<String>::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::default(),
+                );
             })
             .unwrap();
     });

--- a/src/component/slider/mod.rs
+++ b/src/component/slider/mod.rs
@@ -34,7 +34,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -544,7 +544,7 @@ impl Component for Slider {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         match state.orientation {
             SliderOrientation::Horizontal => view_horizontal(state, frame, area, theme),
             SliderOrientation::Vertical => view_vertical(state, frame, area, theme),

--- a/src/component/slider/tests.rs
+++ b/src/component/slider/tests.rs
@@ -582,7 +582,7 @@ fn test_view_horizontal_empty() {
 
     terminal
         .draw(|frame| {
-            Slider::view(&state, frame, frame.area(), &theme);
+            Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -596,7 +596,7 @@ fn test_view_horizontal_half() {
 
     terminal
         .draw(|frame| {
-            Slider::view(&state, frame, frame.area(), &theme);
+            Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -610,7 +610,7 @@ fn test_view_horizontal_full() {
 
     terminal
         .draw(|frame| {
-            Slider::view(&state, frame, frame.area(), &theme);
+            Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -626,7 +626,7 @@ fn test_view_horizontal_with_label() {
 
     terminal
         .draw(|frame| {
-            Slider::view(&state, frame, frame.area(), &theme);
+            Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -642,7 +642,7 @@ fn test_view_horizontal_no_value_display() {
 
     terminal
         .draw(|frame| {
-            Slider::view(&state, frame, frame.area(), &theme);
+            Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -657,7 +657,7 @@ fn test_view_horizontal_focused() {
 
     terminal
         .draw(|frame| {
-            Slider::view(&state, frame, frame.area(), &theme);
+            Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -673,7 +673,7 @@ fn test_view_horizontal_disabled() {
 
     terminal
         .draw(|frame| {
-            Slider::view(&state, frame, frame.area(), &theme);
+            Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -689,7 +689,7 @@ fn test_view_vertical() {
 
     terminal
         .draw(|frame| {
-            Slider::view(&state, frame, frame.area(), &theme);
+            Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -706,7 +706,7 @@ fn test_view_vertical_with_label() {
 
     terminal
         .draw(|frame| {
-            Slider::view(&state, frame, frame.area(), &theme);
+            Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -721,7 +721,7 @@ fn test_view_zero_area() {
     // Should not panic
     terminal
         .draw(|frame| {
-            Slider::view(&state, frame, frame.area(), &theme);
+            Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -764,7 +764,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Slider::view(&state, frame, frame.area(), &theme);
+                Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -784,7 +784,7 @@ fn test_annotation_focused() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Slider::view(&state, frame, frame.area(), &theme);
+                Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -803,7 +803,7 @@ fn test_annotation_disabled() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Slider::view(&state, frame, frame.area(), &theme);
+                Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/span_tree/mod.rs
+++ b/src/component/span_tree/mod.rs
@@ -36,7 +36,7 @@ use std::collections::HashSet;
 
 use ratatui::prelude::*;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
@@ -896,7 +896,7 @@ impl Component for SpanTree {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         render::render_span_tree(state, frame, area, theme);
     }
 }

--- a/src/component/span_tree/snapshot_tests.rs
+++ b/src/component/span_tree/snapshot_tests.rs
@@ -7,7 +7,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 10);
     terminal
         .draw(|frame| {
-            SpanTree::view(&state, frame, frame.area(), &theme);
+            SpanTree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -30,7 +30,7 @@ fn test_snapshot_simple_tree() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            SpanTree::view(&state, frame, frame.area(), &theme);
+            SpanTree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -47,7 +47,7 @@ fn test_snapshot_with_selection() {
     let (mut terminal, theme) = test_utils::setup_render(60, 10);
     terminal
         .draw(|frame| {
-            SpanTree::view(&state, frame, frame.area(), &theme);
+            SpanTree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -63,7 +63,7 @@ fn test_snapshot_collapsed() {
     let (mut terminal, theme) = test_utils::setup_render(60, 10);
     terminal
         .draw(|frame| {
-            SpanTree::view(&state, frame, frame.area(), &theme);
+            SpanTree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -83,7 +83,7 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 10);
     terminal
         .draw(|frame| {
-            SpanTree::view(&state, frame, frame.area(), &theme);
+            SpanTree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -95,7 +95,7 @@ fn test_snapshot_single_span() {
     let (mut terminal, theme) = test_utils::setup_render(60, 8);
     terminal
         .draw(|frame| {
-            SpanTree::view(&state, frame, frame.area(), &theme);
+            SpanTree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -115,7 +115,7 @@ fn test_snapshot_custom_label_width() {
     let (mut terminal, theme) = test_utils::setup_render(60, 10);
     terminal
         .draw(|frame| {
-            SpanTree::view(&state, frame, frame.area(), &theme);
+            SpanTree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/sparkline/mod.rs
+++ b/src/component/sparkline/mod.rs
@@ -34,7 +34,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, RenderDirection, Sparkline as RatatuiSparkline};
 
-use super::{Component, Disableable};
+use super::{Component, Disableable, ViewContext};
 use crate::input::Event;
 use crate::theme::Theme;
 
@@ -528,7 +528,7 @@ impl Component for Sparkline {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         let display_data = match state.max_display_points {
             Some(n) if state.data.len() > n => &state.data[state.data.len() - n..],
             _ => &state.data,

--- a/src/component/sparkline/tests.rs
+++ b/src/component/sparkline/tests.rs
@@ -373,7 +373,7 @@ fn test_view_empty() {
 
     terminal
         .draw(|frame| {
-            Sparkline::view(&state, frame, frame.area(), &theme);
+            Sparkline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -387,7 +387,7 @@ fn test_view_with_data() {
 
     terminal
         .draw(|frame| {
-            Sparkline::view(&state, frame, frame.area(), &theme);
+            Sparkline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -401,7 +401,7 @@ fn test_view_with_title() {
 
     terminal
         .draw(|frame| {
-            Sparkline::view(&state, frame, frame.area(), &theme);
+            Sparkline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -415,7 +415,7 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Sparkline::view(&state, frame, frame.area(), &theme);
+            Sparkline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -430,7 +430,7 @@ fn test_view_right_to_left() {
 
     terminal
         .draw(|frame| {
-            Sparkline::view(&state, frame, frame.area(), &theme);
+            Sparkline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -445,7 +445,7 @@ fn test_view_with_max_display_points() {
 
     terminal
         .draw(|frame| {
-            Sparkline::view(&state, frame, frame.area(), &theme);
+            Sparkline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -459,7 +459,7 @@ fn test_view_with_color() {
 
     terminal
         .draw(|frame| {
-            Sparkline::view(&state, frame, frame.area(), &theme);
+            Sparkline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -477,7 +477,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Sparkline::view(&state, frame, frame.area(), &theme);
+                Sparkline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -496,7 +496,7 @@ fn test_annotation_emitted_no_title() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Sparkline::view(&state, frame, frame.area(), &theme);
+                Sparkline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/spinner/mod.rs
+++ b/src/component/spinner/mod.rs
@@ -41,7 +41,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, Disableable};
+use super::{Component, Disableable, ViewContext};
 use crate::theme::Theme;
 
 /// Built-in spinner animation styles.
@@ -356,7 +356,7 @@ impl Component for Spinner {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         let spinner_char = if state.spinning {
             state.current_frame().to_string()
         } else {

--- a/src/component/spinner/tests.rs
+++ b/src/component/spinner/tests.rs
@@ -173,7 +173,7 @@ fn test_view_spinning() {
 
     terminal
         .draw(|frame| {
-            Spinner::view(&state, frame, frame.area(), &theme);
+            Spinner::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -189,7 +189,7 @@ fn test_view_stopped() {
 
     terminal
         .draw(|frame| {
-            Spinner::view(&state, frame, frame.area(), &theme);
+            Spinner::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -204,7 +204,7 @@ fn test_view_with_label() {
 
     terminal
         .draw(|frame| {
-            Spinner::view(&state, frame, frame.area(), &theme);
+            Spinner::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -283,7 +283,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Spinner::view(&state, frame, frame.area(), &theme);
+                Spinner::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/split_panel/mod.rs
+++ b/src/component/split_panel/mod.rs
@@ -36,7 +36,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::theme::Theme;
 
@@ -522,7 +522,7 @@ impl Component for SplitPanel {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.open(
                 area,

--- a/src/component/split_panel/snapshot_tests.rs
+++ b/src/component/split_panel/snapshot_tests.rs
@@ -11,7 +11,7 @@ fn test_snapshot_default() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            SplitPanel::view(&state, frame, frame.area(), &theme);
+            SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -24,7 +24,7 @@ fn test_snapshot_vertical_focused_first() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            SplitPanel::view(&state, frame, frame.area(), &theme);
+            SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -38,7 +38,7 @@ fn test_snapshot_vertical_focused_second() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            SplitPanel::view(&state, frame, frame.area(), &theme);
+            SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -51,7 +51,7 @@ fn test_snapshot_horizontal() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            SplitPanel::view(&state, frame, frame.area(), &theme);
+            SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -64,7 +64,7 @@ fn test_snapshot_custom_ratio() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            SplitPanel::view(&state, frame, frame.area(), &theme);
+            SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -80,7 +80,7 @@ fn test_snapshot_resized() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            SplitPanel::view(&state, frame, frame.area(), &theme);
+            SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/split_panel/tests.rs
+++ b/src/component/split_panel/tests.rs
@@ -456,7 +456,7 @@ fn test_render_vertical() {
     let (mut terminal, theme) = test_utils::setup_render(80, 24);
     terminal
         .draw(|frame| {
-            SplitPanel::view(&state, frame, frame.area(), &theme);
+            SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -467,7 +467,7 @@ fn test_render_horizontal() {
     let (mut terminal, theme) = test_utils::setup_render(80, 24);
     terminal
         .draw(|frame| {
-            SplitPanel::view(&state, frame, frame.area(), &theme);
+            SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -479,7 +479,7 @@ fn test_render_second_pane_focused() {
     let (mut terminal, theme) = test_utils::setup_render(80, 24);
     terminal
         .draw(|frame| {
-            SplitPanel::view(&state, frame, frame.area(), &theme);
+            SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -490,7 +490,7 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(80, 24);
     terminal
         .draw(|frame| {
-            SplitPanel::view(&state, frame, frame.area(), &theme);
+            SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -539,7 +539,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                SplitPanel::view(&state, frame, frame.area(), &theme);
+                SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/status_bar/mod.rs
+++ b/src/component/status_bar/mod.rs
@@ -60,7 +60,7 @@ pub use item::*;
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, Disableable};
+use super::{Component, Disableable, ViewContext};
 use crate::theme::Theme;
 
 /// Section of the status bar for addressing items.
@@ -611,7 +611,7 @@ impl Component for StatusBar {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         // Render background
         let bg_style = Style::default().bg(state.background);
 

--- a/src/component/status_bar/snapshot_tests.rs
+++ b/src/component/status_bar/snapshot_tests.rs
@@ -11,7 +11,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 1);
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -25,7 +25,7 @@ fn test_snapshot_left_only() {
     let (mut terminal, theme) = test_utils::setup_render(60, 1);
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -38,7 +38,7 @@ fn test_snapshot_center_only() {
     let (mut terminal, theme) = test_utils::setup_render(60, 1);
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -52,7 +52,7 @@ fn test_snapshot_right_only() {
     let (mut terminal, theme) = test_utils::setup_render(60, 1);
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -68,7 +68,7 @@ fn test_snapshot_all_sections() {
     let (mut terminal, theme) = test_utils::setup_render(60, 1);
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -83,7 +83,7 @@ fn test_snapshot_styled_items() {
     let (mut terminal, theme) = test_utils::setup_render(60, 1);
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -105,7 +105,7 @@ fn test_snapshot_counter_item() {
     let (mut terminal, theme) = test_utils::setup_render(60, 1);
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -121,7 +121,7 @@ fn test_snapshot_custom_separator() {
     let (mut terminal, theme) = test_utils::setup_render(60, 1);
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/status_bar/tests/component.rs
+++ b/src/component/status_bar/tests/component.rs
@@ -120,7 +120,7 @@ fn test_view_empty() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -136,7 +136,7 @@ fn test_view_left_only() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -152,7 +152,7 @@ fn test_view_right_only() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -168,7 +168,7 @@ fn test_view_center_only() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -186,7 +186,7 @@ fn test_view_all_sections() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -203,7 +203,7 @@ fn test_view_with_separator() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -220,7 +220,7 @@ fn test_view_custom_separator() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -237,7 +237,7 @@ fn test_view_no_separator_on_last_item() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -254,7 +254,7 @@ fn test_view_styled_items() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -272,7 +272,7 @@ fn test_view_elapsed_time() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -297,7 +297,7 @@ fn test_view_counter_with_label() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -313,7 +313,7 @@ fn test_view_heartbeat() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -332,7 +332,7 @@ fn test_view_left_and_right_no_center() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -351,7 +351,7 @@ fn test_view_many_items_in_section() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -376,7 +376,7 @@ fn test_view_counter_no_label() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -397,7 +397,7 @@ fn test_view_all_styles() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -415,7 +415,7 @@ fn test_view_narrow_width() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -432,7 +432,7 @@ fn test_view_multiple_items_right() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -451,7 +451,7 @@ fn test_view_mixed_dynamic_items() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme);
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -517,7 +517,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                StatusBar::view(&state, frame, frame.area(), &theme);
+                StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/status_log/mod.rs
+++ b/src/component/status_log/mod.rs
@@ -31,7 +31,7 @@ pub use entry::{StatusLogEntry, StatusLogLevel};
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -828,7 +828,7 @@ impl Component for StatusLog {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if area.width == 0 || area.height == 0 {
             return;
         }

--- a/src/component/status_log/tests.rs
+++ b/src/component/status_log/tests.rs
@@ -480,7 +480,7 @@ fn test_view_empty() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
 
     terminal
-        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -495,7 +495,7 @@ fn test_view_with_messages() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
 
     terminal
-        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -509,7 +509,7 @@ fn test_view_with_title() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
 
     terminal
-        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -523,7 +523,7 @@ fn test_view_with_timestamps() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -540,7 +540,7 @@ fn test_view_all_levels() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
 
     terminal
-        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -557,7 +557,7 @@ fn test_view_focused() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
 
     terminal
-        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -573,7 +573,7 @@ fn test_view_unfocused() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
 
     terminal
-        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -858,7 +858,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                StatusLog::view(&state, frame, frame.area(), &theme);
+                StatusLog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/step_indicator/mod.rs
+++ b/src/component/step_indicator/mod.rs
@@ -32,7 +32,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use super::{Component, Focusable};
+use super::{Component, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -672,7 +672,7 @@ impl Component for StepIndicator {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,

--- a/src/component/step_indicator/tests.rs
+++ b/src/component/step_indicator/tests.rs
@@ -644,7 +644,7 @@ fn test_view_horizontal() {
 
     terminal
         .draw(|frame| {
-            StepIndicator::view(&state, frame, frame.area(), &theme);
+            StepIndicator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -664,7 +664,7 @@ fn test_view_vertical() {
 
     terminal
         .draw(|frame| {
-            StepIndicator::view(&state, frame, frame.area(), &theme);
+            StepIndicator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -683,7 +683,7 @@ fn test_view_with_title() {
 
     terminal
         .draw(|frame| {
-            StepIndicator::view(&state, frame, frame.area(), &theme);
+            StepIndicator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -701,7 +701,7 @@ fn test_view_focused_step() {
 
     terminal
         .draw(|frame| {
-            StepIndicator::view(&state, frame, frame.area(), &theme);
+            StepIndicator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -727,7 +727,7 @@ fn test_view_vertical_with_descriptions() {
 
     terminal
         .draw(|frame| {
-            StepIndicator::view(&state, frame, frame.area(), &theme);
+            StepIndicator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -749,7 +749,7 @@ fn test_view_all_statuses() {
 
     terminal
         .draw(|frame| {
-            StepIndicator::view(&state, frame, frame.area(), &theme);
+            StepIndicator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -764,7 +764,7 @@ fn test_view_empty_steps() {
 
     terminal
         .draw(|frame| {
-            StepIndicator::view(&state, frame, frame.area(), &theme);
+            StepIndicator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -784,7 +784,7 @@ fn test_annotation_emission() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                StepIndicator::view(&state, frame, frame.area(), &theme);
+                StepIndicator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/styled_text/mod.rs
+++ b/src/component/styled_text/mod.rs
@@ -40,7 +40,7 @@ pub use content::{StyledBlock, StyledContent, StyledInline};
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
-use super::{Component, Focusable};
+use super::{Component, Focusable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::theme::Theme;
 
@@ -558,7 +558,7 @@ impl Component for StyledText {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,

--- a/src/component/styled_text/tests.rs
+++ b/src/component/styled_text/tests.rs
@@ -504,7 +504,7 @@ fn test_view_heading_and_text() {
 
     terminal
         .draw(|frame| {
-            StyledText::view(&state, frame, frame.area(), &theme);
+            StyledText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -524,7 +524,7 @@ fn test_view_bullet_list() {
 
     terminal
         .draw(|frame| {
-            StyledText::view(&state, frame, frame.area(), &theme);
+            StyledText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -544,7 +544,7 @@ fn test_view_numbered_list() {
 
     terminal
         .draw(|frame| {
-            StyledText::view(&state, frame, frame.area(), &theme);
+            StyledText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -561,7 +561,7 @@ fn test_view_code_block() {
 
     terminal
         .draw(|frame| {
-            StyledText::view(&state, frame, frame.area(), &theme);
+            StyledText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -580,7 +580,7 @@ fn test_view_horizontal_rule() {
 
     terminal
         .draw(|frame| {
-            StyledText::view(&state, frame, frame.area(), &theme);
+            StyledText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -598,7 +598,7 @@ fn test_view_with_title() {
 
     terminal
         .draw(|frame| {
-            StyledText::view(&state, frame, frame.area(), &theme);
+            StyledText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -616,7 +616,7 @@ fn test_view_no_border() {
 
     terminal
         .draw(|frame| {
-            StyledText::view(&state, frame, frame.area(), &theme);
+            StyledText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -631,7 +631,7 @@ fn test_view_empty_content() {
 
     terminal
         .draw(|frame| {
-            StyledText::view(&state, frame, frame.area(), &theme);
+            StyledText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -658,7 +658,7 @@ fn test_view_mixed_content() {
 
     terminal
         .draw(|frame| {
-            StyledText::view(&state, frame, frame.area(), &theme);
+            StyledText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -677,7 +677,7 @@ fn test_annotation_emission() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                StyledText::view(&state, frame, frame.area(), &theme);
+                StyledText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/switch/mod.rs
+++ b/src/component/switch/mod.rs
@@ -37,7 +37,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, Disableable, Focusable, Toggleable};
+use super::{Component, Disableable, Focusable, Toggleable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -417,7 +417,7 @@ impl Component for Switch {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         let indicator = if state.on {
             format!("(*) {}", state.on_label)
         } else {

--- a/src/component/switch/tests.rs
+++ b/src/component/switch/tests.rs
@@ -329,7 +329,7 @@ fn test_view_off() {
 
     terminal
         .draw(|frame| {
-            Switch::view(&state, frame, frame.area(), &theme);
+            Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -343,7 +343,7 @@ fn test_view_on() {
 
     terminal
         .draw(|frame| {
-            Switch::view(&state, frame, frame.area(), &theme);
+            Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -358,7 +358,7 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            Switch::view(&state, frame, frame.area(), &theme);
+            Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -373,7 +373,7 @@ fn test_view_focused_on() {
 
     terminal
         .draw(|frame| {
-            Switch::view(&state, frame, frame.area(), &theme);
+            Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -387,7 +387,7 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Switch::view(&state, frame, frame.area(), &theme);
+            Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -401,7 +401,7 @@ fn test_view_disabled_on() {
 
     terminal
         .draw(|frame| {
-            Switch::view(&state, frame, frame.area(), &theme);
+            Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -415,7 +415,7 @@ fn test_view_with_label() {
 
     terminal
         .draw(|frame| {
-            Switch::view(&state, frame, frame.area(), &theme);
+            Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -429,7 +429,7 @@ fn test_view_with_label_on() {
 
     terminal
         .draw(|frame| {
-            Switch::view(&state, frame, frame.area(), &theme);
+            Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -446,7 +446,7 @@ fn test_view_custom_labels() {
 
     terminal
         .draw(|frame| {
-            Switch::view(&state, frame, frame.area(), &theme);
+            Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -585,7 +585,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Switch::view(&state, frame, frame.area(), &theme);
+                Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -603,7 +603,7 @@ fn test_annotation_on() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Switch::view(&state, frame, frame.area(), &theme);
+                Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -619,7 +619,7 @@ fn test_annotation_with_label() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Switch::view(&state, frame, frame.area(), &theme);
+                Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/tab_bar/mod.rs
+++ b/src/component/tab_bar/mod.rs
@@ -33,7 +33,7 @@
 
 use ratatui::prelude::*;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -872,7 +872,7 @@ impl Component for TabBar {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         render::render_tab_bar(state, frame, area, theme);
     }
 }

--- a/src/component/tab_bar/tests.rs
+++ b/src/component/tab_bar/tests.rs
@@ -660,7 +660,7 @@ fn test_view_renders_basic() {
     ]);
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
     terminal
-        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -671,7 +671,7 @@ fn test_view_focused() {
     state.set_focused(true);
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
     terminal
-        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -682,7 +682,7 @@ fn test_view_disabled() {
     state.set_disabled(true);
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
     terminal
-        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -692,7 +692,7 @@ fn test_view_empty() {
     let state = TabBarState::new(vec![]);
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
     terminal
-        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -705,7 +705,7 @@ fn test_view_with_modified() {
     ]);
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
     terminal
-        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -718,7 +718,7 @@ fn test_view_with_closable() {
     ]);
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
     terminal
-        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -731,7 +731,7 @@ fn test_view_with_icon() {
     ]);
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
     terminal
-        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -747,7 +747,7 @@ fn test_view_with_all_decorations() {
     ]);
     let (mut terminal, theme) = crate::component::test_utils::setup_render(50, 1);
     terminal
-        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -757,7 +757,15 @@ fn test_view_zero_area() {
     let state = TabBarState::new(vec![Tab::new("a", "A")]);
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
     terminal
-        .draw(|frame| TabBar::view(&state, frame, Rect::new(0, 0, 0, 0), &theme))
+        .draw(|frame| {
+            TabBar::view(
+                &state,
+                frame,
+                Rect::new(0, 0, 0, 0),
+                &theme,
+                &ViewContext::default(),
+            )
+        })
         .unwrap();
     // Should not panic
 }
@@ -844,7 +852,9 @@ fn test_annotation_emitted() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
     let registry = with_annotations(|| {
         terminal
-            .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme))
+            .draw(|frame| {
+                TabBar::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            })
             .unwrap();
     });
     assert_eq!(registry.len(), 1);

--- a/src/component/table/mod.rs
+++ b/src/component/table/mod.rs
@@ -68,7 +68,7 @@ use std::marker::PhantomData;
 
 use ratatui::prelude::*;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
@@ -901,7 +901,7 @@ impl<T: TableRow + 'static> Component for Table<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         render::render_table(state, frame, area, theme);
     }
 }

--- a/src/component/table/tests.rs
+++ b/src/component/table/tests.rs
@@ -924,7 +924,13 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Table::<TestRow>::view(&state, frame, frame.area(), &theme);
+                Table::<TestRow>::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::default(),
+                );
             })
             .unwrap();
     });

--- a/src/component/table/view_tests.rs
+++ b/src/component/table/view_tests.rs
@@ -45,7 +45,7 @@ fn test_view_renders() {
 
     terminal
         .draw(|frame| {
-            Table::<TestRow>::view(&state, frame, frame.area(), &theme);
+            Table::<TestRow>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -60,7 +60,7 @@ fn test_view_with_header() {
 
     terminal
         .draw(|frame| {
-            Table::<TestRow>::view(&state, frame, frame.area(), &theme);
+            Table::<TestRow>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -76,7 +76,7 @@ fn test_view_with_sort_indicator() {
 
     terminal
         .draw(|frame| {
-            Table::<TestRow>::view(&state, frame, frame.area(), &theme);
+            Table::<TestRow>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -92,7 +92,7 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            Table::<TestRow>::view(&state, frame, frame.area(), &theme);
+            Table::<TestRow>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -108,7 +108,7 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Table::<TestRow>::view(&state, frame, frame.area(), &theme);
+            Table::<TestRow>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -123,7 +123,7 @@ fn test_view_empty() {
 
     terminal
         .draw(|frame| {
-            Table::<TestRow>::view(&state, frame, frame.area(), &theme);
+            Table::<TestRow>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -141,7 +141,7 @@ fn test_view_descending_sort_indicator() {
 
     terminal
         .draw(|frame| {
-            Table::<TestRow>::view(&state, frame, frame.area(), &theme);
+            Table::<TestRow>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -157,7 +157,7 @@ fn test_view_unfocused() {
 
     terminal
         .draw(|frame| {
-            Table::<TestRow>::view(&state, frame, frame.area(), &theme);
+            Table::<TestRow>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -175,7 +175,7 @@ fn test_view_multi_column_sort_indicators() {
 
     terminal
         .draw(|frame| {
-            Table::<TestRow>::view(&state, frame, frame.area(), &theme);
+            Table::<TestRow>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 

--- a/src/component/tabs/mod.rs
+++ b/src/component/tabs/mod.rs
@@ -31,7 +31,7 @@ use std::marker::PhantomData;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -447,7 +447,7 @@ impl<T: Clone + Display + 'static> Component for Tabs<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         let selected_idx = state.selected.unwrap_or(0);
 
         let titles: Vec<Line> = state

--- a/src/component/tabs/tests.rs
+++ b/src/component/tabs/tests.rs
@@ -267,7 +267,7 @@ fn test_view_renders() {
 
     terminal
         .draw(|frame| {
-            Tabs::<&str>::view(&state, frame, frame.area(), &theme);
+            Tabs::<&str>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -283,7 +283,7 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            Tabs::<&str>::view(&state, frame, frame.area(), &theme);
+            Tabs::<&str>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -299,7 +299,7 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Tabs::<&str>::view(&state, frame, frame.area(), &theme);
+            Tabs::<&str>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -314,7 +314,7 @@ fn test_view_empty() {
 
     terminal
         .draw(|frame| {
-            Tabs::<&str>::view(&state, frame, frame.area(), &theme);
+            Tabs::<&str>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -686,7 +686,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Tabs::<String>::view(&state, frame, frame.area(), &theme);
+                Tabs::<String>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/terminal_output/mod.rs
+++ b/src/component/terminal_output/mod.rs
@@ -48,7 +48,7 @@ pub use ansi::{parse_ansi, AnsiSegment};
 
 use ratatui::prelude::*;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
@@ -750,7 +750,7 @@ impl Component for TerminalOutput {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         render::render(state, frame, area, theme);
     }
 }

--- a/src/component/terminal_output/tests.rs
+++ b/src/component/terminal_output/tests.rs
@@ -625,7 +625,7 @@ fn test_view_empty() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            TerminalOutput::view(&state, frame, frame.area(), &theme);
+            TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -641,7 +641,7 @@ fn test_view_with_content() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            TerminalOutput::view(&state, frame, frame.area(), &theme);
+            TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -657,7 +657,7 @@ fn test_view_with_ansi_colors() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            TerminalOutput::view(&state, frame, frame.area(), &theme);
+            TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -673,7 +673,7 @@ fn test_view_with_line_numbers() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            TerminalOutput::view(&state, frame, frame.area(), &theme);
+            TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -687,7 +687,7 @@ fn test_view_running() {
     let (mut terminal, theme) = test_utils::setup_render(50, 8);
     terminal
         .draw(|frame| {
-            TerminalOutput::view(&state, frame, frame.area(), &theme);
+            TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -702,7 +702,7 @@ fn test_view_exit_code() {
     let (mut terminal, theme) = test_utils::setup_render(50, 8);
     terminal
         .draw(|frame| {
-            TerminalOutput::view(&state, frame, frame.area(), &theme);
+            TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -714,7 +714,7 @@ fn test_view_focused() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            TerminalOutput::view(&state, frame, frame.area(), &theme);
+            TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -727,7 +727,7 @@ fn test_view_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(50, 8);
     terminal
         .draw(|frame| {
-            TerminalOutput::view(&state, frame, frame.area(), &theme);
+            TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -745,7 +745,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                TerminalOutput::view(&state, frame, frame.area(), &theme);
+                TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -764,7 +764,7 @@ fn test_annotation_focused() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                TerminalOutput::view(&state, frame, frame.area(), &theme);
+                TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/tests.rs
+++ b/src/component/tests.rs
@@ -44,7 +44,13 @@ impl Component for TestCounter {
         Some(TestCounterOutput::Changed(state.value))
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, _theme: &Theme) {
+    fn view(
+        state: &Self::State,
+        frame: &mut Frame,
+        area: Rect,
+        _theme: &Theme,
+        _ctx: &ViewContext,
+    ) {
         let text = format!("Count: {}", state.value);
         frame.render_widget(Paragraph::new(text), area);
     }
@@ -104,7 +110,7 @@ fn test_component_view() {
 
     terminal
         .draw(|frame| {
-            TestCounter::view(&state, frame, frame.area(), &theme);
+            TestCounter::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -225,7 +231,14 @@ impl Component for NoOutputComponent {
         None // No output needed
     }
 
-    fn view(_state: &Self::State, _frame: &mut Frame, _area: Rect, _theme: &Theme) {}
+    fn view(
+        _state: &Self::State,
+        _frame: &mut Frame,
+        _area: Rect,
+        _theme: &Theme,
+        _ctx: &ViewContext,
+    ) {
+    }
 }
 
 #[test]
@@ -266,7 +279,13 @@ fn test_component_non_clone_state() {
             }
         }
 
-        fn view(state: &Self::State, frame: &mut Frame, area: Rect, _theme: &Theme) {
+        fn view(
+            state: &Self::State,
+            frame: &mut Frame,
+            area: Rect,
+            _theme: &Theme,
+            _ctx: &ViewContext,
+        ) {
             let text = format!("Value: {}", state.value);
             frame.render_widget(Paragraph::new(text), area);
         }

--- a/src/component/text_area/mod.rs
+++ b/src/component/text_area/mod.rs
@@ -32,7 +32,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 use unicode_width::UnicodeWidthStr;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::theme::Theme;
 use crate::undo::UndoStack;
@@ -658,7 +658,7 @@ impl Component for TextArea {
         state.apply_update(msg)
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             let first_line = state.lines.first().map_or("", |l| l.as_str());
             reg.register(

--- a/src/component/text_area/tests.rs
+++ b/src/component/text_area/tests.rs
@@ -484,7 +484,7 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            TextArea::view(&state, frame, frame.area(), &theme);
+            TextArea::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -498,7 +498,7 @@ fn test_view_unfocused() {
 
     terminal
         .draw(|frame| {
-            TextArea::view(&state, frame, frame.area(), &theme);
+            TextArea::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -512,7 +512,7 @@ fn test_view_placeholder() {
 
     terminal
         .draw(|frame| {
-            TextArea::view(&state, frame, frame.area(), &theme);
+            TextArea::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -528,7 +528,7 @@ fn test_view_renders() {
 
     terminal
         .draw(|frame| {
-            TextArea::view(&state, frame, frame.area(), &theme);
+            TextArea::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -687,7 +687,7 @@ fn test_view_with_scroll() {
 
     terminal
         .draw(|frame| {
-            TextArea::view(&state, frame, frame.area(), &theme);
+            TextArea::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -704,7 +704,7 @@ fn test_view_cursor_above_scroll() {
 
     terminal
         .draw(|frame| {
-            TextArea::view(&state, frame, frame.area(), &theme);
+            TextArea::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -980,7 +980,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                TextArea::view(&state, frame, frame.area(), &theme);
+                TextArea::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/timeline/mod.rs
+++ b/src/component/timeline/mod.rs
@@ -34,7 +34,7 @@ use std::marker::PhantomData;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -782,7 +782,7 @@ impl Component for Timeline {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if area.height < 3 || area.width < 3 {
             return;
         }

--- a/src/component/timeline/snapshot_tests.rs
+++ b/src/component/timeline/snapshot_tests.rs
@@ -24,7 +24,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme);
+            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -39,7 +39,7 @@ fn test_snapshot_events_only() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme);
+            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -54,7 +54,7 @@ fn test_snapshot_spans_only() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme);
+            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -70,7 +70,7 @@ fn test_snapshot_full_timeline() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme);
+            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -88,7 +88,7 @@ fn test_snapshot_with_selection() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme);
+            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -105,7 +105,7 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme);
+            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -126,7 +126,7 @@ fn test_snapshot_span_selected() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme);
+            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/timeline/tests.rs
+++ b/src/component/timeline/tests.rs
@@ -727,7 +727,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme);
+            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -740,7 +740,7 @@ fn test_render_with_events() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme);
+            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -753,7 +753,7 @@ fn test_render_with_spans() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme);
+            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -768,7 +768,7 @@ fn test_render_with_events_and_spans() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme);
+            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -780,7 +780,7 @@ fn test_render_with_selection() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme);
+            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -794,7 +794,7 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme);
+            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -805,7 +805,7 @@ fn test_render_focused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme);
+            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -816,7 +816,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(60, 2);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme);
+            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -827,7 +827,7 @@ fn test_render_minimal_height() {
     let (mut terminal, theme) = test_utils::setup_render(60, 5);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme);
+            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -838,7 +838,7 @@ fn test_render_very_wide() {
     let (mut terminal, theme) = test_utils::setup_render(120, 15);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme);
+            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -855,7 +855,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Timeline::view(&state, frame, frame.area(), &theme);
+                Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -899,7 +899,7 @@ fn test_overlapping_spans_same_lane() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme);
+            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }

--- a/src/component/title_card/mod.rs
+++ b/src/component/title_card/mod.rs
@@ -24,7 +24,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use super::{Component, Disableable};
+use super::{Component, Disableable, ViewContext};
 use crate::theme::Theme;
 
 /// Messages that can be sent to a TitleCard.
@@ -436,7 +436,7 @@ impl Component for TitleCard {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,

--- a/src/component/title_card/tests.rs
+++ b/src/component/title_card/tests.rs
@@ -240,7 +240,7 @@ fn test_view_basic() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            TitleCard::view(&state, frame, frame.area(), &theme);
+            TitleCard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -252,7 +252,7 @@ fn test_view_with_subtitle() {
     let (mut terminal, theme) = test_utils::setup_render(40, 6);
     terminal
         .draw(|frame| {
-            TitleCard::view(&state, frame, frame.area(), &theme);
+            TitleCard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -266,7 +266,7 @@ fn test_view_prefix_suffix() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            TitleCard::view(&state, frame, frame.area(), &theme);
+            TitleCard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -278,7 +278,7 @@ fn test_view_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            TitleCard::view(&state, frame, frame.area(), &theme);
+            TitleCard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -290,7 +290,7 @@ fn test_view_no_border() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            TitleCard::view(&state, frame, frame.area(), &theme);
+            TitleCard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -302,7 +302,7 @@ fn test_view_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(15, 4);
     terminal
         .draw(|frame| {
-            TitleCard::view(&state, frame, frame.area(), &theme);
+            TitleCard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -318,7 +318,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                TitleCard::view(&state, frame, frame.area(), &theme);
+                TitleCard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/toast/mod.rs
+++ b/src/component/toast/mod.rs
@@ -33,6 +33,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
 use super::Component;
+use super::ViewContext;
 use crate::theme::Theme;
 
 /// Default maximum number of visible toasts.
@@ -443,7 +444,7 @@ impl Component for Toast {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if state.toasts.is_empty() {
             return;
         }

--- a/src/component/toast/tests.rs
+++ b/src/component/toast/tests.rs
@@ -389,7 +389,7 @@ fn test_view_empty() {
 
     terminal
         .draw(|frame| {
-            Toast::view(&state, frame, frame.area(), &theme);
+            Toast::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -405,7 +405,7 @@ fn test_view_single() {
 
     terminal
         .draw(|frame| {
-            Toast::view(&state, frame, frame.area(), &theme);
+            Toast::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -423,7 +423,7 @@ fn test_view_multiple() {
 
     terminal
         .draw(|frame| {
-            Toast::view(&state, frame, frame.area(), &theme);
+            Toast::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -441,7 +441,7 @@ fn test_view_multiple_toasts() {
 
     terminal
         .draw(|frame| {
-            Toast::view(&state, frame, frame.area(), &theme);
+            Toast::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -459,7 +459,7 @@ fn test_view_max_visible() {
 
     terminal
         .draw(|frame| {
-            Toast::view(&state, frame, frame.area(), &theme);
+            Toast::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -475,7 +475,7 @@ fn test_view_info_style() {
 
     terminal
         .draw(|frame| {
-            Toast::view(&state, frame, frame.area(), &theme);
+            Toast::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -491,7 +491,7 @@ fn test_view_success_style() {
 
     terminal
         .draw(|frame| {
-            Toast::view(&state, frame, frame.area(), &theme);
+            Toast::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -507,7 +507,7 @@ fn test_view_warning_style() {
 
     terminal
         .draw(|frame| {
-            Toast::view(&state, frame, frame.area(), &theme);
+            Toast::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -523,7 +523,7 @@ fn test_view_error_style() {
 
     terminal
         .draw(|frame| {
-            Toast::view(&state, frame, frame.area(), &theme);
+            Toast::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -640,7 +640,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Toast::view(&state, frame, frame.area(), &theme);
+                Toast::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/tooltip/mod.rs
+++ b/src/component/tooltip/mod.rs
@@ -28,7 +28,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
-use super::{Component, Toggleable};
+use super::{Component, Toggleable, ViewContext};
 use crate::theme::Theme;
 
 /// Position of the tooltip relative to its target.
@@ -489,7 +489,13 @@ impl Component for Tooltip {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, _theme: &Theme) {
+    fn view(
+        state: &Self::State,
+        frame: &mut Frame,
+        area: Rect,
+        _theme: &Theme,
+        _ctx: &ViewContext,
+    ) {
         if state.visible {
             crate::annotation::with_registry(|reg| {
                 reg.register(

--- a/src/component/tooltip/tests.rs
+++ b/src/component/tooltip/tests.rs
@@ -648,7 +648,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Tooltip::view(&state, frame, frame.area(), &theme);
+                Tooltip::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/tree/mod.rs
+++ b/src/component/tree/mod.rs
@@ -30,7 +30,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
@@ -899,7 +899,7 @@ impl<T: Clone + 'static> Component for Tree<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         let all_lines = Self::render_lines(state, area.width, theme);
         let viewport_height = area.height as usize;
 

--- a/src/component/tree/snapshot_tests.rs
+++ b/src/component/tree/snapshot_tests.rs
@@ -11,7 +11,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -23,7 +23,7 @@ fn test_snapshot_single_root() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -38,7 +38,7 @@ fn test_snapshot_expanded_with_children() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -53,7 +53,7 @@ fn test_snapshot_collapsed_with_children() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -71,7 +71,7 @@ fn test_snapshot_focused_selected() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -89,7 +89,7 @@ fn test_snapshot_deep_nesting() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -105,7 +105,7 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -123,7 +123,7 @@ fn test_snapshot_mixed_expanded_collapsed() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/tree/tests/component.rs
+++ b/src/component/tree/tests/component.rs
@@ -220,7 +220,7 @@ fn test_view_empty() {
 
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -236,7 +236,7 @@ fn test_view_single_node() {
 
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -254,7 +254,7 @@ fn test_view_with_children() {
 
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -272,7 +272,7 @@ fn test_view_collapsed_indicator() {
 
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -290,7 +290,7 @@ fn test_view_expanded_indicator() {
 
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -377,7 +377,7 @@ fn test_view_focused_selection() {
 
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -394,7 +394,7 @@ fn test_view_unfocused_selection() {
 
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -469,7 +469,7 @@ fn test_view_leaf_node_no_indicator() {
 
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -579,7 +579,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Tree::view(&state, frame, frame.area(), &theme);
+                Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/tree/tests/events.rs
+++ b/src/component/tree/tests/events.rs
@@ -303,7 +303,7 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 

--- a/src/component/tree/tests/snapshot.rs
+++ b/src/component/tree/tests/snapshot.rs
@@ -15,7 +15,7 @@ fn test_view_multiple_roots_collapsed() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -36,7 +36,7 @@ fn test_view_multiple_roots_expanded() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -57,7 +57,7 @@ fn test_view_multiple_roots_focused() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -78,7 +78,7 @@ fn test_view_selection_on_child() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -101,7 +101,7 @@ fn test_view_deep_nesting() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -124,7 +124,7 @@ fn test_view_deep_nesting_selection_at_leaf() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -146,7 +146,7 @@ fn test_view_mixed_expanded_collapsed() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -166,7 +166,7 @@ fn test_view_unicode_labels() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -187,7 +187,7 @@ fn test_view_disabled_with_children() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -208,7 +208,7 @@ fn test_view_focused_expanded_tree() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -227,7 +227,7 @@ fn test_view_unfocused_expanded_tree() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -253,7 +253,7 @@ fn test_view_filtered() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -273,7 +273,7 @@ fn test_view_filtered_focused() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -289,7 +289,7 @@ fn test_view_filtered_no_matches() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -310,7 +310,7 @@ fn test_view_many_siblings() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 
@@ -332,7 +332,7 @@ fn test_view_selection_on_last_root() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme);
+            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 

--- a/src/component/treemap/mod.rs
+++ b/src/component/treemap/mod.rs
@@ -31,7 +31,7 @@ use std::marker::PhantomData;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
-use super::{Component, Disableable, Focusable};
+use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -835,7 +835,7 @@ impl Component for Treemap {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if area.height < 3 || area.width < 3 {
             return;
         }

--- a/src/component/treemap/snapshot_tests.rs
+++ b/src/component/treemap/snapshot_tests.rs
@@ -7,7 +7,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme);
+            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -23,7 +23,7 @@ fn test_snapshot_simple() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme);
+            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -41,7 +41,7 @@ fn test_snapshot_focused() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme);
+            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -59,7 +59,7 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme);
+            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -78,7 +78,7 @@ fn test_snapshot_with_values() {
     let (mut terminal, theme) = test_utils::setup_render(40, 12);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme);
+            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -100,7 +100,7 @@ fn test_snapshot_zoomed_in() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme);
+            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -118,7 +118,7 @@ fn test_snapshot_selection_moved() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme);
+            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -132,7 +132,7 @@ fn test_snapshot_single_child() {
     let (mut terminal, theme) = test_utils::setup_render(30, 8);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme);
+            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/treemap/tests.rs
+++ b/src/component/treemap/tests.rs
@@ -748,7 +748,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme);
+            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -763,7 +763,7 @@ fn test_render_simple() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme);
+            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -778,7 +778,7 @@ fn test_render_focused() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme);
+            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -793,7 +793,7 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme);
+            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -807,7 +807,7 @@ fn test_render_with_values() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme);
+            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -819,7 +819,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(5, 4);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme);
+            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -831,7 +831,7 @@ fn test_render_too_small() {
     let (mut terminal, theme) = test_utils::setup_render(2, 2);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme);
+            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -849,7 +849,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Treemap::view(&state, frame, frame.area(), &theme);
+                Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/component/usage_display/mod.rs
+++ b/src/component/usage_display/mod.rs
@@ -33,7 +33,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use super::{Component, Disableable};
+use super::{Component, Disableable, ViewContext};
 use crate::theme::Theme;
 
 /// Layout style for usage metrics display.
@@ -724,7 +724,7 @@ impl Component for UsageDisplay {
         None // Display-only, no output
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
         if state.metrics.is_empty() || area.width == 0 || area.height == 0 {
             return;
         }

--- a/src/component/usage_display/tests.rs
+++ b/src/component/usage_display/tests.rs
@@ -507,7 +507,9 @@ fn test_view_empty() {
     let state = UsageDisplayState::new();
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 3);
     terminal
-        .draw(|frame| UsageDisplay::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -517,7 +519,9 @@ fn test_view_horizontal_single() {
     let state = UsageDisplayState::new().metric(UsageMetric::new("CPU", "45%"));
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
     terminal
-        .draw(|frame| UsageDisplay::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -530,7 +534,9 @@ fn test_view_horizontal_multiple() {
         .metric(UsageMetric::new("Disk", "120 GB"));
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 1);
     terminal
-        .draw(|frame| UsageDisplay::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -542,7 +548,9 @@ fn test_view_horizontal_with_color() {
         .metric(UsageMetric::new("Memory", "3.2 GB").with_color(Color::Yellow));
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 1);
     terminal
-        .draw(|frame| UsageDisplay::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -554,7 +562,9 @@ fn test_view_horizontal_with_icon() {
         .metric(UsageMetric::new("Memory", "3.2 GB").with_icon("#"));
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 1);
     terminal
-        .draw(|frame| UsageDisplay::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -567,7 +577,9 @@ fn test_view_horizontal_custom_separator() {
         .metric(UsageMetric::new("Memory", "3.2 GB"));
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
     terminal
-        .draw(|frame| UsageDisplay::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -581,7 +593,9 @@ fn test_view_vertical() {
         .metric(UsageMetric::new("Disk", "120 GB"));
     let (mut terminal, theme) = crate::component::test_utils::setup_render(30, 5);
     terminal
-        .draw(|frame| UsageDisplay::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -595,7 +609,9 @@ fn test_view_vertical_with_title() {
         .metric(UsageMetric::new("Memory", "3.2 GB"));
     let (mut terminal, theme) = crate::component::test_utils::setup_render(30, 4);
     terminal
-        .draw(|frame| UsageDisplay::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -610,7 +626,9 @@ fn test_view_grid_2_columns() {
         .metric(UsageMetric::new("Network", "1.5 Mbps"));
     let (mut terminal, theme) = crate::component::test_utils::setup_render(50, 4);
     terminal
-        .draw(|frame| UsageDisplay::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -625,7 +643,9 @@ fn test_view_grid_3_columns() {
         .metric(UsageMetric::new("Disk", "120 GB"));
     let (mut terminal, theme) = crate::component::test_utils::setup_render(50, 3);
     terminal
-        .draw(|frame| UsageDisplay::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -639,7 +659,9 @@ fn test_view_grid_odd_count() {
         .metric(UsageMetric::new("Disk", "120 GB"));
     let (mut terminal, theme) = crate::component::test_utils::setup_render(50, 4);
     terminal
-        .draw(|frame| UsageDisplay::view(&state, frame, frame.area(), &theme))
+        .draw(|frame| {
+            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+        })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -651,7 +673,7 @@ fn test_view_zero_width() {
     terminal
         .draw(|frame| {
             let area = Rect::new(0, 0, 0, 3);
-            UsageDisplay::view(&state, frame, area, &theme);
+            UsageDisplay::view(&state, frame, area, &theme, &ViewContext::default());
         })
         .unwrap();
     // Should not panic
@@ -664,7 +686,7 @@ fn test_view_zero_height() {
     terminal
         .draw(|frame| {
             let area = Rect::new(0, 0, 60, 0);
-            UsageDisplay::view(&state, frame, area, &theme);
+            UsageDisplay::view(&state, frame, area, &theme, &ViewContext::default());
         })
         .unwrap();
     // Should not panic
@@ -719,7 +741,7 @@ fn test_annotation_emitted_horizontal() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                UsageDisplay::view(&state, frame, frame.area(), &theme);
+                UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -737,7 +759,7 @@ fn test_annotation_emitted_vertical() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                UsageDisplay::view(&state, frame, frame.area(), &theme);
+                UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });
@@ -756,7 +778,7 @@ fn test_annotation_emitted_grid() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                UsageDisplay::view(&state, frame, frame.area(), &theme);
+                UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ pub use app::{
 };
 pub use backend::{CaptureBackend, EnhancedCell, FrameSnapshot};
 // Core component traits and utilities (always available)
-pub use component::{Component, Disableable, FocusManager, Focusable, Toggleable};
+pub use component::{Component, Disableable, FocusManager, Focusable, Toggleable, ViewContext};
 
 // Input components
 #[cfg(feature = "input-components")]

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -20,7 +20,7 @@
 //! let dracula_theme = Theme::dracula();
 //!
 //! // Components use theme in their view() method:
-//! // Component::view(&state, frame, area, &nord_theme);
+//! // Component::view(&state, frame, area, &nord_theme, &ViewContext::default());
 //! ```
 //!
 //! # Creating Custom Themes
@@ -282,7 +282,7 @@ impl Theme {
     ///
     /// let theme = Theme::nord();
     /// // Use with components:
-    /// // Button::view(&state, frame, area, &theme);
+    /// // Button::view(&state, frame, area, &theme, &ViewContext::default());
     /// ```
     pub fn nord() -> Self {
         Self {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "full")]
 //! Integration tests exercising multi-component workflows through the public API.
+use envision::ViewContext;
 
 use envision::component::{
     SearchableList, SearchableListMessage, SearchableListOutput, SearchableListState,
@@ -452,37 +453,37 @@ fn test_components_handle_zero_size_area() {
     // Button
     assert_view_zero_size("Button", |frame, area, theme| {
         let state = ButtonState::new("Click");
-        Button::view(&state, frame, area, theme);
+        Button::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // Checkbox
     assert_view_zero_size("Checkbox", |frame, area, theme| {
         let state = CheckboxState::new("Check");
-        Checkbox::view(&state, frame, area, theme);
+        Checkbox::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // InputField
     assert_view_zero_size("InputField", |frame, area, theme| {
         let state = InputFieldState::new();
-        InputField::view(&state, frame, area, theme);
+        InputField::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // SelectableList
     assert_view_zero_size("SelectableList", |frame, area, theme| {
         let state = SelectableListState::new(vec!["A".to_string(), "B".to_string()]);
-        SelectableList::<String>::view(&state, frame, area, theme);
+        SelectableList::<String>::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // RadioGroup
     assert_view_zero_size("RadioGroup", |frame, area, theme| {
         let state = RadioGroupState::new(vec!["X".to_string(), "Y".to_string()]);
-        RadioGroup::<String>::view(&state, frame, area, theme);
+        RadioGroup::<String>::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // Tabs
     assert_view_zero_size("Tabs", |frame, area, theme| {
         let state = TabsState::new(vec!["Tab1".to_string(), "Tab2".to_string()]);
-        Tabs::<String>::view(&state, frame, area, theme);
+        Tabs::<String>::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // Table
@@ -492,89 +493,89 @@ fn test_components_handle_zero_size_area() {
         }];
         let columns = vec![Column::new("Name", Constraint::Length(10))];
         let state = TableState::new(rows, columns);
-        Table::<SimpleRow>::view(&state, frame, area, theme);
+        Table::<SimpleRow>::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // Tree
     assert_view_zero_size("Tree", |frame, area, theme| {
         let root = TreeNode::new("root", "root_data".to_string());
         let state = TreeState::new(vec![root]);
-        Tree::<String>::view(&state, frame, area, theme);
+        Tree::<String>::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // Accordion
     assert_view_zero_size("Accordion", |frame, area, theme| {
         let panel = AccordionPanel::new("Panel", "Content");
         let state = AccordionState::new(vec![panel]);
-        Accordion::view(&state, frame, area, theme);
+        Accordion::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // Dialog
     assert_view_zero_size("Dialog", |frame, area, theme| {
         let mut state = DialogState::confirm("Title", "Body");
         Dialog::update(&mut state, DialogMessage::Open);
-        Dialog::view(&state, frame, area, theme);
+        Dialog::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // Menu
     assert_view_zero_size("Menu", |frame, area, theme| {
         let items = vec![MenuItem::new("File"), MenuItem::new("Edit")];
         let state = MenuState::new(items);
-        Menu::view(&state, frame, area, theme);
+        Menu::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // Dropdown
     assert_view_zero_size("Dropdown", |frame, area, theme| {
         let state = DropdownState::new(vec!["Option 1", "Option 2"]);
-        Dropdown::view(&state, frame, area, theme);
+        Dropdown::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // Select
     assert_view_zero_size("Select", |frame, area, theme| {
         let state = SelectState::new(vec!["Opt A", "Opt B"]);
-        Select::view(&state, frame, area, theme);
+        Select::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // TextArea
     assert_view_zero_size("TextArea", |frame, area, theme| {
         let state = TextAreaState::new();
-        TextArea::view(&state, frame, area, theme);
+        TextArea::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // ProgressBar
     assert_view_zero_size("ProgressBar", |frame, area, theme| {
         let state = ProgressBarState::new();
-        ProgressBar::view(&state, frame, area, theme);
+        ProgressBar::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // Spinner
     assert_view_zero_size("Spinner", |frame, area, theme| {
         let state = SpinnerState::new();
-        Spinner::view(&state, frame, area, theme);
+        Spinner::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // Toast
     assert_view_zero_size("Toast", |frame, area, theme| {
         let state = ToastState::new();
-        Toast::view(&state, frame, area, theme);
+        Toast::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // Tooltip
     assert_view_zero_size("Tooltip", |frame, area, theme| {
         let state = TooltipState::new("Tip content");
-        Tooltip::view(&state, frame, area, theme);
+        Tooltip::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // StatusBar
     assert_view_zero_size("StatusBar", |frame, area, theme| {
         let state = StatusBarState::new();
-        StatusBar::view(&state, frame, area, theme);
+        StatusBar::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // StatusLog
     assert_view_zero_size("StatusLog", |frame, area, theme| {
         let state = StatusLogState::new();
-        StatusLog::view(&state, frame, area, theme);
+        StatusLog::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // Breadcrumb
@@ -584,43 +585,43 @@ fn test_components_handle_zero_size_area() {
             BreadcrumbSegment::new("Settings"),
         ];
         let state = BreadcrumbState::new(segments);
-        Breadcrumb::view(&state, frame, area, theme);
+        Breadcrumb::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // KeyHints
     assert_view_zero_size("KeyHints", |frame, area, theme| {
         let state = KeyHintsState::with_hints(vec![KeyHint::new("q", "Quit")]);
-        KeyHints::view(&state, frame, area, theme);
+        KeyHints::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // MultiProgress
     assert_view_zero_size("MultiProgress", |frame, area, theme| {
         let state = MultiProgressState::new();
-        MultiProgress::view(&state, frame, area, theme);
+        MultiProgress::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // LoadingList
     assert_view_zero_size("LoadingList", |frame, area, theme| {
         let state: LoadingListState<String> = LoadingListState::new();
-        LoadingList::<String>::view(&state, frame, area, theme);
+        LoadingList::<String>::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // ScrollableText
     assert_view_zero_size("ScrollableText", |frame, area, theme| {
         let state = ScrollableTextState::new();
-        ScrollableText::view(&state, frame, area, theme);
+        ScrollableText::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // TitleCard
     assert_view_zero_size("TitleCard", |frame, area, theme| {
         let state = TitleCardState::new("Title");
-        TitleCard::view(&state, frame, area, theme);
+        TitleCard::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // LineInput
     assert_view_zero_size("LineInput", |frame, area, theme| {
         let state = LineInputState::new();
-        LineInput::view(&state, frame, area, theme);
+        LineInput::view(&state, frame, area, theme, &ViewContext::default());
     });
 }
 

--- a/tests/integration_new_components.rs
+++ b/tests/integration_new_components.rs
@@ -78,6 +78,7 @@ use envision::component::{
     TimelineState,
 };
 use envision::CaptureBackend;
+use envision::ViewContext;
 use ratatui::prelude::*;
 use ratatui::Terminal;
 
@@ -120,7 +121,7 @@ fn test_sparkline_push_data_and_bounded_eviction() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            Sparkline::view(&state, frame, frame.area(), &theme);
+            Sparkline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -159,7 +160,7 @@ fn test_gauge_threshold_color_transitions() {
         let theme = envision::Theme::default();
         terminal
             .draw(|frame| {
-                Gauge::view(&state, frame, frame.area(), &theme);
+                Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
             })
             .unwrap();
     }
@@ -271,7 +272,7 @@ fn test_heatmap_cell_navigation_and_selection() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme);
+            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -331,7 +332,7 @@ fn test_chart_area_scatter_with_thresholds() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme);
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -399,7 +400,7 @@ fn test_timeline_events_spans_and_zoom() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme);
+            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -463,7 +464,7 @@ fn test_span_tree_expand_collapse_navigate() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            SpanTree::view(&state, frame, frame.area(), &theme);
+            SpanTree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -535,7 +536,7 @@ fn test_flame_graph_navigation_zoom_search() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            FlameGraph::view(&state, frame, frame.area(), &theme);
+            FlameGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -692,7 +693,7 @@ fn test_alert_panel_state_transitions() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme);
+            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -816,7 +817,7 @@ fn test_calendar_navigation_and_selection() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            Calendar::view(&state, frame, frame.area(), &theme);
+            Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -924,7 +925,7 @@ fn test_switch_toggle_workflow() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            Switch::view(&state, frame, frame.area(), &theme);
+            Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }

--- a/tests/integration_new_components_2.rs
+++ b/tests/integration_new_components_2.rs
@@ -79,6 +79,7 @@ use envision::component::{
     ThresholdZone,
 };
 use envision::CaptureBackend;
+use envision::ViewContext;
 use ratatui::prelude::*;
 use ratatui::Terminal;
 
@@ -139,7 +140,7 @@ fn test_paginator_boundary_navigation() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme);
+            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -216,7 +217,7 @@ fn test_help_panel_scroll_and_groups() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            HelpPanel::view(&state, frame, frame.area(), &theme);
+            HelpPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -281,7 +282,7 @@ fn test_code_block_set_code_language_scroll() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme);
+            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -359,7 +360,7 @@ fn test_terminal_output_append_and_auto_scroll() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            TerminalOutput::view(&state, frame, frame.area(), &theme);
+            TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -429,7 +430,7 @@ fn test_conversation_view_messages_and_collapse() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme);
+            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -511,7 +512,7 @@ fn test_tab_bar_add_close_navigate() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            TabBar::view(&state, frame, frame.area(), &theme);
+            TabBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
         })
         .unwrap();
 }
@@ -759,49 +760,49 @@ fn test_new_components_handle_zero_size_area() {
     // Sparkline
     assert_view_zero_size("Sparkline", |frame, area, theme| {
         let state = SparklineState::with_data(vec![1, 2, 3]);
-        Sparkline::view(&state, frame, area, theme);
+        Sparkline::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // Gauge
     assert_view_zero_size("Gauge", |frame, area, theme| {
         let state = GaugeState::new(50.0, 100.0);
-        Gauge::view(&state, frame, area, theme);
+        Gauge::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // Calendar
     assert_view_zero_size("Calendar", |frame, area, theme| {
         let state = CalendarState::new(2026, 3);
-        Calendar::view(&state, frame, area, theme);
+        Calendar::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // Slider
     assert_view_zero_size("Slider", |frame, area, theme| {
         let state = SliderState::new(0.0, 100.0);
-        Slider::view(&state, frame, area, theme);
+        Slider::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // Switch
     assert_view_zero_size("Switch", |frame, area, theme| {
         let state = SwitchState::new();
-        Switch::view(&state, frame, area, theme);
+        Switch::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // Paginator
     assert_view_zero_size("Paginator", |frame, area, theme| {
         let state = PaginatorState::new(5);
-        Paginator::view(&state, frame, area, theme);
+        Paginator::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // CodeBlock
     assert_view_zero_size("CodeBlock", |frame, area, theme| {
         let state = CodeBlockState::new().with_code("fn main() {}");
-        CodeBlock::view(&state, frame, area, theme);
+        CodeBlock::view(&state, frame, area, theme, &ViewContext::default());
     });
 
     // TabBar
     assert_view_zero_size("TabBar", |frame, area, theme| {
         let state = TabBarState::new(vec![Tab::new("a", "Tab A")]);
-        TabBar::view(&state, frame, area, theme);
+        TabBar::view(&state, frame, area, theme, &ViewContext::default());
     });
 }
 
@@ -950,10 +951,28 @@ fn test_dashboard_workflow_with_mixed_new_components() {
                 ])
                 .split(frame.area());
 
-            Gauge::view(&cpu_gauge, frame, chunks[0], &theme);
-            Sparkline::view(&mem_sparkline, frame, chunks[1], &theme);
-            AlertPanel::view(&alerts, frame, chunks[2], &theme);
-            Paginator::view(&paginator, frame, chunks[3], &theme);
+            Gauge::view(
+                &cpu_gauge,
+                frame,
+                chunks[0],
+                &theme,
+                &ViewContext::default(),
+            );
+            Sparkline::view(
+                &mem_sparkline,
+                frame,
+                chunks[1],
+                &theme,
+                &ViewContext::default(),
+            );
+            AlertPanel::view(&alerts, frame, chunks[2], &theme, &ViewContext::default());
+            Paginator::view(
+                &paginator,
+                frame,
+                chunks[3],
+                &theme,
+                &ViewContext::default(),
+            );
         })
         .unwrap();
 }

--- a/tests/integration_stress.rs
+++ b/tests/integration_stress.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "full")]
 //! Stress tests exercising components with large datasets (10,000+ items).
+use envision::ViewContext;
 
 use envision::component::{DataGrid, DataGridMessage, DataGridState};
 use envision::{
@@ -96,7 +97,7 @@ fn test_table_stress_10000_rows() {
 
     // Render to verify no panics with large dataset
     assert_renders_ok("Table-10k", 80, 24, |frame, area, theme| {
-        Table::<StressRow>::view(&state, frame, area, theme);
+        Table::<StressRow>::view(&state, frame, area, theme, &ViewContext::default());
     });
 }
 
@@ -155,7 +156,7 @@ fn test_tree_stress_10000_nodes() {
 
     // Render to verify no panics with large tree
     assert_renders_ok("Tree-11k", 100, 40, |frame, area, theme| {
-        Tree::<String>::view(&state, frame, area, theme);
+        Tree::<String>::view(&state, frame, area, theme, &ViewContext::default());
     });
 }
 
@@ -210,7 +211,7 @@ fn test_loading_list_stress_10000_items() {
 
     // Render to verify no panics
     assert_renders_ok("LoadingList-10k", 80, 30, |frame, area, theme| {
-        LoadingList::<String>::view(&state, frame, area, theme);
+        LoadingList::<String>::view(&state, frame, area, theme, &ViewContext::default());
     });
 }
 
@@ -253,7 +254,7 @@ fn test_selectable_list_stress_50000_items() {
 
     // Render to verify no panics with massive list
     assert_renders_ok("SelectableList-50k", 80, 24, |frame, area, theme| {
-        SelectableList::<String>::view(&state, frame, area, theme);
+        SelectableList::<String>::view(&state, frame, area, theme, &ViewContext::default());
     });
 }
 
@@ -293,7 +294,7 @@ fn test_accordion_stress_1000_panels() {
 
     // Render to verify no panics
     assert_renders_ok("Accordion-1k", 80, 40, |frame, area, theme| {
-        Accordion::view(&state, frame, area, theme);
+        Accordion::view(&state, frame, area, theme, &ViewContext::default());
     });
 }
 
@@ -334,7 +335,7 @@ fn test_data_grid_stress_10000_rows() {
 
     // Render to verify no panics
     assert_renders_ok("DataGrid-10k", 120, 40, |frame, area, theme| {
-        DataGrid::<StressRow>::view(&state, frame, area, theme);
+        DataGrid::<StressRow>::view(&state, frame, area, theme, &ViewContext::default());
     });
 }
 


### PR DESCRIPTION
Breaking: view() takes &ViewContext. Focus is now a render-time concern. 265 files, 1827 tests pass.