### PR TITLE
Fix scrollbar off-by-one and code span break

### DIFF
--- a/src/component/conversation_view/render.rs
+++ b/src/component/conversation_view/render.rs
@@ -49,7 +49,22 @@ pub(super) fn render(
 
 /// Renders the message list inside the content area.
 fn render_messages(state: &ConversationViewState, frame: &mut Frame, area: Rect, theme: &Theme) {
-    let display_lines = build_display_lines(state, area.width as usize, theme);
+    // First pass: check if content will be scrollable (needs scrollbar).
+    // If so, reserve 1 column for the scrollbar track.
+    let preliminary_lines = build_display_lines(state, area.width as usize, theme);
+    let needs_scrollbar = preliminary_lines.len() > area.height as usize;
+    let content_width = if needs_scrollbar {
+        (area.width as usize).saturating_sub(1)
+    } else {
+        area.width as usize
+    };
+
+    // Rebuild at correct width if scrollbar is needed
+    let display_lines = if needs_scrollbar {
+        build_display_lines(state, content_width, theme)
+    } else {
+        preliminary_lines
+    };
 
     let total_lines = display_lines.len();
     let visible_lines = area.height as usize;

--- a/src/component/markdown_renderer/render.rs
+++ b/src/component/markdown_renderer/render.rs
@@ -420,6 +420,27 @@ impl<'t> MarkdownLineRenderer<'t> {
                 continue;
             }
 
+            // Inline code spans (backtick-wrapped) are atomic — never break inside them.
+            // If it doesn't fit, flush current line and put it on the next.
+            let is_code_span =
+                span_text.starts_with('`') && span_text.ends_with('`') && span_text.len() > 1;
+            if is_code_span {
+                if !current_line.is_empty() {
+                    self.lines
+                        .push(Line::from(std::mem::take(&mut current_line)));
+                    current_width = 0;
+                    if !cont_prefix.is_empty() {
+                        let prefix_style = self.normal_style();
+                        let prefix_w = unicode_width::UnicodeWidthStr::width(cont_prefix);
+                        current_line.push(Span::styled(cont_prefix.to_string(), prefix_style));
+                        current_width = prefix_w;
+                    }
+                }
+                current_line.push(span);
+                current_width += span_display_width;
+                continue;
+            }
+
             // Need to break this span across lines
             let mut remaining = span_text.to_string();
             while !remaining.is_empty() {


### PR DESCRIPTION
Reserves 1 col for scrollbar when scrollable. Code spans are atomic in markdown wrap. 1831 tests pass.