### PR TITLE
Update README MSRV from 1.81 to 1.85

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Envision follows The Elm Architecture (TEA) pattern:
 
 ## Minimum Supported Rust Version
 
-The minimum supported Rust version is **1.81**.
+The minimum supported Rust version is **1.85** (edition 2024).
 
 ## License
 


### PR DESCRIPTION
Aligns README with Cargo.toml `rust-version = "1.85"` and `edition = "2024"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)