### PR TITLE
Add Language::Hcl and horizontal scroll to CodeBlock

### DIFF
--- a/src/component/code_block/highlight.rs
+++ b/src/component/code_block/highlight.rs
@@ -38,6 +38,8 @@ pub enum Language {
     Toml,
     /// SQL
     Sql,
+    /// HCL (HashiCorp Configuration Language — Terraform, etc.)
+    Hcl,
     /// Plain text (no highlighting)
     #[default]
     Plain,
@@ -66,6 +68,7 @@ impl Language {
             Language::Yaml => "YAML",
             Language::Toml => "TOML",
             Language::Sql => "SQL",
+            Language::Hcl => "HCL",
             Language::Plain => "Plain",
         }
     }
@@ -264,6 +267,32 @@ impl Language {
                 "GRANT",
                 "REVOKE",
             ],
+            Language::Hcl => &[
+                "resource",
+                "data",
+                "variable",
+                "output",
+                "locals",
+                "module",
+                "provider",
+                "terraform",
+                "backend",
+                "required_providers",
+                "required_version",
+                "for_each",
+                "count",
+                "depends_on",
+                "lifecycle",
+                "provisioner",
+                "connection",
+                "dynamic",
+                "content",
+                "for",
+                "in",
+                "if",
+                "else",
+                "endif",
+            ],
             Language::Plain => &[],
         }
     }
@@ -400,6 +429,50 @@ impl Language {
                 "MIN",
                 "MAX",
             ],
+            Language::Hcl => &[
+                "string",
+                "number",
+                "bool",
+                "list",
+                "map",
+                "set",
+                "object",
+                "tuple",
+                "any",
+                "true",
+                "false",
+                "null",
+                "each",
+                "self",
+                "var",
+                "local",
+                "path",
+                "tostring",
+                "tonumber",
+                "tobool",
+                "tolist",
+                "toset",
+                "tomap",
+                "length",
+                "lookup",
+                "merge",
+                "concat",
+                "join",
+                "split",
+                "replace",
+                "format",
+                "formatlist",
+                "file",
+                "templatefile",
+                "jsonencode",
+                "jsondecode",
+                "yamlencode",
+                "yamldecode",
+                "base64encode",
+                "base64decode",
+                "cidrsubnet",
+                "cidrhost",
+            ],
             _ => &[],
         }
     }
@@ -410,7 +483,11 @@ impl Language {
             Language::Rust | Language::Go | Language::JavaScript | Language::TypeScript => {
                 Some("//")
             }
-            Language::Python | Language::Shell | Language::Yaml | Language::Toml => Some("#"),
+            Language::Python
+            | Language::Shell
+            | Language::Yaml
+            | Language::Toml
+            | Language::Hcl => Some("#"),
             Language::Sql => Some("--"),
             Language::Json | Language::Plain => None,
         }

--- a/src/component/code_block/highlight_tests.rs
+++ b/src/component/code_block/highlight_tests.rs
@@ -476,3 +476,49 @@ fn test_highlight_preserves_whitespace() {
     let reconstructed: String = spans.iter().map(|s| s.content.as_ref()).collect();
     assert_eq!(reconstructed, line);
 }
+
+// =============================================================================
+// HCL highlighting
+// =============================================================================
+
+#[test]
+fn test_hcl_language_name() {
+    assert_eq!(Language::Hcl.name(), "HCL");
+}
+
+#[test]
+fn test_hcl_keywords_highlighted() {
+    let spans = highlight_line("resource \"aws_instance\" \"web\" {", &Language::Hcl);
+    assert!(!spans.is_empty());
+    // "resource" should be a keyword
+    let first_word = spans.iter().find(|s| s.content.as_ref() == "resource");
+    assert!(first_word.is_some(), "resource should appear as a span");
+    assert_eq!(
+        first_word.unwrap().style.fg,
+        Some(Color::Magenta),
+        "resource should be keyword-colored"
+    );
+}
+
+#[test]
+fn test_hcl_type_keywords() {
+    let spans = highlight_line("  type = string", &Language::Hcl);
+    let type_span = spans.iter().find(|s| s.content.as_ref() == "string");
+    assert!(type_span.is_some());
+    assert_eq!(type_span.unwrap().style.fg, Some(Color::Cyan));
+}
+
+#[test]
+fn test_hcl_comments() {
+    let spans = highlight_line("# This is a comment", &Language::Hcl);
+    assert_eq!(spans.len(), 1);
+    assert_eq!(spans[0].style.fg, Some(Color::DarkGray));
+}
+
+#[test]
+fn test_hcl_preserves_content() {
+    let line = "  ami           = \"ami-0c55b159cbfafe1f0\"";
+    let spans = highlight_line(line, &Language::Hcl);
+    let reconstructed: String = spans.iter().map(|s| s.content.as_ref()).collect();
+    assert_eq!(reconstructed, line);
+}

