### PR TITLE
Make LogViewerState::push_entry public

### DIFF
--- a/src/component/log_viewer/state.rs
+++ b/src/component/log_viewer/state.rs
@@ -350,8 +350,22 @@ impl LogViewerState {
         )
     }
 
-    /// Internal method to add an entry.
-    pub(super) fn push_entry(
+    /// Adds an entry with the given level and optional timestamp, returning its ID.
+    ///
+    /// This is the general-purpose entry method. For convenience, use
+    /// [`push_info`](Self::push_info), [`push_warning`](Self::push_warning),
+    /// [`push_error`](Self::push_error), or [`push_success`](Self::push_success).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{LogViewerState, StatusLogLevel};
+    ///
+    /// let mut state = LogViewerState::new();
+    /// let id = state.push_entry("Custom entry".into(), StatusLogLevel::Info, None);
+    /// assert_eq!(state.entries().len(), 1);
+    /// ```
+    pub fn push_entry(
         &mut self,
         message: String,
         level: StatusLogLevel,


### PR DESCRIPTION
## Summary
- Change `LogViewerState::push_entry()` from `pub(super)` to `pub`
- Add documentation with example doc test
- This general-purpose method for adding entries with a specific level and optional timestamp was only accessible within the module

## Test plan
- [x] Doc test passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)