### PR TITLE
Re-export FileEntry, Language, and related types in prelude

### DIFF
--- a/src/component/code_block/mod.rs
+++ b/src/component/code_block/mod.rs
@@ -41,7 +41,7 @@ use std::collections::HashSet;
 
 use ratatui::prelude::*;
 
-use self::highlight::Language;
+pub use self::highlight::Language;
 use super::{Component, Disableable, Focusable, ViewContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -318,7 +318,7 @@ pub use calendar::{Calendar, CalendarMessage, CalendarOutput, CalendarState};
 #[cfg(feature = "display-components")]
 pub use canvas::{Canvas, CanvasMarker, CanvasMessage, CanvasShape, CanvasState};
 #[cfg(feature = "display-components")]
-pub use code_block::{CodeBlock, CodeBlockMessage, CodeBlockState};
+pub use code_block::{CodeBlock, CodeBlockMessage, CodeBlockState, Language};
 #[cfg(feature = "display-components")]
 pub use collapsible::{Collapsible, CollapsibleMessage, CollapsibleOutput, CollapsibleState};
 #[cfg(feature = "display-components")]
@@ -387,7 +387,10 @@ pub use event_stream::{
     EventLevel, EventStream, EventStreamMessage, EventStreamOutput, EventStreamState, StreamEvent,
 };
 #[cfg(feature = "compound-components")]
-pub use file_browser::{FileBrowser, FileBrowserMessage, FileBrowserOutput, FileBrowserState};
+pub use file_browser::{
+    FileBrowser, FileBrowserMessage, FileBrowserOutput, FileBrowserState, FileEntry,
+    FileSortDirection, FileSortField, SelectionMode,
+};
 #[cfg(feature = "compound-components")]
 pub use flame_graph::{
     FlameGraph, FlameGraphMessage, FlameGraphOutput, FlameGraphState, FlameNode,


### PR DESCRIPTION
## Summary
- Re-export `Language` from `code_block` module (was only accessible via `code_block::highlight::Language`)
- Re-export `FileEntry`, `FileSortField`, `FileSortDirection`, `SelectionMode` from `file_browser` module
- These types are now available directly through the prelude like all other component types

## Motivation
Discovered during Reference App #4 (File Manager) that these commonly-needed types required deeply nested import paths, unlike every other component type in the framework.

## Test plan
- [x] `cargo test --all-features` — 1831 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo check --no-default-features` — builds
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps` — clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)