### PR TITLE
Add vertical reference lines for chart component

### DIFF
--- a/src/component/chart/enhancement_tests.rs
+++ b/src/component/chart/enhancement_tests.rs
@@ -452,3 +452,94 @@ fn test_disabled_still_processes_y_range_messages() {
     assert_eq!(state.y_min(), Some(0.0));
     assert_eq!(state.y_max(), Some(100.0));
 }
+
+// =============================================================================
+// VerticalLine
+// =============================================================================
+
+#[test]
+fn test_with_vertical_line_builder() {
+    let state = ChartState::line(vec![DataSeries::new("CPU", vec![50.0, 60.0, 70.0])])
+        .with_vertical_line(1.0, "Deploy", Color::Yellow)
+        .with_vertical_line(2.0, "Rollback", Color::Red);
+    assert_eq!(state.vertical_lines().len(), 2);
+    assert_eq!(state.vertical_lines()[0].x_value, 1.0);
+    assert_eq!(state.vertical_lines()[0].label, "Deploy");
+    assert_eq!(state.vertical_lines()[0].color, Color::Yellow);
+    assert_eq!(state.vertical_lines()[1].x_value, 2.0);
+    assert_eq!(state.vertical_lines()[1].label, "Rollback");
+}
+
+#[test]
+fn test_add_vertical_line() {
+    let mut state = ChartState::line(vec![]);
+    state.add_vertical_line(VerticalLine::new(5.0, "Event", Color::Cyan));
+    assert_eq!(state.vertical_lines().len(), 1);
+    assert_eq!(state.vertical_lines()[0].x_value, 5.0);
+}
+
+#[test]
+fn test_clear_vertical_lines() {
+    let mut state = ChartState::line(vec![])
+        .with_vertical_line(1.0, "A", Color::Red)
+        .with_vertical_line(2.0, "B", Color::Blue);
+    assert_eq!(state.vertical_lines().len(), 2);
+    state.clear_vertical_lines();
+    assert!(state.vertical_lines().is_empty());
+}
+
+#[test]
+fn test_set_vertical_lines_message() {
+    let mut state = ChartState::line(vec![DataSeries::new("X", vec![1.0])]);
+    let lines = vec![
+        VerticalLine::new(1.0, "Start", Color::Green),
+        VerticalLine::new(3.0, "End", Color::Red),
+    ];
+    let output = Chart::update(&mut state, ChartMessage::SetVerticalLines(lines));
+    assert_eq!(output, None);
+    assert_eq!(state.vertical_lines().len(), 2);
+    assert_eq!(state.vertical_lines()[0].x_value, 1.0);
+    assert_eq!(state.vertical_lines()[1].x_value, 3.0);
+}
+
+#[test]
+fn test_add_vertical_line_message() {
+    let mut state = ChartState::line(vec![DataSeries::new("X", vec![1.0])]);
+    let output = Chart::update(
+        &mut state,
+        ChartMessage::AddVerticalLine(VerticalLine::new(2.0, "Midpoint", Color::Cyan)),
+    );
+    assert_eq!(output, None);
+    assert_eq!(state.vertical_lines().len(), 1);
+}
+
+#[test]
+fn test_render_chart_with_vertical_lines() {
+    let state = ChartState::line(vec![DataSeries::new(
+        "CPU",
+        vec![45.0, 52.0, 48.0, 65.0, 72.0],
+    )])
+    .with_vertical_line(2.0, "Deploy", Color::Yellow);
+    let (mut terminal, theme) = test_utils::setup_render(60, 20);
+    terminal
+        .draw(|frame| {
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_chart_with_vertical_and_horizontal_lines() {
+    let state = ChartState::line(vec![DataSeries::new(
+        "CPU",
+        vec![45.0, 52.0, 48.0, 65.0, 72.0],
+    )])
+    .with_threshold(60.0, "Warning", Color::Red)
+    .with_vertical_line(2.0, "Deploy", Color::Yellow);
+    let (mut terminal, theme) = test_utils::setup_render(60, 20);
+    terminal
+        .draw(|frame| {
+            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+        })
+        .unwrap();
+}

--- a/src/component/chart/mod.rs
+++ b/src/component/chart/mod.rs
@@ -128,6 +128,46 @@ impl ThresholdLine {
     }
 }
 
+/// A vertical reference line rendered on line, area, and scatter charts.
+///
+/// Vertical lines are drawn as vertical lines spanning the full chart height
+/// at a specified x-value, useful for marking events, transitions, or epochs.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::component::VerticalLine;
+/// use ratatui::style::Color;
+///
+/// let vline = VerticalLine::new(10000.0, "Grokking", Color::Yellow);
+/// assert_eq!(vline.x_value, 10000.0);
+/// assert_eq!(vline.label, "Grokking");
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct VerticalLine {
+    /// The x-value for this vertical line.
+    pub x_value: f64,
+    /// Label for the vertical line.
+    pub label: String,
+    /// Color for the vertical line.
+    pub color: Color,
+}
+
+impl VerticalLine {
+    /// Creates a new vertical reference line.
+    pub fn new(x_value: f64, label: impl Into<String>, color: Color) -> Self {
+        Self {
+            x_value,
+            label: label.into(),
+            color,
+        }
+    }
+}
+
 /// Messages that can be sent to a Chart.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
@@ -147,6 +187,10 @@ pub enum ChartMessage {
     SetYRange(Option<f64>, Option<f64>),
     /// Set the Y-axis scale (Linear, Log10, or SymLog).
     SetYScale(Scale),
+    /// Set vertical reference lines, replacing any existing ones.
+    SetVerticalLines(Vec<VerticalLine>),
+    /// Add a single vertical reference line.
+    AddVerticalLine(VerticalLine),
 }
 
 /// Output messages from a Chart.
@@ -197,6 +241,8 @@ pub struct ChartState {
     pub(crate) y_max: Option<f64>,
     /// Y-axis scale transformation.
     pub(crate) y_scale: Scale,
+    /// Vertical reference lines.
+    pub(crate) vertical_lines: Vec<VerticalLine>,
 }
 
 impl Default for ChartState {
@@ -216,6 +262,7 @@ impl Default for ChartState {
             y_min: None,
             y_max: None,
             y_scale: Scale::default(),
+            vertical_lines: Vec::new(),
         }
     }
 }
@@ -429,6 +476,29 @@ impl ChartState {
         self.y_scale = scale;
         self
     }
+
+    /// Adds a vertical reference line (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    /// use ratatui::style::Color;
+    ///
+    /// let state = ChartState::line(vec![DataSeries::new("CPU", vec![50.0, 60.0, 70.0])])
+    ///     .with_vertical_line(1.0, "Deploy", Color::Yellow);
+    /// assert_eq!(state.vertical_lines().len(), 1);
+    /// ```
+    pub fn with_vertical_line(
+        mut self,
+        x_value: f64,
+        label: impl Into<String>,
+        color: Color,
+    ) -> Self {
+        self.vertical_lines
+            .push(VerticalLine::new(x_value, label, color));
+        self
+    }
 }
 
 /// A chart component for data visualization.
