### PR TITLE
Use vt.dispatch() in reference app demos

### DIFF
--- a/examples/chat_client.rs
+++ b/examples/chat_client.rs
@@ -458,25 +458,21 @@ fn generate_response(msg_num: usize) -> String {
 fn main() -> envision::Result<()> {
     let mut vt = Runtime::<ChatClient, _>::virtual_terminal(90, 28)?;
 
-    // Simulate a conversation
-    // Push a user message and trigger the simulated response
+    // Simulate a conversation using vt.dispatch() so that returned
+    // Command::message() values are automatically processed on tick().
     TextArea::update(
         &mut vt.state_mut().input,
         TextAreaMessage::SetValue("How do I sort a vector in Rust?".to_string()),
     );
-    ChatClient::update(vt.state_mut(), Msg::SubmitInput);
-    // The SubmitInput returns Command::message(SimulateResponse) which the
-    // virtual terminal doesn't process, so dispatch it manually.
-    ChatClient::update(vt.state_mut(), Msg::SimulateResponse);
-    vt.tick()?;
+    vt.dispatch(Msg::SubmitInput);
+    vt.tick()?; // Processes Command::message(SimulateResponse) from SubmitInput
 
     // Push another user message and response
     TextArea::update(
         &mut vt.state_mut().input,
         TextAreaMessage::SetValue("What about ownership?".to_string()),
     );
-    ChatClient::update(vt.state_mut(), Msg::SubmitInput);
-    ChatClient::update(vt.state_mut(), Msg::SimulateResponse);
+    vt.dispatch(Msg::SubmitInput);
     vt.tick()?;
 
     println!("Chat Client — Reference Application");

--- a/examples/file_manager.rs
+++ b/examples/file_manager.rs
@@ -517,11 +517,10 @@ fn main() {
 fn main() -> envision::Result<()> {
     let mut vt = Runtime::<FileManager, _>::virtual_terminal(100, 30)?;
 
-    // Simulate selecting a file
-    FileManager::update(vt.state_mut(), Msg::Browser(FileBrowserMessage::Down));
-    FileManager::update(vt.state_mut(), Msg::Browser(FileBrowserMessage::Down));
-    FileManager::update(vt.state_mut(), Msg::Browser(FileBrowserMessage::Down));
-    // Select Cargo.toml (4th entry after 3 directories)
+    // Simulate selecting a file using vt.dispatch() for proper command processing
+    vt.dispatch(Msg::Browser(FileBrowserMessage::Down));
+    vt.dispatch(Msg::Browser(FileBrowserMessage::Down));
+    vt.dispatch(Msg::Browser(FileBrowserMessage::Down));
     vt.tick()?;
 
     println!("File Manager — Reference Application");


### PR DESCRIPTION
## Summary
- Update chat_client and file_manager examples to use `vt.dispatch(msg)` instead of `App::update(vt.state_mut(), msg)`
- `dispatch()` properly executes returned commands, so `Command::message()` values cascade automatically on `tick()`
- Removes the manual `SimulateResponse` dispatch workaround from chat_client

## Test plan
- [x] `cargo run --example chat_client --all-features` — renders correctly with assistant responses
- [x] `cargo run --example file_manager --all-features` — renders correctly
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)