### PR TITLE
Fix ConversationView markdown rendering to honor role colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hidden, the state's title is not rendered (the title is drawn as
   part of the border block).
 
+### Fixed
+
+- `ConversationView` now honors role colors (User=green, Assistant=blue,
+  etc.) when markdown rendering is enabled. Previously, the role style was
+  discarded in the markdown branch of `format_text_block`, causing all body
+  text to render in the terminal default foreground regardless of role.
+  Markdown-specific styling (bold, inline code) is preserved where set.
+
 ## [0.12.0] - 2026-04-05
 
 ### Breaking

--- a/docs/superpowers/plans/2026-04-09-conversation-view-markdown-role-color-fix.md
+++ b/docs/superpowers/plans/2026-04-09-conversation-view-markdown-role-color-fix.md
@@ -1,0 +1,452 @@
+# ConversationView Markdown Role Color Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix `format_text_block` so that markdown-rendered body text carries the role color (green for User, blue for Assistant), instead of rendering in the terminal default (white).
+
+**Architecture:** Patch `style` (the role color) into each markdown-rendered span via `style.patch(span.style)`, preserving markdown-specific styling where set. Promote `build_display_lines` to `pub(super)` for testability. Add a structural test that inspects span styles directly.
+
+**Tech Stack:** Rust (edition 2024), ratatui (terminal rendering), pulldown-cmark (markdown), cargo-nextest.
+
+**Spec:** `docs/superpowers/specs/2026-04-09-conversation-view-markdown-role-color-fix-design.md`
+
+---
+
+## File Structure
+
+- Modify: `src/component/conversation_view/render.rs` — fix `format_text_block` markdown branch, promote `build_display_lines` visibility
+- Modify: `src/component/conversation_view/render_tests.rs` — add structural test
+- Modify: `CHANGELOG.md` — add entry under `[Unreleased]`
+
+---
+
+## Task 1: Fix markdown branch + structural test (TDD)
+
+**Files:**
+- Modify: `src/component/conversation_view/render.rs` (lines 144, 317-337)
+- Modify: `src/component/conversation_view/render_tests.rs` (add test at end)
+
+---
+
+- [ ] **Step 1.1: Promote `build_display_lines` to `pub(super)`**
+
+In `src/component/conversation_view/render.rs`, change line 144 from:
+
+```rust
+fn build_display_lines<'a>(
+```
+
+to:
+
+```rust
+pub(super) fn build_display_lines<'a>(
+```
+
+This is a visibility-only change. No behavioral effect.
+
+- [ ] **Step 1.2: Write the failing structural test**
+
+Add to `src/component/conversation_view/render_tests.rs`, at the end of the file:
+
+```rust
+#[test]
+fn test_markdown_role_style_propagation() {
+    use ratatui::style::{Color, Modifier, Style};
+
+    let mut state = ConversationViewState::new().with_markdown(true);
+    state.push_user("plain text and **bold** and `inline code`");
+    state.push_assistant("plain text and **bold** and `inline code`");
+
+    let theme = crate::theme::Theme::default();
+    let lines = super::render::build_display_lines(
+        state.source_messages(),
+        &state,
+        80,
+        &theme,
+    );
+
+    // Partition lines into user-section and assistant-section.
+    // The header line for each message contains the role label.
+    let mut user_lines: Vec<&Line> = Vec::new();
+    let mut assistant_lines: Vec<&Line> = Vec::new();
+    let mut current_section: Option<&str> = None;
+
+    for line in &lines {
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        if text.contains("User") && line.spans.iter().any(|s| {
+            s.style.add_modifier.contains(Modifier::BOLD)
+        }) {
+            current_section = Some("user");
+            continue;
+        }
+        if text.contains("Assistant") && line.spans.iter().any(|s| {
+            s.style.add_modifier.contains(Modifier::BOLD)
+        }) {
+            current_section = Some("assistant");
+            continue;
+        }
+        match current_section {
+            Some("user") => user_lines.push(line),
+            Some("assistant") => assistant_lines.push(line),
+            _ => {}
+        }
+    }
+
+    assert!(!user_lines.is_empty(), "should have user message body lines");
+    assert!(!assistant_lines.is_empty(), "should have assistant message body lines");
+
+    // Helper: find a span containing `needle` across a set of lines.
+    let find_span = |lines: &[&Line], needle: &str| -> Option<Style> {
+        for line in lines {
+            for span in &line.spans {
+                if span.content.contains(needle) {
+                    return Some(span.style);
+                }
+            }
+        }
+        None
+    };
+
+    // -- User assertions (role color: Green) --
+    let user_plain = find_span(&user_lines, "plain")
+        .expect("user section should contain a span with 'plain'");
+    assert_eq!(
+        user_plain.fg, Some(Color::Green),
+        "user plain-text span should have fg=Green (role color), got {:?}",
+        user_plain.fg,
+    );
+
+    let user_bold = find_span(&user_lines, "bold")
+        .expect("user section should contain a span with 'bold'");
+    assert!(
+        user_bold.add_modifier.contains(Modifier::BOLD),
+        "user bold span should retain BOLD modifier from markdown",
+    );
+    assert_eq!(
+        user_bold.fg, Some(Color::Green),
+        "user bold span should have fg=Green (role color fills in unset fg)",
+    );
+
+    let user_code = find_span(&user_lines, "inline code")
+        .expect("user section should contain a span with 'inline code'");
+    assert_ne!(
+        user_code.fg, Some(Color::Green),
+        "user inline-code span should NOT have role color — markdown's code styling wins",
+    );
+    assert_eq!(
+        user_code.fg, Some(Color::Yellow),
+        "user inline-code span should retain markdown's Yellow code color",
+    );
+
+    // -- Assistant assertions (role color: Blue) --
+    let asst_plain = find_span(&assistant_lines, "plain")
+        .expect("assistant section should contain a span with 'plain'");
+    assert_eq!(
+        asst_plain.fg, Some(Color::Blue),
+        "assistant plain-text span should have fg=Blue (role color), got {:?}",
+        asst_plain.fg,
+    );
+
+    let asst_bold = find_span(&assistant_lines, "bold")
+        .expect("assistant section should contain a span with 'bold'");
+    assert!(
+        asst_bold.add_modifier.contains(Modifier::BOLD),
+        "assistant bold span should retain BOLD modifier from markdown",
+    );
+    assert_eq!(
+        asst_bold.fg, Some(Color::Blue),
+        "assistant bold span should have fg=Blue (role color fills in unset fg)",
+    );
+
+    let asst_code = find_span(&assistant_lines, "inline code")
+        .expect("assistant section should contain a span with 'inline code'");
+    assert_ne!(
+        asst_code.fg, Some(Color::Blue),
+        "assistant inline-code span should NOT have role color — markdown's code styling wins",
+    );
+
+    // -- Cross-role differentiation (the original complaint) --
+    assert_ne!(
+        user_plain.fg, asst_plain.fg,
+        "user and assistant plain-text spans must have DIFFERENT fg colors",
+    );
+}
+```
+
+- [ ] **Step 1.3: Run the test and verify it fails (RED)**
+
+```bash
+cargo nextest run -p envision conversation_view::render_tests::test_markdown_role_style_propagation
+```
+
+Expected: The test should compile but fail on the `user_plain.fg` assertion.
+The assertion error should show `fg: None` or similar (the role color is
+not reaching the markdown-rendered spans). This confirms the bug exists
+and the test catches it.
+
+If the test fails to **compile** (e.g., visibility error on
+`super::render::build_display_lines`), verify that Step 1.1 was applied
+correctly. If it compiles but the line partitioning fails (empty
+`user_lines` or `assistant_lines`), the header-detection logic may need
+adjustment — check what the actual header lines look like by printing
+`lines` in a debug assertion.
+
+- [ ] **Step 1.4: Apply the fix in `format_text_block`**
+
+In `src/component/conversation_view/render.rs`, replace the markdown
+branch of `format_text_block` (the `#[cfg(feature = "markdown")]` block
+inside `fn format_text_block`, approximately lines 317-337). The current
+code is:
+
+```rust
+    #[cfg(feature = "markdown")]
+    if markdown_enabled {
+        let theme = crate::theme::Theme::default();
+        let indent_display_width = UnicodeWidthStr::width(indent);
+        let available_width = width.saturating_sub(indent_display_width);
+        let md_lines = crate::component::markdown_renderer::render::render_markdown(
+            text,
+            available_width as u16,
+            &theme,
+        );
+        for md_line in md_lines {
+            if indent.is_empty() {
+                lines.push(md_line);
+            } else {
+                let mut spans: Vec<Span> = vec![Span::raw(indent.to_string())];
+                spans.extend(md_line.spans);
+                lines.push(Line::from(spans));
+            }
+        }
+        return;
+    }
+```
+
+Replace with:
+
+```rust
+    #[cfg(feature = "markdown")]
+    if markdown_enabled {
+        let theme = crate::theme::Theme::default();
+        let indent_display_width = UnicodeWidthStr::width(indent);
+        let available_width = width.saturating_sub(indent_display_width);
+        let md_lines = crate::component::markdown_renderer::render::render_markdown(
+            text,
+            available_width as u16,
+            &theme,
+        );
+        for mut md_line in md_lines {
+            for span in md_line.spans.iter_mut() {
+                span.style = style.patch(span.style);
+            }
+            if indent.is_empty() {
+                lines.push(md_line);
+            } else {
+                let mut spans: Vec<Span> = vec![Span::styled(indent.to_string(), style)];
+                spans.extend(md_line.spans);
+                lines.push(Line::from(spans));
+            }
+        }
+        return;
+    }
+```
+
+Three changes:
+1. `for md_line` → `for mut md_line` (need mutability to edit spans).
+2. Added: the `for span in md_line.spans.iter_mut() { span.style = style.patch(span.style); }` loop.
+3. `Span::raw(indent.to_string())` → `Span::styled(indent.to_string(), style)`.
+
+- [ ] **Step 1.5: Run the test and verify it passes (GREEN)**
+
+```bash
+cargo nextest run -p envision conversation_view::render_tests::test_markdown_role_style_propagation
+```
+
+Expected: PASS. All assertions should succeed.
+
+If the test fails, the most likely causes are:
+- Wrong patch direction (`span.style.patch(style)` instead of `style.patch(span.style)`) — would stomp on markdown styling.
+- The markdown renderer splits "plain text" across multiple spans — the `find_span` helper searching for "plain" may find a partial match. Adjust the needle if needed (e.g., search for "plain" alone).
+- The bold span's content may be just "bold" without surrounding text, or may be wrapped differently — check what the markdown renderer actually produces.
+
+Debug by printing the lines: `for line in &lines { eprintln!("{:?}", line); }`.
+
+- [ ] **Step 1.6: Run the full conversation_view test suite**
+
+```bash
+cargo nextest run -p envision conversation_view
+```
+
+Expected: all tests pass, including existing render tests and snapshot tests.
+The snapshot tests may or may not change — if they were generated with
+`with_markdown(false)` (the default), they should be unaffected because the
+non-markdown branch is unchanged. If any snapshot test used
+`with_markdown(true)`, the snapshot will change (body text will now carry
+role colors). In that case, inspect the new snapshot and accept it if it
+now shows colored text where before it showed unstyled text — that's the
+fix working.
+
+- [ ] **Step 1.7: Format and lint**
+
+```bash
+cargo fmt
+cargo clippy -p envision -- -D warnings
+```
+
+Expected: no formatting diffs; clippy reports zero warnings.
+
+- [ ] **Step 1.8: Commit (signed)**
+
+```bash
+git add src/component/conversation_view/render.rs src/component/conversation_view/render_tests.rs
+git commit -S -m "$(cat <<'EOF'
+Fix ConversationView markdown rendering to honor role colors
+
+format_text_block was discarding the role_style parameter in the
+markdown branch, causing all body text to render in the terminal
+default color (white on dark terminals) regardless of role.
+
+Fix: after render_markdown returns, patch role_style into each
+span via style.patch(span.style) so that plain-text spans inherit
+the role color while markdown-specific styling (bold, inline code)
+takes precedence where set. Also style the indent prefix with the
+role color instead of using bare Span::raw.
+
+Promotes build_display_lines to pub(super) for testability.
+
+Adds test_markdown_role_style_propagation which structurally
+inspects span styles to verify User spans carry Green, Assistant
+spans carry Blue, bold spans retain BOLD, and inline-code spans
+retain their Yellow code color.
+
+Part of docs/superpowers/specs/2026-04-09-conversation-view-markdown-role-color-fix-design.md
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+If any snapshot files changed (accepted in Step 1.6), include them in the `git add`:
+```bash
+git add src/component/conversation_view/render.rs src/component/conversation_view/render_tests.rs src/component/conversation_view/snapshots/
+```
+
+---
+
+## Task 2: CHANGELOG + full verification + PR
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+---
+
+- [ ] **Step 2.1: Add a changelog entry**
+
+Open `CHANGELOG.md`. Under `## [Unreleased]`, add a `### Fixed` subsection
+(if one doesn't already exist) with this bullet:
+
+```markdown
+### Fixed
+
+- `ConversationView` now honors role colors (User=green, Assistant=blue,
+  etc.) when markdown rendering is enabled. Previously, the role style was
+  discarded in the markdown branch of `format_text_block`, causing all body
+  text to render in the terminal default foreground regardless of role.
+  Markdown-specific styling (bold, inline code) is preserved where set.
+```
+
+If there is already a `### Fixed` subsection under `[Unreleased]`, append
+the bullet at the end of the existing list.
+
+- [ ] **Step 2.2: Run the full project test suite**
+
+```bash
+cargo nextest run -p envision
+cargo test --doc -p envision
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2.3: Final format + clippy + build check**
+
+```bash
+cargo fmt
+cargo clippy -p envision --all-targets -- -D warnings
+cargo build -p envision
+```
+
+Expected: no formatting diffs, zero clippy warnings, clean build.
+
+- [ ] **Step 2.4: Commit the changelog**
+
+```bash
+git add CHANGELOG.md
+git commit -S -m "$(cat <<'EOF'
+Document ConversationView markdown role color fix in CHANGELOG
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 2.5: Merge origin/main and push**
+
+```bash
+git fetch origin
+git merge origin/main --no-ff -S
+```
+
+If no new commits, this is a no-op. Then push:
+
+```bash
+git push -u origin conversation-view-markdown-role-style-fix
+```
+
+- [ ] **Step 2.6: Open the PR**
+
+```bash
+gh pr create --title "Fix ConversationView markdown rendering to honor role colors" --body "$(cat <<'EOF'
+## Summary
+
+- `format_text_block` was discarding the `role_style` parameter in the markdown branch, causing all body text to render in terminal default (white) regardless of whose message it is.
+- Fix: after `render_markdown` returns, patch `role_style` into each span via `style.patch(span.style)` so plain-text inherits the role color while markdown-specific styling (bold, inline code) takes precedence.
+- Also styles the indent prefix with `role_style` instead of bare `Span::raw`.
+- Promotes `build_display_lines` to `pub(super)` for testability.
+
+Design spec: `docs/superpowers/specs/2026-04-09-conversation-view-markdown-role-color-fix-design.md`
+
+Addresses customer feedback: "all white" text when markdown is enabled in ConversationView.
+
+## Test plan
+
+- [x] `test_markdown_role_style_propagation` — structural test verifying User spans carry `fg: Green`, Assistant spans carry `fg: Blue`, bold spans retain `BOLD`, and inline-code spans retain `fg: Yellow`
+- [x] `cargo nextest run -p envision conversation_view` — all tests pass
+- [x] `cargo test --doc -p envision` — doc tests pass
+- [x] `cargo clippy -p envision --all-targets -- -D warnings` — no warnings
+- [x] `cargo fmt` — no diffs
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2.7: Check CI**
+
+```bash
+gh pr checks $(gh pr view --json number -q .number)
+```
+
+Do not merge until all required checks pass.
+
+---
+
+## Definition of done
+
+- [ ] `format_text_block`'s markdown branch patches role_style into spans.
+- [ ] Indent prefix is styled with role_style.
+- [ ] `build_display_lines` is `pub(super)`.
+- [ ] `test_markdown_role_style_propagation` exists and passes.
+- [ ] All existing conversation_view tests still pass.
+- [ ] `CHANGELOG.md` has an `[Unreleased] / Fixed` entry.
+- [ ] PR opened, CI green, ready for review/merge.
+- [ ] PR will be squash-merged per project conventions.

--- a/docs/superpowers/specs/2026-04-09-conversation-view-markdown-role-color-fix-design.md
+++ b/docs/superpowers/specs/2026-04-09-conversation-view-markdown-role-color-fix-design.md
@@ -1,0 +1,152 @@
+# ConversationView markdown role color fix — design
+
+**Status:** approved
+**Date:** 2026-04-09
+**Source:** customer feedback (customer Claude reported "all white" text
+when markdown is enabled in ConversationView)
+**Scope:** single PR / bug fix
+
+## Problem
+
+`format_text_block` in `src/component/conversation_view/render.rs:304-344`
+takes a `style: Style` parameter that carries the role color (e.g.,
+`fg: Green` for User, `fg: Blue` for Assistant). This style is used
+correctly in the **non-markdown branch** (lines 339-343), but
+**completely discarded** in the **markdown branch** (lines 317-337).
+
+In the markdown branch:
+
+1. `render_markdown(text, width, &theme)` is called and produces styled
+   `Line<'static>` values using the markdown theme's own styling — but with
+   no knowledge of the message role. Plain-text spans come back with no
+   foreground color set (they inherit the terminal default, which is white
+   on a dark terminal).
+
+2. The indent prefix is a bare `Span::raw(indent.to_string())`, which also
+   has no foreground color — unlike the non-markdown branch where the indent
+   implicitly inherits from the styled paragraph.
+
+**Result:** With markdown enabled, every line of body text renders in the
+terminal default foreground (white on a dark terminal) regardless of whose
+message it is. Users cannot visually distinguish User messages from
+Assistant messages.
+
+**Impact:** Any consumer using `ConversationViewState::with_markdown(true)`
+(the expected production configuration for AI chat UIs) sees undifferentiated
+body text. The role color only appears on the header line (the role label),
+not the message body.
+
+## Goal
+
+Make the markdown rendering path honor the role color for plain-text spans,
+so that User and Assistant messages are visually distinguishable by color
+when markdown is enabled — matching the behavior of the non-markdown path.
+
+Non-goals:
+- Role style override API (`HashMap<ConversationRole, Style>` on state).
+  That's a separate follow-up PR.
+- Changing the markdown renderer's API. The fix is local to
+  `format_text_block`.
+- Changing the `ConversationRole::color()` defaults in `types.rs`.
+
+## Fix
+
+### Patch role_style into markdown spans
+
+After `render_markdown` returns its `Vec<Line<'static>>`, iterate over
+each line's spans and apply `style.patch(span.style)`:
+
+```rust
+for span in md_line.spans.iter_mut() {
+    span.style = style.patch(span.style);
+}
+```
+
+**Patch direction:** `style.patch(span.style)` means "start with the role
+style as the base, then overlay the span's existing fields on top". This
+ensures:
+
+- **Plain-text spans** (no fg set by markdown renderer): pick up the role
+  color. User text is green, Assistant text is blue.
+- **Bold spans** (markdown renderer sets `BOLD` but no fg): pick up the
+  role color AND keep `BOLD`.
+- **Inline-code spans** (markdown renderer sets `fg: Yellow, BOLD`): keep
+  `fg: Yellow` because the span's explicit fg overrides the role's fg.
+  The role color does NOT stomp on markdown-specific styling.
+- **Italic, strikethrough, etc.:** same principle — span's set fields win.
+
+### Style the indent prefix
+
+Change `Span::raw(indent.to_string())` to
+`Span::styled(indent.to_string(), style)` so the leading whitespace also
+carries the role color. This matches the non-markdown branch where the
+indent is part of the styled paragraph text.
+
+### What does NOT change
+
+- `render_markdown`'s API or implementation — unchanged. The fix is
+  entirely in `format_text_block`.
+- The non-markdown branch of `format_text_block` — already honors `style`.
+- The `ConversationRole::color()` defaults in `types.rs` — unchanged.
+- Code block / tool use / thinking / error block rendering — these use
+  their own block-type styles (yellow for tool, magenta for thinking, red
+  for error) and are unaffected. The bug is specifically in the text block
+  markdown path.
+- The `format_message` function — unchanged. `role_style` is already
+  computed correctly there and passed to `format_block` → `format_text_block`.
+  The problem was only that `format_text_block` threw it away.
+
+## Visibility change
+
+`build_display_lines` in `render.rs:144` is currently `fn` (private to the
+`render` module). It needs to be promoted to `pub(super)` so the structural
+test in `render_tests.rs` can call it. This is a visibility-only change
+with no behavioral effect — `build_display_lines` is already called through
+`pub(super)` entry points (`render_messages_from`, `total_display_lines`).
+
+## Testing
+
+A **structural render test** (not a snapshot) that inspects `Line`/`Span`
+style values directly. This proves the `Style::patch` semantics work and
+documents the expected behavior as a regression guard.
+
+**Test:** `test_markdown_role_style_propagation` in
+`src/component/conversation_view/render_tests.rs`:
+
+1. Create a `ConversationViewState` with `with_markdown(true)`.
+2. Push a User message with text: `plain text and **bold** and \`inline code\``
+3. Push an Assistant message with the same text.
+4. Call `render::build_display_lines(messages, &state, 80, &Theme::default())`
+   to get `Vec<Line>`.
+5. Partition the returned lines into User-message lines and
+   Assistant-message lines (using the header span containing the role
+   label as the delimiter).
+6. For User message lines, find spans by content and assert:
+   - A span containing "plain" → `fg == Some(Color::Green)`, NOT `None`.
+   - A span containing "bold" with `BOLD` modifier → has `BOLD` AND
+     `fg == Some(Color::Green)` (role color fills in the unset fg, BOLD
+     from markdown survives).
+   - A span containing "inline code" → retains `fg == Some(Color::Yellow)`
+     (the markdown renderer's inline-code color, NOT the role's Green —
+     proves the patch didn't stomp on explicit markdown styling).
+7. For Assistant message lines, same assertions but
+   `fg == Some(Color::Blue)`.
+8. Assert User plain-text fg != Assistant plain-text fg (the original
+   complaint: "all the same color").
+
+**Span matching strategy:** Search by content substring, not by index.
+The markdown renderer may split text into spans differently across
+versions. Searching for substrings makes the test resilient to layout
+changes.
+
+The markdown feature is in the default feature set, so the test
+exercises the markdown branch automatically during normal test runs.
+
+## Risk and rollback
+
+Risk is low. The change is ~10 lines in a single function (`format_text_block`),
+affecting only the markdown branch. The non-markdown path is unchanged.
+The patch semantics are well-defined (ratatui's `Style::patch` is
+well-tested upstream).
+
+Rollback: revert the single PR.

--- a/src/component/conversation_view/render.rs
+++ b/src/component/conversation_view/render.rs
@@ -141,7 +141,7 @@ fn render_messages_from(
     }
 }
 
-fn build_display_lines<'a>(
+pub(super) fn build_display_lines<'a>(
     messages: &[ConversationMessage],
     state: &ConversationViewState,
     width: usize,
@@ -324,11 +324,16 @@ fn format_text_block<'a>(
             available_width as u16,
             &theme,
         );
