### PR TITLE
Convert constructors to chainable builders for TextArea and SplitPanel

### DIFF
--- a/benches/component_events.rs
+++ b/benches/component_events.rs
@@ -111,7 +111,7 @@ fn bench_handle_event(c: &mut Criterion) {
         let event = Event::key(KeyCode::Down);
 
         // Focused
-        let mut state = TextAreaState::with_value(&content);
+        let mut state = TextAreaState::new().with_value(&content);
         state.set_focused(true);
         group.bench_with_input(
             BenchmarkId::new("text_area/focused", size),
@@ -216,7 +216,7 @@ fn bench_dispatch_event(c: &mut Criterion) {
             BenchmarkId::new("text_area/focused", size),
             &size,
             |b, _| {
-                let mut state = TextAreaState::with_value(&content);
+                let mut state = TextAreaState::new().with_value(&content);
                 state.set_focused(true);
                 // Start at top so Down always moves
                 state.set_cursor_position(0, 0);

--- a/examples/chat_client.rs
+++ b/examples/chat_client.rs
@@ -159,7 +159,7 @@ impl App for ChatClient {
             conversations: vec![initial_conv],
             active_tab: 0,
             tab_bar,
-            input: TextAreaState::with_placeholder("Type a message... (Ctrl+Enter to send)"),
+            input: TextAreaState::new().with_placeholder("Type a message... (Ctrl+Enter to send)"),
             palette: CommandPaletteState::new(palette_items)
                 .with_title("Commands")
                 .with_placeholder("Type a command..."),

--- a/examples/chat_markdown_demo.rs
+++ b/examples/chat_markdown_demo.rs
@@ -147,7 +147,7 @@ impl Default for State {
             "09:04",
         );
 
-        let mut input = TextAreaState::with_placeholder("Type a markdown message...");
+        let mut input = TextAreaState::new().with_placeholder("Type a markdown message...");
         input.set_focused(true);
 
         Self {

--- a/examples/file_manager.rs
+++ b/examples/file_manager.rs
@@ -125,7 +125,7 @@ impl App for FileManager {
             browser: FileBrowserState::new("/home/user/project", entries),
             code: sample_code_block("main.rs"),
             diff: sample_diff(),
-            split: SplitPanelState::with_ratio(SplitOrientation::Vertical, 0.3),
+            split: SplitPanelState::new(SplitOrientation::Vertical).with_ratio(0.3),
             breadcrumb: BreadcrumbState::from_path("/home/user/project", "/"),
             palette: CommandPaletteState::new(palette_items)
                 .with_title("File Manager")

--- a/examples/log_explorer.rs
+++ b/examples/log_explorer.rs
@@ -135,7 +135,8 @@ impl App for LogExplorer {
                 .with_title("Command Palette")
                 .with_placeholder("Type to search actions..."),
             status,
-            split: SplitPanelState::with_ratio(SplitOrientation::Vertical, 0.5)
+            split: SplitPanelState::new(SplitOrientation::Vertical)
+                .with_ratio(0.5)
                 .with_bounds(0.25, 0.75),
             focus: FocusManager::with_initial_focus(vec![Pane::LogViewer, Pane::EventStream]),
             tick_count: 0,

--- a/examples/split_panel.rs
+++ b/examples/split_panel.rs
@@ -28,7 +28,8 @@ impl App for SplitPanelApp {
     type Message = Msg;
 
     fn init() -> (State, Command<Msg>) {
-        let mut split = SplitPanelState::with_ratio(SplitOrientation::Vertical, 0.4)
+        let mut split = SplitPanelState::new(SplitOrientation::Vertical)
+            .with_ratio(0.4)
             .with_resize_step(0.1)
             .with_bounds(0.2, 0.8);
 

--- a/examples/text_area.rs
+++ b/examples/text_area.rs
@@ -29,7 +29,7 @@ impl App for TextAreaApp {
 
     fn init() -> (State, Command<Msg>) {
         let initial_text = "Hello, TextArea!\nEdit this content.\nLine three.";
-        let mut editor = TextAreaState::with_value(initial_text);
+        let mut editor = TextAreaState::new().with_value(initial_text);
         editor.set_focused(true);
 
         (State { editor }, Command::none())

--- a/src/component/chat_view/mod.rs
+++ b/src/component/chat_view/mod.rs
@@ -83,7 +83,7 @@ impl Default for ChatViewState {
     fn default() -> Self {
         Self {
             messages: Vec::new(),
-            input: TextAreaState::with_placeholder("Type a message..."),
+            input: TextAreaState::new().with_placeholder("Type a message..."),
             scroll: ScrollState::default(),
             auto_scroll: true,
             max_messages: 1000,

--- a/src/component/split_panel/mod.rs
+++ b/src/component/split_panel/mod.rs
@@ -170,7 +170,7 @@ impl SplitPanelState {
         }
     }
 
-    /// Creates a split panel with a custom ratio.
+    /// Sets the split ratio (builder pattern).
     ///
     /// The ratio is clamped to `[min_ratio, max_ratio]`.
     ///
@@ -179,13 +179,12 @@ impl SplitPanelState {
     /// ```rust
     /// use envision::component::{SplitPanelState, SplitOrientation};
     ///
-    /// let state = SplitPanelState::with_ratio(SplitOrientation::Vertical, 0.3);
+    /// let state = SplitPanelState::new(SplitOrientation::Vertical).with_ratio(0.3);
     /// assert!((state.ratio() - 0.3).abs() < f32::EPSILON);
     /// ```
-    pub fn with_ratio(orientation: SplitOrientation, ratio: f32) -> Self {
-        let mut state = Self::new(orientation);
-        state.ratio = ratio.clamp(state.min_ratio, state.max_ratio);
-        state
+    pub fn with_ratio(mut self, ratio: f32) -> Self {
+        self.ratio = ratio.clamp(self.min_ratio, self.max_ratio);
+        self
     }
 
     /// Returns the current orientation.

--- a/src/component/split_panel/snapshot_tests.rs
+++ b/src/component/split_panel/snapshot_tests.rs
@@ -77,7 +77,7 @@ fn test_snapshot_horizontal() {
 
 #[test]
 fn test_snapshot_custom_ratio() {
-    let mut state = SplitPanelState::with_ratio(SplitOrientation::Vertical, 0.3);
+    let mut state = SplitPanelState::new(SplitOrientation::Vertical).with_ratio(0.3);
     SplitPanel::set_focused(&mut state, true);
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal

--- a/src/component/split_panel/tests.rs
+++ b/src/component/split_panel/tests.rs
@@ -34,16 +34,16 @@ fn test_new_horizontal() {
 
 #[test]
 fn test_with_ratio() {
-    let state = SplitPanelState::with_ratio(SplitOrientation::Vertical, 0.3);
+    let state = SplitPanelState::new(SplitOrientation::Vertical).with_ratio(0.3);
     assert!((state.ratio() - 0.3).abs() < f32::EPSILON);
 }
 
 #[test]
 fn test_with_ratio_clamped() {
-    let state = SplitPanelState::with_ratio(SplitOrientation::Vertical, 0.05);
+    let state = SplitPanelState::new(SplitOrientation::Vertical).with_ratio(0.05);
     assert!((state.ratio() - 0.1).abs() < f32::EPSILON); // min is 0.1
 
-    let state = SplitPanelState::with_ratio(SplitOrientation::Vertical, 0.95);
+    let state = SplitPanelState::new(SplitOrientation::Vertical).with_ratio(0.95);
     assert!((state.ratio() - 0.9).abs() < f32::EPSILON); // max is 0.9
 }
 
@@ -75,7 +75,9 @@ fn test_with_bounds() {
 
 #[test]
 fn test_with_bounds_clamps_ratio() {
-    let state = SplitPanelState::with_ratio(SplitOrientation::Vertical, 0.95).with_bounds(0.2, 0.8);
+    let state = SplitPanelState::new(SplitOrientation::Vertical)
+        .with_ratio(0.95)
+        .with_bounds(0.2, 0.8);
     assert!((state.ratio() - 0.8).abs() < f32::EPSILON);
 }
 
@@ -394,7 +396,7 @@ fn test_layout_horizontal_50_50() {
 
 #[test]
 fn test_layout_vertical_70_30() {
-    let state = SplitPanelState::with_ratio(SplitOrientation::Vertical, 0.7);
+    let state = SplitPanelState::new(SplitOrientation::Vertical).with_ratio(0.7);
     let area = Rect::new(0, 0, 100, 24);
     let (first, second) = state.layout(area);
     assert_eq!(first.width, 70);
@@ -531,7 +533,7 @@ fn test_partial_eq() {
 #[test]
 fn test_partial_eq_different_ratio() {
     let state1 = SplitPanelState::new(SplitOrientation::Vertical);
-    let state2 = SplitPanelState::with_ratio(SplitOrientation::Vertical, 0.3);
+    let state2 = SplitPanelState::new(SplitOrientation::Vertical).with_ratio(0.3);
     assert_ne!(state1, state2);
 }
 

--- a/src/component/text_area/mod.rs
+++ b/src/component/text_area/mod.rs
@@ -242,63 +242,45 @@ impl TextAreaState {
     }
 
     /// Creates a textarea with initial content, split on newlines.
-    /// Cursor is placed at the end of the content.
+    /// Sets the content and places cursor at the end (builder pattern).
     ///
     /// # Examples
     ///
     /// ```
     /// use envision::prelude::*;
     ///
-    /// let state = TextAreaState::with_value("Hello\nWorld");
+    /// let state = TextAreaState::new().with_value("Hello\nWorld");
     /// assert_eq!(state.value(), "Hello\nWorld");
     /// assert_eq!(state.line_count(), 2);
     /// ```
-    pub fn with_value(value: impl Into<String>) -> Self {
+    pub fn with_value(mut self, value: impl Into<String>) -> Self {
         let value = value.into();
-        let lines: Vec<String> = if value.is_empty() {
+        self.lines = if value.is_empty() {
             vec![String::new()]
         } else {
             // Use split('\n') instead of lines() to preserve trailing newlines
             value.split('\n').map(String::from).collect()
         };
 
-        let cursor_row = lines.len().saturating_sub(1);
-        let cursor_col = lines.last().map(|l| l.len()).unwrap_or(0);
-
-        Self {
-            lines,
-            cursor_row,
-            cursor_col,
-            scroll_offset: 0,
-            focused: false,
-            disabled: false,
-            placeholder: String::new(),
-            selection_anchor: None,
-            clipboard: String::new(),
-            undo_stack: UndoStack::default(),
-            show_line_numbers: false,
-            search_query: None,
-            search_matches: Vec::new(),
-            current_match: 0,
-        }
+        self.cursor_row = self.lines.len().saturating_sub(1);
+        self.cursor_col = self.lines.last().map(|l| l.len()).unwrap_or(0);
+        self
     }
 
-    /// Creates a textarea with placeholder text.
+    /// Sets the placeholder text (builder pattern).
     ///
     /// # Examples
     ///
     /// ```
     /// use envision::prelude::*;
     ///
-    /// let state = TextAreaState::with_placeholder("Enter text...");
+    /// let state = TextAreaState::new().with_placeholder("Enter text...");
     /// assert_eq!(state.placeholder(), "Enter text...");
     /// assert!(state.is_empty());
     /// ```
-    pub fn with_placeholder(placeholder: impl Into<String>) -> Self {
-        Self {
-            placeholder: placeholder.into(),
-            ..Default::default()
-        }
+    pub fn with_placeholder(mut self, placeholder: impl Into<String>) -> Self {
+        self.placeholder = placeholder.into();
+        self
     }
 
     /// Returns the full text content (lines joined with \n).
@@ -308,7 +290,7 @@ impl TextAreaState {
     /// ```
     /// use envision::prelude::*;
     ///
-    /// let state = TextAreaState::with_value("line1\nline2");
+    /// let state = TextAreaState::new().with_value("line1\nline2");
     /// assert_eq!(state.value(), "line1\nline2");
     /// ```
     pub fn value(&self) -> String {
@@ -409,7 +391,7 @@ impl TextAreaState {
     /// use envision::prelude::*;
     ///
     /// assert!(TextAreaState::new().is_empty());
-    /// assert!(!TextAreaState::with_value("hi").is_empty());
+    /// assert!(!TextAreaState::new().with_value("hi").is_empty());
     /// ```
     pub fn is_empty(&self) -> bool {
         self.lines.len() == 1 && self.lines[0].is_empty()

--- a/src/component/text_area/selection_tests.rs
+++ b/src/component/text_area/selection_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 fn focused_state(value: &str) -> TextAreaState {
-    let mut state = TextAreaState::with_value(value);
+    let mut state = TextAreaState::new().with_value(value);
     state.set_focused(true);
     state
 }
@@ -12,14 +12,14 @@ fn focused_state(value: &str) -> TextAreaState {
 
 #[test]
 fn test_no_selection_by_default() {
-    let state = TextAreaState::with_value("hello");
+    let state = TextAreaState::new().with_value("hello");
     assert!(!state.has_selection());
     assert_eq!(state.selected_text(), None);
 }
 
 #[test]
 fn test_select_left() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     TextArea::update(&mut state, TextAreaMessage::SelectLeft);
     assert!(state.has_selection());
     assert_eq!(state.selected_text(), Some("o".to_string()));
@@ -27,7 +27,7 @@ fn test_select_left() {
 
 #[test]
 fn test_select_right() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::SelectRight);
     assert_eq!(state.selected_text(), Some("h".to_string()));
@@ -35,14 +35,14 @@ fn test_select_right() {
 
 #[test]
 fn test_select_home() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     TextArea::update(&mut state, TextAreaMessage::SelectHome);
     assert_eq!(state.selected_text(), Some("hello".to_string()));
 }
 
 #[test]
 fn test_select_end() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::SelectEnd);
     assert_eq!(state.selected_text(), Some("hello".to_string()));
@@ -50,7 +50,7 @@ fn test_select_end() {
 
 #[test]
 fn test_select_up() {
-    let mut state = TextAreaState::with_value("line1\nline2");
+    let mut state = TextAreaState::new().with_value("line1\nline2");
     // Cursor at end of line2
     TextArea::update(&mut state, TextAreaMessage::SelectUp);
     assert!(state.has_selection());
@@ -60,7 +60,7 @@ fn test_select_up() {
 
 #[test]
 fn test_select_down() {
-    let mut state = TextAreaState::with_value("line1\nline2");
+    let mut state = TextAreaState::new().with_value("line1\nline2");
     state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::SelectDown);
     assert!(state.has_selection());
@@ -68,14 +68,14 @@ fn test_select_down() {
 
 #[test]
 fn test_select_word_left() {
-    let mut state = TextAreaState::with_value("hello world");
+    let mut state = TextAreaState::new().with_value("hello world");
     TextArea::update(&mut state, TextAreaMessage::SelectWordLeft);
     assert_eq!(state.selected_text(), Some("world".to_string()));
 }
 
 #[test]
 fn test_select_word_right() {
-    let mut state = TextAreaState::with_value("hello world");
+    let mut state = TextAreaState::new().with_value("hello world");
     state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::SelectWordRight);
     assert_eq!(state.selected_text(), Some("hello ".to_string()));
@@ -83,7 +83,7 @@ fn test_select_word_right() {
 
 #[test]
 fn test_select_all() {
-    let mut state = TextAreaState::with_value("line1\nline2");
+    let mut state = TextAreaState::new().with_value("line1\nline2");
     TextArea::update(&mut state, TextAreaMessage::SelectAll);
     assert_eq!(state.selected_text(), Some("line1\nline2".to_string()));
 }
@@ -102,7 +102,7 @@ fn test_select_all_empty() {
 
 #[test]
 fn test_multiline_selection() {
-    let mut state = TextAreaState::with_value("abc\ndef\nghi");
+    let mut state = TextAreaState::new().with_value("abc\ndef\nghi");
     state.set_cursor_position(0, 0);
     // Select from start to end of line 1
     TextArea::update(&mut state, TextAreaMessage::SelectDown);
@@ -114,7 +114,7 @@ fn test_multiline_selection() {
 
 #[test]
 fn test_select_across_lines() {
-    let mut state = TextAreaState::with_value("abc\ndef");
+    let mut state = TextAreaState::new().with_value("abc\ndef");
     state.set_cursor_position(0, 1); // After 'a'
                                      // Select from (0,1) to (1,2) using SelectDown then SelectRight
     TextArea::update(&mut state, TextAreaMessage::SelectDown);
@@ -129,7 +129,7 @@ fn test_select_across_lines() {
 
 #[test]
 fn test_left_clears_selection() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     TextArea::update(&mut state, TextAreaMessage::SelectLeft);
     assert!(state.has_selection());
 
@@ -139,7 +139,7 @@ fn test_left_clears_selection() {
 
 #[test]
 fn test_right_clears_selection() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::SelectRight);
     assert!(state.has_selection());
@@ -150,7 +150,7 @@ fn test_right_clears_selection() {
 
 #[test]
 fn test_up_clears_selection() {
-    let mut state = TextAreaState::with_value("a\nb");
+    let mut state = TextAreaState::new().with_value("a\nb");
     TextArea::update(&mut state, TextAreaMessage::SelectUp);
     assert!(state.has_selection());
 
@@ -164,7 +164,7 @@ fn test_up_clears_selection() {
 
 #[test]
 fn test_insert_replaces_selection() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     TextArea::update(&mut state, TextAreaMessage::SelectAll);
     TextArea::update(&mut state, TextAreaMessage::Insert('X'));
     assert_eq!(state.value(), "X");
@@ -172,7 +172,7 @@ fn test_insert_replaces_selection() {
 
 #[test]
 fn test_backspace_deletes_selection() {
-    let mut state = TextAreaState::with_value("hello world");
+    let mut state = TextAreaState::new().with_value("hello world");
     // Select "world"
     for _ in 0..5 {
         TextArea::update(&mut state, TextAreaMessage::SelectLeft);
@@ -183,7 +183,7 @@ fn test_backspace_deletes_selection() {
 
 #[test]
 fn test_delete_deletes_selection() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     TextArea::update(&mut state, TextAreaMessage::SelectAll);
     TextArea::update(&mut state, TextAreaMessage::Delete);
     assert_eq!(state.value(), "");
@@ -191,7 +191,7 @@ fn test_delete_deletes_selection() {
 
 #[test]
 fn test_multiline_delete_selection() {
-    let mut state = TextAreaState::with_value("abc\ndef\nghi");
+    let mut state = TextAreaState::new().with_value("abc\ndef\nghi");
     TextArea::update(&mut state, TextAreaMessage::SelectAll);
     TextArea::update(&mut state, TextAreaMessage::Delete);
     assert_eq!(state.value(), "");
@@ -200,7 +200,7 @@ fn test_multiline_delete_selection() {
 
 #[test]
 fn test_newline_replaces_selection() {
-    let mut state = TextAreaState::with_value("hello world");
+    let mut state = TextAreaState::new().with_value("hello world");
     TextArea::update(&mut state, TextAreaMessage::SelectAll);
     TextArea::update(&mut state, TextAreaMessage::NewLine);
     assert_eq!(state.value(), "\n");
@@ -212,7 +212,7 @@ fn test_newline_replaces_selection() {
 
 #[test]
 fn test_copy() {
-    let mut state = TextAreaState::with_value("hello world");
+    let mut state = TextAreaState::new().with_value("hello world");
     TextArea::update(&mut state, TextAreaMessage::SelectAll);
     let output = TextArea::update(&mut state, TextAreaMessage::Copy);
     assert_eq!(output, Some(TextAreaOutput::Copied("hello world".into())));
@@ -222,14 +222,14 @@ fn test_copy() {
 
 #[test]
 fn test_copy_without_selection() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     let output = TextArea::update(&mut state, TextAreaMessage::Copy);
     assert_eq!(output, None);
 }
 
 #[test]
 fn test_cut() {
-    let mut state = TextAreaState::with_value("hello world");
+    let mut state = TextAreaState::new().with_value("hello world");
     TextArea::update(&mut state, TextAreaMessage::SelectAll);
     let output = TextArea::update(&mut state, TextAreaMessage::Cut);
     assert_eq!(output, Some(TextAreaOutput::Changed(String::new())));
@@ -239,14 +239,14 @@ fn test_cut() {
 
 #[test]
 fn test_cut_without_selection() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     let output = TextArea::update(&mut state, TextAreaMessage::Cut);
     assert_eq!(output, None);
 }
 
 #[test]
 fn test_paste() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     let output = TextArea::update(&mut state, TextAreaMessage::Paste(" world".into()));
     assert_eq!(state.value(), "hello world");
     assert!(output.is_some());
@@ -254,7 +254,7 @@ fn test_paste() {
 
 #[test]
 fn test_paste_replaces_selection() {
-    let mut state = TextAreaState::with_value("hello world");
+    let mut state = TextAreaState::new().with_value("hello world");
     TextArea::update(&mut state, TextAreaMessage::SelectAll);
     TextArea::update(&mut state, TextAreaMessage::Paste("goodbye".into()));
     assert_eq!(state.value(), "goodbye");
@@ -273,14 +273,14 @@ fn test_paste_multiline() {
 
 #[test]
 fn test_paste_empty() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     let output = TextArea::update(&mut state, TextAreaMessage::Paste(String::new()));
     assert_eq!(output, None);
 }
 
 #[test]
 fn test_copy_then_paste() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     TextArea::update(&mut state, TextAreaMessage::SelectAll);
     TextArea::update(&mut state, TextAreaMessage::Copy);
     TextArea::update(&mut state, TextAreaMessage::End);
@@ -358,7 +358,7 @@ fn test_paste_event() {
 
 #[test]
 fn test_disabled_ignores_selection() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     state.set_disabled(true);
     let output = TextArea::update(&mut state, TextAreaMessage::SelectAll);
     assert_eq!(output, None);
@@ -367,7 +367,7 @@ fn test_disabled_ignores_selection() {
 
 #[test]
 fn test_clear_clears_selection() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     TextArea::update(&mut state, TextAreaMessage::SelectAll);
     TextArea::update(&mut state, TextAreaMessage::Clear);
     assert!(!state.has_selection());
@@ -376,7 +376,7 @@ fn test_clear_clears_selection() {
 
 #[test]
 fn test_set_value_clears_selection() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     TextArea::update(&mut state, TextAreaMessage::SelectAll);
     TextArea::update(&mut state, TextAreaMessage::SetValue("new".into()));
     assert!(!state.has_selection());
@@ -385,7 +385,7 @@ fn test_set_value_clears_selection() {
 
 #[test]
 fn test_delete_partial_multiline_selection() {
-    let mut state = TextAreaState::with_value("abc\ndef\nghi");
+    let mut state = TextAreaState::new().with_value("abc\ndef\nghi");
     // Select from middle of line 0 to middle of line 2
     state.set_cursor_position(0, 1); // After 'a'
     state.selection_anchor = Some((0, 1));

--- a/src/component/text_area/tests.rs
+++ b/src/component/text_area/tests.rs
@@ -24,7 +24,7 @@ fn test_default() {
 
 #[test]
 fn test_with_value() {
-    let state = TextAreaState::with_value("Hello\nWorld");
+    let state = TextAreaState::new().with_value("Hello\nWorld");
     assert_eq!(state.line_count(), 2);
     assert_eq!(state.line(0), Some("Hello"));
     assert_eq!(state.line(1), Some("World"));
@@ -34,14 +34,14 @@ fn test_with_value() {
 
 #[test]
 fn test_with_value_empty() {
-    let state = TextAreaState::with_value("");
+    let state = TextAreaState::new().with_value("");
     assert!(state.is_empty());
     assert_eq!(state.line_count(), 1);
 }
 
 #[test]
 fn test_with_placeholder() {
-    let state = TextAreaState::with_placeholder("Enter text...");
+    let state = TextAreaState::new().with_placeholder("Enter text...");
     assert_eq!(state.placeholder(), "Enter text...");
     assert!(state.is_empty());
 }
@@ -50,7 +50,7 @@ fn test_with_placeholder() {
 
 #[test]
 fn test_value() {
-    let state = TextAreaState::with_value("Line 1\nLine 2\nLine 3");
+    let state = TextAreaState::new().with_value("Line 1\nLine 2\nLine 3");
     assert_eq!(state.value(), "Line 1\nLine 2\nLine 3");
 }
 
@@ -66,7 +66,7 @@ fn test_set_value() {
 
 #[test]
 fn test_line() {
-    let state = TextAreaState::with_value("a\nb\nc");
+    let state = TextAreaState::new().with_value("a\nb\nc");
     assert_eq!(state.line(0), Some("a"));
     assert_eq!(state.line(1), Some("b"));
     assert_eq!(state.line(2), Some("c"));
@@ -75,7 +75,7 @@ fn test_line() {
 
 #[test]
 fn test_current_line() {
-    let mut state = TextAreaState::with_value("Hello\nWorld");
+    let mut state = TextAreaState::new().with_value("Hello\nWorld");
     state.set_cursor_position(0, 0);
     assert_eq!(state.current_line(), "Hello");
     state.set_cursor_position(1, 0);
@@ -85,43 +85,43 @@ fn test_current_line() {
 #[test]
 fn test_line_count() {
     assert_eq!(TextAreaState::new().line_count(), 1);
-    assert_eq!(TextAreaState::with_value("a").line_count(), 1);
-    assert_eq!(TextAreaState::with_value("a\nb").line_count(), 2);
-    assert_eq!(TextAreaState::with_value("a\nb\nc").line_count(), 3);
+    assert_eq!(TextAreaState::new().with_value("a").line_count(), 1);
+    assert_eq!(TextAreaState::new().with_value("a\nb").line_count(), 2);
+    assert_eq!(TextAreaState::new().with_value("a\nb\nc").line_count(), 3);
 }
 
 #[test]
 fn test_is_empty() {
     assert!(TextAreaState::new().is_empty());
-    assert!(!TextAreaState::with_value("a").is_empty());
-    assert!(!TextAreaState::with_value("\n").is_empty()); // Two empty lines
+    assert!(!TextAreaState::new().with_value("a").is_empty());
+    assert!(!TextAreaState::new().with_value("\n").is_empty()); // Two empty lines
 }
 
 // Cursor Tests
 
 #[test]
 fn test_cursor_position() {
-    let state = TextAreaState::with_value("Hello\nWorld");
+    let state = TextAreaState::new().with_value("Hello\nWorld");
     assert_eq!(state.cursor_position(), (1, 5));
 }
 
 #[test]
 fn test_set_cursor_position() {
-    let mut state = TextAreaState::with_value("Hello\nWorld");
+    let mut state = TextAreaState::new().with_value("Hello\nWorld");
     state.set_cursor_position(0, 2);
     assert_eq!(state.cursor_position(), (0, 2));
 }
 
 #[test]
 fn test_cursor_clamp_row() {
-    let mut state = TextAreaState::with_value("Hello");
+    let mut state = TextAreaState::new().with_value("Hello");
     state.set_cursor_position(10, 0); // Row out of bounds
     assert_eq!(state.cursor_row(), 0);
 }
 
 #[test]
 fn test_cursor_clamp_col() {
-    let mut state = TextAreaState::with_value("Hi");
+    let mut state = TextAreaState::new().with_value("Hi");
     state.set_cursor_position(0, 100); // Col out of bounds
     assert_eq!(state.cursor_position(), (0, 2));
 }
@@ -150,7 +150,7 @@ fn test_insert_unicode() {
 
 #[test]
 fn test_newline() {
-    let mut state = TextAreaState::with_value("Hello");
+    let mut state = TextAreaState::new().with_value("Hello");
     state.set_cursor_position(0, 2);
     TextArea::update(&mut state, TextAreaMessage::NewLine);
     assert_eq!(state.line_count(), 2);
@@ -161,7 +161,7 @@ fn test_newline() {
 
 #[test]
 fn test_newline_at_start() {
-    let mut state = TextAreaState::with_value("Hello");
+    let mut state = TextAreaState::new().with_value("Hello");
     state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::NewLine);
     assert_eq!(state.line(0), Some(""));
@@ -170,7 +170,7 @@ fn test_newline_at_start() {
 
 #[test]
 fn test_newline_at_end() {
-    let mut state = TextAreaState::with_value("Hello");
+    let mut state = TextAreaState::new().with_value("Hello");
     TextArea::update(&mut state, TextAreaMessage::NewLine);
     assert_eq!(state.line(0), Some("Hello"));
     assert_eq!(state.line(1), Some(""));
@@ -178,7 +178,7 @@ fn test_newline_at_end() {
 
 #[test]
 fn test_backspace() {
-    let mut state = TextAreaState::with_value("Hello");
+    let mut state = TextAreaState::new().with_value("Hello");
     let output = TextArea::update(&mut state, TextAreaMessage::Backspace);
     assert_eq!(state.value(), "Hell");
     assert!(matches!(output, Some(TextAreaOutput::Changed(_))));
@@ -186,7 +186,7 @@ fn test_backspace() {
 
 #[test]
 fn test_backspace_join_lines() {
-    let mut state = TextAreaState::with_value("Hello\nWorld");
+    let mut state = TextAreaState::new().with_value("Hello\nWorld");
     state.set_cursor_position(1, 0); // Start of second line
     TextArea::update(&mut state, TextAreaMessage::Backspace);
     assert_eq!(state.value(), "HelloWorld");
@@ -195,7 +195,7 @@ fn test_backspace_join_lines() {
 
 #[test]
 fn test_backspace_first_line_start() {
-    let mut state = TextAreaState::with_value("Hello");
+    let mut state = TextAreaState::new().with_value("Hello");
     state.set_cursor_position(0, 0);
     let output = TextArea::update(&mut state, TextAreaMessage::Backspace);
     assert_eq!(output, None);
@@ -204,7 +204,7 @@ fn test_backspace_first_line_start() {
 
 #[test]
 fn test_delete() {
-    let mut state = TextAreaState::with_value("Hello");
+    let mut state = TextAreaState::new().with_value("Hello");
     state.set_cursor_position(0, 0);
     let output = TextArea::update(&mut state, TextAreaMessage::Delete);
     assert_eq!(state.value(), "ello");
@@ -213,7 +213,7 @@ fn test_delete() {
 
 #[test]
 fn test_delete_join_lines() {
-    let mut state = TextAreaState::with_value("Hello\nWorld");
+    let mut state = TextAreaState::new().with_value("Hello\nWorld");
     state.set_cursor_position(0, 5); // End of first line
     TextArea::update(&mut state, TextAreaMessage::Delete);
     assert_eq!(state.value(), "HelloWorld");
@@ -221,7 +221,7 @@ fn test_delete_join_lines() {
 
 #[test]
 fn test_delete_last_line_end() {
-    let mut state = TextAreaState::with_value("Hello");
+    let mut state = TextAreaState::new().with_value("Hello");
     // Cursor is already at end
     let output = TextArea::update(&mut state, TextAreaMessage::Delete);
     assert_eq!(output, None);
@@ -231,14 +231,14 @@ fn test_delete_last_line_end() {
 
 #[test]
 fn test_left() {
-    let mut state = TextAreaState::with_value("Hello");
+    let mut state = TextAreaState::new().with_value("Hello");
     TextArea::update(&mut state, TextAreaMessage::Left);
     assert_eq!(state.cursor_position(), (0, 4));
 }
 
 #[test]
 fn test_left_wrap() {
-    let mut state = TextAreaState::with_value("Hello\nWorld");
+    let mut state = TextAreaState::new().with_value("Hello\nWorld");
     state.set_cursor_position(1, 0);
     TextArea::update(&mut state, TextAreaMessage::Left);
     assert_eq!(state.cursor_position(), (0, 5)); // End of first line
@@ -246,7 +246,7 @@ fn test_left_wrap() {
 
 #[test]
 fn test_left_at_start() {
-    let mut state = TextAreaState::with_value("Hello");
+    let mut state = TextAreaState::new().with_value("Hello");
     state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::Left);
     assert_eq!(state.cursor_position(), (0, 0)); // Stays at start
@@ -254,7 +254,7 @@ fn test_left_at_start() {
 
 #[test]
 fn test_right() {
-    let mut state = TextAreaState::with_value("Hello");
+    let mut state = TextAreaState::new().with_value("Hello");
     state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::Right);
     assert_eq!(state.cursor_position(), (0, 1));
@@ -262,7 +262,7 @@ fn test_right() {
 
 #[test]
 fn test_right_wrap() {
-    let mut state = TextAreaState::with_value("Hello\nWorld");
+    let mut state = TextAreaState::new().with_value("Hello\nWorld");
     state.set_cursor_position(0, 5); // End of first line
     TextArea::update(&mut state, TextAreaMessage::Right);
     assert_eq!(state.cursor_position(), (1, 0)); // Start of second line
@@ -270,7 +270,7 @@ fn test_right_wrap() {
 
 #[test]
 fn test_right_at_end() {
-    let mut state = TextAreaState::with_value("Hello");
+    let mut state = TextAreaState::new().with_value("Hello");
     // Already at end
     TextArea::update(&mut state, TextAreaMessage::Right);
     assert_eq!(state.cursor_position(), (0, 5)); // Stays at end
@@ -278,14 +278,14 @@ fn test_right_at_end() {
 
 #[test]
 fn test_up() {
-    let mut state = TextAreaState::with_value("Hello\nWorld");
+    let mut state = TextAreaState::new().with_value("Hello\nWorld");
     TextArea::update(&mut state, TextAreaMessage::Up);
     assert_eq!(state.cursor_position(), (0, 5));
 }
 
 #[test]
 fn test_up_clamps_column() {
-    let mut state = TextAreaState::with_value("Hi\nHello");
+    let mut state = TextAreaState::new().with_value("Hi\nHello");
     state.set_cursor_position(1, 5); // End of "Hello"
     TextArea::update(&mut state, TextAreaMessage::Up);
     assert_eq!(state.cursor_position(), (0, 2)); // Clamped to "Hi" length
@@ -293,7 +293,7 @@ fn test_up_clamps_column() {
 
 #[test]
 fn test_up_at_first_line() {
-    let mut state = TextAreaState::with_value("Hello\nWorld");
+    let mut state = TextAreaState::new().with_value("Hello\nWorld");
     state.set_cursor_position(0, 2);
     TextArea::update(&mut state, TextAreaMessage::Up);
     assert_eq!(state.cursor_position(), (0, 2)); // Stays on first line
@@ -301,7 +301,7 @@ fn test_up_at_first_line() {
 
 #[test]
 fn test_down() {
-    let mut state = TextAreaState::with_value("Hello\nWorld");
+    let mut state = TextAreaState::new().with_value("Hello\nWorld");
     state.set_cursor_position(0, 2);
     TextArea::update(&mut state, TextAreaMessage::Down);
     assert_eq!(state.cursor_position(), (1, 2));
@@ -309,7 +309,7 @@ fn test_down() {
 
 #[test]
 fn test_down_clamps_column() {
-    let mut state = TextAreaState::with_value("Hello\nHi");
+    let mut state = TextAreaState::new().with_value("Hello\nHi");
     state.set_cursor_position(0, 5); // End of "Hello"
     TextArea::update(&mut state, TextAreaMessage::Down);
     assert_eq!(state.cursor_position(), (1, 2)); // Clamped to "Hi" length
@@ -317,7 +317,7 @@ fn test_down_clamps_column() {
 
 #[test]
 fn test_down_at_last_line() {
-    let mut state = TextAreaState::with_value("Hello\nWorld");
+    let mut state = TextAreaState::new().with_value("Hello\nWorld");
     // Already on last line
     TextArea::update(&mut state, TextAreaMessage::Down);
     assert_eq!(state.cursor_row(), 1); // Stays on last line
@@ -325,14 +325,14 @@ fn test_down_at_last_line() {
 
 #[test]
 fn test_home() {
-    let mut state = TextAreaState::with_value("Hello");
+    let mut state = TextAreaState::new().with_value("Hello");
     TextArea::update(&mut state, TextAreaMessage::Home);
     assert_eq!(state.cursor_position(), (0, 0));
 }
 
 #[test]
 fn test_end() {
-    let mut state = TextAreaState::with_value("Hello");
+    let mut state = TextAreaState::new().with_value("Hello");
     state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::End);
     assert_eq!(state.cursor_position(), (0, 5));
@@ -340,14 +340,14 @@ fn test_end() {
 
 #[test]
 fn test_text_start() {
-    let mut state = TextAreaState::with_value("Hello\nWorld");
+    let mut state = TextAreaState::new().with_value("Hello\nWorld");
     TextArea::update(&mut state, TextAreaMessage::TextStart);
     assert_eq!(state.cursor_position(), (0, 0));
 }
 
 #[test]
 fn test_text_end() {
-    let mut state = TextAreaState::with_value("Hello\nWorld");
+    let mut state = TextAreaState::new().with_value("Hello\nWorld");
     state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::TextEnd);
     assert_eq!(state.cursor_position(), (1, 5));
@@ -355,14 +355,14 @@ fn test_text_end() {
 
 #[test]
 fn test_word_left() {
-    let mut state = TextAreaState::with_value("hello world");
+    let mut state = TextAreaState::new().with_value("hello world");
     TextArea::update(&mut state, TextAreaMessage::WordLeft);
     assert_eq!(state.cursor_position(), (0, 6)); // Start of "world"
 }
 
 #[test]
 fn test_word_right() {
-    let mut state = TextAreaState::with_value("hello world");
+    let mut state = TextAreaState::new().with_value("hello world");
     state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::WordRight);
     assert_eq!(state.cursor_position(), (0, 6)); // After "hello "
@@ -372,7 +372,7 @@ fn test_word_right() {
 
 #[test]
 fn test_delete_line() {
-    let mut state = TextAreaState::with_value("Line 1\nLine 2\nLine 3");
+    let mut state = TextAreaState::new().with_value("Line 1\nLine 2\nLine 3");
     state.set_cursor_position(1, 0);
     TextArea::update(&mut state, TextAreaMessage::DeleteLine);
     assert_eq!(state.line_count(), 2);
@@ -381,7 +381,7 @@ fn test_delete_line() {
 
 #[test]
 fn test_delete_line_single() {
-    let mut state = TextAreaState::with_value("Hello");
+    let mut state = TextAreaState::new().with_value("Hello");
     TextArea::update(&mut state, TextAreaMessage::DeleteLine);
     assert!(state.is_empty());
     assert_eq!(state.line_count(), 1);
@@ -389,7 +389,7 @@ fn test_delete_line_single() {
 
 #[test]
 fn test_delete_to_end() {
-    let mut state = TextAreaState::with_value("Hello World");
+    let mut state = TextAreaState::new().with_value("Hello World");
     state.set_cursor_position(0, 5);
     TextArea::update(&mut state, TextAreaMessage::DeleteToEnd);
     assert_eq!(state.value(), "Hello");
@@ -397,7 +397,7 @@ fn test_delete_to_end() {
 
 #[test]
 fn test_delete_to_start() {
-    let mut state = TextAreaState::with_value("Hello World");
+    let mut state = TextAreaState::new().with_value("Hello World");
     state.set_cursor_position(0, 6);
     TextArea::update(&mut state, TextAreaMessage::DeleteToStart);
     assert_eq!(state.value(), "World");
@@ -408,7 +408,7 @@ fn test_delete_to_start() {
 
 #[test]
 fn test_clear() {
-    let mut state = TextAreaState::with_value("Hello\nWorld");
+    let mut state = TextAreaState::new().with_value("Hello\nWorld");
     let output = TextArea::update(&mut state, TextAreaMessage::Clear);
     assert!(state.is_empty());
     assert!(matches!(output, Some(TextAreaOutput::Changed(_))));
@@ -434,14 +434,14 @@ fn test_set_value_message() {
 
 #[test]
 fn test_set_value_same() {
-    let mut state = TextAreaState::with_value("Same");
+    let mut state = TextAreaState::new().with_value("Same");
     let output = TextArea::update(&mut state, TextAreaMessage::SetValue("Same".to_string()));
     assert_eq!(output, None);
 }
 
 #[test]
 fn test_submit() {
-    let mut state = TextAreaState::with_value("My content");
+    let mut state = TextAreaState::new().with_value("My content");
     let output = TextArea::update(&mut state, TextAreaMessage::Submit);
     assert_eq!(
         output,
@@ -459,7 +459,7 @@ fn test_scroll_offset() {
 
 #[test]
 fn test_ensure_cursor_visible_down() {
-    let mut state = TextAreaState::with_value("1\n2\n3\n4\n5\n6\n7\n8\n9\n10");
+    let mut state = TextAreaState::new().with_value("1\n2\n3\n4\n5\n6\n7\n8\n9\n10");
     state.set_cursor_position(9, 0); // Last line
     state.ensure_cursor_visible(5);
     assert!(state.scroll_offset > 0);
@@ -469,7 +469,7 @@ fn test_ensure_cursor_visible_down() {
 
 #[test]
 fn test_ensure_cursor_visible_up() {
-    let mut state = TextAreaState::with_value("1\n2\n3\n4\n5\n6\n7\n8\n9\n10");
+    let mut state = TextAreaState::new().with_value("1\n2\n3\n4\n5\n6\n7\n8\n9\n10");
     state.scroll_offset = 5;
     state.set_cursor_position(2, 0);
     state.ensure_cursor_visible(5);
@@ -478,7 +478,7 @@ fn test_ensure_cursor_visible_up() {
 
 #[test]
 fn test_view_focused() {
-    let mut state = TextAreaState::with_value("Hello");
+    let mut state = TextAreaState::new().with_value("Hello");
     state.focused = true;
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
 
@@ -499,7 +499,7 @@ fn test_view_focused() {
 
 #[test]
 fn test_view_unfocused() {
-    let state = TextAreaState::with_value("Hello");
+    let state = TextAreaState::new().with_value("Hello");
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
 
     terminal
@@ -513,7 +513,7 @@ fn test_view_unfocused() {
 
 #[test]
 fn test_view_placeholder() {
-    let state = TextAreaState::with_placeholder("Enter text...");
+    let state = TextAreaState::new().with_placeholder("Enter text...");
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
 
     terminal
@@ -529,7 +529,7 @@ fn test_view_placeholder() {
 
 #[test]
 fn test_view_renders() {
-    let state = TextAreaState::with_value("Line 1\nLine 2\nLine 3");
+    let state = TextAreaState::new().with_value("Line 1\nLine 2\nLine 3");
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
 
     terminal
@@ -592,7 +592,7 @@ fn test_init() {
 
 #[test]
 fn test_set_value_empty_string() {
-    let mut state = TextAreaState::with_value("Hello\nWorld");
+    let mut state = TextAreaState::new().with_value("Hello\nWorld");
     state.set_value("");
     assert!(state.is_empty());
     assert_eq!(state.line_count(), 1);
@@ -608,13 +608,13 @@ fn test_set_placeholder_method() {
 
 #[test]
 fn test_cursor_col_accessor() {
-    let state = TextAreaState::with_value("Hello");
+    let state = TextAreaState::new().with_value("Hello");
     assert_eq!(state.cursor_col(), 5);
 }
 
 #[test]
 fn test_word_left_at_line_start() {
-    let mut state = TextAreaState::with_value("Hello\nWorld");
+    let mut state = TextAreaState::new().with_value("Hello\nWorld");
     state.set_cursor_position(1, 0); // Start of "World"
     TextArea::update(&mut state, TextAreaMessage::WordLeft);
     // Should wrap to end of previous line
@@ -623,7 +623,7 @@ fn test_word_left_at_line_start() {
 
 #[test]
 fn test_word_left_skip_whitespace() {
-    let mut state = TextAreaState::with_value("hello   world");
+    let mut state = TextAreaState::new().with_value("hello   world");
     state.set_cursor_position(0, 8); // In the middle of spaces
     TextArea::update(&mut state, TextAreaMessage::WordLeft);
     assert!(state.cursor_col() < 8);
@@ -631,7 +631,7 @@ fn test_word_left_skip_whitespace() {
 
 #[test]
 fn test_word_right_at_line_end() {
-    let mut state = TextAreaState::with_value("Hello\nWorld");
+    let mut state = TextAreaState::new().with_value("Hello\nWorld");
     state.set_cursor_position(0, 5); // End of "Hello"
     TextArea::update(&mut state, TextAreaMessage::WordRight);
     // Should wrap to start of next line
@@ -640,7 +640,7 @@ fn test_word_right_at_line_end() {
 
 #[test]
 fn test_word_right_skip_word() {
-    let mut state = TextAreaState::with_value("abc def");
+    let mut state = TextAreaState::new().with_value("abc def");
     state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::WordRight);
     // Should skip past "abc " to start of "def"
@@ -649,7 +649,7 @@ fn test_word_right_skip_word() {
 
 #[test]
 fn test_delete_line_last_line() {
-    let mut state = TextAreaState::with_value("Line 1\nLine 2");
+    let mut state = TextAreaState::new().with_value("Line 1\nLine 2");
     state.set_cursor_position(1, 3); // On last line
     TextArea::update(&mut state, TextAreaMessage::DeleteLine);
     // Should adjust cursor_row when deleting the last line
@@ -667,7 +667,7 @@ fn test_delete_line_single_empty() {
 
 #[test]
 fn test_delete_to_end_at_end() {
-    let mut state = TextAreaState::with_value("Hello");
+    let mut state = TextAreaState::new().with_value("Hello");
     // Cursor already at end
     let output = TextArea::update(&mut state, TextAreaMessage::DeleteToEnd);
     assert_eq!(output, None);
@@ -675,7 +675,7 @@ fn test_delete_to_end_at_end() {
 
 #[test]
 fn test_delete_to_start_at_start() {
-    let mut state = TextAreaState::with_value("Hello");
+    let mut state = TextAreaState::new().with_value("Hello");
     state.set_cursor_position(0, 0);
     let output = TextArea::update(&mut state, TextAreaMessage::DeleteToStart);
     assert_eq!(output, None);
@@ -684,7 +684,7 @@ fn test_delete_to_start_at_start() {
 #[test]
 fn test_view_with_scroll() {
     // Create a long content that needs scrolling
-    let mut state = TextAreaState::with_value(
+    let mut state = TextAreaState::new().with_value(
         "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6\nLine 7\nLine 8\nLine 9\nLine 10",
     );
     state.focused = true;
@@ -708,7 +708,7 @@ fn test_view_with_scroll() {
 
 #[test]
 fn test_view_cursor_above_scroll() {
-    let mut state = TextAreaState::with_value("1\n2\n3\n4\n5\n6\n7\n8\n9\n10");
+    let mut state = TextAreaState::new().with_value("1\n2\n3\n4\n5\n6\n7\n8\n9\n10");
     state.scroll_offset = 5; // Scroll down
     state.set_cursor_position(2, 0); // Cursor above scroll
     state.focused = true;
@@ -731,7 +731,7 @@ fn test_view_cursor_above_scroll() {
 
 #[test]
 fn test_ensure_cursor_visible_zero_lines() {
-    let mut state = TextAreaState::with_value("Hello");
+    let mut state = TextAreaState::new().with_value("Hello");
     state.ensure_cursor_visible(0);
     // Should not panic or change anything
     assert_eq!(state.scroll_offset(), 0);
@@ -739,14 +739,14 @@ fn test_ensure_cursor_visible_zero_lines() {
 
 #[test]
 fn test_backspace_unicode() {
-    let mut state = TextAreaState::with_value("日本");
+    let mut state = TextAreaState::new().with_value("日本");
     TextArea::update(&mut state, TextAreaMessage::Backspace);
     assert_eq!(state.value(), "日");
 }
 
 #[test]
 fn test_delete_unicode() {
-    let mut state = TextAreaState::with_value("日本");
+    let mut state = TextAreaState::new().with_value("日本");
     state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::Delete);
     assert_eq!(state.value(), "本");
@@ -976,7 +976,7 @@ fn test_cursor_display_position_multiline_emoji() {
 
 #[test]
 fn test_cursor_display_position_ascii() {
-    let state = TextAreaState::with_value("hello");
+    let state = TextAreaState::new().with_value("hello");
     // For ASCII, display position equals character position.
     assert_eq!(state.cursor_display_position(), (0, 5));
     assert_eq!(state.cursor_position(), (0, 5));

--- a/src/component/text_area/undo_tests.rs
+++ b/src/component/text_area/undo_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 fn focused_state(value: &str) -> TextAreaState {
-    let mut state = TextAreaState::with_value(value);
+    let mut state = TextAreaState::new().with_value(value);
     state.set_focused(true);
     state
 }
@@ -12,7 +12,7 @@ fn focused_state(value: &str) -> TextAreaState {
 
 #[test]
 fn test_undo_single_insert() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     TextArea::update(&mut state, TextAreaMessage::Insert('!'));
     TextArea::update(&mut state, TextAreaMessage::Undo);
     assert_eq!(state.value(), "hello");
@@ -20,7 +20,7 @@ fn test_undo_single_insert() {
 
 #[test]
 fn test_redo_after_undo() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     TextArea::update(&mut state, TextAreaMessage::Insert('!'));
     TextArea::update(&mut state, TextAreaMessage::Undo);
     assert_eq!(state.value(), "hello");
@@ -31,7 +31,7 @@ fn test_redo_after_undo() {
 
 #[test]
 fn test_undo_empty_stack_no_change() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     let output = TextArea::update(&mut state, TextAreaMessage::Undo);
     assert_eq!(output, None);
     assert_eq!(state.value(), "hello");
@@ -39,7 +39,7 @@ fn test_undo_empty_stack_no_change() {
 
 #[test]
 fn test_redo_empty_stack_no_change() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     let output = TextArea::update(&mut state, TextAreaMessage::Redo);
     assert_eq!(output, None);
     assert_eq!(state.value(), "hello");
@@ -91,7 +91,7 @@ fn test_whitespace_breaks_insert_group() {
 
 #[test]
 fn test_grouped_backspace_undo_together() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     TextArea::update(&mut state, TextAreaMessage::Backspace);
     TextArea::update(&mut state, TextAreaMessage::Backspace);
     assert_eq!(state.value(), "hel");
@@ -102,7 +102,7 @@ fn test_grouped_backspace_undo_together() {
 
 #[test]
 fn test_grouped_delete_undo_together() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     state.set_cursor_position(0, 0);
     TextArea::update(&mut state, TextAreaMessage::Delete);
     TextArea::update(&mut state, TextAreaMessage::Delete);
@@ -118,7 +118,7 @@ fn test_grouped_delete_undo_together() {
 
 #[test]
 fn test_newline_is_own_undo_entry() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     TextArea::update(&mut state, TextAreaMessage::NewLine);
     assert_eq!(state.line_count(), 2);
 
@@ -158,7 +158,7 @@ fn test_newline_breaks_insert_group() {
 
 #[test]
 fn test_delete_line_undo() {
-    let mut state = TextAreaState::with_value("abc\ndef\nghi");
+    let mut state = TextAreaState::new().with_value("abc\ndef\nghi");
     state.set_cursor_position(1, 0);
     TextArea::update(&mut state, TextAreaMessage::DeleteLine);
     assert_eq!(state.value(), "abc\nghi");
@@ -169,7 +169,7 @@ fn test_delete_line_undo() {
 
 #[test]
 fn test_delete_to_end_undo() {
-    let mut state = TextAreaState::with_value("hello world");
+    let mut state = TextAreaState::new().with_value("hello world");
     state.set_cursor_position(0, 5);
     TextArea::update(&mut state, TextAreaMessage::DeleteToEnd);
     assert_eq!(state.value(), "hello");
@@ -180,7 +180,7 @@ fn test_delete_to_end_undo() {
 
 #[test]
 fn test_delete_to_start_undo() {
-    let mut state = TextAreaState::with_value("hello world");
+    let mut state = TextAreaState::new().with_value("hello world");
     state.set_cursor_position(0, 6);
     TextArea::update(&mut state, TextAreaMessage::DeleteToStart);
     assert_eq!(state.value(), "world");
@@ -195,7 +195,7 @@ fn test_delete_to_start_undo() {
 
 #[test]
 fn test_clear_undo() {
-    let mut state = TextAreaState::with_value("hello\nworld");
+    let mut state = TextAreaState::new().with_value("hello\nworld");
     TextArea::update(&mut state, TextAreaMessage::Clear);
     assert_eq!(state.value(), "");
 
@@ -205,7 +205,7 @@ fn test_clear_undo() {
 
 #[test]
 fn test_set_value_undo() {
-    let mut state = TextAreaState::with_value("original");
+    let mut state = TextAreaState::new().with_value("original");
     TextArea::update(&mut state, TextAreaMessage::SetValue("replaced".into()));
     assert_eq!(state.value(), "replaced");
 
@@ -219,7 +219,7 @@ fn test_set_value_undo() {
 
 #[test]
 fn test_undo_restores_cursor_position() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     let (row_before, col_before) = (state.cursor_row(), state.cursor_col());
     TextArea::update(&mut state, TextAreaMessage::Insert('!'));
     TextArea::update(&mut state, TextAreaMessage::Undo);
@@ -229,7 +229,7 @@ fn test_undo_restores_cursor_position() {
 
 #[test]
 fn test_undo_restores_multiline_cursor() {
-    let mut state = TextAreaState::with_value("abc\ndef");
+    let mut state = TextAreaState::new().with_value("abc\ndef");
     // Cursor at end of "def" (row=1, col=3)
     TextArea::update(&mut state, TextAreaMessage::NewLine);
     // Now on row 2
@@ -244,7 +244,7 @@ fn test_undo_restores_multiline_cursor() {
 
 #[test]
 fn test_new_edit_clears_redo() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     TextArea::update(&mut state, TextAreaMessage::Insert('!'));
     TextArea::update(&mut state, TextAreaMessage::Undo);
 
@@ -261,7 +261,7 @@ fn test_new_edit_clears_redo() {
 
 #[test]
 fn test_undo_ignored_when_disabled() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     TextArea::update(&mut state, TextAreaMessage::Insert('!'));
     state.set_disabled(true);
     let output = TextArea::update(&mut state, TextAreaMessage::Undo);
@@ -293,7 +293,7 @@ fn test_ctrl_y_maps_to_redo() {
 
 #[test]
 fn test_can_undo() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     assert!(!state.can_undo());
 
     TextArea::update(&mut state, TextAreaMessage::Insert('!'));
@@ -305,7 +305,7 @@ fn test_can_undo() {
 
 #[test]
 fn test_can_redo() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     assert!(!state.can_redo());
 
     TextArea::update(&mut state, TextAreaMessage::Insert('!'));
@@ -322,7 +322,7 @@ fn test_can_redo() {
 
 #[test]
 fn test_backspace_join_lines_undo() {
-    let mut state = TextAreaState::with_value("abc\ndef");
+    let mut state = TextAreaState::new().with_value("abc\ndef");
     state.set_cursor_position(1, 0);
     TextArea::update(&mut state, TextAreaMessage::Backspace);
     assert_eq!(state.value(), "abcdef");
@@ -371,7 +371,7 @@ fn test_multiple_undo_redo_cycles() {
 
 #[test]
 fn test_undo_clears_selection() {
-    let mut state = TextAreaState::with_value("hello");
+    let mut state = TextAreaState::new().with_value("hello");
     TextArea::update(&mut state, TextAreaMessage::Insert('!'));
     TextArea::update(&mut state, TextAreaMessage::SelectAll);
     assert!(state.has_selection());

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -48,7 +48,7 @@ fn test_input_field_state_round_trip() {
 
 #[test]
 fn test_text_area_state_round_trip() {
-    let state = TextAreaState::with_value("line 1\nline 2\nline 3");
+    let state = TextAreaState::new().with_value("line 1\nline 2\nline 3");
     let restored = round_trip(&state);
     assert_eq!(restored.value(), "line 1\nline 2\nline 3");
     assert_eq!(restored.line_count(), 3);


### PR DESCRIPTION
## Summary
**BREAKING CHANGES** for v0.11.0:

- `TextAreaState::with_value()` now takes `mut self` — use `TextAreaState::new().with_value("...")`
- `TextAreaState::with_placeholder()` now takes `mut self` — use `TextAreaState::new().with_placeholder("...")`
- `SplitPanelState::with_ratio()` now takes `mut self` — use `SplitPanelState::new(orientation).with_ratio(0.3)`

All `with_*` methods are now chainable from `new()`, making the builder pattern consistent across the framework.

## Migration
```rust
// Before (0.10.x)
let state = TextAreaState::with_value("hello");
let split = SplitPanelState::with_ratio(SplitOrientation::Vertical, 0.3);

// After (0.11.0)
let state = TextAreaState::new().with_value("hello");
let split = SplitPanelState::new(SplitOrientation::Vertical).with_ratio(0.3);
```

## Test plan
- [x] 173 TextArea tests pass
- [x] 62 SplitPanel tests pass
- [x] 1834 doc tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] All examples build and run
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)