### PR TITLE
Remove #[non_exhaustive] from all Output enums

### DIFF
--- a/examples/chat_app.rs
+++ b/examples/chat_app.rs
@@ -69,7 +69,6 @@ impl App for ChatApp {
                     }
                 }
                 LineInputOutput::Changed(_) | LineInputOutput::Copied(_) => {}
-                _ => {}
             },
             Msg::Quit => return Command::quit(),
         }

--- a/examples/chat_markdown_demo.rs
+++ b/examples/chat_markdown_demo.rs
@@ -212,7 +212,6 @@ impl App for ChatMarkdownApp {
                     }
                 }
                 TextAreaOutput::Changed(_) | TextAreaOutput::Copied(_) => {}
-                _ => {}
             },
             Msg::SubmitInput => {
                 let text = state.input.value();

--- a/examples/command_palette.rs
+++ b/examples/command_palette.rs
@@ -99,7 +99,6 @@ impl App for CommandPaletteApp {
                             state.selections.push("-- Dismissed --".to_string());
                         }
                         CommandPaletteOutput::QueryChanged(_) => {}
-                        _ => {}
                     }
                 }
             }

--- a/examples/dialog.rs
+++ b/examples/dialog.rs
@@ -59,7 +59,6 @@ impl App for DialogApp {
                         DialogOutput::Closed => {
                             state.last_result = Some("Dialog closed".into());
                         }
-                        _ => {}
                     }
                 }
             }

