### PR TITLE
ViewContext Phase 2: components read ctx for rendering

### DIFF
--- a/src/component/accordion/mod.rs
+++ b/src/component/accordion/mod.rs
@@ -705,7 +705,7 @@ impl Component for Accordion {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if state.panels.is_empty() {
             return;
         }
@@ -714,8 +714,8 @@ impl Component for Accordion {
             reg.register(
                 area,
                 crate::annotation::Annotation::accordion("accordion")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 
@@ -727,11 +727,11 @@ impl Component for Accordion {
             }
 
             // Header line
-            let is_focused_panel = state.focused && i == state.focused_index;
+            let is_focused_panel = ctx.focused && i == state.focused_index;
             let icon = if panel.expanded { "▼" } else { "▶" };
             let header = format!("{} {}", icon, panel.title);
 
-            let header_style = if state.disabled {
+            let header_style = if ctx.disabled {
                 theme.disabled_style()
             } else if is_focused_panel {
                 theme.focused_bold_style()
@@ -752,7 +752,7 @@ impl Component for Accordion {
                 if content_height > 0 {
                     let content_area =
                         Rect::new(area.x + 2, y, area.width.saturating_sub(2), content_height);
-                    let content_style = if state.disabled {
+                    let content_style = if ctx.disabled {
                         theme.disabled_style()
                     } else {
                         theme.placeholder_style()

--- a/src/component/alert_panel/mod.rs
+++ b/src/component/alert_panel/mod.rs
@@ -943,8 +943,8 @@ impl Component for AlertPanel {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
-        render::render_alert_panel(state, frame, area, theme);
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+        render::render_alert_panel(state, frame, area, theme, ctx.focused, ctx.disabled);
     }
 }
 

--- a/src/component/alert_panel/render.rs
+++ b/src/component/alert_panel/render.rs
@@ -21,6 +21,8 @@ pub(super) fn render_alert_panel(
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
+    focused: bool,
+    disabled: bool,
 ) {
     if area.height < 3 || area.width < 3 {
         return;
@@ -30,15 +32,15 @@ pub(super) fn render_alert_panel(
         reg.register(
             area,
             crate::annotation::Annotation::container("alert_panel")
-                .with_focus(state.is_focused())
-                .with_disabled(state.is_disabled()),
+                .with_focus(focused)
+                .with_disabled(disabled),
         );
     });
 
     // Outer border with title showing aggregate counts
-    let outer_border_style = if state.is_disabled() {
+    let outer_border_style = if disabled {
         theme.disabled_style()
-    } else if state.is_focused() {
+    } else if focused {
         theme.focused_border_style()
     } else {
         theme.border_style()
@@ -85,13 +87,23 @@ pub(super) fn render_alert_panel(
             let metric_idx = row_idx * cols + col_idx;
             if let Some(metric) = state.metrics().get(metric_idx) {
                 let is_selected = state.selected() == Some(metric_idx);
-                render_metric_card(metric, is_selected, state, frame, *col_area, theme);
+                render_metric_card(
+                    metric,
+                    is_selected,
+                    state,
+                    frame,
+                    *col_area,
+                    theme,
+                    focused,
+                    disabled,
+                );
             }
         }
     }
 }
 
 /// Renders a single metric card within the grid.
+#[allow(clippy::too_many_arguments)]
 fn render_metric_card(
     metric: &super::AlertMetric,
     is_selected: bool,
@@ -99,10 +111,12 @@ fn render_metric_card(
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
+    focused: bool,
+    disabled: bool,
 ) {
-    let border_style = if state.is_disabled() {
+    let border_style = if disabled {
         theme.disabled_style()
-    } else if is_selected && state.is_focused() {
+    } else if is_selected && focused {
         theme.focused_border_style()
     } else {
         theme.border_style()
@@ -120,7 +134,7 @@ fn render_metric_card(
         return;
     }
 
-    let state_style = if state.is_disabled() {
+    let state_style = if disabled {
         theme.disabled_style()
     } else {
         state_color(metric.state(), theme)
@@ -193,7 +207,7 @@ fn render_metric_card(
     // Sparkline
     if show_sparkline && chunk_idx < chunks.len() {
         let data = history_to_sparkline_data(metric.history());
-        let sparkline_style = if state.is_disabled() {
+        let sparkline_style = if disabled {
             theme.disabled_style()
         } else {
             state_color(metric.state(), theme)

--- a/src/component/alert_panel/snapshot_tests.rs
+++ b/src/component/alert_panel/snapshot_tests.rs
@@ -59,7 +59,13 @@ fn test_snapshot_focused() {
     let (mut terminal, theme) = test_utils::setup_render(80, 25);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            AlertPanel::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -74,7 +80,13 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(80, 25);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            AlertPanel::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/alert_panel/tests.rs
+++ b/src/component/alert_panel/tests.rs
@@ -718,7 +718,13 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            AlertPanel::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 }

--- a/src/component/big_text/mod.rs
+++ b/src/component/big_text/mod.rs
@@ -469,13 +469,13 @@ impl Component for BigText {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,
                 crate::annotation::Annotation::big_text("big_text")
                     .with_label(&state.text)
-                    .with_disabled(state.disabled),
+                    .with_disabled(ctx.disabled),
             );
         });
 
@@ -483,7 +483,7 @@ impl Component for BigText {
             return;
         }
 
-        let style = if state.disabled {
+        let style = if ctx.disabled {
             theme.disabled_style()
         } else if let Some(color) = state.color {
             Style::default().fg(color)

--- a/src/component/big_text/tests.rs
+++ b/src/component/big_text/tests.rs
@@ -446,7 +446,13 @@ fn test_view_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(30, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BigText::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -544,7 +550,13 @@ fn test_annotation_disabled() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                BigText::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::new().disabled(true),
+                );
             })
             .unwrap();
     });

--- a/src/component/box_plot/mod.rs
+++ b/src/component/box_plot/mod.rs
@@ -738,7 +738,7 @@ impl Component for BoxPlot {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if area.height < 3 || area.width < 3 {
             return;
         }
@@ -747,14 +747,14 @@ impl Component for BoxPlot {
             reg.register(
                 area,
                 crate::annotation::Annotation::container("box_plot")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 
-        let border_style = if state.disabled {
+        let border_style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_border_style()
         } else {
             theme.border_style()
@@ -777,10 +777,10 @@ impl Component for BoxPlot {
 
         match state.orientation {
             BoxPlotOrientation::Vertical => {
-                render::render_vertical(state, frame, inner, theme);
+                render::render_vertical(state, frame, inner, theme, ctx.focused, ctx.disabled);
             }
             BoxPlotOrientation::Horizontal => {
-                render::render_horizontal(state, frame, inner, theme);
+                render::render_horizontal(state, frame, inner, theme, ctx.focused, ctx.disabled);
             }
         }
     }

--- a/src/component/box_plot/render.rs
+++ b/src/component/box_plot/render.rs
@@ -27,7 +27,14 @@ fn value_to_position(value: f64, data_min: f64, data_max: f64, length: u16) -> u
 }
 
 /// Renders vertical box plots (values on Y axis, datasets on X axis).
-pub(super) fn render_vertical(state: &BoxPlotState, frame: &mut Frame, area: Rect, theme: &Theme) {
+pub(super) fn render_vertical(
+    state: &BoxPlotState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    focused: bool,
+    disabled: bool,
+) {
     let dataset_count = state.datasets().len() as u16;
     if dataset_count == 0 || area.height < 3 || area.width < 3 {
         return;
@@ -53,7 +60,7 @@ pub(super) fn render_vertical(state: &BoxPlotState, frame: &mut Frame, area: Rec
     let data_min = state.global_min();
     let data_max = state.global_max();
 
-    let style = if state.disabled {
+    let style = if disabled {
         theme.disabled_style()
     } else {
         theme.normal_style()
@@ -64,14 +71,14 @@ pub(super) fn render_vertical(state: &BoxPlotState, frame: &mut Frame, area: Rec
         let col_x = area.x + (i as u16) * col_width;
         let center_x = col_x + col_width / 2;
 
-        let box_color = if state.disabled {
+        let box_color = if disabled {
             Color::DarkGray
         } else {
             dataset.color()
         };
         let box_style = Style::default().fg(box_color);
 
-        let selected_indicator = if i == state.selected() && state.is_focused() {
+        let selected_indicator = if i == state.selected() && focused {
             Style::default().fg(box_color).add_modifier(Modifier::BOLD)
         } else {
             box_style
@@ -210,6 +217,8 @@ pub(super) fn render_horizontal(
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
+    focused: bool,
+    disabled: bool,
 ) {
     let dataset_count = state.datasets().len() as u16;
     if dataset_count == 0 || area.height < 3 || area.width < 3 {
@@ -240,7 +249,7 @@ pub(super) fn render_horizontal(
     let data_min = state.global_min();
     let data_max = state.global_max();
 
-    let style = if state.disabled {
+    let style = if disabled {
         theme.disabled_style()
     } else {
         theme.normal_style()
@@ -250,14 +259,14 @@ pub(super) fn render_horizontal(
         let row_y = area.y + (i as u16) * row_height;
         let center_y = row_y + row_height / 2;
 
-        let box_color = if state.disabled {
+        let box_color = if disabled {
             Color::DarkGray
         } else {
             dataset.color()
         };
         let box_style = Style::default().fg(box_color);
 
-        let selected_indicator = if i == state.selected() && state.is_focused() {
+        let selected_indicator = if i == state.selected() && focused {
             Style::default().fg(box_color).add_modifier(Modifier::BOLD)
         } else {
             box_style

--- a/src/component/box_plot/snapshot_tests.rs
+++ b/src/component/box_plot/snapshot_tests.rs
@@ -90,7 +90,13 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BoxPlot::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -124,7 +130,13 @@ fn test_annotation_with_focus() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                BoxPlot::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::new().focused(true),
+                );
             })
             .unwrap();
     });
@@ -141,7 +153,13 @@ fn test_annotation_with_disabled() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                BoxPlot::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::new().disabled(true),
+                );
             })
             .unwrap();
     });

--- a/src/component/box_plot/tests.rs
+++ b/src/component/box_plot/tests.rs
@@ -816,7 +816,13 @@ fn test_render_focused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BoxPlot::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 }
@@ -828,7 +834,13 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BoxPlot::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 }
@@ -912,7 +924,13 @@ fn test_render_horizontal_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BoxPlot::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 }

--- a/src/component/breadcrumb/mod.rs
+++ b/src/component/breadcrumb/mod.rs
@@ -583,7 +583,7 @@ impl Component for Breadcrumb {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if state.segments.is_empty() {
             return;
         }
@@ -600,9 +600,9 @@ impl Component for Breadcrumb {
         for seg_idx in start..end {
             let segment = &state.segments[seg_idx];
             let is_last = seg_idx == state.segments.len() - 1;
-            let is_focused_segment = state.focused && seg_idx == state.focused_index;
+            let is_focused_segment = ctx.focused && seg_idx == state.focused_index;
 
-            let style = if state.disabled {
+            let style = if ctx.disabled {
                 theme.disabled_style()
             } else if is_focused_segment {
                 theme
@@ -626,8 +626,8 @@ impl Component for Breadcrumb {
         let line = Line::from(spans);
 
         let annotation = crate::annotation::Annotation::breadcrumb("breadcrumb")
-            .with_focus(state.focused)
-            .with_disabled(state.disabled);
+            .with_focus(ctx.focused)
+            .with_disabled(ctx.disabled);
         let annotated = crate::annotation::Annotate::new(Paragraph::new(line), annotation);
         frame.render_widget(annotated, area);
     }

--- a/src/component/breadcrumb/tests.rs
+++ b/src/component/breadcrumb/tests.rs
@@ -495,7 +495,13 @@ fn test_view_focused_highlight() {
 
     terminal
         .draw(|frame| {
-            Breadcrumb::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Breadcrumb::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -544,7 +550,13 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Breadcrumb::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Breadcrumb::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 

--- a/src/component/button/mod.rs
+++ b/src/component/button/mod.rs
@@ -320,16 +320,16 @@ impl Component for Button {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
-        let style = if state.disabled {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+        let style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_style()
         } else {
             theme.normal_style()
         };
 
-        let border_style = if state.focused && !state.disabled {
+        let border_style = if ctx.focused && !ctx.disabled {
             theme.focused_border_style()
         } else {
             theme.border_style()
@@ -347,8 +347,8 @@ impl Component for Button {
         let annotation =
             crate::annotation::Annotation::button("button").with_label(state.label.as_str());
         let annotated = crate::annotation::Annotate::new(paragraph, annotation)
-            .focused(state.focused)
-            .disabled(state.disabled);
+            .focused(ctx.focused)
+            .disabled(ctx.disabled);
         frame.render_widget(annotated, area);
     }
 }

--- a/src/component/button/tests.rs
+++ b/src/component/button/tests.rs
@@ -64,7 +64,13 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            Button::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Button::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -79,7 +85,13 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Button::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Button::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 
@@ -198,7 +210,13 @@ fn test_annotation_focused() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Button::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Button::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::new().focused(true),
+                );
             })
             .unwrap();
     });

--- a/src/component/calendar/mod.rs
+++ b/src/component/calendar/mod.rs
@@ -819,7 +819,7 @@ impl Component for Calendar {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if area.height == 0 || area.width == 0 {
             return;
         }
@@ -831,29 +831,29 @@ impl Component for Calendar {
                     "Calendar".to_string(),
                 ))
                 .with_id("calendar")
-                .with_focus(state.focused)
-                .with_disabled(state.disabled),
+                .with_focus(ctx.focused)
+                .with_disabled(ctx.disabled),
             );
         });
 
         // Determine styles
-        let border_style = if state.disabled {
+        let border_style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_border_style()
         } else {
             theme.border_style()
         };
 
-        let normal_style = if state.disabled {
+        let normal_style = if ctx.disabled {
             theme.disabled_style()
         } else {
             theme.normal_style()
         };
 
-        let header_style = if state.disabled {
+        let header_style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_bold_style()
         } else {
             Style::default()
@@ -861,7 +861,7 @@ impl Component for Calendar {
                 .add_modifier(Modifier::BOLD)
         };
 
-        let day_header_style = if state.disabled {
+        let day_header_style = if ctx.disabled {
             theme.disabled_style()
         } else {
             Style::default()
@@ -901,10 +901,10 @@ impl Component for Calendar {
         let first_dow = day_of_week(state.year, state.month, 1);
         let total_days = days_in_month(state.year, state.month);
 
-        let selected_style = if state.disabled {
+        let selected_style = if ctx.disabled {
             theme.disabled_style()
         } else {
-            theme.selected_highlight_style(state.focused)
+            theme.selected_highlight_style(ctx.focused)
         };
 
         // Build week rows
@@ -952,7 +952,7 @@ impl Component for Calendar {
         }
 
         // Navigation hint footer
-        let footer_style = if state.disabled {
+        let footer_style = if ctx.disabled {
             theme.disabled_style()
         } else {
             theme.placeholder_style()

--- a/src/component/calendar/view_tests.rs
+++ b/src/component/calendar/view_tests.rs
@@ -74,7 +74,13 @@ fn test_view_disabled() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(34, 12);
     terminal
         .draw(|frame| {
-            Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Calendar::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -167,7 +173,13 @@ fn test_annotation_reflects_state() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Calendar::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::new().focused(true).disabled(true),
+                );
             })
             .unwrap();
     });

--- a/src/component/canvas/mod.rs
+++ b/src/component/canvas/mod.rs
@@ -615,7 +615,7 @@ impl Component for Canvas {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if area.height < 2 || area.width < 2 {
             return;
         }
@@ -624,22 +624,22 @@ impl Component for Canvas {
             reg.register(
                 area,
                 crate::annotation::Annotation::canvas("canvas")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 
-        let needs_border = state.title.is_some() || state.focused;
+        let needs_border = state.title.is_some() || ctx.focused;
 
-        let border_style = if state.disabled {
+        let border_style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_border_style()
         } else {
             theme.border_style()
         };
 
-        let content_style = if state.disabled {
+        let content_style = if ctx.disabled {
             theme.disabled_style()
         } else {
             theme.normal_style()
@@ -669,7 +669,7 @@ impl Component for Canvas {
         let x_bounds = state.x_bounds;
         let y_bounds = state.y_bounds;
         let shapes = state.shapes.clone();
-        let is_disabled = state.disabled;
+        let is_disabled = ctx.disabled;
         let disabled_style = theme.disabled_style();
 
         let canvas = RatatuiCanvas::default()

--- a/src/component/canvas/tests.rs
+++ b/src/component/canvas/tests.rs
@@ -604,7 +604,13 @@ fn test_render_focused() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            Canvas::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Canvas::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -625,7 +631,13 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            Canvas::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Canvas::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 

--- a/src/component/chart/enhancement_tests.rs
+++ b/src/component/chart/enhancement_tests.rs
@@ -384,7 +384,13 @@ fn test_area_chart_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 }
@@ -396,7 +402,13 @@ fn test_scatter_chart_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 }

--- a/src/component/chart/mod.rs
+++ b/src/component/chart/mod.rs
@@ -827,7 +827,7 @@ impl Component for Chart {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if area.height < 3 || area.width < 3 {
             return;
         }
@@ -836,14 +836,14 @@ impl Component for Chart {
             reg.register(
                 area,
                 crate::annotation::Annotation::container("chart")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 
-        let border_style = if state.disabled {
+        let border_style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_border_style()
         } else {
             theme.border_style()
@@ -904,16 +904,40 @@ impl Component for Chart {
         };
 
         match state.kind {
-            ChartKind::Line => render::render_line_chart(state, frame, chart_area, theme),
-            ChartKind::BarVertical => {
-                render::render_bar_chart(state, frame, chart_area, theme, false)
-            }
-            ChartKind::BarHorizontal => {
-                render::render_bar_chart(state, frame, chart_area, theme, true)
-            }
-            ChartKind::Area | ChartKind::Scatter => {
-                render::render_shared_axis_chart(state, frame, chart_area, theme)
-            }
+            ChartKind::Line => render::render_line_chart(
+                state,
+                frame,
+                chart_area,
+                theme,
+                ctx.focused,
+                ctx.disabled,
+            ),
+            ChartKind::BarVertical => render::render_bar_chart(
+                state,
+                frame,
+                chart_area,
+                theme,
+                false,
+                ctx.focused,
+                ctx.disabled,
+            ),
+            ChartKind::BarHorizontal => render::render_bar_chart(
+                state,
+                frame,
+                chart_area,
+                theme,
+                true,
+                ctx.focused,
+                ctx.disabled,
+            ),
+            ChartKind::Area | ChartKind::Scatter => render::render_shared_axis_chart(
+                state,
+                frame,
+                chart_area,
+                theme,
+                ctx.focused,
+                ctx.disabled,
+            ),
         }
     }
 }

--- a/src/component/chart/render.rs
+++ b/src/component/chart/render.rs
@@ -39,7 +39,14 @@ pub(super) fn render_legend(state: &ChartState, frame: &mut Frame, area: Rect) {
 }
 
 /// Renders a line chart using sparkline.
-pub(super) fn render_line_chart(state: &ChartState, frame: &mut Frame, area: Rect, theme: &Theme) {
+pub(super) fn render_line_chart(
+    state: &ChartState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    _focused: bool,
+    disabled: bool,
+) {
     if state.series.is_empty() {
         return;
     }
@@ -85,7 +92,7 @@ pub(super) fn render_line_chart(state: &ChartState, frame: &mut Frame, area: Rec
         // Single series: full area sparkline
         let series = &state.series[state.active_series];
         let data = series_to_sparkline_data(series, state.max_display_points);
-        let style = if state.disabled {
+        let style = if disabled {
             theme.disabled_style()
         } else {
             Style::default().fg(series.color())
@@ -107,7 +114,7 @@ pub(super) fn render_line_chart(state: &ChartState, frame: &mut Frame, area: Rec
         for (i, series) in state.series.iter().enumerate() {
             if let Some(sparkline_area) = areas.get(i) {
                 let data = series_to_sparkline_data(series, state.max_display_points);
-                let style = if state.disabled {
+                let style = if disabled {
                     theme.disabled_style()
                 } else if i == state.active_series {
                     Style::default()
@@ -156,6 +163,8 @@ pub(super) fn render_bar_chart(
     area: Rect,
     theme: &Theme,
     horizontal: bool,
+    _focused: bool,
+    disabled: bool,
 ) {
     if state.series.is_empty() {
         return;
@@ -167,7 +176,7 @@ pub(super) fn render_bar_chart(
         return;
     }
 
-    let style = if state.disabled {
+    let style = if disabled {
         theme.disabled_style()
     } else {
         Style::default().fg(series.color())
@@ -211,6 +220,8 @@ pub(super) fn render_shared_axis_chart(
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
+    _focused: bool,
+    disabled: bool,
 ) {
     if state.series.is_empty() && state.thresholds.is_empty() {
         return;
@@ -273,7 +284,7 @@ pub(super) fn render_shared_axis_chart(
         .iter()
         .enumerate()
         .map(|(i, s)| {
-            let style = if state.disabled {
+            let style = if disabled {
                 theme.disabled_style()
             } else if i == state.active_series {
                 Style::default().fg(s.color()).add_modifier(Modifier::BOLD)

--- a/src/component/chart/snapshot_tests.rs
+++ b/src/component/chart/snapshot_tests.rs
@@ -46,7 +46,13 @@ fn test_snapshot_focused_line_chart() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/chart/tests.rs
+++ b/src/component/chart/tests.rs
@@ -501,7 +501,13 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 }

--- a/src/component/chat_view/component_impl.rs
+++ b/src/component/chat_view/component_impl.rs
@@ -206,7 +206,7 @@ impl Component for ChatView {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if area.height < 4 {
             return;
         }
@@ -215,8 +215,8 @@ impl Component for ChatView {
             reg.open(
                 area,
                 crate::annotation::Annotation::container("chat_view")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 
@@ -230,8 +230,15 @@ impl Component for ChatView {
         let history_area = chunks[0];
         let input_area = chunks[1];
 
-        render_helpers::render_history(state, frame, history_area, theme);
-        render_helpers::render_input(state, frame, input_area, theme);
+        render_helpers::render_history(
+            state,
+            frame,
+            history_area,
+            theme,
+            ctx.focused,
+            ctx.disabled,
+        );
+        render_helpers::render_input(state, frame, input_area, theme, ctx.focused, ctx.disabled);
 
         crate::annotation::with_registry(|reg| {
             reg.close();

--- a/src/component/chat_view/render_helpers.rs
+++ b/src/component/chat_view/render_helpers.rs
@@ -11,10 +11,17 @@ use crate::layout::Position;
 use crate::theme::Theme;
 
 /// Renders the message history area.
-pub(super) fn render_history(state: &ChatViewState, frame: &mut Frame, area: Rect, theme: &Theme) {
-    let border_style = if state.disabled {
+pub(super) fn render_history(
+    state: &ChatViewState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    focused: bool,
+    disabled: bool,
+) {
+    let border_style = if disabled {
         theme.disabled_style()
-    } else if state.focused && state.focus == Focus::History {
+    } else if focused && state.focus == Focus::History {
         theme.focused_border_style()
     } else {
         theme.border_style()
@@ -185,18 +192,25 @@ fn format_message_markdown(
 }
 
 /// Renders the input area.
-pub(super) fn render_input(state: &ChatViewState, frame: &mut Frame, area: Rect, theme: &Theme) {
-    let border_style = if state.disabled {
+pub(super) fn render_input(
+    state: &ChatViewState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    focused: bool,
+    disabled: bool,
+) {
+    let border_style = if disabled {
         theme.disabled_style()
-    } else if state.focused && state.focus == Focus::Input {
+    } else if focused && state.focus == Focus::Input {
         theme.focused_border_style()
     } else {
         theme.border_style()
     };
 
-    let text_style = if state.disabled {
+    let text_style = if disabled {
         theme.disabled_style()
-    } else if state.focused && state.focus == Focus::Input {
+    } else if focused && state.focus == Focus::Input {
         theme.focused_style()
     } else {
         theme.normal_style()
@@ -227,7 +241,7 @@ pub(super) fn render_input(state: &ChatViewState, frame: &mut Frame, area: Rect,
     frame.render_widget(paragraph, area);
 
     // Show cursor when input is focused
-    if state.focused && state.focus == Focus::Input && !state.disabled {
+    if focused && state.focus == Focus::Input && !disabled {
         let (cursor_row, cursor_col) = state.input.cursor_display_position();
         let cursor_x = area.x + 1 + cursor_col as u16;
         let cursor_y = area.y + 1 + cursor_row as u16;

--- a/src/component/chat_view/snapshot_tests.rs
+++ b/src/component/chat_view/snapshot_tests.rs
@@ -92,7 +92,13 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ChatView::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -107,7 +113,13 @@ fn test_snapshot_with_timestamps() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ChatView::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/chat_view/tests.rs
+++ b/src/component/chat_view/tests.rs
@@ -673,7 +673,13 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ChatView::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 }
@@ -923,7 +929,13 @@ fn test_render_with_custom_role_styles() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ChatView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ChatView::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     // Just verify it renders without panicking

--- a/src/component/checkbox/mod.rs
+++ b/src/component/checkbox/mod.rs
@@ -335,13 +335,13 @@ impl Component for Checkbox {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         let check_mark = if state.checked { "x" } else { " " };
         let text = format!("[{}] {}", check_mark, state.label);
 
-        let style = if state.disabled {
+        let style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_style()
         } else {
             theme.normal_style()
@@ -353,8 +353,8 @@ impl Component for Checkbox {
             .with_label(state.label.as_str())
             .with_selected(state.checked);
         let annotated = crate::annotation::Annotate::new(paragraph, annotation)
-            .focused(state.focused)
-            .disabled(state.disabled);
+            .focused(ctx.focused)
+            .disabled(ctx.disabled);
         frame.render_widget(annotated, area);
     }
 }

--- a/src/component/checkbox/tests.rs
+++ b/src/component/checkbox/tests.rs
@@ -112,7 +112,13 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            Checkbox::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Checkbox::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -127,7 +133,13 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Checkbox::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Checkbox::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 

--- a/src/component/code_block/mod.rs
+++ b/src/component/code_block/mod.rs
@@ -498,8 +498,8 @@ impl Component for CodeBlock {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
-        render::render(state, frame, area, theme);
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+        render::render(state, frame, area, theme, ctx.focused, ctx.disabled);
     }
 }
 

--- a/src/component/code_block/render.rs
+++ b/src/component/code_block/render.rs
@@ -18,19 +18,26 @@ use crate::theme::Theme;
 const GUTTER_WIDTH: u16 = 7;
 
 /// Renders the CodeBlock in the given area.
-pub(super) fn render(state: &CodeBlockState, frame: &mut Frame, area: Rect, theme: &Theme) {
+pub(super) fn render(
+    state: &CodeBlockState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    focused: bool,
+    disabled: bool,
+) {
     crate::annotation::with_registry(|reg| {
         reg.register(
             area,
             crate::annotation::Annotation::custom("CodeBlock", "code_block")
-                .with_focus(state.focused)
-                .with_disabled(state.disabled),
+                .with_focus(focused)
+                .with_disabled(disabled),
         );
     });
 
-    let border_style = if state.disabled {
+    let border_style = if disabled {
         theme.disabled_style()
-    } else if state.focused {
+    } else if focused {
         theme.focused_border_style()
     } else {
         theme.border_style()
@@ -83,7 +90,15 @@ pub(super) fn render(state: &CodeBlockState, frame: &mut Frame, area: Rect, them
         // Render line number gutter
         if state.show_line_numbers {
             let gutter_area = Rect::new(inner.x, y, gutter_width, 1);
-            render_gutter(line_num, is_highlighted, state, frame, gutter_area, theme);
+            render_gutter(
+                line_num,
+                is_highlighted,
+                state,
+                frame,
+                gutter_area,
+                theme,
+                disabled,
+            );
         }
 
         // Render code content
@@ -96,6 +111,7 @@ pub(super) fn render(state: &CodeBlockState, frame: &mut Frame, area: Rect, them
             frame,
             code_line_area,
             theme,
+            disabled,
         );
     }
 
@@ -123,12 +139,14 @@ fn build_title(state: &CodeBlockState) -> String {
 fn render_gutter(
     line_num: usize,
     is_highlighted: bool,
-    state: &CodeBlockState,
+    _state: &CodeBlockState,
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
+
+    disabled: bool,
 ) {
-    let gutter_style = if state.disabled {
+    let gutter_style = if disabled {
         theme.disabled_style()
     } else if is_highlighted {
         Style::default()
@@ -151,8 +169,10 @@ fn render_code_line(
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
+
+    disabled: bool,
 ) {
-    if state.disabled {
+    if disabled {
         let paragraph = Paragraph::new(line_text).style(theme.disabled_style());
         frame.render_widget(paragraph, area);
         return;

--- a/src/component/code_block/tests.rs
+++ b/src/component/code_block/tests.rs
@@ -601,7 +601,13 @@ fn test_view_focused() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CodeBlock::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -616,7 +622,13 @@ fn test_view_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CodeBlock::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -702,7 +714,13 @@ fn test_annotation_focused() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                CodeBlock::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::new().focused(true),
+                );
             })
             .unwrap();
     });

--- a/src/component/collapsible/mod.rs
+++ b/src/component/collapsible/mod.rs
@@ -554,7 +554,7 @@ impl Component for Collapsible {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if area.height == 0 || area.width == 0 {
             return;
         }
@@ -566,8 +566,8 @@ impl Component for Collapsible {
                     "Collapsible".to_string(),
                 ))
                 .with_id("collapsible")
-                .with_focus(state.focused)
-                .with_disabled(state.disabled)
+                .with_focus(ctx.focused)
+                .with_disabled(ctx.disabled)
                 .with_expanded(state.expanded),
             );
         });
@@ -579,9 +579,9 @@ impl Component for Collapsible {
         };
         let header_text = format!("{} {}", indicator, state.header);
 
-        let header_style = if state.disabled {
+        let header_style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_style()
         } else {
             theme.normal_style()
@@ -598,9 +598,9 @@ impl Component for Collapsible {
 
             if content_h > 0 {
                 let content_area = Rect::new(area.x, area.y + 1, area.width, content_h);
-                let border_style = if state.disabled {
+                let border_style = if ctx.disabled {
                     theme.disabled_style()
-                } else if state.focused {
+                } else if ctx.focused {
                     theme.focused_border_style()
                 } else {
                     theme.border_style()

--- a/src/component/collapsible/tests.rs
+++ b/src/component/collapsible/tests.rs
@@ -655,7 +655,13 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Collapsible::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Collapsible::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 
@@ -742,7 +748,13 @@ fn test_annotation_reflects_state() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Collapsible::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Collapsible::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::new().focused(true).disabled(true),
+                );
             })
             .unwrap();
     });

--- a/src/component/command_palette/mod.rs
+++ b/src/component/command_palette/mod.rs
@@ -867,8 +867,8 @@ impl Component for CommandPalette {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
-        render::render_command_palette(state, frame, area, theme);
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+        render::render_command_palette(state, frame, area, theme, ctx.focused, ctx.disabled);
     }
 }
 

--- a/src/component/command_palette/render.rs
+++ b/src/component/command_palette/render.rs
@@ -13,6 +13,8 @@ pub(super) fn render_command_palette(
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
+    focused: bool,
+    disabled: bool,
 ) {
     if !state.visible {
         return;
@@ -22,8 +24,8 @@ pub(super) fn render_command_palette(
         reg.register(
             area,
             crate::annotation::Annotation::command_palette("command_palette")
-                .with_focus(state.focused)
-                .with_disabled(state.disabled)
+                .with_focus(focused)
+                .with_disabled(disabled)
                 .with_expanded(state.visible),
         );
     });
@@ -51,7 +53,7 @@ pub(super) fn render_command_palette(
     // Clear the area behind the palette
     frame.render_widget(Clear, palette_area);
 
-    let border_style = if state.focused && !state.disabled {
+    let border_style = if focused && !disabled {
         theme.focused_border_style()
     } else {
         theme.border_style()
@@ -101,7 +103,7 @@ pub(super) fn render_command_palette(
     frame.render_widget(input_widget, input_area);
 
     // Cursor position
-    if state.focused && !state.disabled {
+    if focused && !disabled {
         let cursor_x = input_area.x + 2 + state.query.len() as u16;
         let cursor_y = input_area.y;
         if cursor_x < input_area.x + input_area.width {
@@ -197,7 +199,7 @@ pub(super) fn render_command_palette(
             };
 
             let style = if is_selected {
-                theme.selected_style(state.focused)
+                theme.selected_style(focused)
             } else {
                 theme.normal_style()
             };

--- a/src/component/command_palette/snapshot_tests.rs
+++ b/src/component/command_palette/snapshot_tests.rs
@@ -95,7 +95,13 @@ fn test_snapshot_custom_title_and_placeholder() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CommandPalette::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -109,7 +115,13 @@ fn test_snapshot_empty_items() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CommandPalette::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -131,7 +143,13 @@ fn test_snapshot_with_descriptions() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CommandPalette::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/command_palette/tests.rs
+++ b/src/component/command_palette/tests.rs
@@ -761,7 +761,13 @@ fn test_render_empty_items() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CommandPalette::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 }

--- a/src/component/confirm_dialog/mod.rs
+++ b/src/component/confirm_dialog/mod.rs
@@ -672,7 +672,7 @@ impl Component for ConfirmDialog {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if !state.visible {
             return;
         }
@@ -683,8 +683,8 @@ impl Component for ConfirmDialog {
                 crate::annotation::Annotation::new(crate::annotation::WidgetType::ConfirmDialog)
                     .with_id("confirm_dialog")
                     .with_label(state.title.as_str())
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 

--- a/src/component/confirm_dialog/tests.rs
+++ b/src/component/confirm_dialog/tests.rs
@@ -418,7 +418,13 @@ fn test_view_ok_dialog() {
 
     terminal
         .draw(|frame| {
-            ConfirmDialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConfirmDialog::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -434,7 +440,13 @@ fn test_view_yes_no_dialog() {
 
     terminal
         .draw(|frame| {
-            ConfirmDialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConfirmDialog::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -454,7 +466,13 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                ConfirmDialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                ConfirmDialog::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::new().focused(true),
+                );
             })
             .unwrap();
     });

--- a/src/component/conversation_view/mod.rs
+++ b/src/component/conversation_view/mod.rs
@@ -878,7 +878,7 @@ impl Component for ConversationView {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if area.height < 3 || area.width < 5 {
             return;
         }
@@ -887,12 +887,12 @@ impl Component for ConversationView {
             reg.open(
                 area,
                 crate::annotation::Annotation::container("conversation_view")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 
-        render::render(state, frame, area, theme);
+        render::render(state, frame, area, theme, ctx.focused, ctx.disabled);
 
         crate::annotation::with_registry(|reg| {
             reg.close();

--- a/src/component/conversation_view/render.rs
+++ b/src/component/conversation_view/render.rs
@@ -9,13 +9,23 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, List, ListItem};
 use ratatui::Frame;
 
+use unicode_width::UnicodeWidthChar;
+use unicode_width::UnicodeWidthStr;
+
 use crate::theme::Theme;
 
 /// Renders the full conversation view into the given area.
-pub(super) fn render(state: &ConversationViewState, frame: &mut Frame, area: Rect, theme: &Theme) {
-    let border_style = if state.disabled {
+pub(super) fn render(
+    state: &ConversationViewState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    focused: bool,
+    disabled: bool,
+) {
+    let border_style = if disabled {
         theme.disabled_style()
-    } else if state.focused {
+    } else if focused {
         theme.focused_border_style()
     } else {
         theme.border_style()
@@ -193,30 +203,48 @@ fn format_block<'a>(
 
 /// Word-wraps text at the given width, preserving existing newlines.
 /// Returns wrapped lines with the given prefix prepended.
+///
+/// Uses `unicode_width` for accurate width calculations so that CJK
+/// characters and other wide glyphs are measured correctly.
 fn wrap_lines(text: &str, prefix: &str, width: usize) -> Vec<String> {
-    let effective_width = width.saturating_sub(prefix.len());
+    let prefix_width = UnicodeWidthStr::width(prefix);
+    let effective_width = width.saturating_sub(prefix_width);
     if effective_width == 0 {
         return text.lines().map(|l| format!("{}{}", prefix, l)).collect();
     }
 
     let mut result = Vec::new();
     for line in text.lines() {
-        if line.len() <= effective_width {
+        let line_width = UnicodeWidthStr::width(line);
+        if line_width <= effective_width {
             result.push(format!("{}{}", prefix, line));
         } else {
-            // Word-wrap at effective_width
+            // Word-wrap using unicode display widths
             let mut remaining = line;
             while !remaining.is_empty() {
-                if remaining.len() <= effective_width {
+                let rem_width = UnicodeWidthStr::width(remaining);
+                if rem_width <= effective_width {
                     result.push(format!("{}{}", prefix, remaining));
                     break;
                 }
-                // Find last space within width, or force-break
-                let break_at = remaining[..effective_width]
-                    .rfind(' ')
-                    .map(|i| i + 1)
-                    .unwrap_or(effective_width);
-                result.push(format!("{}{}", prefix, &remaining[..break_at].trim_end()));
+                // Walk characters to find the byte offset that fills effective_width
+                let mut col = 0;
+                let mut last_space_byte = None;
+                let mut byte_at_width = remaining.len();
+                for (byte_idx, ch) in remaining.char_indices() {
+                    let ch_w = UnicodeWidthChar::width(ch).unwrap_or(0);
+                    if col + ch_w > effective_width {
+                        byte_at_width = byte_idx;
+                        break;
+                    }
+                    if ch == ' ' {
+                        last_space_byte = Some(byte_idx + 1); // break after the space
+                    }
+                    col += ch_w;
+                }
+                let break_at = last_space_byte.unwrap_or(byte_at_width);
+                let segment = &remaining[..break_at];
+                result.push(format!("{}{}", prefix, segment.trim_end()));
                 remaining = &remaining[break_at..];
                 if remaining.starts_with(' ') {
                     remaining = &remaining[1..];
@@ -248,13 +276,28 @@ fn format_text_block<'a>(
     #[cfg(feature = "markdown")]
     if markdown_enabled {
         let theme = crate::theme::Theme::default();
+        let indent_display_width = UnicodeWidthStr::width(indent);
+        let available_width = width.saturating_sub(indent_display_width);
         let md_lines = crate::component::markdown_renderer::render::render_markdown(
             text,
-            width as u16,
+            available_width as u16,
             &theme,
         );
         for md_line in md_lines {
-            if indent.is_empty() {
+            // Check if the rendered line overflows the available width.
+            // If it does, fall back to plain-text wrapping for that line.
+            let line_width: usize = md_line
+                .spans
+                .iter()
+                .map(|s| UnicodeWidthStr::width(s.content.as_ref()))
+                .sum();
+            if line_width > available_width {
+                // Fall back to plain-text wrapping (loses markdown styling on overflow)
+                let plain: String = md_line.spans.iter().map(|s| s.content.as_ref()).collect();
+                for wrapped in wrap_lines(&plain, indent, width) {
+                    lines.push(Line::from(Span::styled(wrapped, style)));
+                }
+            } else if indent.is_empty() {
                 lines.push(md_line);
             } else {
                 // Prepend indent to first span

--- a/src/component/conversation_view/render_tests.rs
+++ b/src/component/conversation_view/render_tests.rs
@@ -59,7 +59,13 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 }

--- a/src/component/conversation_view/snapshot_tests.rs
+++ b/src/component/conversation_view/snapshot_tests.rs
@@ -67,7 +67,13 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/data_grid/mod.rs
+++ b/src/component/data_grid/mod.rs
@@ -754,7 +754,7 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if state.columns.is_empty() {
             return;
         }
@@ -763,8 +763,8 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
             reg.register(
                 area,
                 crate::annotation::Annotation::table("data_grid")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 
@@ -786,7 +786,7 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
             .iter()
             .enumerate()
             .map(|(i, col)| {
-                if !state.editing && state.focused && i == state.selected_column {
+                if !state.editing && ctx.focused && i == state.selected_column {
                     format!("[{}]", col.header())
                 } else {
                     col.header().to_string()
@@ -794,7 +794,7 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
             })
             .collect();
 
-        let header_style = if state.disabled {
+        let header_style = if ctx.disabled {
             theme.disabled_style()
         } else {
             Style::default().add_modifier(Modifier::BOLD)
@@ -828,18 +828,18 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
             })
             .collect();
 
-        let border_style = if state.disabled {
+        let border_style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_border_style()
         } else {
             theme.border_style()
         };
 
-        let highlight_style = if state.disabled {
+        let highlight_style = if ctx.disabled {
             theme.disabled_style()
         } else {
-            theme.selected_highlight_style(state.focused)
+            theme.selected_highlight_style(ctx.focused)
         };
 
         let table = RatatuiTable::new(rows, widths)
@@ -868,7 +868,7 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
         }
 
         // Show cursor when editing
-        if state.editing && state.focused {
+        if state.editing && ctx.focused {
             if let Some(row_idx) = state.selected_row {
                 // Calculate cursor position for the edit cell
                 // This is approximate — exact positioning depends on column widths

--- a/src/component/data_grid/snapshot_tests.rs
+++ b/src/component/data_grid/snapshot_tests.rs
@@ -72,7 +72,13 @@ fn test_snapshot_focused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DataGrid::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -86,7 +92,13 @@ fn test_snapshot_focused_second_column() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DataGrid::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -100,7 +112,13 @@ fn test_snapshot_editing() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DataGrid::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/data_grid/tests.rs
+++ b/src/component/data_grid/tests.rs
@@ -568,7 +568,13 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DataGrid::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 }

--- a/src/component/dependency_graph/mod.rs
+++ b/src/component/dependency_graph/mod.rs
@@ -942,8 +942,8 @@ impl Component for DependencyGraph {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
-        render::render_dependency_graph(state, frame, area, theme);
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+        render::render_dependency_graph(state, frame, area, theme, ctx.focused, ctx.disabled);
     }
 }
 

--- a/src/component/dependency_graph/render.rs
+++ b/src/component/dependency_graph/render.rs
@@ -43,10 +43,12 @@ pub(super) fn render_dependency_graph(
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
+    focused: bool,
+    disabled: bool,
 ) {
-    let border_style = if state.disabled {
+    let border_style = if disabled {
         theme.disabled_style()
-    } else if state.focused {
+    } else if focused {
         theme.focused_border_style()
     } else {
         theme.normal_style()
@@ -71,13 +73,13 @@ pub(super) fn render_dependency_graph(
                 "DependencyGraph".to_string(),
             ))
             .with_id("dependency_graph")
-            .with_focus(state.focused)
-            .with_disabled(state.disabled),
+            .with_focus(focused)
+            .with_disabled(disabled),
         );
     });
 
     if state.nodes.is_empty() {
-        render_empty_state(state, frame, inner, theme);
+        render_empty_state(state, frame, inner, theme, disabled);
         return;
     }
 
@@ -92,7 +94,7 @@ pub(super) fn render_dependency_graph(
             .get(edge_idx)
             .and_then(|e| e.color)
             .unwrap_or_else(|| {
-                if state.disabled {
+                if disabled {
                     Color::DarkGray
                 } else {
                     theme.normal_style().fg.unwrap_or(Color::White)
@@ -109,7 +111,7 @@ pub(super) fn render_dependency_graph(
             edge_color,
             edge_label,
             inner,
-            state.disabled,
+            disabled,
             theme,
         );
     }
@@ -124,14 +126,30 @@ pub(super) fn render_dependency_graph(
             .unwrap_or(false);
 
         if let Some(node) = graph_node {
-            render_node(frame, node, layout_node, is_selected, state, inner, theme);
+            render_node(
+                frame,
+                node,
+                layout_node,
+                is_selected,
+                state,
+                inner,
+                theme,
+                focused,
+                disabled,
+            );
         }
     }
 }
 
 /// Renders an empty state message centered in the area.
-fn render_empty_state(state: &DependencyGraphState, frame: &mut Frame, area: Rect, theme: &Theme) {
-    let style = if state.disabled {
+fn render_empty_state(
+    _state: &DependencyGraphState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    disabled: bool,
+) {
+    let style = if disabled {
         theme.disabled_style()
     } else {
         theme.normal_style()
@@ -144,14 +162,18 @@ fn render_empty_state(state: &DependencyGraphState, frame: &mut Frame, area: Rec
 }
 
 /// Renders a single graph node as a bordered box with label and status.
+#[allow(clippy::too_many_arguments)]
 fn render_node(
     frame: &mut Frame,
     node: &super::GraphNode,
     layout_node: &LayoutNode,
     is_selected: bool,
-    state: &DependencyGraphState,
+    _state: &DependencyGraphState,
     clip: Rect,
     theme: &Theme,
+
+    focused: bool,
+    disabled: bool,
 ) {
     // Clip node to inner area
     let node_area = clip_rect(
@@ -169,9 +191,9 @@ fn render_node(
 
     let node_color = node.color.unwrap_or_else(|| status_color(&node.status));
 
-    let border_style = if state.disabled {
+    let border_style = if disabled {
         theme.disabled_style()
-    } else if is_selected && state.focused {
+    } else if is_selected && focused {
         Style::default().fg(node_color).add_modifier(Modifier::BOLD)
     } else if is_selected {
         Style::default().fg(node_color)
@@ -207,7 +229,7 @@ fn render_node(
     let label = status_label(&node.status);
     let content = format!("{} {}", indicator, label);
 
-    let content_style = if state.disabled {
+    let content_style = if disabled {
         theme.disabled_style()
     } else {
         Style::default().fg(node_color)

--- a/src/component/dependency_graph/snapshot_tests.rs
+++ b/src/component/dependency_graph/snapshot_tests.rs
@@ -57,7 +57,13 @@ fn test_snapshot_with_selection() {
     let (mut terminal, theme) = test_utils::setup_render(80, 12);
     terminal
         .draw(|frame| {
-            DependencyGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DependencyGraph::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -94,7 +100,13 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(80, 12);
     terminal
         .draw(|frame| {
-            DependencyGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DependencyGraph::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/dialog/mod.rs
+++ b/src/component/dialog/mod.rs
@@ -642,7 +642,7 @@ impl Component for Dialog {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if !state.visible {
             return;
         }
@@ -652,8 +652,8 @@ impl Component for Dialog {
                 area,
                 crate::annotation::Annotation::dialog(state.title.as_str())
                     .with_id("dialog")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 

--- a/src/component/diff_viewer/mod.rs
+++ b/src/component/diff_viewer/mod.rs
@@ -956,8 +956,8 @@ impl Component for DiffViewer {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
-        render::render(state, frame, area, theme);
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+        render::render(state, frame, area, theme, ctx.focused, ctx.disabled);
     }
 }
 

--- a/src/component/diff_viewer/render.rs
+++ b/src/component/diff_viewer/render.rs
@@ -10,19 +10,26 @@ use crate::scroll::ScrollState;
 use crate::theme::Theme;
 
 /// Renders the DiffViewer in the given area.
-pub(super) fn render(state: &DiffViewerState, frame: &mut Frame, area: Rect, theme: &Theme) {
+pub(super) fn render(
+    state: &DiffViewerState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    focused: bool,
+    disabled: bool,
+) {
     crate::annotation::with_registry(|reg| {
         reg.register(
             area,
             crate::annotation::Annotation::diff_viewer("diff_viewer")
-                .with_focus(state.focused)
-                .with_disabled(state.disabled),
+                .with_focus(focused)
+                .with_disabled(disabled),
         );
     });
 
-    let border_style = if state.disabled {
+    let border_style = if disabled {
         theme.disabled_style()
-    } else if state.focused {
+    } else if focused {
         theme.focused_border_style()
     } else {
         theme.border_style()
@@ -42,8 +49,8 @@ pub(super) fn render(state: &DiffViewerState, frame: &mut Frame, area: Rect, the
     }
 
     match state.mode {
-        DiffMode::Unified => render_unified(state, frame, inner, theme),
-        DiffMode::SideBySide => render_side_by_side(state, frame, inner, theme),
+        DiffMode::Unified => render_unified(state, frame, inner, theme, disabled),
+        DiffMode::SideBySide => render_side_by_side(state, frame, inner, theme, disabled),
     }
 }
 
@@ -71,8 +78,8 @@ fn header_style(theme: &Theme) -> Style {
 }
 
 /// Returns the style for an added line.
-fn added_style(state: &DiffViewerState, theme: &Theme) -> Style {
-    if state.disabled {
+fn added_style(_state: &DiffViewerState, theme: &Theme, disabled: bool) -> Style {
+    if disabled {
         theme.disabled_style()
     } else {
         Style::default().fg(Color::Green).bg(Color::Rgb(0, 40, 0))
@@ -80,8 +87,8 @@ fn added_style(state: &DiffViewerState, theme: &Theme) -> Style {
 }
 
 /// Returns the style for a removed line.
-fn removed_style(state: &DiffViewerState, theme: &Theme) -> Style {
-    if state.disabled {
+fn removed_style(_state: &DiffViewerState, theme: &Theme, disabled: bool) -> Style {
+    if disabled {
         theme.disabled_style()
     } else {
         Style::default().fg(Color::Red).bg(Color::Rgb(40, 0, 0))
@@ -89,8 +96,8 @@ fn removed_style(state: &DiffViewerState, theme: &Theme) -> Style {
 }
 
 /// Returns the style for a context line.
-fn context_style(state: &DiffViewerState, theme: &Theme) -> Style {
-    if state.disabled {
+fn context_style(_state: &DiffViewerState, theme: &Theme, disabled: bool) -> Style {
+    if disabled {
         theme.disabled_style()
     } else {
         theme.normal_style()
@@ -98,7 +105,13 @@ fn context_style(state: &DiffViewerState, theme: &Theme) -> Style {
 }
 
 /// Renders the diff in unified mode.
-fn render_unified(state: &DiffViewerState, frame: &mut Frame, area: Rect, theme: &Theme) {
+fn render_unified(
+    state: &DiffViewerState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    disabled: bool,
+) {
     let all_lines = state.collect_display_lines();
     let total = all_lines.len();
     let visible = area.height as usize;
@@ -120,17 +133,17 @@ fn render_unified(state: &DiffViewerState, frame: &mut Frame, area: Rect, theme:
             DiffLineType::Added => {
                 let prefix = build_unified_prefix(display_line, state.show_line_numbers, '+');
                 let text = format!("{}{}", prefix, display_line.content);
-                (text, added_style(state, theme))
+                (text, added_style(state, theme, disabled))
             }
             DiffLineType::Removed => {
                 let prefix = build_unified_prefix(display_line, state.show_line_numbers, '-');
                 let text = format!("{}{}", prefix, display_line.content);
-                (text, removed_style(state, theme))
+                (text, removed_style(state, theme, disabled))
             }
             DiffLineType::Context => {
                 let prefix = build_unified_prefix(display_line, state.show_line_numbers, ' ');
                 let text = format!("{}{}", prefix, display_line.content);
-                (text, context_style(state, theme))
+                (text, context_style(state, theme, disabled))
             }
         };
 
@@ -165,7 +178,13 @@ fn build_unified_prefix(line: &super::DiffLine, show_line_numbers: bool, sigil: 
 }
 
 /// Renders the diff in side-by-side mode.
-fn render_side_by_side(state: &DiffViewerState, frame: &mut Frame, area: Rect, theme: &Theme) {
+fn render_side_by_side(
+    state: &DiffViewerState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    disabled: bool,
+) {
     let pairs = state.collect_side_by_side_pairs();
     let total = pairs.len();
     let visible = area.height as usize;
@@ -211,9 +230,9 @@ fn render_side_by_side(state: &DiffViewerState, frame: &mut Frame, area: Rect, t
         let right_rect = Rect::new(right_x, y, right_width, 1);
 
         // Left side (prefer old line numbers)
-        render_side_line(left_line, frame, left_rect, state, theme, false);
+        render_side_line(left_line, frame, left_rect, state, theme, false, disabled);
         // Right side (prefer new line numbers)
-        render_side_line(right_line, frame, right_rect, state, theme, true);
+        render_side_line(right_line, frame, right_rect, state, theme, true, disabled);
     }
 
     // Render scrollbar
@@ -236,13 +255,14 @@ fn render_side_line(
     state: &DiffViewerState,
     theme: &Theme,
     prefer_new: bool,
+    disabled: bool,
 ) {
     if let Some(ref diff_line) = line {
         let style = match diff_line.line_type {
             DiffLineType::Header => header_style(theme),
-            DiffLineType::Added => added_style(state, theme),
-            DiffLineType::Removed => removed_style(state, theme),
-            DiffLineType::Context => context_style(state, theme),
+            DiffLineType::Added => added_style(state, theme, disabled),
+            DiffLineType::Removed => removed_style(state, theme, disabled),
+            DiffLineType::Context => context_style(state, theme, disabled),
         };
 
         let line_num = if prefer_new {
@@ -265,7 +285,7 @@ fn render_side_line(
         frame.render_widget(paragraph, line_area);
     } else {
         // Empty line (padding for alignment)
-        let style = context_style(state, theme);
+        let style = context_style(state, theme, disabled);
         let paragraph = Paragraph::new("").style(style);
         frame.render_widget(paragraph, line_area);
     }

--- a/src/component/diff_viewer/tests.rs
+++ b/src/component/diff_viewer/tests.rs
@@ -740,7 +740,13 @@ fn test_view_unified_focused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            DiffViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DiffViewer::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -754,7 +760,13 @@ fn test_view_unified_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            DiffViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DiffViewer::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/divider/mod.rs
+++ b/src/component/divider/mod.rs
@@ -440,13 +440,13 @@ impl Component for Divider {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,
                 crate::annotation::Annotation::divider("divider")
                     .with_label(state.label.as_deref().unwrap_or(""))
-                    .with_disabled(state.disabled),
+                    .with_disabled(ctx.disabled),
             );
         });
 
@@ -454,7 +454,7 @@ impl Component for Divider {
             return;
         }
 
-        let style = if state.disabled {
+        let style = if ctx.disabled {
             theme.disabled_style()
         } else if let Some(color) = state.color {
             Style::default().fg(color)

--- a/src/component/divider/tests.rs
+++ b/src/component/divider/tests.rs
@@ -289,7 +289,13 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Divider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Divider::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 
@@ -394,7 +400,13 @@ fn test_annotation_disabled() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Divider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Divider::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::new().disabled(true),
+                );
             })
             .unwrap();
     });

--- a/src/component/dropdown/mod.rs
+++ b/src/component/dropdown/mod.rs
@@ -810,11 +810,11 @@ impl Component for Dropdown {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             let mut ann = crate::annotation::Annotation::dropdown("dropdown")
-                .with_focus(state.focused)
-                .with_disabled(state.disabled)
+                .with_focus(ctx.focused)
+                .with_disabled(ctx.disabled)
                 .with_expanded(state.is_open);
             if let Some(val) = state.selected_value() {
                 ann = ann.with_value(val.to_string());
@@ -822,15 +822,15 @@ impl Component for Dropdown {
             reg.register(area, ann);
         });
 
-        let style = if state.disabled {
+        let style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_style()
         } else {
             theme.normal_style()
         };
 
-        let border_style = if state.focused && !state.disabled {
+        let border_style = if ctx.focused && !ctx.disabled {
             theme.focused_border_style()
         } else {
             theme.border_style()
@@ -853,8 +853,8 @@ impl Component for Dropdown {
 
         let text_style = if !state.is_open
             && state.selected_value().is_none()
-            && !state.disabled
-            && !state.focused
+            && !ctx.disabled
+            && !ctx.focused
         {
             theme.placeholder_style()
         } else {
@@ -913,7 +913,7 @@ impl Component for Dropdown {
                             };
                             let text = format!("{}{}", prefix, opt);
                             let item_style = if i == state.highlighted_index {
-                                theme.selected_style(state.focused)
+                                theme.selected_style(ctx.focused)
                             } else {
                                 theme.normal_style()
                             };

--- a/src/component/event_stream/event_tests.rs
+++ b/src/component/event_stream/event_tests.rs
@@ -293,7 +293,13 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(70, 15);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            EventStream::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 }

--- a/src/component/event_stream/mod.rs
+++ b/src/component/event_stream/mod.rs
@@ -382,8 +382,8 @@ impl Component for EventStream {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
-        render::render_event_stream(state, frame, area, theme);
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+        render::render_event_stream(state, frame, area, theme, ctx.focused, ctx.disabled);
     }
 }
 

--- a/src/component/event_stream/render.rs
+++ b/src/component/event_stream/render.rs
@@ -10,6 +10,8 @@ pub(super) fn render_event_stream(
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
+    focused: bool,
+    disabled: bool,
 ) {
     if area.height < 3 {
         return;
@@ -19,8 +21,8 @@ pub(super) fn render_event_stream(
         reg.register(
             area,
             crate::annotation::Annotation::container("event_stream")
-                .with_focus(state.is_focused())
-                .with_disabled(state.is_disabled()),
+                .with_focus(focused)
+                .with_disabled(disabled),
         );
     });
 
@@ -34,19 +36,26 @@ pub(super) fn render_event_stream(
     let status_area = chunks[1];
 
     // Render event list
-    render_event_list(state, frame, list_area, theme);
+    render_event_list(state, frame, list_area, theme, focused, disabled);
 
     // Render status bar (filter + level + auto-scroll indicator)
-    render_status_bar(state, frame, status_area, theme);
+    render_status_bar(state, frame, status_area, theme, focused, disabled);
 }
 
 /// Renders the event list area with a bordered block.
-fn render_event_list(state: &EventStreamState, frame: &mut Frame, area: Rect, theme: &Theme) {
+fn render_event_list(
+    state: &EventStreamState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    focused: bool,
+    disabled: bool,
+) {
     let visible = state.visible_events();
 
-    let border_style = if state.is_disabled() {
+    let border_style = if disabled {
         theme.disabled_style()
-    } else if state.is_focused() && !state.is_search_focused() {
+    } else if focused && !state.is_search_focused() {
         theme.focused_border_style()
     } else {
         theme.border_style()
@@ -90,7 +99,7 @@ fn render_event_list(state: &EventStreamState, frame: &mut Frame, area: Rect, th
 
     if inner.height >= 1 {
         let header_area = Rect::new(inner.x, inner.y, inner.width, 1);
-        render_header(state, frame, header_area, theme);
+        render_header(state, frame, header_area, theme, disabled);
     }
 
     if data_height == 0 {
@@ -114,7 +123,7 @@ fn render_event_list(state: &EventStreamState, frame: &mut Frame, area: Rect, th
         .iter()
         .skip(effective_offset)
         .take(data_height as usize)
-        .map(|event| render_event_row(state, event, inner.width as usize, theme))
+        .map(|event| render_event_row(state, event, inner.width as usize, theme, disabled))
         .collect();
 
     let list = List::new(items);
@@ -130,8 +139,14 @@ fn render_event_list(state: &EventStreamState, frame: &mut Frame, area: Rect, th
 }
 
 /// Renders the column header line.
-fn render_header(state: &EventStreamState, frame: &mut Frame, area: Rect, theme: &Theme) {
-    let style = if state.is_disabled() {
+fn render_header(
+    state: &EventStreamState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    disabled: bool,
+) {
+    let style = if disabled {
         theme.disabled_style()
     } else {
         theme.normal_style().add_modifier(Modifier::BOLD)
@@ -171,9 +186,10 @@ fn render_event_row<'a>(
     event: &super::StreamEvent,
     _max_width: usize,
     theme: &Theme,
+    disabled: bool,
 ) -> ListItem<'a> {
     let level_color = event.level.color();
-    let style = if state.is_disabled() {
+    let style = if disabled {
         theme.disabled_style()
     } else {
         Style::default().fg(level_color)
@@ -223,7 +239,7 @@ fn render_event_row<'a>(
     let text = parts.join(" ");
 
     // Highlight search matches
-    if !state.filter_text().is_empty() && !state.is_disabled() {
+    if !state.filter_text().is_empty() && !disabled {
         let text_lower = text.to_lowercase();
         let search_lower = state.filter_text().to_lowercase();
         if text_lower.contains(&search_lower) {
@@ -236,8 +252,15 @@ fn render_event_row<'a>(
 }
 
 /// Renders the status bar at the bottom.
-fn render_status_bar(state: &EventStreamState, frame: &mut Frame, area: Rect, theme: &Theme) {
-    let style = if state.is_disabled() {
+fn render_status_bar(
+    state: &EventStreamState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    focused: bool,
+    disabled: bool,
+) {
+    let style = if disabled {
         theme.disabled_style()
     } else if state.is_search_focused() {
         theme.focused_style()
@@ -281,7 +304,7 @@ fn render_status_bar(state: &EventStreamState, frame: &mut Frame, area: Rect, th
     frame.render_widget(paragraph, area);
 
     // Show cursor when search is focused
-    if state.is_focused() && state.is_search_focused() && !state.is_disabled() {
+    if focused && state.is_search_focused() && !disabled {
         // "Filter: [" is 9 chars, cursor is at that offset plus cursor position
         let cursor_x = area.x + 9 + state.search_cursor_position() as u16;
         if cursor_x < area.right() {

--- a/src/component/event_stream/snapshot_tests.rs
+++ b/src/component/event_stream/snapshot_tests.rs
@@ -74,7 +74,13 @@ fn test_snapshot_focused() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            EventStream::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -101,7 +107,13 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            EventStream::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -131,7 +143,13 @@ fn test_snapshot_search_active() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            EventStream::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/file_browser/snapshot_tests.rs
+++ b/src/component/file_browser/snapshot_tests.rs
@@ -66,7 +66,13 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            FileBrowser::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            FileBrowser::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true).disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -93,7 +99,13 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 8);
     terminal
         .draw(|frame| {
-            FileBrowser::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            FileBrowser::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/flame_graph/mod.rs
+++ b/src/component/flame_graph/mod.rs
@@ -969,8 +969,8 @@ impl Component for FlameGraph {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
-        render::render_flame_graph(state, frame, area, theme);
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+        render::render_flame_graph(state, frame, area, theme, ctx.focused, ctx.disabled);
     }
 }
 

--- a/src/component/flame_graph/render.rs
+++ b/src/component/flame_graph/render.rs
@@ -13,10 +13,12 @@ pub(super) fn render_flame_graph(
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
+    focused: bool,
+    disabled: bool,
 ) {
-    let border_style = if state.disabled {
+    let border_style = if disabled {
         theme.disabled_style()
-    } else if state.focused {
+    } else if focused {
         theme.focused_border_style()
     } else {
         theme.normal_style()
@@ -41,8 +43,8 @@ pub(super) fn render_flame_graph(
                 "FlameGraph".to_string(),
             ))
             .with_id("flame_graph")
-            .with_focus(state.focused)
-            .with_disabled(state.disabled),
+            .with_focus(focused)
+            .with_disabled(disabled),
         );
     });
 
@@ -50,7 +52,7 @@ pub(super) fn render_flame_graph(
         Some(r) => r,
         None => {
             // Render empty state
-            let style = if state.disabled {
+            let style = if disabled {
                 theme.disabled_style()
             } else {
                 theme.normal_style()
@@ -81,7 +83,9 @@ pub(super) fn render_flame_graph(
             break;
         }
         let row_area = Rect::new(inner.x, y, inner.width, 1);
-        render_depth_row(state, frame, view_root, root_total, depth, row_area, theme);
+        render_depth_row(
+            state, frame, view_root, root_total, depth, row_area, theme, focused, disabled,
+        );
     }
 
     // Render separator and detail bar
@@ -89,7 +93,7 @@ pub(super) fn render_flame_graph(
     if sep_y < inner.bottom() {
         let sep_area = Rect::new(inner.x, sep_y, inner.width, 1);
         let sep_line: String = "\u{2500}".repeat(inner.width as usize);
-        let sep_style = if state.disabled {
+        let sep_style = if disabled {
             theme.disabled_style()
         } else {
             theme.normal_style()
@@ -100,11 +104,12 @@ pub(super) fn render_flame_graph(
     let detail_y = sep_y + 1;
     if detail_y < inner.bottom() {
         let detail_area = Rect::new(inner.x, detail_y, inner.width, 1);
-        render_detail_bar(state, frame, root_total, detail_area, theme);
+        render_detail_bar(state, frame, root_total, detail_area, theme, disabled);
     }
 }
 
 /// Renders a single depth row of the flame graph.
+#[allow(clippy::too_many_arguments)]
 fn render_depth_row(
     state: &FlameGraphState,
     frame: &mut Frame,
@@ -113,6 +118,9 @@ fn render_depth_row(
     depth: usize,
     area: Rect,
     theme: &Theme,
+
+    focused: bool,
+    disabled: bool,
 ) {
     let width = area.width as usize;
     if width == 0 {
@@ -147,7 +155,15 @@ fn render_depth_row(
                 .to_lowercase()
                 .contains(&state.search_query.to_lowercase());
 
-        let style = compute_frame_style(state, node, is_selected, matches_search, theme);
+        let style = compute_frame_style(
+            state,
+            node,
+            is_selected,
+            matches_search,
+            theme,
+            focused,
+            disabled,
+        );
 
         // Build the label, truncating or padding to fit
         let label = &node.label;
@@ -188,7 +204,7 @@ fn render_depth_row(
     // Fill remaining space
     if total_cols_used < width {
         let remaining = width - total_cols_used;
-        let bg_style = if state.disabled {
+        let bg_style = if disabled {
             theme.disabled_style()
         } else {
             theme.normal_style()
@@ -202,17 +218,20 @@ fn render_depth_row(
 
 /// Computes the style for a frame.
 fn compute_frame_style(
-    state: &FlameGraphState,
+    _state: &FlameGraphState,
     node: &FlameNode,
     is_selected: bool,
     matches_search: bool,
     theme: &Theme,
+
+    focused: bool,
+    disabled: bool,
 ) -> Style {
-    if state.disabled {
+    if disabled {
         return theme.disabled_style();
     }
 
-    if is_selected && state.focused {
+    if is_selected && focused {
         // Selected + focused: use highlight style with the frame's color
         Style::default()
             .fg(Color::Black)
@@ -240,8 +259,10 @@ fn render_detail_bar(
     root_total: u64,
     area: Rect,
     theme: &Theme,
+
+    disabled: bool,
 ) {
-    let style = if state.disabled {
+    let style = if disabled {
         theme.disabled_style()
     } else {
         theme.normal_style()
@@ -279,7 +300,7 @@ mod tests {
         let state = FlameGraphState::with_root(FlameNode::new("main()", 500)).with_disabled(true);
         let node = FlameNode::new("test()", 100);
         let theme = Theme::default();
-        let style = compute_frame_style(&state, &node, false, false, &theme);
+        let style = compute_frame_style(&state, &node, false, false, &theme, false, true);
         assert_eq!(style, theme.disabled_style());
     }
 
@@ -289,7 +310,7 @@ mod tests {
         state.set_focused(true);
         let node = FlameNode::new("test()", 100).with_color(Color::Red);
         let theme = Theme::default();
-        let style = compute_frame_style(&state, &node, true, false, &theme);
+        let style = compute_frame_style(&state, &node, true, false, &theme, true, false);
         assert_eq!(style.fg, Some(Color::Black));
         assert_eq!(style.bg, Some(Color::Red));
     }
@@ -300,7 +321,7 @@ mod tests {
         state.set_search("test".to_string());
         let node = FlameNode::new("test()", 100);
         let theme = Theme::default();
-        let style = compute_frame_style(&state, &node, false, true, &theme);
+        let style = compute_frame_style(&state, &node, false, true, &theme, false, false);
         assert_eq!(style.bg, Some(Color::Yellow));
     }
 
@@ -309,7 +330,7 @@ mod tests {
         let state = FlameGraphState::with_root(FlameNode::new("main()", 500));
         let node = FlameNode::new("test()", 100).with_color(Color::Green);
         let theme = Theme::default();
-        let style = compute_frame_style(&state, &node, false, false, &theme);
+        let style = compute_frame_style(&state, &node, false, false, &theme, false, false);
         assert_eq!(style.fg, Some(Color::Green));
     }
 }

--- a/src/component/flame_graph/snapshot_tests.rs
+++ b/src/component/flame_graph/snapshot_tests.rs
@@ -60,7 +60,13 @@ fn test_snapshot_focused_with_selection() {
     let (mut terminal, theme) = test_utils::setup_render(60, 8);
     terminal
         .draw(|frame| {
-            FlameGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            FlameGraph::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -84,7 +90,13 @@ fn test_snapshot_zoomed() {
     let (mut terminal, theme) = test_utils::setup_render(60, 8);
     terminal
         .draw(|frame| {
-            FlameGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            FlameGraph::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -99,7 +111,13 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 8);
     terminal
         .draw(|frame| {
-            FlameGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            FlameGraph::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/form/mod.rs
+++ b/src/component/form/mod.rs
@@ -792,7 +792,7 @@ impl Component for Form {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if state.fields.is_empty() {
             return;
         }
@@ -802,8 +802,8 @@ impl Component for Form {
                 area,
                 crate::annotation::Annotation::new(crate::annotation::WidgetType::Form)
                     .with_id("form")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 
@@ -830,7 +830,7 @@ impl Component for Form {
             .zip(chunks.iter())
             .enumerate()
         {
-            let is_field_focused = state.focused && i == state.focused_index;
+            let is_field_focused = ctx.focused && i == state.focused_index;
 
             match field_state {
                 FieldState::Text(s) => {

--- a/src/component/form/snapshot_tests.rs
+++ b/src/component/form/snapshot_tests.rs
@@ -39,7 +39,13 @@ fn test_snapshot_populated() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Form::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -52,7 +58,13 @@ fn test_snapshot_focused_text_field() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Form::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -66,7 +78,13 @@ fn test_snapshot_focused_checkbox() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Form::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -81,7 +99,13 @@ fn test_snapshot_focused_select() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Form::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/form/tests.rs
+++ b/src/component/form/tests.rs
@@ -597,7 +597,13 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Form::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 }

--- a/src/component/gauge/tests.rs
+++ b/src/component/gauge/tests.rs
@@ -592,7 +592,13 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Gauge::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 

--- a/src/component/heatmap/mod.rs
+++ b/src/component/heatmap/mod.rs
@@ -874,7 +874,7 @@ impl Component for Heatmap {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if area.height < 3 || area.width < 3 {
             return;
         }
@@ -883,14 +883,14 @@ impl Component for Heatmap {
             reg.register(
                 area,
                 crate::annotation::Annotation::container("heatmap")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 
-        let border_style = if state.disabled {
+        let border_style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_border_style()
         } else {
             theme.border_style()
@@ -911,7 +911,7 @@ impl Component for Heatmap {
             return;
         }
 
-        render::render_heatmap(state, frame, inner, theme);
+        render::render_heatmap(state, frame, inner, theme, ctx.focused, ctx.disabled);
     }
 }
 

--- a/src/component/heatmap/render.rs
+++ b/src/component/heatmap/render.rs
@@ -7,7 +7,14 @@ use super::{value_to_color, HeatmapState};
 use crate::theme::Theme;
 
 /// Renders the heatmap grid inside the border.
-pub(super) fn render_heatmap(state: &HeatmapState, frame: &mut Frame, area: Rect, theme: &Theme) {
+pub(super) fn render_heatmap(
+    state: &HeatmapState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    focused: bool,
+    disabled: bool,
+) {
     let num_rows = state.rows();
     let num_cols = state.cols();
 
@@ -51,7 +58,7 @@ pub(super) fn render_heatmap(state: &HeatmapState, frame: &mut Frame, area: Rect
 
     // Render column labels
     if col_label_height > 0 {
-        render_col_labels(state, frame, area, grid_x, cell_width, theme);
+        render_col_labels(state, frame, area, grid_x, cell_width, theme, disabled);
     }
 
     // Render row labels and cells
@@ -63,7 +70,16 @@ pub(super) fn render_heatmap(state: &HeatmapState, frame: &mut Frame, area: Rect
 
         // Row label
         if !state.row_labels().is_empty() {
-            render_row_label(state, frame, area.x, y, row_label_width, ri, theme);
+            render_row_label(
+                state,
+                frame,
+                area.x,
+                y,
+                row_label_width,
+                ri,
+                theme,
+                disabled,
+            );
         }
 
         // Cells
@@ -79,6 +95,8 @@ pub(super) fn render_heatmap(state: &HeatmapState, frame: &mut Frame, area: Rect
             min_val,
             max_val,
             theme,
+            focused,
+            disabled,
         );
     }
 }
@@ -91,6 +109,7 @@ fn render_col_labels(
     grid_x: u16,
     cell_width: u16,
     theme: &Theme,
+    disabled: bool,
 ) {
     for (ci, label) in state.col_labels().iter().enumerate() {
         let x = grid_x + (ci as u16) * cell_width;
@@ -103,7 +122,7 @@ fn render_col_labels(
         }
         let label_area = Rect::new(x, area.y, available, 1);
         let truncated = truncate_str(label, available as usize);
-        let style = if state.is_disabled() {
+        let style = if disabled {
             theme.disabled_style()
         } else {
             theme.normal_style().add_modifier(Modifier::BOLD)
@@ -116,6 +135,7 @@ fn render_col_labels(
 }
 
 /// Renders a single row label.
+#[allow(clippy::too_many_arguments)]
 fn render_row_label(
     state: &HeatmapState,
     frame: &mut Frame,
@@ -124,11 +144,12 @@ fn render_row_label(
     width: u16,
     row_index: usize,
     theme: &Theme,
+    disabled: bool,
 ) {
     if let Some(label) = state.row_labels().get(row_index) {
         let label_area = Rect::new(x, y, width, 1);
         let truncated = truncate_str(label, width as usize);
-        let style = if state.is_disabled() {
+        let style = if disabled {
             theme.disabled_style()
         } else {
             theme.normal_style()
@@ -152,6 +173,8 @@ fn render_row_cells(
     min_val: f64,
     max_val: f64,
     theme: &Theme,
+    focused: bool,
+    disabled: bool,
 ) {
     let _ = theme; // reserved for future style customization
     let row_data = &state.data()[ri];
@@ -166,7 +189,7 @@ fn render_row_cells(
         }
         let cell_area = Rect::new(x, y, available_w, cell_height);
 
-        let bg_color = if state.is_disabled() {
+        let bg_color = if disabled {
             Color::DarkGray
         } else {
             value_to_color(value, min_val, max_val, state.color_scale())
@@ -174,7 +197,7 @@ fn render_row_cells(
 
         let is_selected = state.selected() == Some((ri, ci));
 
-        let cell_style = if is_selected && state.is_focused() && !state.is_disabled() {
+        let cell_style = if is_selected && focused && !disabled {
             // Selected cell: invert colors for visibility
             Style::default()
                 .fg(bg_color)

--- a/src/component/heatmap/snapshot_tests.rs
+++ b/src/component/heatmap/snapshot_tests.rs
@@ -62,7 +62,13 @@ fn test_snapshot_focused() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Heatmap::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -77,7 +83,13 @@ fn test_snapshot_focused_with_selection() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Heatmap::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -91,7 +103,13 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Heatmap::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/heatmap/tests.rs
+++ b/src/component/heatmap/tests.rs
@@ -720,7 +720,13 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Heatmap::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 }
@@ -735,7 +741,13 @@ fn test_render_focused_with_selection() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Heatmap::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 }

--- a/src/component/help_panel/mod.rs
+++ b/src/component/help_panel/mod.rs
@@ -679,19 +679,19 @@ impl Component for HelpPanel {
         None // Display-only, no output
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,
                 crate::annotation::Annotation::help_panel("help_panel")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 
-        let border_style = if state.disabled {
+        let border_style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_border_style()
         } else {
             theme.border_style()

--- a/src/component/help_panel/tests.rs
+++ b/src/component/help_panel/tests.rs
@@ -602,7 +602,13 @@ fn test_view_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 16);
     terminal
         .draw(|frame| {
-            HelpPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            HelpPanel::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true).disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -655,7 +661,13 @@ fn test_annotation_focused() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                HelpPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                HelpPanel::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::new().focused(true),
+                );
             })
             .unwrap();
     });

--- a/src/component/histogram/mod.rs
+++ b/src/component/histogram/mod.rs
@@ -651,7 +651,7 @@ impl Component for Histogram {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if area.height < 3 || area.width < 3 {
             return;
         }
@@ -660,14 +660,14 @@ impl Component for Histogram {
             reg.register(
                 area,
                 crate::annotation::Annotation::container("histogram")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 
-        let border_style = if state.disabled {
+        let border_style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_border_style()
         } else {
             theme.border_style()
@@ -743,7 +743,7 @@ impl Component for Histogram {
         let max_count = bins.iter().map(|(_, _, c)| *c).max().unwrap_or(0);
 
         let bar_color = state.color.unwrap_or(Color::Cyan);
-        let bar_style = if state.disabled {
+        let bar_style = if ctx.disabled {
             theme.disabled_style()
         } else {
             Style::default().fg(bar_color)

--- a/src/component/histogram/tests.rs
+++ b/src/component/histogram/tests.rs
@@ -511,7 +511,13 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Histogram::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 }
@@ -524,7 +530,13 @@ fn test_render_focused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Histogram::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 }
@@ -607,7 +619,13 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Histogram::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/input_field/mod.rs
+++ b/src/component/input_field/mod.rs
@@ -784,18 +784,18 @@ impl Component for InputField {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,
                 crate::annotation::Annotation::input("input_field")
                     .with_value(state.value.as_str())
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 
-        let border_style = if state.focused {
+        let border_style = if ctx.focused {
             theme.focused_border_style()
         } else {
             theme.border_style()
@@ -807,9 +807,9 @@ impl Component for InputField {
 
         let is_placeholder = state.value.is_empty() && !state.placeholder.is_empty();
 
-        let base_style = if state.disabled {
+        let base_style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_style()
         } else if is_placeholder {
             theme.placeholder_style()
@@ -842,7 +842,7 @@ impl Component for InputField {
         frame.render_widget(paragraph, area);
 
         // Show cursor when focused
-        if state.focused && area.width > 2 && area.height > 2 {
+        if ctx.focused && area.width > 2 && area.height > 2 {
             let cursor_x = area.x + 1 + state.cursor_display_position() as u16;
             let cursor_y = area.y + 1;
 

--- a/src/component/input_field/tests.rs
+++ b/src/component/input_field/tests.rs
@@ -260,7 +260,13 @@ fn test_view() {
 
     terminal
         .draw(|frame| {
-            InputField::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            InputField::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -289,7 +295,13 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            InputField::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            InputField::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 

--- a/src/component/line_input/tests.rs
+++ b/src/component/line_input/tests.rs
@@ -663,7 +663,13 @@ fn test_snapshot_focused() {
     state.set_focused(true);
     terminal
         .draw(|frame| {
-            LineInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LineInput::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -687,7 +693,13 @@ fn test_snapshot_disabled() {
     let state = LineInputState::with_value("hello").with_disabled(true);
     terminal
         .draw(|frame| {
-            LineInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LineInput::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -712,7 +724,13 @@ fn test_snapshot_wrapped() {
     state.set_focused(true);
     terminal
         .draw(|frame| {
-            LineInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LineInput::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -725,7 +743,13 @@ fn test_snapshot_wide_chars() {
     state.set_focused(true);
     terminal
         .draw(|frame| {
-            LineInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LineInput::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -740,7 +764,13 @@ fn test_snapshot_selection() {
     state.selection_anchor = Some(5);
     terminal
         .draw(|frame| {
-            LineInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LineInput::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/loading_list/mod.rs
+++ b/src/component/loading_list/mod.rs
@@ -1017,8 +1017,8 @@ impl<T: Clone> Component for LoadingList<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
-        render::render_loading_list(state, frame, area, theme);
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+        render::render_loading_list(state, frame, area, theme, ctx.focused, ctx.disabled);
     }
 }
 

--- a/src/component/loading_list/render.rs
+++ b/src/component/loading_list/render.rs
@@ -13,6 +13,8 @@ pub(super) fn render_loading_list<T: Clone>(
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
+    focused: bool,
+    disabled: bool,
 ) {
     if area.width == 0 || area.height == 0 {
         return;
@@ -20,8 +22,8 @@ pub(super) fn render_loading_list<T: Clone>(
 
     crate::annotation::with_registry(|reg| {
         let mut ann = crate::annotation::Annotation::loading_list("loading_list")
-            .with_focus(state.focused)
-            .with_disabled(state.disabled);
+            .with_focus(focused)
+            .with_disabled(disabled);
         if let Some(idx) = state.selected {
             ann = ann.with_selected(true).with_value(idx.to_string());
         }

--- a/src/component/loading_list/snapshot_tests.rs
+++ b/src/component/loading_list/snapshot_tests.rs
@@ -117,7 +117,13 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LoadingList::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/loading_list/tests/view.rs
+++ b/src/component/loading_list/tests/view.rs
@@ -151,7 +151,13 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            LoadingList::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            )
         })
         .unwrap();
 
@@ -223,7 +229,13 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            LoadingList::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            )
         })
         .unwrap();
 

--- a/src/component/log_correlation/mod.rs
+++ b/src/component/log_correlation/mod.rs
@@ -820,8 +820,8 @@ impl Component for LogCorrelation {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
-        render::render(state, frame, area, theme);
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+        render::render(state, frame, area, theme, ctx.focused, ctx.disabled);
     }
 }
 

--- a/src/component/log_correlation/render.rs
+++ b/src/component/log_correlation/render.rs
@@ -5,7 +5,14 @@ use super::LogCorrelationState;
 use crate::theme::Theme;
 
 /// Renders the entire LogCorrelation component.
-pub(super) fn render(state: &LogCorrelationState, frame: &mut Frame, area: Rect, theme: &Theme) {
+pub(super) fn render(
+    state: &LogCorrelationState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    focused: bool,
+    disabled: bool,
+) {
     if area.height < 3 || area.width < 3 {
         return;
     }
@@ -14,8 +21,8 @@ pub(super) fn render(state: &LogCorrelationState, frame: &mut Frame, area: Rect,
         reg.register(
             area,
             crate::annotation::Annotation::container("log_correlation")
-                .with_focus(state.is_focused())
-                .with_disabled(state.is_disabled()),
+                .with_focus(focused)
+                .with_disabled(disabled),
         );
     });
 
@@ -28,16 +35,23 @@ pub(super) fn render(state: &LogCorrelationState, frame: &mut Frame, area: Rect,
     let streams_area = chunks[0];
     let status_area = chunks[1];
 
-    render_streams(state, frame, streams_area, theme);
-    render_status_bar(state, frame, status_area, theme);
+    render_streams(state, frame, streams_area, theme, focused, disabled);
+    render_status_bar(state, frame, status_area, theme, disabled);
 }
 
 /// Renders the side-by-side stream panels.
-fn render_streams(state: &LogCorrelationState, frame: &mut Frame, area: Rect, theme: &Theme) {
+fn render_streams(
+    state: &LogCorrelationState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    focused: bool,
+    disabled: bool,
+) {
     if state.streams.is_empty() {
-        let border_style = if state.is_disabled() {
+        let border_style = if disabled {
             theme.disabled_style()
-        } else if state.is_focused() {
+        } else if focused {
             theme.focused_border_style()
         } else {
             theme.border_style()
@@ -62,9 +76,9 @@ fn render_streams(state: &LogCorrelationState, frame: &mut Frame, area: Rect, th
     }
 
     // Outer border with title
-    let outer_border_style = if state.is_disabled() {
+    let outer_border_style = if disabled {
         theme.disabled_style()
-    } else if state.is_focused() {
+    } else if focused {
         theme.focused_border_style()
     } else {
         theme.border_style()
@@ -121,6 +135,8 @@ fn render_streams(state: &LogCorrelationState, frame: &mut Frame, area: Rect, th
             frame,
             stream_area,
             theme,
+            focused,
+            disabled,
         );
     }
 }
@@ -137,20 +153,22 @@ fn render_single_stream(
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
+    focused: bool,
+    disabled: bool,
 ) {
     if area.width < 2 || area.height < 2 {
         return;
     }
 
-    let border_style = if state.is_disabled() {
+    let border_style = if disabled {
         theme.disabled_style()
-    } else if is_active && state.is_focused() {
+    } else if is_active && focused {
         theme.focused_border_style()
     } else {
         theme.border_style()
     };
 
-    let title_style = if state.is_disabled() {
+    let title_style = if disabled {
         theme.disabled_style()
     } else {
         Style::default().fg(stream.color)
@@ -190,7 +208,7 @@ fn render_single_stream(
                 if idx < filtered_entries.len() {
                     let entry = filtered_entries[idx];
                     let line = format_entry(entry, inner.width as usize);
-                    let style = if state.is_disabled() {
+                    let style = if disabled {
                         theme.disabled_style()
                     } else {
                         Style::default().fg(entry.level.color())
@@ -255,8 +273,14 @@ fn format_timestamp(ts: f64) -> String {
 }
 
 /// Renders the status bar at the bottom.
-fn render_status_bar(state: &LogCorrelationState, frame: &mut Frame, area: Rect, theme: &Theme) {
-    let style = if state.is_disabled() {
+fn render_status_bar(
+    state: &LogCorrelationState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    disabled: bool,
+) {
+    let style = if disabled {
         theme.disabled_style()
     } else {
         theme.normal_style()

--- a/src/component/log_correlation/snapshot_tests.rs
+++ b/src/component/log_correlation/snapshot_tests.rs
@@ -92,7 +92,13 @@ fn test_snapshot_focused() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LogCorrelation::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -125,7 +131,13 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LogCorrelation::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/log_correlation/tests.rs
+++ b/src/component/log_correlation/tests.rs
@@ -786,7 +786,13 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LogCorrelation::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 }

--- a/src/component/log_viewer/mod.rs
+++ b/src/component/log_viewer/mod.rs
@@ -451,7 +451,7 @@ impl Component for LogViewer {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if area.height < 3 {
             return;
         }
@@ -460,8 +460,8 @@ impl Component for LogViewer {
             reg.register(
                 area,
                 crate::annotation::Annotation::container("log_viewer")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 

--- a/src/component/log_viewer/snapshot_tests.rs
+++ b/src/component/log_viewer/snapshot_tests.rs
@@ -45,7 +45,13 @@ fn test_snapshot_focused() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LogViewer::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -92,7 +98,13 @@ fn test_snapshot_search_active() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LogViewer::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/log_viewer/tests.rs
+++ b/src/component/log_viewer/tests.rs
@@ -806,7 +806,13 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LogViewer::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 }

--- a/src/component/markdown_renderer/mod.rs
+++ b/src/component/markdown_renderer/mod.rs
@@ -472,7 +472,7 @@ impl Component for MarkdownRenderer {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,
@@ -480,14 +480,14 @@ impl Component for MarkdownRenderer {
                     "MarkdownRenderer".to_string(),
                 ))
                 .with_id("markdown_renderer")
-                .with_focus(state.focused)
-                .with_disabled(state.disabled),
+                .with_focus(ctx.focused)
+                .with_disabled(ctx.disabled),
             );
         });
 
-        let border_style = if state.disabled {
+        let border_style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_border_style()
         } else {
             theme.border_style()
@@ -511,7 +511,7 @@ impl Component for MarkdownRenderer {
 
         if state.show_source {
             // Raw source view
-            let text_style = if state.disabled {
+            let text_style = if ctx.disabled {
                 theme.disabled_style()
             } else {
                 theme.normal_style()

--- a/src/component/markdown_renderer/tests.rs
+++ b/src/component/markdown_renderer/tests.rs
@@ -465,7 +465,13 @@ fn test_view_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            MarkdownRenderer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            MarkdownRenderer::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/menu/mod.rs
+++ b/src/component/menu/mod.rs
@@ -499,7 +499,7 @@ impl Component for Menu {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         let mut menu_text = String::new();
 
         for (idx, item) in state.items.iter().enumerate() {
@@ -507,7 +507,7 @@ impl Component for Menu {
                 menu_text.push_str("  ");
             }
 
-            let item_text = if Some(idx) == state.selected_index && state.focused {
+            let item_text = if Some(idx) == state.selected_index && ctx.focused {
                 format!("[{}]", item.label())
             } else {
                 item.label().to_string()
@@ -517,9 +517,9 @@ impl Component for Menu {
         }
 
         // Determine style based on state
-        let style = if state.disabled {
+        let style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_style()
         } else {
             theme.normal_style()
@@ -529,8 +529,8 @@ impl Component for Menu {
 
         let annotation = crate::annotation::Annotation::new(crate::annotation::WidgetType::Menu)
             .with_id("menu")
-            .with_focus(state.focused)
-            .with_disabled(state.disabled);
+            .with_focus(ctx.focused)
+            .with_disabled(ctx.disabled);
         let annotated = crate::annotation::Annotate::new(paragraph, annotation);
         frame.render_widget(annotated, area);
     }

--- a/src/component/menu/tests.rs
+++ b/src/component/menu/tests.rs
@@ -335,7 +335,13 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            Menu::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Menu::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -356,7 +362,13 @@ fn test_view_selected() {
 
     terminal
         .draw(|frame| {
-            Menu::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Menu::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 

--- a/src/component/metrics_dashboard/mod.rs
+++ b/src/component/metrics_dashboard/mod.rs
@@ -700,7 +700,7 @@ impl Component for MetricsDashboard {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if state.widgets.is_empty() || area.height < 3 || area.width < 3 {
             return;
         }
@@ -709,8 +709,8 @@ impl Component for MetricsDashboard {
             reg.register(
                 area,
                 crate::annotation::Annotation::container("metrics_dashboard")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 

--- a/src/component/metrics_dashboard/snapshot_tests.rs
+++ b/src/component/metrics_dashboard/snapshot_tests.rs
@@ -47,7 +47,13 @@ fn test_snapshot_focused() {
     let (mut terminal, theme) = test_utils::setup_render(80, 25);
     terminal
         .draw(|frame| {
-            MetricsDashboard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            MetricsDashboard::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -61,7 +67,13 @@ fn test_snapshot_focused_second_widget() {
     let (mut terminal, theme) = test_utils::setup_render(80, 25);
     terminal
         .draw(|frame| {
-            MetricsDashboard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            MetricsDashboard::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/metrics_dashboard/tests.rs
+++ b/src/component/metrics_dashboard/tests.rs
@@ -542,7 +542,13 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            MetricsDashboard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            MetricsDashboard::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 }

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -74,8 +74,8 @@
 //!         Some(CounterOutput::ValueChanged(state.value))
 //!     }
 //!
-//!     fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
-//!         let style = if state.focused {
+//!     fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+//!         let style = if ctx.focused {
 //!             theme.focused_style()
 //!         } else {
 //!             theme.normal_style()
@@ -511,6 +511,13 @@ pub use focus_manager::FocusManager;
 /// time, such as whether a component is focused or disabled. This separates
 /// render-time concerns from persistent component state, allowing parents
 /// to control visual appearance without mutating component state.
+///
+/// # Precedence
+///
+/// `ctx` values are authoritative for rendering. Components read
+/// `ctx.focused` / `ctx.disabled` for visual appearance (border style,
+/// text color, cursor). `state.focused` / `state.disabled` remain the
+/// source of truth for behavior (`handle_event` guards).
 ///
 /// # Example
 ///

--- a/src/component/multi_progress/mod.rs
+++ b/src/component/multi_progress/mod.rs
@@ -990,7 +990,7 @@ impl Component for MultiProgress {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if area.width == 0 || area.height == 0 {
             return;
         }
@@ -1028,7 +1028,7 @@ impl Component for MultiProgress {
             .take(visible_count)
             .map(|item| {
                 let symbol = item.status.symbol();
-                let style = if state.disabled {
+                let style = if ctx.disabled {
                     theme.disabled_style()
                 } else {
                     item.status.style(theme)

--- a/src/component/multi_progress/snapshot_tests.rs
+++ b/src/component/multi_progress/snapshot_tests.rs
@@ -113,7 +113,13 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            MultiProgress::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/multi_progress/tests/workflow.rs
+++ b/src/component/multi_progress/tests/workflow.rs
@@ -428,7 +428,13 @@ fn test_view_disabled_state() {
 
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            MultiProgress::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            )
         })
         .unwrap();
 

--- a/src/component/number_input/mod.rs
+++ b/src/component/number_input/mod.rs
@@ -630,12 +630,12 @@ impl Component for NumberInput {
     }
 
     #[allow(clippy::cast_possible_truncation)]
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if area.width == 0 || area.height == 0 {
             return;
         }
 
-        let border_style = if state.focused {
+        let border_style = if ctx.focused {
             theme.focused_border_style()
         } else {
             theme.border_style()
@@ -645,9 +645,9 @@ impl Component for NumberInput {
             .borders(Borders::ALL)
             .border_style(border_style);
 
-        let content_style = if state.disabled {
+        let content_style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_style()
         } else {
             theme.normal_style()
@@ -696,8 +696,8 @@ impl Component for NumberInput {
         };
 
         let annotated = crate::annotation::Annotate::new(paragraph, annotation)
-            .focused(state.focused)
-            .disabled(state.disabled);
+            .focused(ctx.focused)
+            .disabled(ctx.disabled);
         frame.render_widget(annotated, area);
     }
 }

--- a/src/component/number_input/view_tests.rs
+++ b/src/component/number_input/view_tests.rs
@@ -26,7 +26,13 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            NumberInput::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -56,7 +62,13 @@ fn test_view_editing() {
 
     terminal
         .draw(|frame| {
-            NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            NumberInput::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -72,7 +84,13 @@ fn test_view_editing_with_label() {
 
     terminal
         .draw(|frame| {
-            NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            NumberInput::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -86,7 +104,13 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            NumberInput::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 
@@ -166,7 +190,13 @@ fn test_annotation_focused() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                NumberInput::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::new().focused(true),
+                );
             })
             .unwrap();
     });
@@ -183,7 +213,13 @@ fn test_annotation_disabled() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                NumberInput::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::new().disabled(true),
+                );
             })
             .unwrap();
     });

--- a/src/component/paginator/mod.rs
+++ b/src/component/paginator/mod.rs
@@ -605,20 +605,20 @@ impl Component for Paginator {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,
                 crate::annotation::Annotation::paginator("paginator")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled)
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled)
                     .with_value(format!("{}/{}", state.display_page(), state.total_pages)),
             );
         });
 
-        let text_style = if state.disabled {
+        let text_style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_style()
         } else {
             theme.normal_style()

--- a/src/component/paginator/tests.rs
+++ b/src/component/paginator/tests.rs
@@ -789,7 +789,13 @@ fn test_view_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Paginator::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -827,7 +833,13 @@ fn test_annotation_focused() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Paginator::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::new().focused(true),
+                );
             })
             .unwrap();
     });

--- a/src/component/pane_layout/mod.rs
+++ b/src/component/pane_layout/mod.rs
@@ -1058,22 +1058,22 @@ impl Component for PaneLayout {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,
                 crate::annotation::Annotation::new(crate::annotation::WidgetType::PaneLayout)
                     .with_id("pane_layout")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 
         let rects = state.layout(area);
 
         for (i, (pane, rect)) in state.panes.iter().zip(rects.iter()).enumerate() {
-            let is_focused_pane = state.focused && i == state.focused_pane;
-            let border_style = if state.disabled {
+            let is_focused_pane = ctx.focused && i == state.focused_pane;
+            let border_style = if ctx.disabled {
                 theme.disabled_style()
             } else if is_focused_pane {
                 theme.focused_border_style()

--- a/src/component/pane_layout/tests.rs
+++ b/src/component/pane_layout/tests.rs
@@ -729,7 +729,13 @@ fn test_view_three_panes_focused() {
 
     terminal
         .draw(|frame| {
-            PaneLayout::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            PaneLayout::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -764,7 +770,13 @@ fn test_annotation_emission() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                PaneLayout::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                PaneLayout::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::new().focused(true),
+                );
             })
             .unwrap();
     });

--- a/src/component/radio_group/mod.rs
+++ b/src/component/radio_group/mod.rs
@@ -389,7 +389,7 @@ impl<T: Clone + std::fmt::Display + 'static> Component for RadioGroup<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         let items: Vec<ListItem> = state
             .options
             .iter()
@@ -399,9 +399,9 @@ impl<T: Clone + std::fmt::Display + 'static> Component for RadioGroup<T> {
                 let indicator = if is_selected { "(•)" } else { "( )" };
                 let text = format!("{} {}", indicator, option);
 
-                let style = if state.disabled {
+                let style = if ctx.disabled {
                     theme.disabled_style()
-                } else if is_selected && state.focused {
+                } else if is_selected && ctx.focused {
                     theme.focused_style()
                 } else {
                     theme.normal_style()
@@ -415,8 +415,8 @@ impl<T: Clone + std::fmt::Display + 'static> Component for RadioGroup<T> {
 
         let mut ann = crate::annotation::Annotation::new(crate::annotation::WidgetType::RadioGroup)
             .with_id("radio_group")
-            .with_focus(state.focused)
-            .with_disabled(state.disabled);
+            .with_focus(ctx.focused)
+            .with_disabled(ctx.disabled);
         if let Some(idx) = state.selected {
             ann = ann.with_selected(true).with_value(idx.to_string());
         }

--- a/src/component/radio_group/tests.rs
+++ b/src/component/radio_group/tests.rs
@@ -177,7 +177,13 @@ fn test_view_renders_indicators() {
 
     terminal
         .draw(|frame| {
-            RadioGroup::<&str>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            RadioGroup::<&str>::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -192,7 +198,13 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            RadioGroup::<&str>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            RadioGroup::<&str>::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 
@@ -239,7 +251,13 @@ fn test_view_focused_not_selected() {
 
     terminal
         .draw(|frame| {
-            RadioGroup::<&str>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            RadioGroup::<&str>::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 

--- a/src/component/scroll_view/mod.rs
+++ b/src/component/scroll_view/mod.rs
@@ -645,7 +645,7 @@ impl Component for ScrollView {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if area.width == 0 || area.height == 0 {
             return;
         }
@@ -657,14 +657,14 @@ impl Component for ScrollView {
                     "ScrollView".to_string(),
                 ))
                 .with_id("scroll_view")
-                .with_focus(state.focused)
-                .with_disabled(state.disabled),
+                .with_focus(ctx.focused)
+                .with_disabled(ctx.disabled),
             );
         });
 
-        let border_style = if state.disabled {
+        let border_style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_border_style()
         } else {
             theme.border_style()

--- a/src/component/scroll_view/tests.rs
+++ b/src/component/scroll_view/tests.rs
@@ -696,7 +696,13 @@ fn test_view_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ScrollView::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -804,7 +810,13 @@ fn test_annotation_reflects_focus_and_disabled() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                ScrollView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                ScrollView::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::new().focused(true).disabled(true),
+                );
             })
             .unwrap();
     });

--- a/src/component/scrollable_text/mod.rs
+++ b/src/component/scrollable_text/mod.rs
@@ -386,27 +386,27 @@ impl Component for ScrollableText {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,
                 crate::annotation::Annotation::scrollable_text("scrollable_text")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 
-        let border_style = if state.disabled {
+        let border_style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_border_style()
         } else {
             theme.border_style()
         };
 
-        let text_style = if state.disabled {
+        let text_style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_style()
         } else {
             theme.normal_style()

--- a/src/component/scrollable_text/tests.rs
+++ b/src/component/scrollable_text/tests.rs
@@ -422,7 +422,13 @@ fn test_view_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollableText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ScrollableText::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/searchable_list/mod.rs
+++ b/src/component/searchable_list/mod.rs
@@ -1030,8 +1030,8 @@ impl<T: Clone + Display + 'static> Component for SearchableList<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
-        render::render_searchable_list(state, frame, area, theme);
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+        render::render_searchable_list(state, frame, area, theme, ctx.focused, ctx.disabled);
     }
 }
 

--- a/src/component/searchable_list/render.rs
+++ b/src/component/searchable_list/render.rs
@@ -15,14 +15,16 @@ pub(super) fn render_searchable_list<T: Clone + Display>(
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
+    focused: bool,
+    disabled: bool,
 ) {
     crate::annotation::with_registry(|reg| {
         reg.open(
             area,
             crate::annotation::Annotation::new(crate::annotation::WidgetType::SearchableList)
                 .with_id("searchable_list")
-                .with_focus(state.focused)
-                .with_disabled(state.disabled),
+                .with_focus(focused)
+                .with_disabled(disabled),
         );
     });
 
@@ -33,8 +35,8 @@ pub(super) fn render_searchable_list<T: Clone + Display>(
         .split(area);
 
     // Render filter input
-    let filter_focused = state.focused && state.internal_focus == Focus::Filter;
-    let filter_border_style = if state.disabled {
+    let filter_focused = focused && state.internal_focus == Focus::Filter;
+    let filter_border_style = if disabled {
         theme.disabled_style()
     } else if filter_focused {
         theme.focused_border_style()
@@ -59,15 +61,15 @@ pub(super) fn render_searchable_list<T: Clone + Display>(
     frame.render_widget(filter_widget, chunks[0]);
 
     // Show cursor in filter when focused
-    if filter_focused && !state.disabled {
+    if filter_focused && !disabled {
         let cursor_x = chunks[0].x + 1 + state.filter_text.len() as u16;
         let cursor_y = chunks[0].y + 1;
         frame.set_cursor_position(Position::new(cursor_x, cursor_y));
     }
 
     // Render filtered list
-    let list_focused = state.focused && state.internal_focus == Focus::List;
-    let list_border_style = if state.disabled {
+    let list_focused = focused && state.internal_focus == Focus::List;
+    let list_border_style = if disabled {
         theme.disabled_style()
     } else if list_focused {
         theme.focused_border_style()
@@ -82,7 +84,7 @@ pub(super) fn render_searchable_list<T: Clone + Display>(
         .map(|item| ListItem::new(format!("{}", item)))
         .collect();
 
-    let highlight_style = if state.disabled {
+    let highlight_style = if disabled {
         theme.disabled_style()
     } else {
         theme.selected_highlight_style(list_focused)

--- a/src/component/searchable_list/snapshot_tests.rs
+++ b/src/component/searchable_list/snapshot_tests.rs
@@ -46,7 +46,13 @@ fn test_snapshot_focused_filter() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SearchableList::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -60,7 +66,13 @@ fn test_snapshot_focused_list() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SearchableList::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -74,7 +86,13 @@ fn test_snapshot_filtered() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SearchableList::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -91,7 +109,13 @@ fn test_snapshot_no_matches() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SearchableList::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/searchable_list/tests.rs
+++ b/src/component/searchable_list/tests.rs
@@ -628,7 +628,13 @@ fn test_render_focused_filter() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SearchableList::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 }
@@ -641,7 +647,13 @@ fn test_render_focused_list() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SearchableList::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 }
@@ -657,7 +669,13 @@ fn test_render_with_filter() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SearchableList::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 }
@@ -669,7 +687,13 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SearchableList::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 }

--- a/src/component/select/mod.rs
+++ b/src/component/select/mod.rs
@@ -639,12 +639,12 @@ impl Component for Select {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             let mut ann = crate::annotation::Annotation::new(crate::annotation::WidgetType::Select)
                 .with_id("select")
-                .with_focus(state.focused)
-                .with_disabled(state.disabled)
+                .with_focus(ctx.focused)
+                .with_disabled(ctx.disabled)
                 .with_expanded(state.is_open);
             if let Some(val) = state.selected_value() {
                 ann = ann.with_value(val.to_string());
@@ -652,15 +652,15 @@ impl Component for Select {
             reg.register(area, ann);
         });
 
-        let style = if state.disabled {
+        let style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_style()
         } else {
             theme.normal_style()
         };
 
-        let border_style = if state.focused && !state.disabled {
+        let border_style = if ctx.focused && !ctx.disabled {
             theme.focused_border_style()
         } else {
             theme.border_style()
@@ -715,7 +715,7 @@ impl Component for Select {
                         };
                         let text = format!("{}{}", prefix, opt);
                         let item_style = if idx == state.highlighted_index {
-                            theme.selected_style(state.focused)
+                            theme.selected_style(ctx.focused)
                         } else {
                             theme.normal_style()
                         };

--- a/src/component/selectable_list/mod.rs
+++ b/src/component/selectable_list/mod.rs
@@ -698,11 +698,11 @@ impl<T: Clone + std::fmt::Display + 'static> Component for SelectableList<T> {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             let mut ann = crate::annotation::Annotation::list("selectable_list")
-                .with_focus(state.focused)
-                .with_disabled(state.disabled);
+                .with_focus(ctx.focused)
+                .with_disabled(ctx.disabled);
             if let Some(idx) = state.selected_index() {
                 ann = ann.with_selected(true).with_value(idx.to_string());
             }
@@ -714,10 +714,10 @@ impl<T: Clone + std::fmt::Display + 'static> Component for SelectableList<T> {
             items.push(ListItem::new(state.items[idx].to_string()));
         }
 
-        let highlight_style = if state.disabled {
+        let highlight_style = if ctx.disabled {
             theme.disabled_style()
         } else {
-            theme.selected_highlight_style(state.focused)
+            theme.selected_highlight_style(ctx.focused)
         };
 
         let block = Block::default().borders(Borders::ALL);

--- a/src/component/selectable_list/tests.rs
+++ b/src/component/selectable_list/tests.rs
@@ -264,7 +264,7 @@ fn test_view() {
                 frame,
                 frame.area(),
                 &theme,
-                &ViewContext::default(),
+                &ViewContext::new().focused(true),
             );
         })
         .unwrap();
@@ -731,7 +731,7 @@ fn test_filter_view() {
                 frame,
                 frame.area(),
                 &theme,
-                &ViewContext::default(),
+                &ViewContext::new().focused(true),
             );
         })
         .unwrap();

--- a/src/component/slider/tests.rs
+++ b/src/component/slider/tests.rs
@@ -657,7 +657,13 @@ fn test_view_horizontal_focused() {
 
     terminal
         .draw(|frame| {
-            Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Slider::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -673,7 +679,13 @@ fn test_view_horizontal_disabled() {
 
     terminal
         .draw(|frame| {
-            Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Slider::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 
@@ -784,7 +796,13 @@ fn test_annotation_focused() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Slider::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::new().focused(true),
+                );
             })
             .unwrap();
     });
@@ -803,7 +821,13 @@ fn test_annotation_disabled() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Slider::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::new().disabled(true),
+                );
             })
             .unwrap();
     });

--- a/src/component/span_tree/mod.rs
+++ b/src/component/span_tree/mod.rs
@@ -896,8 +896,8 @@ impl Component for SpanTree {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
-        render::render_span_tree(state, frame, area, theme);
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+        render::render_span_tree(state, frame, area, theme, ctx.focused, ctx.disabled);
     }
 }
 

--- a/src/component/span_tree/render.rs
+++ b/src/component/span_tree/render.rs
@@ -13,10 +13,12 @@ pub(super) fn render_span_tree(
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
+    focused: bool,
+    disabled: bool,
 ) {
-    let border_style = if state.disabled {
+    let border_style = if disabled {
         theme.disabled_style()
-    } else if state.focused {
+    } else if focused {
         theme.focused_border_style()
     } else {
         theme.normal_style()
@@ -35,8 +37,8 @@ pub(super) fn render_span_tree(
     }
 
     let annotation = crate::annotation::Annotation::span_tree("span_tree")
-        .with_focus(state.focused)
-        .with_disabled(state.disabled);
+        .with_focus(focused)
+        .with_disabled(disabled);
     let empty = Paragraph::new("");
     let annotated = crate::annotation::Annotate::new(empty, annotation);
     frame.render_widget(annotated, inner);
@@ -57,6 +59,7 @@ pub(super) fn render_span_tree(
         effective_label_width,
         bar_area_width,
         theme,
+        disabled,
     );
 
     // Separator line
@@ -71,7 +74,7 @@ pub(super) fn render_span_tree(
                 sep_line.push('─');
             }
         }
-        let sep_style = if state.disabled {
+        let sep_style = if disabled {
             theme.disabled_style()
         } else {
             theme.normal_style()
@@ -103,6 +106,8 @@ pub(super) fn render_span_tree(
         label_width: effective_label_width,
         bar_width: bar_area_width,
         theme,
+        focused,
+        disabled,
     };
 
     for (row_idx, span) in visible_spans.iter().enumerate() {
@@ -130,10 +135,11 @@ fn render_header(
     label_width: u16,
     bar_width: u16,
     theme: &Theme,
+    disabled: bool,
 ) {
     let header_area = Rect::new(inner.x, inner.y, inner.width, 1);
 
-    let style = if state.disabled {
+    let style = if disabled {
         theme.disabled_style()
     } else {
         theme.normal_style()
@@ -271,6 +277,8 @@ struct RowContext<'a> {
     label_width: u16,
     bar_width: u16,
     theme: &'a Theme,
+    focused: bool,
+    disabled: bool,
 }
 
 /// Renders a single span row with label and timing bar.
@@ -285,10 +293,10 @@ fn render_row(
     let row_area = Rect::new(x, y, ctx.label_width + 1 + ctx.bar_width, 1);
 
     // Determine styles
-    let (label_style, bar_bg_style) = if ctx.state.disabled {
+    let (label_style, bar_bg_style) = if ctx.disabled {
         (ctx.theme.disabled_style(), ctx.theme.disabled_style())
     } else if is_selected {
-        let hl = ctx.theme.selected_highlight_style(ctx.state.focused);
+        let hl = ctx.theme.selected_highlight_style(ctx.focused);
         (hl, ctx.theme.normal_style())
     } else {
         (ctx.theme.normal_style(), ctx.theme.normal_style())
@@ -329,7 +337,7 @@ fn render_row(
     );
 
     // Combine into spans
-    let bar_style = if ctx.state.disabled {
+    let bar_style = if ctx.disabled {
         ctx.theme.disabled_style()
     } else {
         Style::default()

--- a/src/component/span_tree/snapshot_tests.rs
+++ b/src/component/span_tree/snapshot_tests.rs
@@ -47,7 +47,13 @@ fn test_snapshot_with_selection() {
     let (mut terminal, theme) = test_utils::setup_render(60, 10);
     terminal
         .draw(|frame| {
-            SpanTree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SpanTree::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -83,7 +89,13 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 10);
     terminal
         .draw(|frame| {
-            SpanTree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SpanTree::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/sparkline/mod.rs
+++ b/src/component/sparkline/mod.rs
@@ -528,13 +528,13 @@ impl Component for Sparkline {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         let display_data = match state.max_display_points {
             Some(n) if state.data.len() > n => &state.data[state.data.len() - n..],
             _ => &state.data,
         };
 
-        let style = if state.disabled {
+        let style = if ctx.disabled {
             theme.disabled_style()
         } else if let Some(color) = state.color {
             Style::default().fg(color)

--- a/src/component/sparkline/tests.rs
+++ b/src/component/sparkline/tests.rs
@@ -415,7 +415,13 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Sparkline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Sparkline::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 

--- a/src/component/split_panel/mod.rs
+++ b/src/component/split_panel/mod.rs
@@ -522,23 +522,23 @@ impl Component for SplitPanel {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.open(
                 area,
                 crate::annotation::Annotation::new(crate::annotation::WidgetType::SplitPanel)
                     .with_id("split_panel")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 
         let (first_area, second_area) = state.layout(area);
 
-        let first_focused = state.focused && state.focused_pane == Pane::First;
-        let second_focused = state.focused && state.focused_pane == Pane::Second;
+        let first_focused = ctx.focused && state.focused_pane == Pane::First;
+        let second_focused = ctx.focused && state.focused_pane == Pane::Second;
 
-        let first_border = if state.disabled {
+        let first_border = if ctx.disabled {
             theme.disabled_style()
         } else if first_focused {
             theme.focused_border_style()
@@ -546,7 +546,7 @@ impl Component for SplitPanel {
             theme.border_style()
         };
 
-        let second_border = if state.disabled {
+        let second_border = if ctx.disabled {
             theme.disabled_style()
         } else if second_focused {
             theme.focused_border_style()

--- a/src/component/split_panel/snapshot_tests.rs
+++ b/src/component/split_panel/snapshot_tests.rs
@@ -24,7 +24,13 @@ fn test_snapshot_vertical_focused_first() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SplitPanel::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -38,7 +44,13 @@ fn test_snapshot_vertical_focused_second() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SplitPanel::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -51,7 +63,13 @@ fn test_snapshot_horizontal() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SplitPanel::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -64,7 +82,13 @@ fn test_snapshot_custom_ratio() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SplitPanel::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -80,7 +104,13 @@ fn test_snapshot_resized() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SplitPanel::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/split_panel/tests.rs
+++ b/src/component/split_panel/tests.rs
@@ -490,7 +490,13 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(80, 24);
     terminal
         .draw(|frame| {
-            SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SplitPanel::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 }

--- a/src/component/status_log/mod.rs
+++ b/src/component/status_log/mod.rs
@@ -828,7 +828,7 @@ impl Component for StatusLog {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if area.width == 0 || area.height == 0 {
             return;
         }
@@ -857,7 +857,7 @@ impl Component for StatusLog {
             .take(inner.height as usize)
             .map(|entry| {
                 let prefix = entry.level.prefix();
-                let style = if state.disabled {
+                let style = if ctx.disabled {
                     theme.disabled_style()
                 } else {
                     match entry.level {

--- a/src/component/status_log/tests.rs
+++ b/src/component/status_log/tests.rs
@@ -557,7 +557,15 @@ fn test_view_focused() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
 
     terminal
-        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| {
+            StatusLog::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            )
+        })
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/step_indicator/mod.rs
+++ b/src/component/step_indicator/mod.rs
@@ -672,14 +672,14 @@ impl Component for StepIndicator {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,
                 crate::annotation::Annotation::new(crate::annotation::WidgetType::StepIndicator)
                     .with_id("step_indicator")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 
@@ -687,7 +687,7 @@ impl Component for StepIndicator {
             Block::default()
                 .title(format!(" {} ", title))
                 .borders(Borders::ALL)
-                .border_style(if state.focused {
+                .border_style(if ctx.focused {
                     theme.focused_border_style()
                 } else {
                     theme.border_style()
@@ -695,7 +695,7 @@ impl Component for StepIndicator {
         } else {
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(if state.focused {
+                .border_style(if ctx.focused {
                     theme.focused_border_style()
                 } else {
                     theme.border_style()

--- a/src/component/step_indicator/tests.rs
+++ b/src/component/step_indicator/tests.rs
@@ -701,7 +701,13 @@ fn test_view_focused_step() {
 
     terminal
         .draw(|frame| {
-            StepIndicator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StepIndicator::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -784,7 +790,13 @@ fn test_annotation_emission() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                StepIndicator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                StepIndicator::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::new().focused(true),
+                );
             })
             .unwrap();
     });

--- a/src/component/styled_text/mod.rs
+++ b/src/component/styled_text/mod.rs
@@ -558,20 +558,20 @@ impl Component for StyledText {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,
                 crate::annotation::Annotation::new(crate::annotation::WidgetType::StyledText)
                     .with_id("styled_text")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 
-        let border_style = if state.disabled {
+        let border_style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_border_style()
         } else {
             theme.border_style()

--- a/src/component/styled_text/tests.rs
+++ b/src/component/styled_text/tests.rs
@@ -677,7 +677,13 @@ fn test_annotation_emission() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                StyledText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                StyledText::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::new().focused(true),
+                );
             })
             .unwrap();
     });

--- a/src/component/switch/mod.rs
+++ b/src/component/switch/mod.rs
@@ -417,7 +417,7 @@ impl Component for Switch {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         let indicator = if state.on {
             format!("(*) {}", state.on_label)
         } else {
@@ -430,15 +430,15 @@ impl Component for Switch {
             indicator
         };
 
-        let style = if state.disabled {
+        let style = if ctx.disabled {
             theme.disabled_style()
         } else if state.on {
-            if state.focused {
+            if ctx.focused {
                 theme.focused_style()
             } else {
                 theme.success_style()
             }
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_style()
         } else {
             theme.normal_style()
@@ -453,8 +453,8 @@ impl Component for Switch {
             annotation
         };
         let annotated = crate::annotation::Annotate::new(paragraph, annotation)
-            .focused(state.focused)
-            .disabled(state.disabled);
+            .focused(ctx.focused)
+            .disabled(ctx.disabled);
         frame.render_widget(annotated, area);
     }
 }

--- a/src/component/switch/tests.rs
+++ b/src/component/switch/tests.rs
@@ -358,7 +358,13 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Switch::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -373,7 +379,13 @@ fn test_view_focused_on() {
 
     terminal
         .draw(|frame| {
-            Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Switch::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -387,7 +399,13 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Switch::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 
@@ -401,7 +419,13 @@ fn test_view_disabled_on() {
 
     terminal
         .draw(|frame| {
-            Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Switch::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 

--- a/src/component/tab_bar/mod.rs
+++ b/src/component/tab_bar/mod.rs
@@ -872,8 +872,8 @@ impl Component for TabBar {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
-        render::render_tab_bar(state, frame, area, theme);
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+        render::render_tab_bar(state, frame, area, theme, ctx.focused, ctx.disabled);
     }
 }
 

--- a/src/component/tab_bar/render.rs
+++ b/src/component/tab_bar/render.rs
@@ -9,7 +9,14 @@ use unicode_width::UnicodeWidthStr;
 use super::*;
 
 /// Renders the tab bar into the given frame area.
-pub(super) fn render_tab_bar(state: &TabBarState, frame: &mut Frame, area: Rect, theme: &Theme) {
+pub(super) fn render_tab_bar(
+    state: &TabBarState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    focused: bool,
+    disabled: bool,
+) {
     if area.height == 0 || area.width == 0 {
         return;
     }
@@ -28,7 +35,7 @@ pub(super) fn render_tab_bar(state: &TabBarState, frame: &mut Frame, area: Rect,
         .enumerate()
         .map(|(i, tab)| {
             let is_active = state.active == Some(i);
-            let base_style = if state.disabled {
+            let base_style = if disabled {
                 theme.disabled_style()
             } else if is_active {
                 theme.focused_style().add_modifier(Modifier::BOLD)
@@ -54,7 +61,7 @@ pub(super) fn render_tab_bar(state: &TabBarState, frame: &mut Frame, area: Rect,
             parts.push(Span::styled(label_text, base_style));
 
             if tab.modified {
-                let mod_style = if state.disabled {
+                let mod_style = if disabled {
                     theme.disabled_style()
                 } else {
                     theme.warning_style()
@@ -63,7 +70,7 @@ pub(super) fn render_tab_bar(state: &TabBarState, frame: &mut Frame, area: Rect,
             }
 
             if tab.closable {
-                let close_style = if state.disabled {
+                let close_style = if disabled {
                     theme.disabled_style()
                 } else {
                     theme.error_style()
@@ -118,7 +125,7 @@ pub(super) fn render_tab_bar(state: &TabBarState, frame: &mut Frame, area: Rect,
     let mut spans: Vec<Span<'static>> = Vec::new();
 
     if has_left_overflow {
-        let indicator_style = if state.disabled {
+        let indicator_style = if disabled {
             theme.disabled_style()
         } else {
             theme.info_style()
@@ -135,7 +142,7 @@ pub(super) fn render_tab_bar(state: &TabBarState, frame: &mut Frame, area: Rect,
     }
 
     if has_right_overflow {
-        let indicator_style = if state.disabled {
+        let indicator_style = if disabled {
             theme.disabled_style()
         } else {
             theme.info_style()
@@ -148,8 +155,8 @@ pub(super) fn render_tab_bar(state: &TabBarState, frame: &mut Frame, area: Rect,
 
     let annotation = crate::annotation::Annotation::new(crate::annotation::WidgetType::TabBar)
         .with_id("tab_bar")
-        .with_focus(state.focused)
-        .with_disabled(state.disabled)
+        .with_focus(focused)
+        .with_disabled(disabled)
         .with_selected(state.active.is_some())
         .with_value(state.active.map(|i| i.to_string()).unwrap_or_default());
     let annotated = crate::annotation::Annotate::new(paragraph, annotation);

--- a/src/component/tab_bar/tests.rs
+++ b/src/component/tab_bar/tests.rs
@@ -671,7 +671,15 @@ fn test_view_focused() {
     state.set_focused(true);
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
     terminal
-        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| {
+            TabBar::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            )
+        })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -682,7 +690,15 @@ fn test_view_disabled() {
     state.set_disabled(true);
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
     terminal
-        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| {
+            TabBar::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            )
+        })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }

--- a/src/component/table/mod.rs
+++ b/src/component/table/mod.rs
@@ -901,8 +901,8 @@ impl<T: TableRow + 'static> Component for Table<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
-        render::render_table(state, frame, area, theme);
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+        render::render_table(state, frame, area, theme, ctx.focused, ctx.disabled);
     }
 }
 

--- a/src/component/table/render.rs
+++ b/src/component/table/render.rs
@@ -13,11 +13,13 @@ pub(super) fn render_table<T: TableRow>(
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
+    focused: bool,
+    disabled: bool,
 ) {
     crate::annotation::with_registry(|reg| {
         let mut ann = crate::annotation::Annotation::table("table")
-            .with_focus(state.focused)
-            .with_disabled(state.disabled);
+            .with_focus(focused)
+            .with_disabled(disabled);
         if let Some(idx) = state.selected {
             ann = ann.with_selected(true).with_value(idx.to_string());
         }
@@ -52,7 +54,7 @@ pub(super) fn render_table<T: TableRow>(
         })
         .collect();
 
-    let header_style = if state.disabled {
+    let header_style = if disabled {
         theme.disabled_style()
     } else {
         Style::default().add_modifier(Modifier::BOLD)
@@ -76,16 +78,16 @@ pub(super) fn render_table<T: TableRow>(
 
     let widths: Vec<Constraint> = state.columns.iter().map(|c| c.width()).collect();
 
-    let border_style = if state.focused && !state.disabled {
+    let border_style = if focused && !disabled {
         theme.focused_border_style()
     } else {
         theme.border_style()
     };
 
-    let row_highlight_style = if state.disabled {
+    let row_highlight_style = if disabled {
         theme.disabled_style()
     } else {
-        theme.selected_highlight_style(state.focused)
+        theme.selected_highlight_style(focused)
     };
 
     let table = ratatui::widgets::Table::new(rows, widths)

--- a/src/component/table/view_tests.rs
+++ b/src/component/table/view_tests.rs
@@ -92,7 +92,13 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            Table::<TestRow>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Table::<TestRow>::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -108,7 +114,13 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Table::<TestRow>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Table::<TestRow>::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 

--- a/src/component/tabs/mod.rs
+++ b/src/component/tabs/mod.rs
@@ -447,7 +447,7 @@ impl<T: Clone + Display + 'static> Component for Tabs<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         let selected_idx = state.selected.unwrap_or(0);
 
         let titles: Vec<Line> = state
@@ -455,10 +455,10 @@ impl<T: Clone + Display + 'static> Component for Tabs<T> {
             .iter()
             .enumerate()
             .map(|(i, tab)| {
-                let style = if state.disabled {
+                let style = if ctx.disabled {
                     theme.disabled_style()
                 } else if i == selected_idx {
-                    theme.selected_style(state.focused)
+                    theme.selected_style(ctx.focused)
                 } else {
                     theme.normal_style()
                 };
@@ -466,16 +466,16 @@ impl<T: Clone + Display + 'static> Component for Tabs<T> {
             })
             .collect();
 
-        let border_style = if state.focused && !state.disabled {
+        let border_style = if ctx.focused && !ctx.disabled {
             theme.focused_border_style()
         } else {
             theme.border_style()
         };
 
-        let highlight_style = if state.disabled {
+        let highlight_style = if ctx.disabled {
             theme.disabled_style()
         } else {
-            theme.selected_style(state.focused)
+            theme.selected_style(ctx.focused)
         };
 
         let tabs_widget = ratatui::widgets::Tabs::new(titles)
@@ -489,8 +489,8 @@ impl<T: Clone + Display + 'static> Component for Tabs<T> {
 
         let annotation = crate::annotation::Annotation::new(crate::annotation::WidgetType::TabBar)
             .with_id("tabs")
-            .with_focus(state.focused)
-            .with_disabled(state.disabled)
+            .with_focus(ctx.focused)
+            .with_disabled(ctx.disabled)
             .with_selected(true)
             .with_value(selected_idx.to_string());
         let annotated = crate::annotation::Annotate::new(tabs_widget, annotation);

--- a/src/component/tabs/tests.rs
+++ b/src/component/tabs/tests.rs
@@ -283,7 +283,13 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            Tabs::<&str>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tabs::<&str>::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -299,7 +305,13 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Tabs::<&str>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tabs::<&str>::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 

--- a/src/component/terminal_output/mod.rs
+++ b/src/component/terminal_output/mod.rs
@@ -750,8 +750,8 @@ impl Component for TerminalOutput {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
-        render::render(state, frame, area, theme);
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+        render::render(state, frame, area, theme, ctx.focused, ctx.disabled);
     }
 }
 

--- a/src/component/terminal_output/render.rs
+++ b/src/component/terminal_output/render.rs
@@ -14,19 +14,26 @@ use crate::theme::Theme;
 /// - ANSI-colored content lines with optional line numbers
 /// - Status bar at the bottom (inside the border)
 /// - Scrollbar on the right edge (inside the border)
-pub(super) fn render(state: &TerminalOutputState, frame: &mut Frame, area: Rect, theme: &Theme) {
+pub(super) fn render(
+    state: &TerminalOutputState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    focused: bool,
+    disabled: bool,
+) {
     crate::annotation::with_registry(|reg| {
         reg.register(
             area,
             crate::annotation::Annotation::terminal_output("terminal_output")
-                .with_focus(state.focused)
-                .with_disabled(state.disabled),
+                .with_focus(focused)
+                .with_disabled(disabled),
         );
     });
 
-    let border_style = if state.disabled {
+    let border_style = if disabled {
         theme.disabled_style()
-    } else if state.focused {
+    } else if focused {
         theme.focused_border_style()
     } else {
         theme.border_style()
@@ -54,7 +61,7 @@ pub(super) fn render(state: &TerminalOutputState, frame: &mut Frame, area: Rect,
     if content_height == 0 {
         // Only room for status bar
         let status_area = Rect::new(inner.x, inner.y, inner.width, inner.height.min(1));
-        render_status_bar(state, frame, status_area, theme);
+        render_status_bar(state, frame, status_area, theme, disabled);
         return;
     }
 
@@ -66,8 +73,8 @@ pub(super) fn render(state: &TerminalOutputState, frame: &mut Frame, area: Rect,
         status_bar_height,
     );
 
-    render_content(state, frame, content_area, theme);
-    render_status_bar(state, frame, status_area, theme);
+    render_content(state, frame, content_area, theme, disabled);
+    render_status_bar(state, frame, status_area, theme, disabled);
 
     // Render scrollbar when content exceeds viewport
     let total_lines = state.lines.len();
@@ -81,7 +88,13 @@ pub(super) fn render(state: &TerminalOutputState, frame: &mut Frame, area: Rect,
 }
 
 /// Renders the ANSI-colored content lines.
-fn render_content(state: &TerminalOutputState, frame: &mut Frame, area: Rect, theme: &Theme) {
+fn render_content(
+    state: &TerminalOutputState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    disabled: bool,
+) {
     let visible_lines = area.height as usize;
     let offset = state.scroll.offset();
 
@@ -98,13 +111,13 @@ fn render_content(state: &TerminalOutputState, frame: &mut Frame, area: Rect, th
         0
     };
 
-    let text_style = if state.disabled {
+    let text_style = if disabled {
         theme.disabled_style()
     } else {
         theme.normal_style()
     };
 
-    let line_num_style = if state.disabled {
+    let line_num_style = if disabled {
         theme.disabled_style()
     } else {
         Style::default().fg(Color::DarkGray)
@@ -134,7 +147,7 @@ fn render_content(state: &TerminalOutputState, frame: &mut Frame, area: Rect, th
         // Render the ANSI-styled line content
         let line = &state.lines[line_idx];
 
-        if state.disabled {
+        if disabled {
             // When disabled, render without ANSI colors
             let remaining = (max_x.saturating_sub(x)) as usize;
             let display: String = line.chars().take(remaining).collect();
@@ -164,12 +177,18 @@ fn render_content(state: &TerminalOutputState, frame: &mut Frame, area: Rect, th
 }
 
 /// Renders the status bar at the bottom of the component.
-fn render_status_bar(state: &TerminalOutputState, frame: &mut Frame, area: Rect, theme: &Theme) {
+fn render_status_bar(
+    state: &TerminalOutputState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    disabled: bool,
+) {
     if area.width == 0 || area.height == 0 {
         return;
     }
 
-    let status_style = if state.disabled {
+    let status_style = if disabled {
         theme.disabled_style()
     } else {
         Style::default().fg(Color::DarkGray).bg(Color::Black)

--- a/src/component/terminal_output/tests.rs
+++ b/src/component/terminal_output/tests.rs
@@ -727,7 +727,13 @@ fn test_view_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(50, 8);
     terminal
         .draw(|frame| {
-            TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TerminalOutput::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -764,7 +770,13 @@ fn test_annotation_focused() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                TerminalOutput::view(
+                    &state,
+                    frame,
+                    frame.area(),
+                    &theme,
+                    &ViewContext::new().focused(true),
+                );
             })
             .unwrap();
     });

--- a/src/component/text_area/mod.rs
+++ b/src/component/text_area/mod.rs
@@ -658,15 +658,15 @@ impl Component for TextArea {
         state.apply_update(msg)
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             let first_line = state.lines.first().map_or("", |l| l.as_str());
             reg.register(
                 area,
                 crate::annotation::Annotation::text_area("text_area")
                     .with_value(first_line)
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 
@@ -697,9 +697,9 @@ impl Component for TextArea {
                 .join("\n")
         };
 
-        let style = if state.disabled {
+        let style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_style()
         } else if state.is_empty() && !state.placeholder.is_empty() {
             theme.placeholder_style()
@@ -707,7 +707,7 @@ impl Component for TextArea {
             theme.normal_style()
         };
 
-        let border_style = if state.focused && !state.disabled {
+        let border_style = if ctx.focused && !ctx.disabled {
             theme.focused_border_style()
         } else {
             theme.border_style()
@@ -722,7 +722,7 @@ impl Component for TextArea {
         frame.render_widget(paragraph, area);
 
         // Show cursor when focused
-        if state.focused && area.width > 2 && area.height > 2 {
+        if ctx.focused && area.width > 2 && area.height > 2 {
             let cursor_row_in_view = state.cursor_row.saturating_sub(scroll);
             let (_, display_col) = state.cursor_display_position();
 

--- a/src/component/text_area/tests.rs
+++ b/src/component/text_area/tests.rs
@@ -484,7 +484,13 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            TextArea::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TextArea::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -687,7 +693,13 @@ fn test_view_with_scroll() {
 
     terminal
         .draw(|frame| {
-            TextArea::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TextArea::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -704,7 +716,13 @@ fn test_view_cursor_above_scroll() {
 
     terminal
         .draw(|frame| {
-            TextArea::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TextArea::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 

--- a/src/component/timeline/mod.rs
+++ b/src/component/timeline/mod.rs
@@ -782,7 +782,7 @@ impl Component for Timeline {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if area.height < 3 || area.width < 3 {
             return;
         }
@@ -791,14 +791,14 @@ impl Component for Timeline {
             reg.register(
                 area,
                 crate::annotation::Annotation::container("timeline")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 
-        let border_style = if state.disabled {
+        let border_style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_border_style()
         } else {
             theme.border_style()
@@ -819,7 +819,7 @@ impl Component for Timeline {
             return;
         }
 
-        render::render_timeline(state, frame, inner, theme);
+        render::render_timeline(state, frame, inner, theme, ctx.focused, ctx.disabled);
     }
 }
 

--- a/src/component/timeline/render.rs
+++ b/src/component/timeline/render.rs
@@ -11,7 +11,14 @@ use super::{SelectedType, TimelineState};
 use crate::theme::Theme;
 
 /// Renders the complete timeline inside the block's inner area.
-pub(super) fn render_timeline(state: &TimelineState, frame: &mut Frame, area: Rect, theme: &Theme) {
+pub(super) fn render_timeline(
+    state: &TimelineState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    _focused: bool,
+    disabled: bool,
+) {
     // Layout:
     //  1 row: time axis
     //  1 row: separator
@@ -44,7 +51,7 @@ pub(super) fn render_timeline(state: &TimelineState, frame: &mut Frame, area: Re
 
     // Time axis - always present
     let axis_area = Rect::new(area.x, y, area.width, 1);
-    render_time_axis(state, frame, axis_area, theme);
+    render_time_axis(state, frame, axis_area, theme, disabled);
     y += 1;
 
     if remaining < 2 {
@@ -53,7 +60,7 @@ pub(super) fn render_timeline(state: &TimelineState, frame: &mut Frame, area: Re
 
     // Separator
     let sep1_area = Rect::new(area.x, y, area.width, 1);
-    render_separator(frame, sep1_area, theme, state.disabled);
+    render_separator(frame, sep1_area, theme, disabled);
     y += 1;
 
     // If we don't have room for anything else, stop
@@ -86,31 +93,31 @@ pub(super) fn render_timeline(state: &TimelineState, frame: &mut Frame, area: Re
             break;
         }
         let lane_area = Rect::new(area.x, y, area.width, 1);
-        render_span_lane(state, frame, lane_area, lane_idx as usize, theme);
+        render_span_lane(state, frame, lane_area, lane_idx as usize, theme, disabled);
         y += 1;
     }
 
     // Render event row
     if has_events && y < area.y + area.height {
         let event_area = Rect::new(area.x, y, area.width, 1);
-        render_events(state, frame, event_area, theme);
+        render_events(state, frame, event_area, theme, disabled);
         y += 1;
     }
 
     // Detail bar (separator + detail)
     if has_selection && y + 1 < area.y + area.height {
         let sep2_area = Rect::new(area.x, y, area.width, 1);
-        render_separator(frame, sep2_area, theme, state.disabled);
+        render_separator(frame, sep2_area, theme, disabled);
         y += 1;
 
         if y < area.y + area.height {
             let detail_area = Rect::new(area.x, y, area.width, 1);
-            render_detail_bar(state, frame, detail_area, theme);
+            render_detail_bar(state, frame, detail_area, theme, disabled);
         }
     } else if has_selection && y < area.y + area.height {
         // Just the detail bar, no separator
         let detail_area = Rect::new(area.x, y, area.width, 1);
-        render_detail_bar(state, frame, detail_area, theme);
+        render_detail_bar(state, frame, detail_area, theme, disabled);
     }
 
     // Suppress unused variable warning
@@ -118,12 +125,18 @@ pub(super) fn render_timeline(state: &TimelineState, frame: &mut Frame, area: Re
 }
 
 /// Renders the time axis with tick labels.
-fn render_time_axis(state: &TimelineState, frame: &mut Frame, area: Rect, theme: &Theme) {
+fn render_time_axis(
+    state: &TimelineState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    disabled: bool,
+) {
     if area.width == 0 {
         return;
     }
 
-    let style = if state.disabled {
+    let style = if disabled {
         theme.disabled_style()
     } else {
         theme.normal_style()
@@ -185,6 +198,8 @@ fn render_span_lane(
     area: Rect,
     lane_idx: usize,
     theme: &Theme,
+
+    disabled: bool,
 ) {
     if area.width == 0 {
         return;
@@ -214,7 +229,7 @@ fn render_span_lane(
         let is_selected =
             state.selected_type == SelectedType::Span && state.selected_index == Some(*span_idx);
 
-        let style = if state.disabled {
+        let style = if disabled {
             theme.disabled_style()
         } else if is_selected {
             Style::default()
@@ -277,7 +292,13 @@ fn render_span_lane(
 }
 
 /// Renders point events as markers.
-fn render_events(state: &TimelineState, frame: &mut Frame, area: Rect, theme: &Theme) {
+fn render_events(
+    state: &TimelineState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    disabled: bool,
+) {
     if area.width == 0 {
         return;
     }
@@ -306,7 +327,7 @@ fn render_events(state: &TimelineState, frame: &mut Frame, area: Rect, theme: &T
         let is_selected =
             state.selected_type == SelectedType::Event && state.selected_index == Some(event_idx);
 
-        let style = if state.disabled {
+        let style = if disabled {
             theme.disabled_style()
         } else if is_selected {
             Style::default()
@@ -331,7 +352,13 @@ fn render_events(state: &TimelineState, frame: &mut Frame, area: Rect, theme: &T
 }
 
 /// Renders the detail bar showing information about the selected item.
-fn render_detail_bar(state: &TimelineState, frame: &mut Frame, area: Rect, theme: &Theme) {
+fn render_detail_bar(
+    state: &TimelineState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    disabled: bool,
+) {
     let detail = match state.selected_type {
         SelectedType::Event => {
             if let Some(event) = state.selected_event() {
@@ -359,7 +386,7 @@ fn render_detail_bar(state: &TimelineState, frame: &mut Frame, area: Rect, theme
         }
     };
 
-    let style = if state.disabled {
+    let style = if disabled {
         theme.disabled_style()
     } else {
         theme.normal_style().add_modifier(Modifier::DIM)

--- a/src/component/timeline/snapshot_tests.rs
+++ b/src/component/timeline/snapshot_tests.rs
@@ -88,7 +88,13 @@ fn test_snapshot_with_selection() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Timeline::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -105,7 +111,13 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Timeline::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -126,7 +138,13 @@ fn test_snapshot_span_selected() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Timeline::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/timeline/tests.rs
+++ b/src/component/timeline/tests.rs
@@ -794,7 +794,13 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Timeline::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 }

--- a/src/component/title_card/mod.rs
+++ b/src/component/title_card/mod.rs
@@ -436,18 +436,18 @@ impl Component for TitleCard {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         crate::annotation::with_registry(|reg| {
             reg.register(
                 area,
                 crate::annotation::Annotation::title_card("title_card")
                     .with_label(state.title.as_str())
-                    .with_disabled(state.disabled),
+                    .with_disabled(ctx.disabled),
             );
         });
 
         let render_area = if state.bordered {
-            let border_style = if state.disabled {
+            let border_style = if ctx.disabled {
                 theme.disabled_style()
             } else {
                 theme.border_style()
@@ -469,13 +469,13 @@ impl Component for TitleCard {
         }
 
         // Build title line with optional prefix and suffix
-        let title_style = if state.disabled {
+        let title_style = if ctx.disabled {
             theme.disabled_style()
         } else {
             state.title_style
         };
 
-        let subtitle_style = if state.disabled {
+        let subtitle_style = if ctx.disabled {
             theme.disabled_style()
         } else {
             state.subtitle_style

--- a/src/component/title_card/tests.rs
+++ b/src/component/title_card/tests.rs
@@ -278,7 +278,13 @@ fn test_view_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            TitleCard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TitleCard::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/tree/mod.rs
+++ b/src/component/tree/mod.rs
@@ -899,7 +899,7 @@ impl<T: Clone + 'static> Component for Tree<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         let all_lines = Self::render_lines(state, area.width, theme);
         let viewport_height = area.height as usize;
 
@@ -922,8 +922,8 @@ impl<T: Clone + 'static> Component for Tree<T> {
 
         let annotation = crate::annotation::Annotation::new(crate::annotation::WidgetType::Tree)
             .with_id("tree")
-            .with_focus(state.focused)
-            .with_disabled(state.disabled);
+            .with_focus(ctx.focused)
+            .with_disabled(ctx.disabled);
         let annotated = crate::annotation::Annotate::new(paragraph, annotation);
         frame.render_widget(annotated, area);
 

--- a/src/component/tree/snapshot_tests.rs
+++ b/src/component/tree/snapshot_tests.rs
@@ -71,7 +71,13 @@ fn test_snapshot_focused_selected() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -105,7 +111,13 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/tree/tests/component.rs
+++ b/src/component/tree/tests/component.rs
@@ -377,7 +377,13 @@ fn test_view_focused_selection() {
 
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 

--- a/src/component/tree/tests/events.rs
+++ b/src/component/tree/tests/events.rs
@@ -303,7 +303,13 @@ fn test_view_disabled() {
 
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 

--- a/src/component/tree/tests/snapshot.rs
+++ b/src/component/tree/tests/snapshot.rs
@@ -57,7 +57,13 @@ fn test_view_multiple_roots_focused() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -78,7 +84,13 @@ fn test_view_selection_on_child() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -124,7 +136,13 @@ fn test_view_deep_nesting_selection_at_leaf() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -187,7 +205,13 @@ fn test_view_disabled_with_children() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 
@@ -208,7 +232,13 @@ fn test_view_focused_expanded_tree() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -273,7 +303,13 @@ fn test_view_filtered_focused() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 
@@ -332,7 +368,13 @@ fn test_view_selection_on_last_root() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 

--- a/src/component/treemap/mod.rs
+++ b/src/component/treemap/mod.rs
@@ -835,7 +835,7 @@ impl Component for Treemap {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if area.height < 3 || area.width < 3 {
             return;
         }
@@ -844,14 +844,14 @@ impl Component for Treemap {
             reg.register(
                 area,
                 crate::annotation::Annotation::container("treemap")
-                    .with_focus(state.focused)
-                    .with_disabled(state.disabled),
+                    .with_focus(ctx.focused)
+                    .with_disabled(ctx.disabled),
             );
         });
 
-        let border_style = if state.disabled {
+        let border_style = if ctx.disabled {
             theme.disabled_style()
-        } else if state.focused {
+        } else if ctx.focused {
             theme.focused_border_style()
         } else {
             theme.border_style()
@@ -872,7 +872,7 @@ impl Component for Treemap {
             return;
         }
 
-        render::render_treemap(state, frame, inner, theme);
+        render::render_treemap(state, frame, inner, theme, ctx.focused, ctx.disabled);
     }
 }
 

--- a/src/component/treemap/render.rs
+++ b/src/component/treemap/render.rs
@@ -8,7 +8,14 @@ use super::TreemapState;
 use crate::theme::Theme;
 
 /// Renders the treemap inside the border area.
-pub(super) fn render_treemap(state: &TreemapState, frame: &mut Frame, area: Rect, theme: &Theme) {
+pub(super) fn render_treemap(
+    state: &TreemapState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    focused: bool,
+    disabled: bool,
+) {
     let view_node = state.current_view_node();
     let children = match view_node {
         Some(node) => &node.children,
@@ -25,6 +32,7 @@ pub(super) fn render_treemap(state: &TreemapState, frame: &mut Frame, area: Rect
                 state,
                 frame,
                 area,
+                disabled,
             );
         }
         return;
@@ -47,27 +55,32 @@ pub(super) fn render_treemap(state: &TreemapState, frame: &mut Frame, area: Rect
 
     // Render each rectangle.
     for rect in &rects {
-        let is_selected =
-            state.focused && !state.disabled && rect.node_index.first() == Some(&selected_index);
+        let is_selected = focused && !disabled && rect.node_index.first() == Some(&selected_index);
 
-        render_rect(rect, is_selected, state, frame);
+        render_rect(rect, is_selected, state, frame, disabled);
     }
 
     // Render detail bar.
     if let Some(detail) = detail_area {
-        render_detail_bar(state, frame, detail, theme);
+        render_detail_bar(state, frame, detail, theme, disabled);
     }
 }
 
 /// Render a single layout rectangle.
-fn render_rect(rect: &LayoutRect, is_selected: bool, state: &TreemapState, frame: &mut Frame) {
+fn render_rect(
+    rect: &LayoutRect,
+    is_selected: bool,
+    state: &TreemapState,
+    frame: &mut Frame,
+    disabled: bool,
+) {
     let cell_area = Rect::new(rect.x, rect.y, rect.width, rect.height);
 
     if cell_area.width == 0 || cell_area.height == 0 {
         return;
     }
 
-    let bg = if state.disabled {
+    let bg = if disabled {
         Color::DarkGray
     } else {
         rect.color
@@ -130,12 +143,10 @@ fn render_leaf(
     state: &TreemapState,
     frame: &mut Frame,
     area: Rect,
+
+    disabled: bool,
 ) {
-    let bg = if state.disabled {
-        Color::DarkGray
-    } else {
-        color
-    };
+    let bg = if disabled { Color::DarkGray } else { color };
     let fg = contrasting_fg(bg);
     let style = Style::default().bg(bg).fg(fg);
 
@@ -166,8 +177,14 @@ fn render_leaf(
 }
 
 /// Render the detail bar at the bottom.
-fn render_detail_bar(state: &TreemapState, frame: &mut Frame, area: Rect, theme: &Theme) {
-    let style = if state.disabled {
+fn render_detail_bar(
+    state: &TreemapState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    disabled: bool,
+) {
+    let style = if disabled {
         theme.disabled_style()
     } else {
         theme.normal_style()

--- a/src/component/treemap/snapshot_tests.rs
+++ b/src/component/treemap/snapshot_tests.rs
@@ -41,7 +41,13 @@ fn test_snapshot_focused() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Treemap::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -59,7 +65,13 @@ fn test_snapshot_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Treemap::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -100,7 +112,13 @@ fn test_snapshot_zoomed_in() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Treemap::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -118,7 +136,13 @@ fn test_snapshot_selection_moved() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Treemap::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/treemap/tests.rs
+++ b/src/component/treemap/tests.rs
@@ -778,7 +778,13 @@ fn test_render_focused() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Treemap::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
         })
         .unwrap();
 }
@@ -793,7 +799,13 @@ fn test_render_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Treemap::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().disabled(true),
+            );
         })
         .unwrap();
 }


### PR DESCRIPTION
Fix 1-5 for v0.10.1 feedback. All 74 component view functions now read ctx.focused/ctx.disabled for rendering. Unicode wrap and markdown width fix included. See commit message for details.