--- a/src/component/code_block/mod.rs
+++ b/src/component/code_block/mod.rs
@@ -11,7 +11,7 @@
 //! # Supported Languages
 //!
 //! Rust, Python, JavaScript, TypeScript, Go, Shell, JSON, YAML, TOML,
-//! SQL, and Plain text. See [`Language`].
+//! SQL, HCL, and Plain text. See [`Language`].
 //!
 //! # Example
 //!
@@ -66,6 +66,10 @@ pub enum CodeBlockMessage {
     Home,
     /// Scroll to the bottom.
     End,
+    /// Scroll left by one column.
+    ScrollLeft,
+    /// Scroll right by one column.
+    ScrollRight,
     /// Replace the code content.
     SetCode(String),
     /// Set the language for syntax highlighting.
@@ -96,6 +100,8 @@ pub struct CodeBlockState {
     pub(crate) language: Language,
     /// Scroll state tracking offset and providing scrollbar support.
     pub(crate) scroll: ScrollState,
+    /// Horizontal scroll offset in characters.
+    pub(crate) horizontal_offset: usize,
     /// Whether to show line numbers.
     pub(crate) show_line_numbers: bool,
     /// Set of 1-based line numbers to highlight.
@@ -113,6 +119,7 @@ impl PartialEq for CodeBlockState {
         self.code == other.code
             && self.language == other.language
             && self.scroll == other.scroll
+            && self.horizontal_offset == other.horizontal_offset
             && self.show_line_numbers == other.show_line_numbers
             && self.highlight_lines == other.highlight_lines
             && self.title == other.title
@@ -354,6 +361,16 @@ impl CodeBlockState {
         self.scroll.set_offset(offset);
     }
 
+    /// Returns the horizontal scroll offset.
+    pub fn horizontal_offset(&self) -> usize {
+        self.horizontal_offset
+    }
+
+    /// Sets the horizontal scroll offset.
+    pub fn set_horizontal_offset(&mut self, offset: usize) {
+        self.horizontal_offset = offset;
+    }
+
     // ---- State accessors ----
 
     /// Returns true if the component is focused.
@@ -414,11 +431,13 @@ impl CodeBlockState {
 ///
 /// - `Up` / `k` -- Scroll up one line
 /// - `Down` / `j` -- Scroll down one line
+/// - `Left` / `h` -- Scroll left one column
+/// - `Right` / `l` -- Scroll right one column
 /// - `PageUp` / `Ctrl+u` -- Scroll up half a page
 /// - `PageDown` / `Ctrl+d` -- Scroll down half a page
 /// - `Home` / `g` -- Scroll to top
 /// - `End` / `G` -- Scroll to bottom
-/// - `l` -- Toggle line numbers
+/// - `n` -- Toggle line numbers
 pub struct CodeBlock;
 
 impl Component for CodeBlock {
@@ -442,6 +461,8 @@ impl Component for CodeBlock {
         match key.code {
             KeyCode::Up | KeyCode::Char('k') if !ctrl => Some(CodeBlockMessage::ScrollUp),
             KeyCode::Down | KeyCode::Char('j') if !ctrl => Some(CodeBlockMessage::ScrollDown),
+            KeyCode::Left | KeyCode::Char('h') if !ctrl => Some(CodeBlockMessage::ScrollLeft),
+            KeyCode::Right | KeyCode::Char('l') if !ctrl => Some(CodeBlockMessage::ScrollRight),
             KeyCode::PageUp => Some(CodeBlockMessage::PageUp(10)),
             KeyCode::PageDown => Some(CodeBlockMessage::PageDown(10)),
             KeyCode::Char('u') if ctrl => Some(CodeBlockMessage::PageUp(10)),
@@ -450,7 +471,7 @@ impl Component for CodeBlock {
             KeyCode::End | KeyCode::Char('G') if shift || key.code == KeyCode::End => {
                 Some(CodeBlockMessage::End)
             }
-            KeyCode::Char('l') if !ctrl => Some(CodeBlockMessage::ToggleLineNumbers),
+            KeyCode::Char('n') if !ctrl => Some(CodeBlockMessage::ToggleLineNumbers),
             _ => None,
         }
     }
@@ -469,8 +490,19 @@ impl Component for CodeBlock {
             CodeBlockMessage::PageDown(n) => {
                 state.scroll.page_down(n);
             }
+            CodeBlockMessage::ScrollLeft => {
+                state.horizontal_offset = state.horizontal_offset.saturating_sub(1);
+            }
+            CodeBlockMessage::ScrollRight => {
+                // Clamp to max line width (computed lazily)
+                let max_width = state.code.lines().map(|l| l.len()).max().unwrap_or(0);
+                if state.horizontal_offset < max_width {
+                    state.horizontal_offset += 1;
+                }
+            }
             CodeBlockMessage::Home => {
                 state.scroll.scroll_to_start();
+                state.horizontal_offset = 0;
             }
             CodeBlockMessage::End => {
                 state.scroll.scroll_to_end();
@@ -478,6 +510,7 @@ impl Component for CodeBlock {
             CodeBlockMessage::SetCode(code) => {
                 state.code = code;
                 state.scroll = ScrollState::new(state.code.lines().count().max(1));
+                state.horizontal_offset = 0;
             }
             CodeBlockMessage::SetLanguage(lang) => {
                 state.language = lang;

--- a/src/component/code_block/render.rs
+++ b/src/component/code_block/render.rs
@@ -18,6 +18,7 @@ use crate::theme::Theme;
 const GUTTER_WIDTH: u16 = 7;
 
 /// Renders the CodeBlock in the given area.
+#[allow(clippy::too_many_lines)]
 pub(super) fn render(
     state: &CodeBlockState,
     frame: &mut Frame,
@@ -101,7 +102,7 @@ pub(super) fn render(
             );
         }
 
-        // Render code content
+        // Render code content with horizontal scroll offset
         let code_x = inner.x + gutter_width;
         let code_line_area = Rect::new(code_x, y, code_area_width, 1);
         render_code_line(
@@ -112,6 +113,7 @@ pub(super) fn render(
             code_line_area,
             theme,
             disabled,
+            state.horizontal_offset,
         );
     }
 
@@ -161,7 +163,38 @@ fn render_gutter(
     frame.render_widget(paragraph, area);
 }
 
+/// Applies a horizontal offset to a list of styled spans, skipping
+/// the first `offset` characters while preserving styling.
+fn apply_horizontal_offset<'a>(spans: Vec<Span<'a>>, offset: usize) -> Vec<Span<'a>> {
+    if offset == 0 {
+        return spans;
+    }
+
+    let mut remaining = offset;
+    let mut result = Vec::new();
+
+    for span in spans {
+        let len = span.content.len();
+        if remaining >= len {
+            // Skip this entire span
+            remaining -= len;
+            continue;
+        }
+        if remaining > 0 {
+            // Partially skip this span
+            let trimmed: String = span.content.chars().skip(remaining).collect();
+            result.push(Span::styled(trimmed, span.style));
+            remaining = 0;
+        } else {
+            result.push(span);
+        }
+    }
+
+    result
+}
+
 /// Renders a single line of highlighted code.
+#[allow(clippy::too_many_arguments)]
 fn render_code_line(
     line_text: &str,
     is_highlighted: bool,
@@ -169,11 +202,12 @@ fn render_code_line(
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
-
     disabled: bool,
+    horizontal_offset: usize,
 ) {
     if disabled {
-        let paragraph = Paragraph::new(line_text).style(theme.disabled_style());
+        let visible: String = line_text.chars().skip(horizontal_offset).collect();
+        let paragraph = Paragraph::new(visible).style(theme.disabled_style());
         frame.render_widget(paragraph, area);
         return;
     }
@@ -182,7 +216,8 @@ fn render_code_line(
         // Highlighted lines get a distinct background
         let hl_bg = Color::Rgb(50, 50, 20);
         let spans = highlight_line(line_text, &state.language);
-        let styled_spans: Vec<Span<'_>> = spans
+        let shifted = apply_horizontal_offset(spans, horizontal_offset);
+        let styled_spans: Vec<Span<'_>> = shifted
             .into_iter()
             .map(|s| {
                 let mut style = s.style;
@@ -204,7 +239,8 @@ fn render_code_line(
         frame.render_widget(paragraph, area);
     } else {
         let spans = highlight_line(line_text, &state.language);
-        let line = Line::from(spans);
+        let shifted = apply_horizontal_offset(spans, horizontal_offset);
+        let line = Line::from(shifted);
         let paragraph = Paragraph::new(line);
         frame.render_widget(paragraph, area);
     }

--- a/src/component/code_block/tests.rs
+++ b/src/component/code_block/tests.rs
@@ -448,10 +448,19 @@ fn test_handle_event_g_and_G() {
 }
 
 #[test]
-fn test_handle_event_l_toggle_line_numbers() {
+fn test_handle_event_l_scroll_right() {
     let state = focused_state();
     assert_eq!(
         CodeBlock::handle_event(&state, &Event::char('l')),
+        Some(CodeBlockMessage::ScrollRight)
+    );
+}
+
+#[test]
+fn test_handle_event_n_toggle_line_numbers() {
+    let state = focused_state();
+    assert_eq!(
+        CodeBlock::handle_event(&state, &Event::char('n')),
         Some(CodeBlockMessage::ToggleLineNumbers)
     );
 }
@@ -768,4 +777,135 @@ fn test_scroll_beyond_content() {
         })
         .unwrap();
     // Should not panic; scroll is clamped during render
+}
+
+// =============================================================================
+// Horizontal scroll
+// =============================================================================
+
+#[test]
+fn test_horizontal_scroll_right() {
+    let mut state = CodeBlockState::new().with_code("Hello, World!");
+    assert_eq!(state.horizontal_offset(), 0);
+
+    CodeBlock::update(&mut state, CodeBlockMessage::ScrollRight);
+    assert_eq!(state.horizontal_offset(), 1);
+
+    CodeBlock::update(&mut state, CodeBlockMessage::ScrollRight);
+    assert_eq!(state.horizontal_offset(), 2);
+}
+
+#[test]
+fn test_horizontal_scroll_left() {
+    let mut state = CodeBlockState::new().with_code("Hello, World!");
+    state.set_horizontal_offset(5);
+
+    CodeBlock::update(&mut state, CodeBlockMessage::ScrollLeft);
+    assert_eq!(state.horizontal_offset(), 4);
+}
+
+#[test]
+fn test_horizontal_scroll_left_at_zero() {
+    let mut state = CodeBlockState::new().with_code("Hello");
+
+    CodeBlock::update(&mut state, CodeBlockMessage::ScrollLeft);
+    assert_eq!(state.horizontal_offset(), 0); // Cannot go below 0
+}
+
+#[test]
+fn test_horizontal_scroll_clamped_to_max_width() {
+    let mut state = CodeBlockState::new().with_code("abc"); // 3 chars
+
+    for _ in 0..10 {
+        CodeBlock::update(&mut state, CodeBlockMessage::ScrollRight);
+    }
+    // Should not exceed line length
+    assert!(state.horizontal_offset() <= 3);
+}
+
+#[test]
+fn test_home_resets_horizontal_scroll() {
+    let mut state = CodeBlockState::new().with_code("Hello, World!");
+    state.set_horizontal_offset(5);
+    state.set_scroll_offset(3);
+
+    CodeBlock::update(&mut state, CodeBlockMessage::Home);
+    assert_eq!(state.horizontal_offset(), 0);
+    assert_eq!(state.scroll_offset(), 0);
+}
+
+#[test]
+fn test_set_code_resets_horizontal_scroll() {
+    let mut state = CodeBlockState::new().with_code("Hello");
+    state.set_horizontal_offset(3);
+
+    CodeBlock::update(
+        &mut state,
+        CodeBlockMessage::SetCode("New code".to_string()),
+    );
+    assert_eq!(state.horizontal_offset(), 0);
+}
+
+#[test]
+fn test_horizontal_scroll_key_bindings() {
+    let mut state = CodeBlockState::new().with_code("Long line of code here");
+    CodeBlock::set_focused(&mut state, true);
+
+    // Left arrow
+    let msg = CodeBlock::handle_event(&state, &Event::key(KeyCode::Left));
+    assert_eq!(msg, Some(CodeBlockMessage::ScrollLeft));
+
+    // Right arrow
+    let msg = CodeBlock::handle_event(&state, &Event::key(KeyCode::Right));
+    assert_eq!(msg, Some(CodeBlockMessage::ScrollRight));
+
+    // h key
+    let msg = CodeBlock::handle_event(&state, &Event::char('h'));
+    assert_eq!(msg, Some(CodeBlockMessage::ScrollLeft));
+
+    // l key (now horizontal scroll, not toggle line numbers)
+    let msg = CodeBlock::handle_event(&state, &Event::char('l'));
+    assert_eq!(msg, Some(CodeBlockMessage::ScrollRight));
+
+    // n key (toggle line numbers)
+    let msg = CodeBlock::handle_event(&state, &Event::char('n'));
+    assert_eq!(msg, Some(CodeBlockMessage::ToggleLineNumbers));
+}
+
+#[test]
+fn test_horizontal_scroll_renders_shifted_content() {
+    let code = "resource \"aws_instance\" \"web\" {\n  ami = \"ami-0c55b159\"\n}";
+    let mut state = CodeBlockState::new()
+        .with_code(code)
+        .with_language(Language::Hcl);
+    CodeBlock::set_focused(&mut state, true);
+    state.set_horizontal_offset(10);
+
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(33, 7);
+    terminal
+        .draw(|frame| {
+            CodeBlock::view(
+                &state,
+                frame,
+                frame.area(),
+                &theme,
+                &ViewContext::new().focused(true),
+            );
+        })
+        .unwrap();
+
+    let output = terminal.backend().to_string();
+    // After scrolling 10 chars right, "resource \"" is gone,
+    // the visible part should start with "aws_instance"
+    assert!(
+        output.contains("aws_instance"),
+        "Should see aws_instance after scrolling right 10 chars, got:\n{}",
+        output
+    );
+    // "resource" should NOT be visible
+    assert!(
+        !output.contains("resource"),
+        "resource should be scrolled off-screen, got:\n{}",
+        output
+    );
 }


### PR DESCRIPTION
## Summary
Fixes the release blocker: "60-char terraform line in a 33-col right panel → name invisible."

### Language::Hcl
- New `Language::Hcl` variant for HCL/Terraform syntax highlighting
- Keywords: `resource`, `data`, `variable`, `output`, `locals`, `module`, `provider`, `terraform`, `backend`, `for_each`, `count`, `depends_on`, `lifecycle`, etc.
- Built-in functions: `lookup`, `merge`, `concat`, `join`, `cidrsubnet`, `jsonencode`, `yamldecode`, `templatefile`, etc.
- Type keywords: `string`, `number`, `bool`, `list`, `map`, `set`, `object`, `tuple`, `any`, `true`, `false`, `null`
- Comment prefix: `#`

### Horizontal scroll
- New `ScrollLeft` / `ScrollRight` messages
- Lines render with character offset instead of `Paragraph::wrap`, which broke mid-identifier
- Key bindings: `Left`/`h` scroll left, `Right`/`l` scroll right
- `Home` resets both vertical and horizontal scroll
- `SetCode` resets horizontal scroll to 0

### BREAKING
- `l` key now scrolls right (was toggle line numbers). Use `n` for toggle line numbers.

## Test plan
- [x] 5 new HCL highlighting tests
- [x] 8 new horizontal scroll tests (state, key bindings, rendering)
- [x] All 160 code_block tests pass
- [x] 13 doc tests pass
- [x] Clippy clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)