### PR TITLE
Add strip_markdown fallback when markdown feature is disabled

### DIFF
--- a/src/component/chat_view/render_helpers.rs
+++ b/src/component/chat_view/render_helpers.rs
@@ -95,13 +95,20 @@ pub(super) fn format_message(
         return format_message_markdown(msg, state.show_timestamps, width, base_style, theme);
     }
 
-    format_message_plain(msg, state.show_timestamps, base_style)
+    format_message_plain(
+        msg,
+        state.show_timestamps,
+        state.markdown_enabled,
+        base_style,
+    )
 }
 
 /// Plain text message formatting (original behavior).
+/// When `strip_md` is true, markdown markers are stripped for readable output.
 fn format_message_plain(
     msg: &ChatMessage,
     show_timestamps: bool,
+    strip_md: bool,
     base_style: Style,
 ) -> Vec<(Line<'static>, ChatRole)> {
     let mut result = Vec::new();
@@ -124,8 +131,14 @@ fn format_message_plain(
 
     result.push((Line::from(header_spans), role));
 
-    // Content lines
-    for line in msg.content().lines() {
+    // Content lines — strip markdown markers when feature is off but markdown_enabled
+    let content = if strip_md {
+        std::borrow::Cow::Owned(crate::util::strip_markdown(msg.content()))
+    } else {
+        std::borrow::Cow::Borrowed(msg.content())
+    };
+
+    for line in content.lines() {
         result.push((
             Line::from(Span::styled(format!("  {}", line), base_style)),
             role,
@@ -133,7 +146,7 @@ fn format_message_plain(
     }
 
     // Handle empty content
-    if msg.content().is_empty() {
+    if content.is_empty() {
         result.push((Line::from(Span::styled("  ", base_style)), role));
     }
 

--- a/src/component/conversation_view/render.rs
+++ b/src/component/conversation_view/render.rs
@@ -336,9 +336,15 @@ fn format_text_block<'a>(
         return;
     }
 
-    let _ = markdown_enabled;
+    // When markdown feature is off but markdown_enabled is true,
+    // strip markers so output is readable plain text, not raw syntax.
+    let text = if markdown_enabled {
+        std::borrow::Cow::Owned(crate::util::strip_markdown(text))
+    } else {
+        std::borrow::Cow::Borrowed(text)
+    };
 
-    for wrapped in wrap_lines(text, indent, width) {
+    for wrapped in wrap_lines(&text, indent, width) {
         lines.push(Line::from(Span::styled(wrapped, style)));
     }
 }

--- a/src/util/markdown_strip/mod.rs
+++ b/src/util/markdown_strip/mod.rs
@@ -1,0 +1,244 @@
+//! Lightweight markdown stripping for plain-text fallback.
+//!
+//! When the `markdown` feature is disabled, this module strips common
+//! markdown syntax so output is readable plain text rather than raw markup.
+
+#[cfg(test)]
+mod tests;
+
+/// Strips common markdown syntax from text, returning readable plain text.
+///
+/// Handles: bold, italic, inline code, headings, blockquotes, unordered
+/// lists, and links. Does not attempt full markdown parsing — just removes
+/// the most common formatting markers.
+///
+/// # Examples
+///
+/// ```rust
+/// use envision::util::strip_markdown;
+///
+/// assert_eq!(strip_markdown("**bold**"), "bold");
+/// assert_eq!(strip_markdown("*italic*"), "italic");
+/// assert_eq!(strip_markdown("`code`"), "code");
+/// assert_eq!(strip_markdown("# Heading"), "Heading");
+/// assert_eq!(strip_markdown("[text](url)"), "text");
+/// ```
+pub fn strip_markdown(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+
+    for line in input.split('\n') {
+        if !result.is_empty() {
+            result.push('\n');
+        }
+        let stripped = strip_line(line);
+        result.push_str(&stripped);
+    }
+
+    result
+}
+
+/// Strips block-level markers from a single line, then inline markers.
+fn strip_line(line: &str) -> String {
+    let trimmed = line.trim_start();
+
+    // Heading: # through ######
+    let after_block = if trimmed.starts_with('#') {
+        let rest = trimmed.trim_start_matches('#');
+        rest.strip_prefix(' ').unwrap_or(rest)
+    }
+    // Blockquote: >
+    else if let Some(rest) = trimmed.strip_prefix('>') {
+        rest.strip_prefix(' ').unwrap_or(rest)
+    }
+    // Unordered list: - item or * item (but not ** bold)
+    else if (trimmed.starts_with("- ") || trimmed.starts_with("* ")) && !trimmed.starts_with("**")
+    {
+        &trimmed[2..]
+    } else {
+        line
+    };
+
+    strip_inline(after_block)
+}
+
+/// Strips inline markdown markers from text.
+fn strip_inline(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let chars: Vec<char> = input.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+
+    while i < len {
+        // Backslash escape
+        if chars[i] == '\\' && i + 1 < len {
+            result.push(chars[i + 1]);
+            i += 2;
+            continue;
+        }
+
+        // Inline code: `code`
+        if chars[i] == '`' {
+            if let Some((content, end)) = parse_delimited(&chars, i, '`') {
+                result.push_str(&content);
+                i = end;
+                continue;
+            }
+        }
+
+        // Bold+italic: ***text***
+        if i + 2 < len && chars[i] == '*' && chars[i + 1] == '*' && chars[i + 2] == '*' {
+            if let Some((content, end)) = parse_triple_delimited(&chars, i, '*') {
+                result.push_str(&strip_inline(&content));
+                i = end;
+                continue;
+            }
+        }
+
+        // Bold: **text** or __text__
+        if i + 1 < len && chars[i] == '*' && chars[i + 1] == '*' {
+            if let Some((content, end)) = parse_double_delimited(&chars, i, '*') {
+                result.push_str(&strip_inline(&content));
+                i = end;
+                continue;
+            }
+        }
+        if i + 1 < len && chars[i] == '_' && chars[i + 1] == '_' {
+            if let Some((content, end)) = parse_double_delimited(&chars, i, '_') {
+                result.push_str(&strip_inline(&content));
+                i = end;
+                continue;
+            }
+        }
+
+        // Italic: *text* or _text_
+        if chars[i] == '*' {
+            if let Some((content, end)) = parse_delimited(&chars, i, '*') {
+                result.push_str(&strip_inline(&content));
+                i = end;
+                continue;
+            }
+        }
+        if chars[i] == '_' {
+            if let Some((content, end)) = parse_delimited(&chars, i, '_') {
+                result.push_str(&strip_inline(&content));
+                i = end;
+                continue;
+            }
+        }
+
+        // Link: [text](url)
+        if chars[i] == '[' {
+            if let Some((text, end)) = parse_link(&chars, i) {
+                result.push_str(&text);
+                i = end;
+                continue;
+            }
+        }
+
+        result.push(chars[i]);
+        i += 1;
+    }
+
+    result
+}
+
+/// Parses `*content*` or `` `content` `` starting at position `start`.
+/// Returns (content, position_after_closing_delimiter).
+fn parse_delimited(chars: &[char], start: usize, delim: char) -> Option<(String, usize)> {
+    if chars[start] != delim {
+        return None;
+    }
+    let mut i = start + 1;
+    let mut content = String::new();
+    while i < chars.len() {
+        if chars[i] == delim {
+            if !content.is_empty() {
+                return Some((content, i + 1));
+            }
+            return None; // Empty delimiters like ** or ``
+        }
+        content.push(chars[i]);
+        i += 1;
+    }
+    None // No closing delimiter
+}
+
+/// Parses `**content**` or `__content__` starting at position `start`.
+fn parse_double_delimited(chars: &[char], start: usize, delim: char) -> Option<(String, usize)> {
+    if start + 1 >= chars.len() || chars[start] != delim || chars[start + 1] != delim {
+        return None;
+    }
+    let mut i = start + 2;
+    let mut content = String::new();
+    while i + 1 < chars.len() {
+        if chars[i] == delim && chars[i + 1] == delim {
+            if !content.is_empty() {
+                return Some((content, i + 2));
+            }
+            return None;
+        }
+        content.push(chars[i]);
+        i += 1;
+    }
+    None
+}
+
+/// Parses `***content***` starting at position `start`.
+fn parse_triple_delimited(chars: &[char], start: usize, delim: char) -> Option<(String, usize)> {
+    if start + 2 >= chars.len()
+        || chars[start] != delim
+        || chars[start + 1] != delim
+        || chars[start + 2] != delim
+    {
+        return None;
+    }
+    let mut i = start + 3;
+    let mut content = String::new();
+    while i + 2 < chars.len() {
+        if chars[i] == delim && chars[i + 1] == delim && chars[i + 2] == delim {
+            if !content.is_empty() {
+                return Some((content, i + 3));
+            }
+            return None;
+        }
+        content.push(chars[i]);
+        i += 1;
+    }
+    None
+}
+
+/// Parses `[text](url)` starting at position `start`.
+/// Returns (text, position_after_closing_paren).
+fn parse_link(chars: &[char], start: usize) -> Option<(String, usize)> {
+    if chars[start] != '[' {
+        return None;
+    }
+    let mut i = start + 1;
+    let mut text = String::new();
+
+    // Find closing ]
+    while i < chars.len() && chars[i] != ']' {
+        text.push(chars[i]);
+        i += 1;
+    }
+    if i >= chars.len() {
+        return None;
+    }
+    i += 1; // skip ]
+
+    // Expect (
+    if i >= chars.len() || chars[i] != '(' {
+        return None;
+    }
+    i += 1;
+
+    // Find closing )
+    while i < chars.len() && chars[i] != ')' {
+        i += 1;
+    }
+    if i >= chars.len() {
+        return None;
+    }
+
+    Some((text, i + 1))
+}

--- a/src/util/markdown_strip/tests.rs
+++ b/src/util/markdown_strip/tests.rs
@@ -1,0 +1,202 @@
+use super::strip_markdown;
+
+// =============================================================================
+// Bold
+// =============================================================================
+
+#[test]
+fn test_bold_asterisks() {
+    assert_eq!(strip_markdown("**bold**"), "bold");
+}
+
+#[test]
+fn test_bold_underscores() {
+    assert_eq!(strip_markdown("__bold__"), "bold");
+}
+
+#[test]
+fn test_bold_in_sentence() {
+    assert_eq!(strip_markdown("this is **bold** text"), "this is bold text");
+}
+
+// =============================================================================
+// Italic
+// =============================================================================
+
+#[test]
+fn test_italic_asterisk() {
+    assert_eq!(strip_markdown("*italic*"), "italic");
+}
+
+#[test]
+fn test_italic_underscore() {
+    assert_eq!(strip_markdown("_italic_"), "italic");
+}
+
+#[test]
+fn test_italic_in_sentence() {
+    assert_eq!(
+        strip_markdown("this is *italic* text"),
+        "this is italic text"
+    );
+}
+
+// =============================================================================
+// Inline code
+// =============================================================================
+
+#[test]
+fn test_inline_code() {
+    assert_eq!(strip_markdown("`code`"), "code");
+}
+
+#[test]
+fn test_inline_code_in_sentence() {
+    assert_eq!(
+        strip_markdown("use `strip_markdown()` here"),
+        "use strip_markdown() here"
+    );
+}
+
+// =============================================================================
+// Headings
+// =============================================================================
+
+#[test]
+fn test_heading_h1() {
+    assert_eq!(strip_markdown("# Heading"), "Heading");
+}
+
+#[test]
+fn test_heading_h2() {
+    assert_eq!(strip_markdown("## Subheading"), "Subheading");
+}
+
+#[test]
+fn test_heading_h3() {
+    assert_eq!(strip_markdown("### Third"), "Third");
+}
+
+// =============================================================================
+// Blockquotes
+// =============================================================================
+
+#[test]
+fn test_blockquote() {
+    assert_eq!(strip_markdown("> quoted text"), "quoted text");
+}
+
+#[test]
+fn test_blockquote_no_space() {
+    assert_eq!(strip_markdown(">quoted"), "quoted");
+}
+
+// =============================================================================
+// Lists
+// =============================================================================
+
+#[test]
+fn test_unordered_list_dash() {
+    assert_eq!(strip_markdown("- item one"), "item one");
+}
+
+#[test]
+fn test_unordered_list_asterisk() {
+    assert_eq!(strip_markdown("* item two"), "item two");
+}
+
+// =============================================================================
+// Links
+// =============================================================================
+
+#[test]
+fn test_link() {
+    assert_eq!(
+        strip_markdown("[click here](https://example.com)"),
+        "click here"
+    );
+}
+
+#[test]
+fn test_link_in_sentence() {
+    assert_eq!(
+        strip_markdown("see [docs](https://docs.rs) for info"),
+        "see docs for info"
+    );
+}
+
+// =============================================================================
+// Nested / combined
+// =============================================================================
+
+#[test]
+fn test_bold_italic() {
+    assert_eq!(strip_markdown("***bold italic***"), "bold italic");
+}
+
+#[test]
+fn test_bold_in_heading() {
+    assert_eq!(strip_markdown("# **Bold Heading**"), "Bold Heading");
+}
+
+#[test]
+fn test_multiple_inline() {
+    assert_eq!(
+        strip_markdown("**bold** and *italic* and `code`"),
+        "bold and italic and code"
+    );
+}
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
+#[test]
+fn test_empty_input() {
+    assert_eq!(strip_markdown(""), "");
+}
+
+#[test]
+fn test_no_markdown() {
+    assert_eq!(strip_markdown("plain text"), "plain text");
+}
+
+#[test]
+fn test_unmatched_bold() {
+    assert_eq!(strip_markdown("**unmatched"), "**unmatched");
+}
+
+#[test]
+fn test_unmatched_italic() {
+    assert_eq!(strip_markdown("*unmatched"), "*unmatched");
+}
+
+#[test]
+fn test_escaped_marker() {
+    assert_eq!(strip_markdown("\\*not italic\\*"), "*not italic*");
+}
+
+#[test]
+fn test_multiline() {
+    let input = "# Title\n\n**bold** paragraph\n\n- list item";
+    let expected = "Title\n\nbold paragraph\n\nlist item";
+    assert_eq!(strip_markdown(input), expected);
+}
+
+#[test]
+fn test_link_without_url_parens() {
+    // Incomplete link syntax should be left as-is
+    assert_eq!(strip_markdown("[text]"), "[text]");
+}
+
+#[test]
+fn test_empty_bold() {
+    // Empty bold markers should be left as-is
+    assert_eq!(strip_markdown("****"), "****");
+}
+
+#[test]
+fn test_single_asterisk_not_stripped() {
+    // A lone * without a closing pair shouldn't be stripped
+    assert_eq!(strip_markdown("5 * 3 = 15"), "5 * 3 = 15");
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -188,5 +188,8 @@ pub fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
     Rect::new(x, y, width.min(area.width), height.min(area.height))
 }
 
+mod markdown_strip;
+pub use markdown_strip::strip_markdown;
+
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Summary
When the `markdown` feature is off but `markdown_enabled` is true on ConversationView or ChatView, raw markdown syntax like `**bold**` was rendered literally. Now common markers are stripped so output is readable plain text.

### Patterns stripped
- `**bold**` / `__bold__` → `bold`
- `*italic*` / `_italic_` → `italic`
- `***bold italic***` → `bold italic`
- `` `code` `` → `code`
- `# Heading` → `Heading` (any level)
- `> blockquote` → `blockquote`
- `- list item` / `* list item` → `list item`
- `[text](url)` → `text`
- `\*escaped\*` → `*escaped*`

### Implementation
- `strip_markdown()` in `src/util/markdown_strip/` — always available, no feature flag dependency
- ConversationView: strips text blocks in `format_text_block` when markdown feature is off
- ChatView: strips message content in `format_message_plain` when `strip_md` is true

## Test plan
- [x] 29 unit tests for strip_markdown covering all patterns + edge cases
- [x] Clippy clean with `--all-features` AND without
- [x] Builds without `--all-features`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)