### PR TITLE
Add vertical reference lines for chart component

### DIFF
--- a/src/component/chart/enhancement_tests.rs
+++ b/src/component/chart/enhancement_tests.rs
@@ -457,3 +457,88 @@ fn test_disabled_still_processes_y_range_messages() {
     assert_eq!(state.y_min(), Some(0.0));
     assert_eq!(state.y_max(), Some(100.0));
 }
+
+// =============================================================================
+// Vertical reference lines
+// =============================================================================
+
+#[test]
+fn test_with_vertical_line_builder() {
+    let state = ChartState::line(vec![DataSeries::new("Loss", vec![1.0, 2.0, 3.0])])
+        .with_vertical_line(2.0, "Event", Color::Yellow);
+    assert_eq!(state.vertical_lines().len(), 1);
+    assert_eq!(state.vertical_lines()[0].x_value, 2.0);
+    assert_eq!(state.vertical_lines()[0].label, "Event");
+}
+
+#[test]
+fn test_add_vertical_line() {
+    let mut state = ChartState::line(vec![]);
+    state.add_vertical_line(VerticalLine::new(10.0, "Transition", Color::Cyan));
+    assert_eq!(state.vertical_lines().len(), 1);
+}
+
+#[test]
+fn test_clear_vertical_lines() {
+    let mut state = ChartState::line(vec![])
+        .with_vertical_line(5.0, "A", Color::Red)
+        .with_vertical_line(10.0, "B", Color::Blue);
+    assert_eq!(state.vertical_lines().len(), 2);
+    state.clear_vertical_lines();
+    assert!(state.vertical_lines().is_empty());
+}
+
+#[test]
+fn test_set_vertical_lines_message() {
+    let mut state = ChartState::line(vec![DataSeries::new("X", vec![1.0])]);
+    let lines = vec![
+        VerticalLine::new(5.0, "Start", Color::Green),
+        VerticalLine::new(15.0, "End", Color::Red),
+    ];
+    let output = Chart::update(&mut state, ChartMessage::SetVerticalLines(lines));
+    assert_eq!(output, None);
+    assert_eq!(state.vertical_lines().len(), 2);
+}
+
+#[test]
+fn test_add_vertical_line_message() {
+    let mut state = ChartState::line(vec![DataSeries::new("X", vec![1.0])]);
+    let output = Chart::update(
+        &mut state,
+        ChartMessage::AddVerticalLine(VerticalLine::new(10.0, "Mark", Color::Yellow)),
+    );
+    assert_eq!(output, None);
+    assert_eq!(state.vertical_lines().len(), 1);
+}
+
+#[test]
+fn test_render_chart_with_vertical_lines() {
+    let state = ChartState::line(vec![DataSeries::new(
+        "Loss",
+        vec![100.0, 80.0, 50.0, 20.0, 5.0],
+    )])
+    .with_vertical_line(2.0, "Grokking", Color::Yellow)
+    .with_title("Training");
+    let (mut terminal, theme) = test_utils::setup_render(60, 20);
+    terminal
+        .draw(|frame| {
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_chart_with_vertical_and_horizontal_lines() {
+    let state = ChartState::line(vec![DataSeries::new(
+        "Loss",
+        vec![100.0, 80.0, 50.0, 20.0, 5.0],
+    )])
+    .with_vertical_line(3.0, "Epoch 3", Color::Yellow)
+    .with_threshold(50.0, "Target", Color::Green);
+    let (mut terminal, theme) = test_utils::setup_render(60, 20);
+    terminal
+        .draw(|frame| {
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+        })
+        .unwrap();
+}

--- a/src/component/chart/mod.rs
+++ b/src/component/chart/mod.rs
@@ -122,6 +122,57 @@ impl ThresholdLine {
     }
 }
 
+/// A vertical reference line rendered on line, area, and scatter charts.
+///
+/// Vertical lines are drawn as vertical lines spanning the full chart height
+/// at a specified x-value, useful for marking events, transitions, or epochs.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::component::VerticalLine;
+/// use ratatui::style::Color;
+///
+/// let vline = VerticalLine::new(10000.0, "Grokking", Color::Yellow);
+/// assert_eq!(vline.x_value, 10000.0);
+/// assert_eq!(vline.label, "Grokking");
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct VerticalLine {
+    /// The x-value for this vertical line.
+    pub x_value: f64,
+    /// Label for the vertical line.
+    pub label: String,
+    /// Color for the vertical line.
+    pub color: Color,
+}
+
+impl VerticalLine {
+    /// Creates a new vertical reference line.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::VerticalLine;
+    /// use ratatui::style::Color;
+    ///
+    /// let v = VerticalLine::new(5000.0, "Transition", Color::Cyan);
+    /// assert_eq!(v.x_value, 5000.0);
+    /// assert_eq!(v.label, "Transition");
+    /// ```
+    pub fn new(x_value: f64, label: impl Into<String>, color: Color) -> Self {
+        Self {
+            x_value,
+            label: label.into(),
+            color,
+        }
+    }
+}
+
 /// Messages that can be sent to a Chart.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
@@ -139,6 +190,10 @@ pub enum ChartMessage {
     AddThreshold(ThresholdLine),
     /// Set the manual Y-axis range. `None` values fall back to auto-scaling.
     SetYRange(Option<f64>, Option<f64>),
+    /// Set vertical reference lines, replacing any existing ones.
+    SetVerticalLines(Vec<VerticalLine>),
+    /// Add a single vertical reference line.
+    AddVerticalLine(VerticalLine),
 }
 
 /// Output messages from a Chart.
@@ -191,6 +246,8 @@ pub struct ChartState {
     pub(crate) y_min: Option<f64>,
     /// Manual Y-axis maximum (None = auto from data).
     pub(crate) y_max: Option<f64>,
+    /// Vertical reference lines.
+    pub(crate) vertical_lines: Vec<VerticalLine>,
 }
 
 impl Default for ChartState {
@@ -211,6 +268,7 @@ impl Default for ChartState {
             thresholds: Vec::new(),
             y_min: None,
             y_max: None,
+            vertical_lines: Vec::new(),
         }
     }
 }
@@ -415,6 +473,29 @@ impl ChartState {
         self
     }
 
+    /// Adds a vertical reference line (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries, VerticalLine};
+    /// use ratatui::style::Color;
+    ///
+    /// let state = ChartState::line(vec![DataSeries::new("Loss", vec![1.0, 2.0, 3.0])])
+    ///     .with_vertical_line(2.0, "Event", Color::Yellow);
+    /// assert_eq!(state.vertical_lines().len(), 1);
+    /// ```
+    pub fn with_vertical_line(
+        mut self,
+        x_value: f64,
+        label: impl Into<String>,
+        color: Color,
+    ) -> Self {
+        self.vertical_lines
+            .push(VerticalLine::new(x_value, label, color));
+        self
+    }
+
     // ---- Accessors ----
 
     /// Returns the data series.
@@ -575,6 +656,21 @@ impl ChartState {
     /// Returns the manual Y-axis maximum, if set.
     pub fn y_max(&self) -> Option<f64> {
         self.y_max
+    }
+
+    /// Returns the vertical reference lines.
+    pub fn vertical_lines(&self) -> &[VerticalLine] {
+        &self.vertical_lines
+    }
+
+    /// Adds a vertical reference line.
+    pub fn add_vertical_line(&mut self, line: VerticalLine) {
+        self.vertical_lines.push(line);
+    }
+
+    /// Clears all vertical reference lines.
+    pub fn clear_vertical_lines(&mut self) {
+        self.vertical_lines.clear();
     }
 
     /// Adds a series.
@@ -802,6 +898,14 @@ impl Component for Chart {
             ChartMessage::SetYRange(min, max) => {
                 state.y_min = min;
                 state.y_max = max;
+                None
+            }
+            ChartMessage::SetVerticalLines(lines) => {
+                state.vertical_lines = lines;
+                None
+            }
+            ChartMessage::AddVerticalLine(line) => {
+                state.vertical_lines.push(line);
                 None
             }
             ChartMessage::NextSeries | ChartMessage::PrevSeries => {

--- a/src/component/chart/render.rs
+++ b/src/component/chart/render.rs
@@ -105,7 +105,7 @@ pub(super) fn render_shared_axis_chart(
     _focused: bool,
     disabled: bool,
 ) {
-    if state.series.is_empty() && state.thresholds.is_empty() {
+    if state.series.is_empty() && state.thresholds.is_empty() && state.vertical_lines.is_empty() {
         return;
     }
 
@@ -153,11 +153,18 @@ pub(super) fn render_shared_axis_chart(
         })
         .collect();
 
-    // Build threshold data vectors
+    // Build threshold data vectors (horizontal reference lines)
     let threshold_data: Vec<Vec<(f64, f64)>> = state
         .thresholds
         .iter()
         .map(|t| vec![(0.0, t.value), (max_x, t.value)])
+        .collect();
+
+    // Build vertical reference line data vectors
+    let vline_data: Vec<Vec<(f64, f64)>> = state
+        .vertical_lines
+        .iter()
+        .map(|v| vec![(v.x_value, effective_min), (v.x_value, effective_max)])
         .collect();
 
     // Build datasets referencing the data vectors
@@ -189,6 +196,19 @@ pub(super) fn render_shared_axis_chart(
             Dataset::default()
                 .name(threshold.label.as_str())
                 .data(&threshold_data[i])
+                .marker(symbols::Marker::Braille)
+                .graph_type(GraphType::Line)
+                .style(style),
+        );
+    }
+
+    // Add vertical reference lines as additional datasets
+    for (i, vline) in state.vertical_lines.iter().enumerate() {
+        let style = Style::default().fg(vline.color);
+        datasets.push(
+            Dataset::default()
+                .name(vline.label.as_str())
+                .data(&vline_data[i])
                 .marker(symbols::Marker::Braille)
                 .graph_type(GraphType::Line)
                 .style(style),

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -358,6 +358,7 @@ pub use box_plot::{BoxPlot, BoxPlotData, BoxPlotMessage, BoxPlotOrientation, Box
 #[cfg(feature = "compound-components")]
 pub use chart::{
     Chart, ChartKind, ChartMessage, ChartOutput, ChartState, DataSeries, ThresholdLine,
+    VerticalLine,
 };
 #[cfg(feature = "compound-components")]
 pub use chat_view::{


### PR DESCRIPTION
## Summary

- Add `VerticalLine` struct mirroring `ThresholdLine` for vertical reference lines
- Useful for marking events, transitions, or epochs on time-series data (e.g., "Grokking begins" at epoch 10000)
- Builder: `.with_vertical_line(x, label, color)`, setter: `add_vertical_line()`, messages: `SetVerticalLines`, `AddVerticalLine`
- Rendered as braille datasets spanning the full Y range

**Depends on**: #336 (independent of #337, #338, #339, #340)

## Test plan

- [x] 7 tests for builders, setters, messages, and rendering
- [x] All 1840 tests pass (`cargo test --all-features`)
- [x] Clippy clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)