### PR TITLE
Fix StatusBar right section truncation on overflow

### DIFF
--- a/src/component/status_bar/mod.rs
+++ b/src/component/status_bar/mod.rs
@@ -485,6 +485,44 @@ impl StatusBar {
 
         spans
     }
+
+    /// Truncates a list of spans to fit within `max_width` characters.
+    /// Appends an ellipsis if truncation occurs.
+    fn truncate_spans(spans: Vec<Span<'static>>, max_width: usize) -> Vec<Span<'static>> {
+        if max_width == 0 {
+            return Vec::new();
+        }
+
+        let total: usize = spans.iter().map(|s| s.content.len()).sum();
+        if total <= max_width {
+            return spans;
+        }
+
+        let mut result = Vec::new();
+        let mut remaining = max_width.saturating_sub(1); // Reserve 1 for ellipsis
+
+        for span in spans {
+            let len = span.content.len();
+            if remaining == 0 {
+                break;
+            }
+            if len <= remaining {
+                remaining -= len;
+                result.push(span);
+            } else {
+                // Truncate this span
+                let truncated: String = span.content.chars().take(remaining).collect();
+                result.push(Span::styled(truncated, span.style));
+                remaining = 0;
+            }
+        }
+
+        // Add ellipsis with the style of the last span
+        let ellipsis_style = result.last().map(|s| s.style).unwrap_or_default();
+        result.push(Span::styled("…", ellipsis_style));
+
+        result
+    }
 }
 
 impl Component for StatusBar {
@@ -627,6 +665,16 @@ impl Component for StatusBar {
 
         let total_width = area.width as usize;
 
+        // Determine how much space is available for center after left and right.
+        // Priority: left (full), right (full), center (gets remainder).
+        let available_for_center = total_width
+            .saturating_sub(left_width)
+            .saturating_sub(right_width);
+        let effective_center_width = center_width.min(available_for_center);
+
+        // Truncate center spans if they exceed available space
+        let center_spans = Self::truncate_spans(center_spans, effective_center_width);
+
         // Build the line with proper spacing
         let mut line_spans: Vec<Span> = Vec::new();
 
@@ -634,8 +682,8 @@ impl Component for StatusBar {
         line_spans.extend(left_spans);
 
         // Calculate padding for center
-        let left_padding = if !state.center.is_empty() {
-            let center_start = (total_width.saturating_sub(center_width)) / 2;
+        let left_padding = if effective_center_width > 0 {
+            let center_start = (total_width.saturating_sub(effective_center_width)) / 2;
             center_start.saturating_sub(left_width)
         } else {
             0
@@ -649,7 +697,7 @@ impl Component for StatusBar {
         line_spans.extend(center_spans);
 
         // Calculate padding for right
-        let current_width = left_width + left_padding + center_width;
+        let current_width = left_width + left_padding + effective_center_width;
         let right_padding = total_width.saturating_sub(current_width + right_width);
 
         if right_padding > 0 {

--- a/src/component/status_bar/tests/component.rs
+++ b/src/component/status_bar/tests/component.rs
@@ -529,3 +529,59 @@ fn test_annotation_emitted() {
         Some(&"0".to_string())
     );
 }
+
+#[test]
+fn test_view_overflow_truncates_center() {
+    // When left + center + right exceeds terminal width, center should truncate
+    // to preserve the right section which usually has critical status info.
+    let mut state = StatusBarState::new();
+    state.push_left(StatusBarItem::new("Mode: Normal"));
+    state.push_center(StatusBarItem::new("very-long-center-section-text"));
+    state.push_right(StatusBarItem::new("Ln 42, Col 8"));
+
+    // Total content: 12 + 29 + 12 = 53 chars, but terminal is only 40 wide
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
+
+    terminal
+        .draw(|frame| {
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+        })
+        .unwrap();
+
+    let output = terminal.backend().to_string();
+    // Right section must appear in full
+    assert!(
+        output.contains("Ln 42, Col 8"),
+        "Right section should not be truncated, got: {output}"
+    );
+    // Left section must appear in full
+    assert!(
+        output.contains("Mode: Normal"),
+        "Left section should not be truncated, got: {output}"
+    );
+}
+
+#[test]
+fn test_view_severe_overflow_drops_center() {
+    // When left + right alone fill the terminal, center should be dropped entirely
+    let mut state = StatusBarState::new();
+    state.push_left(StatusBarItem::new("Left Section Here"));
+    state.push_center(StatusBarItem::new("Center"));
+    state.push_right(StatusBarItem::new("Right Section Here"));
+
+    // left=17, center=6, right=18 → total 41, terminal only 35
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(35, 1);
+
+    terminal
+        .draw(|frame| {
+            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+        })
+        .unwrap();
+
+    let output = terminal.backend().to_string();
+    // Right section must appear in full
+    assert!(
+        output.contains("Right Section Here"),
+        "Right section should not be truncated, got: {output}"
+    );
+}


### PR DESCRIPTION
## Summary
- When left + center + right sections exceeded terminal width, the right section was silently clipped
- Now the center section is truncated first (with ellipsis "…") to preserve left and right sections
- Left and right sections typically contain more critical status information (mode, line/col, encoding)

## Implementation
- Added `truncate_spans()` helper that truncates styled spans to a max width with ellipsis
- Center section width is clamped to `total_width - left_width - right_width` before layout
- If no space remains for center, it's dropped entirely

## Test plan
- [x] Added `test_view_overflow_truncates_center` — verifies right section preserved when center overflows
- [x] Added `test_view_severe_overflow_drops_center` — verifies behavior when left+right alone fill the bar
- [x] All 179 existing StatusBar tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)