--- a/src/component/accordion/mod.rs
+++ b/src/component/accordion/mod.rs
@@ -151,7 +151,6 @@ pub enum AccordionMessage {
 
 /// Output messages from an Accordion.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum AccordionOutput {
     /// A panel was expanded (index).
     Expanded(usize),

--- a/src/component/alert_panel/mod.rs
+++ b/src/component/alert_panel/mod.rs
@@ -121,7 +121,6 @@ pub enum AlertPanelMessage {
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[non_exhaustive]
 pub enum AlertPanelOutput {
     /// A metric changed alert state.
     StateChanged {

--- a/src/component/breadcrumb/mod.rs
+++ b/src/component/breadcrumb/mod.rs
@@ -132,7 +132,6 @@ pub enum BreadcrumbMessage {
 
 /// Output messages from a Breadcrumb component.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum BreadcrumbOutput {
     /// A segment was selected (for navigation).
     Selected(usize),

--- a/src/component/button/mod.rs
+++ b/src/component/button/mod.rs
@@ -45,7 +45,6 @@ pub enum ButtonMessage {
 
 /// Output messages from a Button.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum ButtonOutput {
     /// The button was pressed.
     Pressed,

--- a/src/component/calendar/mod.rs
+++ b/src/component/calendar/mod.rs
@@ -179,7 +179,6 @@ pub enum CalendarMessage {
 
 /// Output messages from a Calendar.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum CalendarOutput {
     /// A date was confirmed (Enter/Space pressed on selected day).
     DateSelected(i32, u32, u32),

--- a/src/component/chart/mod.rs
+++ b/src/component/chart/mod.rs
@@ -145,7 +145,6 @@ pub enum ChartMessage {
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[non_exhaustive]
 pub enum ChartOutput {
     /// The active series changed.
     ActiveSeriesChanged(usize),

--- a/src/component/checkbox/mod.rs
+++ b/src/component/checkbox/mod.rs
@@ -48,7 +48,6 @@ pub enum CheckboxMessage {
 
 /// Output messages from a Checkbox.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum CheckboxOutput {
     /// The checkbox was toggled. Contains the new checked state.
     Toggled(bool),

--- a/src/component/collapsible/mod.rs
+++ b/src/component/collapsible/mod.rs
@@ -58,7 +58,6 @@ pub enum CollapsibleMessage {
 
 /// Output messages from a Collapsible.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum CollapsibleOutput {
     /// The section was expanded.
     Expanded,

--- a/src/component/command_palette/mod.rs
+++ b/src/component/command_palette/mod.rs
@@ -73,7 +73,6 @@ pub enum CommandPaletteMessage {
 
 /// Output messages from a CommandPalette.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum CommandPaletteOutput {
     /// An item was confirmed/selected.
     Selected(PaletteItem),

--- a/src/component/confirm_dialog/mod.rs
+++ b/src/component/confirm_dialog/mod.rs
@@ -117,7 +117,6 @@ pub enum ConfirmDialogMessage {
 
 /// Output messages from a ConfirmDialog.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum ConfirmDialogOutput {
     /// A result was selected.
     Confirmed(ConfirmDialogResult),

--- a/src/component/conversation_view/mod.rs
+++ b/src/component/conversation_view/mod.rs
@@ -79,7 +79,6 @@ pub enum ConversationViewMessage {
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[non_exhaustive]
 pub enum ConversationViewOutput {
     /// The scroll position changed.
     ScrollChanged {

--- a/src/component/data_grid/mod.rs
+++ b/src/component/data_grid/mod.rs
@@ -100,7 +100,6 @@ pub enum DataGridMessage {
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[non_exhaustive]
 pub enum DataGridOutput<T: Clone> {
     /// A cell was edited. Contains the row index, column index, and new value.
     CellEdited {

--- a/src/component/dependency_graph/mod.rs
+++ b/src/component/dependency_graph/mod.rs
@@ -116,7 +116,6 @@ pub enum DependencyGraphMessage {
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[non_exhaustive]
 pub enum DependencyGraphOutput {
     /// A node was selected.
     NodeSelected(String),

--- a/src/component/dialog/mod.rs
+++ b/src/component/dialog/mod.rs
@@ -107,7 +107,6 @@ pub enum DialogMessage {
 
 /// Output messages from a Dialog component.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum DialogOutput {
     /// A button was pressed (returns the button id).
     ButtonPressed(String),

--- a/src/component/diff_viewer/mod.rs
+++ b/src/component/diff_viewer/mod.rs
@@ -152,7 +152,6 @@ impl Eq for DiffViewerMessage {}
 
 /// Output messages from a DiffViewer.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum DiffViewerOutput {
     /// The current hunk index changed.
     HunkChanged(usize),

--- a/src/component/dropdown/mod.rs
+++ b/src/component/dropdown/mod.rs
@@ -65,7 +65,6 @@ pub enum DropdownMessage {
 
 /// Output messages from a Dropdown.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum DropdownOutput {
     /// A new item was selected (contains the selected value).
     Selected(String),

--- a/src/component/event_stream/mod.rs
+++ b/src/component/event_stream/mod.rs
@@ -120,7 +120,6 @@ pub enum EventStreamMessage {
 
 /// Output messages from an EventStream.
 #[derive(Clone, Debug, PartialEq)]
-#[non_exhaustive]
 pub enum EventStreamOutput {
     /// An event was added (includes event ID).
     EventAdded(u64),

--- a/src/component/file_browser/mod.rs
+++ b/src/component/file_browser/mod.rs
@@ -103,7 +103,6 @@ pub enum FileBrowserMessage {
 
 /// Output messages from a FileBrowser.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum FileBrowserOutput {
     /// A file was selected (Enter on a file).
     FileSelected(FileEntry),

--- a/src/component/flame_graph/mod.rs
+++ b/src/component/flame_graph/mod.rs
@@ -110,7 +110,6 @@ pub enum FlameGraphMessage {
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[non_exhaustive]
 pub enum FlameGraphOutput {
     /// A frame was selected.
     FrameSelected {

--- a/src/component/form/mod.rs
+++ b/src/component/form/mod.rs
@@ -103,7 +103,6 @@ pub enum FormMessage {
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[non_exhaustive]
 pub enum FormOutput {
     /// The form was submitted. Contains field ID-value pairs.
     Submitted(Vec<(String, FormValue)>),

--- a/src/component/heatmap/mod.rs
+++ b/src/component/heatmap/mod.rs
@@ -148,7 +148,6 @@ pub enum HeatmapMessage {
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[non_exhaustive]
 pub enum HeatmapOutput {
     /// A cell was selected/confirmed with Enter.
     CellSelected {

--- a/src/component/input_field/mod.rs
+++ b/src/component/input_field/mod.rs
@@ -106,7 +106,6 @@ pub enum InputFieldMessage {
 
 /// Output messages from an InputField.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum InputFieldOutput {
     /// The value was submitted (e.g., Enter pressed).
     Submitted(String),

--- a/src/component/line_input/types.rs
+++ b/src/component/line_input/types.rs
@@ -78,7 +78,6 @@ pub enum LineInputMessage {
 
 /// Output events from the [`super::LineInput`] component.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum LineInputOutput {
     /// The buffer was submitted (Enter pressed). Contains the submitted text.
     /// The buffer is cleared and the text is pushed to history.

--- a/src/component/loading_list/mod.rs
+++ b/src/component/loading_list/mod.rs
@@ -278,7 +278,6 @@ pub enum LoadingListMessage<T: Clone> {
 
 /// Output messages from LoadingList.
 #[derive(Clone, Debug, PartialEq)]
-#[non_exhaustive]
 pub enum LoadingListOutput<T: Clone> {
     /// An item was selected.
     Selected(T),

--- a/src/component/log_correlation/mod.rs
+++ b/src/component/log_correlation/mod.rs
@@ -303,7 +303,6 @@ pub enum LogCorrelationMessage {
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[non_exhaustive]
 pub enum LogCorrelationOutput {
     /// The active stream changed.
     StreamFocused(usize),

--- a/src/component/log_viewer/mod.rs
+++ b/src/component/log_viewer/mod.rs
@@ -132,7 +132,6 @@ pub enum LogViewerMessage {
 
 /// Output messages from a LogViewer.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum LogViewerOutput {
     /// A log entry was added.
     Added(u64),

--- a/src/component/menu/mod.rs
+++ b/src/component/menu/mod.rs
@@ -115,7 +115,6 @@ pub enum MenuMessage {
 
 /// Output messages from a Menu.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum MenuOutput {
     /// A menu item was selected (contains the item index).
     Selected(usize),

--- a/src/component/metrics_dashboard/mod.rs
+++ b/src/component/metrics_dashboard/mod.rs
@@ -69,7 +69,6 @@ pub enum MetricsDashboardMessage {
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[non_exhaustive]
 pub enum MetricsDashboardOutput {
     /// The selected widget changed.
     SelectionChanged(usize),

--- a/src/component/multi_progress/mod.rs
+++ b/src/component/multi_progress/mod.rs
@@ -243,7 +243,6 @@ pub enum MultiProgressMessage {
 
 /// Output messages from MultiProgress.
 #[derive(Clone, Debug, PartialEq)]
-#[non_exhaustive]
 pub enum MultiProgressOutput {
     /// An item was added.
     Added(String),

--- a/src/component/number_input/mod.rs
+++ b/src/component/number_input/mod.rs
@@ -61,7 +61,6 @@ pub enum NumberInputMessage {
 
 /// Output messages from a NumberInput.
 #[derive(Clone, Debug, PartialEq)]
-#[non_exhaustive]
 pub enum NumberInputOutput {
     /// The numeric value changed. Contains the new value.
     ValueChanged(f64),

--- a/src/component/paginator/mod.rs
+++ b/src/component/paginator/mod.rs
@@ -97,7 +97,6 @@ pub enum PaginatorMessage {
 
 /// Output messages from a Paginator.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum PaginatorOutput {
     /// The current page changed. Contains the new page index (0-indexed).
     PageChanged(usize),

--- a/src/component/pane_layout/mod.rs
+++ b/src/component/pane_layout/mod.rs
@@ -293,7 +293,6 @@ pub enum PaneLayoutMessage {
 
 /// Output messages from a PaneLayout.
 #[derive(Clone, Debug, PartialEq)]
-#[non_exhaustive]
 pub enum PaneLayoutOutput {
     /// Focus changed to a different pane.
     FocusChanged {

--- a/src/component/progress_bar/mod.rs
+++ b/src/component/progress_bar/mod.rs
@@ -59,7 +59,6 @@ pub enum ProgressBarMessage {
 
 /// Output messages from a ProgressBar.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum ProgressBarOutput {
     /// Progress reached 100%.
     Completed,

--- a/src/component/radio_group/mod.rs
+++ b/src/component/radio_group/mod.rs
@@ -54,7 +54,6 @@ pub enum RadioGroupMessage {
 
 /// Output messages from a RadioGroup.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum RadioGroupOutput<T: Clone> {
     /// The selection changed to a new value.
     Selected(T),

--- a/src/component/router/mod.rs
+++ b/src/component/router/mod.rs
@@ -89,7 +89,6 @@ pub enum RouterMessage<S: Clone + PartialEq> {
 
 /// Output messages from the Router component.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum RouterOutput<S: Clone + PartialEq> {
     /// Screen changed (from, to).
     ScreenChanged {

--- a/src/component/scrollable_text/mod.rs
+++ b/src/component/scrollable_text/mod.rs
@@ -56,7 +56,6 @@ pub enum ScrollableTextMessage {
 
 /// Output messages from a ScrollableText.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum ScrollableTextOutput {
     /// The scroll position changed.
     ScrollChanged(usize),

--- a/src/component/searchable_list/mod.rs
+++ b/src/component/searchable_list/mod.rs
@@ -83,7 +83,6 @@ pub enum SearchableListMessage {
 
 /// Output messages from a SearchableList.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum SearchableListOutput<T: Clone> {
     /// An item was selected (e.g., Enter pressed while list is focused).
     Selected(T),

--- a/src/component/select/mod.rs
+++ b/src/component/select/mod.rs
@@ -54,7 +54,6 @@ pub enum SelectMessage {
 
 /// Output messages from a Select.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum SelectOutput {
     /// A new item was selected (contains the selected value).
     Selected(String),

--- a/src/component/selectable_list/mod.rs
+++ b/src/component/selectable_list/mod.rs
@@ -60,7 +60,6 @@ pub enum SelectableListMessage {
 
 /// Output messages from a SelectableList.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum SelectableListOutput<T: Clone> {
     /// An item was selected (e.g., Enter pressed).
     Selected(T),

--- a/src/component/slider/mod.rs
+++ b/src/component/slider/mod.rs
@@ -73,7 +73,6 @@ pub enum SliderMessage {
 
 /// Output messages from a Slider.
 #[derive(Clone, Debug, PartialEq)]
-#[non_exhaustive]
 pub enum SliderOutput {
     /// The slider value changed. Contains the new value.
     ValueChanged(f64),

--- a/src/component/span_tree/mod.rs
+++ b/src/component/span_tree/mod.rs
@@ -106,7 +106,6 @@ pub enum SpanTreeMessage {
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[non_exhaustive]
 pub enum SpanTreeOutput {
     /// A span was selected. Contains the span id.
     Selected(String),

--- a/src/component/split_panel/mod.rs
+++ b/src/component/split_panel/mod.rs
@@ -74,7 +74,6 @@ pub enum SplitPanelMessage {
 
 /// Output messages from a SplitPanel.
 #[derive(Clone, Debug, PartialEq)]
-#[non_exhaustive]
 pub enum SplitPanelOutput {
     /// Focus changed to the first pane.
     FocusedFirst,

--- a/src/component/status_log/mod.rs
+++ b/src/component/status_log/mod.rs
@@ -63,7 +63,6 @@ pub enum StatusLogMessage {
 
 /// Output messages from a StatusLog component.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum StatusLogOutput {
     /// An entry was added (returns ID).
     Added(u64),

--- a/src/component/step_indicator/mod.rs
+++ b/src/component/step_indicator/mod.rs
@@ -191,7 +191,6 @@ pub enum StepIndicatorMessage {
 
 /// Output messages from a StepIndicator.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum StepIndicatorOutput {
     /// A step's status changed.
     StatusChanged {

--- a/src/component/styled_text/mod.rs
+++ b/src/component/styled_text/mod.rs
@@ -69,7 +69,6 @@ pub enum StyledTextMessage {
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[non_exhaustive]
 pub enum StyledTextOutput {
     /// The scroll position changed.
     ScrollChanged(usize),

--- a/src/component/switch/mod.rs
+++ b/src/component/switch/mod.rs
@@ -54,7 +54,6 @@ pub enum SwitchMessage {
 
 /// Output messages from a Switch.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum SwitchOutput {
     /// The switch was toggled. Contains the new on/off value.
     Toggled(bool),

--- a/src/component/tab_bar/mod.rs
+++ b/src/component/tab_bar/mod.rs
@@ -117,7 +117,6 @@ pub enum TabBarMessage {
 
 /// Output messages from a [`TabBar`] component.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum TabBarOutput {
     /// A tab was selected (contains the new active index).
     TabSelected(usize),

--- a/src/component/table/types.rs
+++ b/src/component/table/types.rs
@@ -471,7 +471,6 @@ pub enum TableMessage {
 
 /// Output messages from a Table component.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum TableOutput<T: Clone> {
     /// A row was selected (e.g., Enter pressed).
     Selected(T),

--- a/src/component/tabs/mod.rs
+++ b/src/component/tabs/mod.rs
@@ -54,7 +54,6 @@ pub enum TabsMessage {
 
 /// Output messages from a Tabs component.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum TabsOutput<T: Clone> {
     /// The selected tab changed.
     Selected(T),

--- a/src/component/terminal_output/mod.rs
+++ b/src/component/terminal_output/mod.rs
@@ -55,7 +55,6 @@ use crate::theme::Theme;
 
 /// Messages that can be sent to a TerminalOutput component.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum TerminalOutputMessage {
     /// Push a new line of output.
     PushLine(String),
@@ -87,7 +86,6 @@ pub enum TerminalOutputMessage {
 
 /// Output messages from a TerminalOutput component.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum TerminalOutputOutput {
     /// The scroll position changed.
     ScrollChanged(usize),

--- a/src/component/text_area/mod.rs
+++ b/src/component/text_area/mod.rs
@@ -155,7 +155,6 @@ pub enum TextAreaMessage {
 
 /// Output messages from a TextArea.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum TextAreaOutput {
     /// The value was submitted.
     Submitted(String),

--- a/src/component/timeline/types.rs
+++ b/src/component/timeline/types.rs
@@ -312,7 +312,6 @@ pub enum TimelineMessage {
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[non_exhaustive]
 pub enum TimelineOutput {
     /// An event was selected (carries event id).
     EventSelected(String),

--- a/src/component/toast/mod.rs
+++ b/src/component/toast/mod.rs
@@ -128,7 +128,6 @@ pub enum ToastMessage {
 
 /// Output messages from a Toast component.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum ToastOutput {
     /// A toast was added (returns ID).
     Added(u64),

--- a/src/component/tooltip/mod.rs
+++ b/src/component/tooltip/mod.rs
@@ -80,7 +80,6 @@ pub enum TooltipMessage {
 
 /// Output messages from a Tooltip component.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum TooltipOutput {
     /// Tooltip was shown.
     Shown,

--- a/src/component/tree/mod.rs
+++ b/src/component/tree/mod.rs
@@ -206,7 +206,6 @@ pub enum TreeMessage {
 
 /// Output messages from a Tree component.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum TreeOutput {
     /// A node was selected (activated). Contains the path to the node.
     Selected(Vec<usize>),

--- a/src/component/treemap/mod.rs
+++ b/src/component/treemap/mod.rs
@@ -295,7 +295,6 @@ pub enum TreemapMessage {
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[non_exhaustive]
 pub enum TreemapOutput {
     /// A node was confirmed/selected.
     NodeSelected {


### PR DESCRIPTION
## Summary

- Removes all 57 `#[non_exhaustive]` attributes from Output enums (and one Message enum in `terminal_output`) across the codebase
- Removes 4 now-unreachable wildcard `_ => {}` arms from examples (`dialog`, `chat_app`, `chat_markdown_demo`, `command_palette`)
- Restores Rust's exhaustive match checking for downstream users, so the compiler will flag incomplete matches when new variants are added

## Motivation

The `#[non_exhaustive]` attribute was originally added to prevent breaking changes when adding new Output enum variants. However, it defeats Rust's exhaustive match checking -- every `match` on an Output enum required a wildcard arm, which silently swallowed new variants. This is the opposite of the desired behavior: users should get a compiler error when a new variant is added so they can handle it explicitly.

Since envision is pre-1.0, semver allows breaking changes on minor version bumps anyway, making `#[non_exhaustive]` unnecessary.

## Test plan

- [x] `cargo fmt` -- clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- zero warnings
- [x] `cargo test --all-features --quiet` -- all 9116 tests pass (7152 unit + 1834 doc + integration/stress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)