### PR TITLE
Add status-line slot to ConversationView

### DIFF
--- a/src/component/conversation_view/mod.rs
+++ b/src/component/conversation_view/mod.rs
@@ -121,6 +121,8 @@ pub struct ConversationViewState {
     pub(super) disabled: bool,
     /// Set of collapsed block keys (e.g., "tool:search", "thinking").
     pub(super) collapsed_blocks: HashSet<String>,
+    /// Optional status text rendered at the bottom of the viewport, above the border.
+    pub(super) status: Option<String>,
     /// Next unique ID for message handles.
     #[cfg_attr(feature = "serialization", serde(skip, default))]
     pub(super) next_id: u64,
@@ -141,6 +143,7 @@ impl Default for ConversationViewState {
             focused: false,
             disabled: false,
             collapsed_blocks: HashSet::new(),
+            status: None,
             next_id: 1,
         }
     }
@@ -158,6 +161,7 @@ impl PartialEq for ConversationViewState {
             && self.focused == other.focused
             && self.disabled == other.disabled
             && self.collapsed_blocks == other.collapsed_blocks
+            && self.status == other.status
         // next_id is intentionally excluded from equality
     }
 }
@@ -531,6 +535,38 @@ impl ConversationViewState {
         self.title = Some(title.into());
     }
 
+    /// Returns the status text, if set.
+    ///
+    /// The status line renders at the bottom of the viewport, above the
+    /// border. Use it for transient information like rate-limit backoff
+    /// or connection state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ConversationViewState;
+    ///
+    /// let mut state = ConversationViewState::new();
+    /// assert!(state.status().is_none());
+    ///
+    /// state.set_status(Some("Rate limited"));
+    /// assert_eq!(state.status(), Some("Rate limited"));
+    ///
+    /// state.set_status(None::<&str>);
+    /// assert!(state.status().is_none());
+    /// ```
+    pub fn status(&self) -> Option<&str> {
+        self.status.as_deref()
+    }
+
+    /// Sets or clears the status text.
+    ///
+    /// When `Some`, a single line is rendered at the bottom of the
+    /// viewport inside the border. When `None`, the full viewport
+    /// is used for messages.
+    pub fn set_status(&mut self, status: Option<impl Into<String>>) {
+        self.status = status.map(|s| s.into());
+    }
     /// Returns the scroll offset.
     pub fn scroll_offset(&self) -> usize {
         self.scroll.offset()

--- a/src/component/conversation_view/render.rs
+++ b/src/component/conversation_view/render.rs
@@ -44,7 +44,32 @@ pub(super) fn render(
         return;
     }
 
-    render_messages(state, frame, inner, theme);
+    // Reserve the bottom row for the status line when present.
+    let (message_area, status_area) = if state.status.is_some() && inner.height > 1 {
+        let msg = Rect {
+            height: inner.height - 1,
+            ..inner
+        };
+        let status = Rect {
+            y: inner.y + inner.height - 1,
+            height: 1,
+            ..inner
+        };
+        (msg, Some(status))
+    } else {
+        (inner, None)
+    };
+
+    render_messages(state, frame, message_area, theme);
+
+    if let Some((status_rect, text)) = status_area.zip(state.status.as_deref()) {
+        let style = Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::ITALIC);
+        let line = Line::from(Span::styled(text, style));
+        let paragraph = ratatui::widgets::Paragraph::new(line);
+        frame.render_widget(paragraph, status_rect);
+    }
 }
 
 /// Renders the message list inside the content area.


### PR DESCRIPTION
## Summary
Adds `set_status(Option<impl Into<String>>)` to `ConversationViewState` which renders a single line at the bottom of the viewport, inside the border.

### Use case
Customer Claude reported needing to overlay rate-limit backoff info below the ConversationView because there was nowhere inside the border to put it. This status line slot solves that.

### API
```rust
// Show status
state.set_status(Some("Rate limited — retrying in 3s"));

// Read status
assert_eq!(state.status(), Some("Rate limited — retrying in 3s"));

// Clear status (restores full viewport for messages)
state.set_status(None::<&str>);
```

### Rendering
- Status renders in yellow italic at the bottom row of the inner area
- Message area is reduced by 1 row when status is present
- When status is `None` (default), no space is reserved

## Test plan
- [x] 123 conversation_view unit tests pass
- [x] 47 doc tests pass
- [x] Clippy clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)