@@ -488,6 +558,14 @@ impl Component for Chart {
             }
             ChartMessage::SetYScale(scale) => {
                 state.y_scale = scale;
+                None
+            }
+            ChartMessage::SetVerticalLines(lines) => {
+                state.vertical_lines = lines;
+                None
+            }
+            ChartMessage::AddVerticalLine(line) => {
+                state.vertical_lines.push(line);
                 None
             }
             ChartMessage::NextSeries | ChartMessage::PrevSeries => {

--- a/src/component/chart/render.rs
+++ b/src/component/chart/render.rs
@@ -106,7 +106,7 @@ pub(super) fn render_shared_axis_chart(
     _focused: bool,
     disabled: bool,
 ) {
-    if state.series.is_empty() && state.thresholds.is_empty() {
+    if state.series.is_empty() && state.thresholds.is_empty() && state.vertical_lines.is_empty() {
         return;
     }
 
@@ -194,6 +194,18 @@ pub(super) fn render_shared_axis_chart(
         })
         .collect();
 
+    // Build vertical line data vectors (with scale transforms)
+    let scale = &state.y_scale;
+    let vline_data: Vec<Vec<(f64, f64)>> = state
+        .vertical_lines
+        .iter()
+        .map(|v| {
+            let tv_min = scale.transform(effective_min);
+            let tv_max = scale.transform(effective_max);
+            vec![(v.x_value, tv_min), (v.x_value, tv_max)]
+        })
+        .collect();
+
     // Build datasets referencing the data vectors
     let mut datasets: Vec<Dataset> = state
         .series
@@ -223,6 +235,19 @@ pub(super) fn render_shared_axis_chart(
             Dataset::default()
                 .name(threshold.label.as_str())
                 .data(&threshold_data[i])
+                .marker(symbols::Marker::Braille)
+                .graph_type(GraphType::Line)
+                .style(style),
+        );
+    }
+
+    // Add vertical reference lines as additional datasets
+    for (i, vline) in state.vertical_lines.iter().enumerate() {
+        let style = Style::default().fg(vline.color);
+        datasets.push(
+            Dataset::default()
+                .name(vline.label.as_str())
+                .data(&vline_data[i])
                 .marker(symbols::Marker::Braille)
                 .graph_type(GraphType::Line)
                 .style(style),

--- a/src/component/chart/state.rs
+++ b/src/component/chart/state.rs
@@ -4,6 +4,7 @@
 
 use super::{
     Chart, ChartKind, ChartMessage, ChartOutput, ChartState, DataSeries, Scale, ThresholdLine,
+    VerticalLine,
 };
 use crate::component::Component;
 
@@ -256,6 +257,44 @@ impl ChartState {
     /// ```
     pub fn clear_thresholds(&mut self) {
         self.thresholds.clear();
+    }
+
+    /// Returns the vertical reference lines.
+    pub fn vertical_lines(&self) -> &[VerticalLine] {
+        &self.vertical_lines
+    }
+
+    /// Adds a vertical reference line.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries, VerticalLine};
+    /// use ratatui::style::Color;
+    ///
+    /// let mut state = ChartState::line(vec![DataSeries::new("CPU", vec![50.0, 60.0])]);
+    /// state.add_vertical_line(VerticalLine::new(1.0, "Deploy", Color::Yellow));
+    /// assert_eq!(state.vertical_lines().len(), 1);
+    /// ```
+    pub fn add_vertical_line(&mut self, line: VerticalLine) {
+        self.vertical_lines.push(line);
+    }
+
+    /// Clears all vertical reference lines.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    /// use ratatui::style::Color;
+    ///
+    /// let mut state = ChartState::line(vec![DataSeries::new("CPU", vec![50.0, 60.0])])
+    ///     .with_vertical_line(1.0, "Deploy", Color::Yellow);
+    /// state.clear_vertical_lines();
+    /// assert!(state.vertical_lines().is_empty());
+    /// ```
+    pub fn clear_vertical_lines(&mut self) {
+        self.vertical_lines.clear();
     }
 
     /// Sets the manual Y-axis range.

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -345,6 +345,7 @@ pub use box_plot::{BoxPlot, BoxPlotData, BoxPlotMessage, BoxPlotOrientation, Box
 #[cfg(feature = "compound-components")]
 pub use chart::{
     Chart, ChartKind, ChartMessage, ChartOutput, ChartState, DataSeries, Scale, ThresholdLine,
+    VerticalLine,
 };
 #[cfg(feature = "compound-components")]
 pub use conversation_view::{


### PR DESCRIPTION
## Summary
- Add `VerticalLine` struct for marking x-axis positions on line, area, and scatter charts
- Add `SetVerticalLines` and `AddVerticalLine` message variants to `ChartMessage`
- Add builder method (`with_vertical_line`), accessors (`vertical_lines`), and mutators (`add_vertical_line`, `clear_vertical_lines`) to `ChartState`
- Render vertical lines as datasets spanning full chart height in `render_shared_axis_chart`
- Re-export `VerticalLine` from `component::mod`

## Test plan
- [x] Unit tests for builder pattern (`test_with_vertical_line_builder`)
- [x] Unit tests for add/clear mutators (`test_add_vertical_line`, `test_clear_vertical_lines`)
- [x] Unit tests for message handling (`test_set_vertical_lines_message`, `test_add_vertical_line_message`)
- [x] Render tests for vertical lines alone and combined with horizontal thresholds
- [x] All 6683 unit tests pass
- [x] All 1597 doc tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)