-        for md_line in md_lines {
+        for mut md_line in md_lines {
+            for span in md_line.spans.iter_mut() {
+                if span.style.fg == Some(theme.foreground) {
+                    span.style.fg = style.fg;
+                }
+            }
             if indent.is_empty() {
                 lines.push(md_line);
             } else {
-                let mut spans: Vec<Span> = vec![Span::raw(indent.to_string())];
+                let mut spans: Vec<Span> = vec![Span::styled(indent.to_string(), style)];
                 spans.extend(md_line.spans);
                 lines.push(Line::from(spans));
             }

--- a/src/component/conversation_view/render_tests.rs
+++ b/src/component/conversation_view/render_tests.rs
@@ -593,3 +593,140 @@ fn test_view_from_collapsed_blocks_use_state_config() {
     // Collapsed should be shorter (different output)
     assert_ne!(output_expanded, output_collapsed);
 }
+
+#[test]
+fn test_markdown_role_style_propagation() {
+    use ratatui::style::{Color, Modifier, Style};
+
+    let mut state = ConversationViewState::new().with_markdown(true);
+    state.push_user("plain text and **bold** and `inline code`");
+    state.push_assistant("plain text and **bold** and `inline code`");
+
+    let theme = crate::theme::Theme::default();
+    let lines = super::render::build_display_lines(state.source_messages(), &state, 80, &theme);
+
+    // Partition lines into user-section and assistant-section.
+    // The header line for each message contains the role label.
+    let mut user_lines: Vec<&Line> = Vec::new();
+    let mut assistant_lines: Vec<&Line> = Vec::new();
+    let mut current_section: Option<&str> = None;
+
+    for line in &lines {
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        if text.contains("User")
+            && line
+                .spans
+                .iter()
+                .any(|s| s.style.add_modifier.contains(Modifier::BOLD))
+        {
+            current_section = Some("user");
+            continue;
+        }
+        if text.contains("Assistant")
+            && line
+                .spans
+                .iter()
+                .any(|s| s.style.add_modifier.contains(Modifier::BOLD))
+        {
+            current_section = Some("assistant");
+            continue;
+        }
+        match current_section {
+            Some("user") => user_lines.push(line),
+            Some("assistant") => assistant_lines.push(line),
+            _ => {}
+        }
+    }
+
+    assert!(
+        !user_lines.is_empty(),
+        "should have user message body lines"
+    );
+    assert!(
+        !assistant_lines.is_empty(),
+        "should have assistant message body lines"
+    );
+
+    // Helper: find a span containing `needle` across a set of lines.
+    let find_span = |lines: &[&Line], needle: &str| -> Option<Style> {
+        for line in lines {
+            for span in &line.spans {
+                if span.content.contains(needle) {
+                    return Some(span.style);
+                }
+            }
+        }
+        None
+    };
+
+    // -- User assertions (role color: Green) --
+    let user_plain =
+        find_span(&user_lines, "plain").expect("user section should contain a span with 'plain'");
+    assert_eq!(
+        user_plain.fg,
+        Some(Color::Green),
+        "user plain-text span should have fg=Green (role color), got {:?}",
+        user_plain.fg,
+    );
+
+    let user_bold =
+        find_span(&user_lines, "bold").expect("user section should contain a span with 'bold'");
+    assert!(
+        user_bold.add_modifier.contains(Modifier::BOLD),
+        "user bold span should retain BOLD modifier from markdown",
+    );
+    assert_eq!(
+        user_bold.fg,
+        Some(Color::Green),
+        "user bold span should have fg=Green (role color fills in unset fg)",
+    );
+
+    let user_code = find_span(&user_lines, "inline code")
+        .expect("user section should contain a span with 'inline code'");
+    assert_ne!(
+        user_code.fg,
+        Some(Color::Green),
+        "user inline-code span should NOT have role color — markdown's code styling wins",
+    );
+    assert_eq!(
+        user_code.fg,
+        Some(Color::Yellow),
+        "user inline-code span should retain markdown's Yellow code color",
+    );
+
+    // -- Assistant assertions (role color: Blue) --
+    let asst_plain = find_span(&assistant_lines, "plain")
+        .expect("assistant section should contain a span with 'plain'");
+    assert_eq!(
+        asst_plain.fg,
+        Some(Color::Blue),
+        "assistant plain-text span should have fg=Blue (role color), got {:?}",
+        asst_plain.fg,
+    );
+
+    let asst_bold = find_span(&assistant_lines, "bold")
+        .expect("assistant section should contain a span with 'bold'");
+    assert!(
+        asst_bold.add_modifier.contains(Modifier::BOLD),
+        "assistant bold span should retain BOLD modifier from markdown",
+    );
+    assert_eq!(
+        asst_bold.fg,
+        Some(Color::Blue),
+        "assistant bold span should have fg=Blue (role color fills in unset fg)",
+    );
+
+    let asst_code = find_span(&assistant_lines, "inline code")
+        .expect("assistant section should contain a span with 'inline code'");
+    assert_ne!(
+        asst_code.fg,
+        Some(Color::Blue),
+        "assistant inline-code span should NOT have role color — markdown's code styling wins",
+    );
+
+    // -- Cross-role differentiation (the original complaint) --
+    assert_ne!(
+        user_plain.fg, asst_plain.fg,
+        "user and assistant plain-text spans must have DIFFERENT fg colors",
+    );
+}

--- a/src/component/conversation_view/render_tests.rs
+++ b/src/component/conversation_view/render_tests.rs
@@ -594,6 +594,7 @@ fn test_view_from_collapsed_blocks_use_state_config() {
     assert_ne!(output_expanded, output_collapsed);
 }
 
+#[cfg(feature = "markdown")]
 #[test]
 fn test_markdown_role_style_propagation() {
     use ratatui::style::{Color, Modifier, Style};


### PR DESCRIPTION
## Summary

- `format_text_block` was discarding the `role_style` parameter in the markdown branch, causing all body text to render in terminal default (white) regardless of whose message it is.
- Fix: after `render_markdown` returns, replace the theme's default foreground with the role color on each span so plain-text inherits the role color while markdown-specific styling (bold, inline code) takes precedence.
- Also styles the indent prefix with `role_style` instead of bare `Span::raw`.
- Promotes `build_display_lines` to `pub(super)` for testability.

Design spec: `docs/superpowers/specs/2026-04-09-conversation-view-markdown-role-color-fix-design.md`

Addresses customer feedback: "all white" text when markdown is enabled in ConversationView.

## Test plan

- [x] `test_markdown_role_style_propagation` — structural test verifying User spans carry `fg: Green`, Assistant spans carry `fg: Blue`, bold spans retain `BOLD`, and inline-code spans retain `fg: Yellow`
- [x] `cargo nextest run -p envision conversation_view` — all tests pass
- [x] `cargo test --doc -p envision` — doc tests pass
- [x] `cargo clippy -p envision --all-targets -- -D warnings` — no warnings
- [x] `cargo fmt` — no diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)