### PR TITLE
Add LTTB downsampling and raise max_display_points to 500

### DIFF
--- a/src/component/chart/downsample.rs
+++ b/src/component/chart/downsample.rs
@@ -1,0 +1,172 @@
+//! Data downsampling algorithms for chart components.
+//!
+//! Implements the Largest Triangle Three Buckets (LTTB) algorithm for
+//! reducing the number of data points while preserving the visual shape
+//! of the data. This is critical for rendering large datasets (25000+
+//! points) at terminal resolution.
+
+/// Downsamples data using the Largest Triangle Three Buckets algorithm.
+///
+/// Reduces `data` to at most `target` points while preserving the visual
+/// shape. The first and last points are always kept. Interior points are
+/// selected by dividing the data into buckets and choosing the point in
+/// each bucket that forms the largest triangle with the selected points
+/// in adjacent buckets.
+///
+/// Returns the original data if it has `target` or fewer points.
+pub fn lttb(data: &[(f64, f64)], target: usize) -> Vec<(f64, f64)> {
+    if data.len() <= target || target < 3 {
+        return data.to_vec();
+    }
+
+    let mut result = Vec::with_capacity(target);
+
+    // Always keep the first point
+    result.push(data[0]);
+
+    let bucket_size = (data.len() - 2) as f64 / (target - 2) as f64;
+
+    let mut prev_selected = 0;
+
+    for i in 0..(target - 2) {
+        // Current bucket range
+        let bucket_start = ((i as f64 * bucket_size) as usize + 1).min(data.len() - 1);
+        let bucket_end = (((i + 1) as f64 * bucket_size) as usize + 1).min(data.len() - 1);
+
+        // Next bucket range (for computing the average point)
+        let next_start = bucket_end;
+        let next_end = (((i + 2) as f64 * bucket_size) as usize + 1).min(data.len());
+
+        // Average of the next bucket
+        let (avg_x, avg_y) = if next_start < next_end {
+            let count = (next_end - next_start) as f64;
+            let sum_x: f64 = data[next_start..next_end].iter().map(|(x, _)| x).sum();
+            let sum_y: f64 = data[next_start..next_end].iter().map(|(_, y)| y).sum();
+            (sum_x / count, sum_y / count)
+        } else {
+            // Last bucket: use the last point
+            data[data.len() - 1]
+        };
+
+        // Find the point in the current bucket that forms the largest
+        // triangle with the previously selected point and the next average
+        let (prev_x, prev_y) = data[prev_selected];
+        let mut max_area = -1.0;
+        let mut max_idx = bucket_start;
+
+        for (j, &(cx, cy)) in data.iter().enumerate().take(bucket_end).skip(bucket_start) {
+            // Triangle area (doubled, no division needed for comparison)
+            let area =
+                ((prev_x - avg_x) * (cy - prev_y) - (prev_x - cx) * (avg_y - prev_y)).abs();
+            if area > max_area {
+                max_area = area;
+                max_idx = j;
+            }
+        }
+
+        result.push(data[max_idx]);
+        prev_selected = max_idx;
+    }
+
+    // Always keep the last point
+    result.push(data[data.len() - 1]);
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lttb_preserves_endpoints() {
+        let data: Vec<(f64, f64)> = (0..100).map(|i| (i as f64, (i as f64).sin())).collect();
+        let result = lttb(&data, 10);
+        assert_eq!(result.first(), Some(&data[0]));
+        assert_eq!(result.last(), Some(&data[99]));
+    }
+
+    #[test]
+    fn test_lttb_output_length() {
+        let data: Vec<(f64, f64)> = (0..100).map(|i| (i as f64, i as f64)).collect();
+        let result = lttb(&data, 10);
+        assert_eq!(result.len(), 10);
+    }
+
+    #[test]
+    fn test_lttb_fewer_than_target() {
+        let data = vec![(0.0, 1.0), (1.0, 2.0), (2.0, 3.0)];
+        let result = lttb(&data, 10);
+        assert_eq!(result, data);
+    }
+
+    #[test]
+    fn test_lttb_exact_target() {
+        let data = vec![(0.0, 1.0), (1.0, 2.0), (2.0, 3.0)];
+        let result = lttb(&data, 3);
+        assert_eq!(result, data);
+    }
+
+    #[test]
+    fn test_lttb_target_two() {
+        // target < 3 returns original data
+        let data: Vec<(f64, f64)> = (0..10).map(|i| (i as f64, i as f64)).collect();
+        let result = lttb(&data, 2);
+        assert_eq!(result, data);
+    }
+
+    #[test]
+    fn test_lttb_empty() {
+        let data: Vec<(f64, f64)> = vec![];
+        let result = lttb(&data, 10);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_lttb_single_point() {
+        let data = vec![(0.0, 42.0)];
+        let result = lttb(&data, 10);
+        assert_eq!(result, data);
+    }
+
+    #[test]
+    fn test_lttb_preserves_extremes() {
+        // Data with a spike: LTTB should preserve the peak
+        let mut data: Vec<(f64, f64)> = (0..100).map(|i| (i as f64, 0.0)).collect();
+        data[50] = (50.0, 100.0); // spike at index 50
+
+        let result = lttb(&data, 10);
+
+        // The spike should be preserved
+        let max_y = result
+            .iter()
+            .map(|(_, y)| *y)
+            .fold(f64::NEG_INFINITY, f64::max);
+        assert_eq!(max_y, 100.0);
+    }
+
+    #[test]
+    fn test_lttb_large_dataset() {
+        let data: Vec<(f64, f64)> = (0..25000)
+            .map(|i| {
+                let x = i as f64;
+                let y = (x / 100.0).sin() * 100.0;
+                (x, y)
+            })
+            .collect();
+        let result = lttb(&data, 500);
+        assert_eq!(result.len(), 500);
+        assert_eq!(result.first(), Some(&data[0]));
+        assert_eq!(result.last(), Some(&data[24999]));
+    }
+
+    #[test]
+    fn test_lttb_monotonic_increasing() {
+        // For monotonically increasing data, all selected x values should be increasing
+        let data: Vec<(f64, f64)> = (0..100).map(|i| (i as f64, i as f64)).collect();
+        let result = lttb(&data, 10);
+        for i in 1..result.len() {
+            assert!(result[i].0 > result[i - 1].0);
+        }
+    }
+}

--- a/src/component/chart/mod.rs
+++ b/src/component/chart/mod.rs
@@ -31,6 +31,7 @@ use super::{Component, Disableable, ViewContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
+pub(crate) mod downsample;
 mod render;
 mod series;
 
@@ -203,7 +204,7 @@ impl Default for ChartState {
             x_label: None,
             y_label: None,
             show_legend: true,
-            max_display_points: 50,
+            max_display_points: 500,
             bar_width: 3,
             bar_gap: 1,
             focused: false,

--- a/src/component/chart/render.rs
+++ b/src/component/chart/render.rs
@@ -112,18 +112,12 @@ pub(super) fn render_shared_axis_chart(
     let effective_min = state.effective_min();
     let effective_max = state.effective_max();
 
-    // Compute max x value across all series
+    // Compute max x value across all series (use full series length since
+    // LTTB preserves original x coordinates)
     let max_x = state
         .series
         .iter()
-        .map(|s| {
-            let len = s.values().len();
-            if len > state.max_display_points {
-                state.max_display_points
-            } else {
-                len
-            }
-        })
+        .map(|s| s.values().len())
         .max()
         .unwrap_or(1)
         .max(1) as f64
@@ -135,21 +129,25 @@ pub(super) fn render_shared_axis_chart(
         _ => GraphType::Line,
     };
 
-    // Build data vectors that outlive the datasets
+    // Build data vectors, using LTTB downsampling for large datasets.
+    // Width-adaptive: braille gives 2x horizontal resolution per character.
+    let effective_max_points = (area.width as usize * 2).min(state.max_display_points);
+
     let series_data: Vec<Vec<(f64, f64)>> = state
         .series
         .iter()
         .map(|s| {
-            let values = if s.values().len() > state.max_display_points {
-                &s.values()[s.values().len() - state.max_display_points..]
-            } else {
-                s.values()
-            };
-            values
+            let indexed: Vec<(f64, f64)> = s
+                .values()
                 .iter()
                 .enumerate()
                 .map(|(i, v)| (i as f64, *v))
-                .collect()
+                .collect();
+            if indexed.len() > effective_max_points {
+                super::downsample::lttb(&indexed, effective_max_points)
+            } else {
+                indexed
+            }
         })
         .collect();
 

--- a/src/component/chart/tests.rs
+++ b/src/component/chart/tests.rs
@@ -149,7 +149,7 @@ fn test_default() {
     let state = ChartState::default();
     assert!(state.is_empty());
     assert_eq!(state.kind(), &ChartKind::Line);
-    assert_eq!(state.max_display_points(), 50);
+    assert_eq!(state.max_display_points(), 500);
     assert_eq!(state.bar_width(), 3);
     assert_eq!(state.bar_gap(), 1);
     assert!(state.show_legend());


### PR DESCRIPTION
## Summary

- Add `downsample` module with LTTB (Largest Triangle Three Buckets) algorithm that preserves visual features while reducing points
- Raise default `max_display_points` from 50 to 500 — the old default was far too low for datasets with thousands of epochs
- Width-adaptive targeting: `effective_points = min(width * 2, max_display_points)` leverages braille's 2x horizontal resolution
- LTTB preserves endpoints and extremes (spikes, transitions) unlike simple tail truncation

**Depends on**: #336 (independent of #337, #338, #339)

## Test plan

- [x] 10 unit tests for LTTB (endpoints, length, extremes, monotonicity, large dataset)
- [x] All 1837 tests pass (`cargo test --all-features`)
- [x] Clippy clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)