### PR TITLE
Add doc tests to 12 under-documented components

### DIFF
--- a/src/component/box_plot/mod.rs
+++ b/src/component/box_plot/mod.rs
@@ -211,21 +211,62 @@ impl BoxPlotData {
     }
 
     /// Sets the label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BoxPlotData;
+    ///
+    /// let mut data = BoxPlotData::new("Old Label", 1.0, 2.0, 3.0, 4.0, 5.0);
+    /// data.set_label("New Label");
+    /// assert_eq!(data.label(), "New Label");
+    /// ```
     pub fn set_label(&mut self, label: impl Into<String>) {
         self.label = label.into();
     }
 
     /// Sets the color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BoxPlotData;
+    /// use ratatui::style::Color;
+    ///
+    /// let mut data = BoxPlotData::new("CPU", 1.0, 2.0, 3.0, 4.0, 5.0);
+    /// data.set_color(Color::Green);
+    /// assert_eq!(data.color(), Color::Green);
+    /// ```
     pub fn set_color(&mut self, color: Color) {
         self.color = color;
     }
 
     /// Sets the outliers.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BoxPlotData;
+    ///
+    /// let mut data = BoxPlotData::new("Latency", 1.0, 2.0, 3.0, 4.0, 5.0);
+    /// data.set_outliers(vec![0.1, 8.0]);
+    /// assert_eq!(data.outliers(), &[0.1, 8.0]);
+    /// ```
     pub fn set_outliers(&mut self, outliers: Vec<f64>) {
         self.outliers = outliers;
     }
 
     /// Adds a single outlier value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BoxPlotData;
+    ///
+    /// let mut data = BoxPlotData::new("Test", 1.0, 2.0, 3.0, 4.0, 5.0);
+    /// data.add_outlier(9.5);
+    /// assert_eq!(data.outliers(), &[9.5]);
+    /// ```
     pub fn add_outlier(&mut self, value: f64) {
         self.outliers.push(value);
     }
@@ -430,61 +471,193 @@ impl BoxPlotState {
     // ---- Accessors ----
 
     /// Returns the datasets.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{BoxPlotState, BoxPlotData};
+    ///
+    /// let state = BoxPlotState::new(vec![
+    ///     BoxPlotData::new("A", 1.0, 2.0, 3.0, 4.0, 5.0),
+    ///     BoxPlotData::new("B", 2.0, 3.0, 4.0, 5.0, 6.0),
+    /// ]);
+    /// assert_eq!(state.datasets().len(), 2);
+    /// ```
     pub fn datasets(&self) -> &[BoxPlotData] {
         &self.datasets
     }
 
     /// Returns a mutable reference to the datasets.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{BoxPlotState, BoxPlotData};
+    /// use ratatui::style::Color;
+    ///
+    /// let mut state = BoxPlotState::new(vec![
+    ///     BoxPlotData::new("A", 1.0, 2.0, 3.0, 4.0, 5.0),
+    /// ]);
+    /// state.datasets_mut()[0].set_color(Color::Red);
+    /// assert_eq!(state.datasets()[0].color(), Color::Red);
+    /// ```
     pub fn datasets_mut(&mut self) -> &mut [BoxPlotData] {
         &mut self.datasets
     }
 
     /// Returns the dataset at the given index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{BoxPlotState, BoxPlotData};
+    ///
+    /// let state = BoxPlotState::new(vec![
+    ///     BoxPlotData::new("Service A", 1.0, 2.0, 3.0, 4.0, 5.0),
+    /// ]);
+    /// assert_eq!(state.get_dataset(0).unwrap().label(), "Service A");
+    /// assert!(state.get_dataset(99).is_none());
+    /// ```
     pub fn get_dataset(&self, index: usize) -> Option<&BoxPlotData> {
         self.datasets.get(index)
     }
 
     /// Returns a mutable reference to the dataset at the given index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{BoxPlotState, BoxPlotData};
+    ///
+    /// let mut state = BoxPlotState::new(vec![
+    ///     BoxPlotData::new("Service A", 1.0, 2.0, 3.0, 4.0, 5.0),
+    /// ]);
+    /// if let Some(ds) = state.get_dataset_mut(0) {
+    ///     ds.set_label("Service B");
+    /// }
+    /// assert_eq!(state.datasets()[0].label(), "Service B");
+    /// ```
     pub fn get_dataset_mut(&mut self, index: usize) -> Option<&mut BoxPlotData> {
         self.datasets.get_mut(index)
     }
 
     /// Returns the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BoxPlotState;
+    ///
+    /// let state = BoxPlotState::default().with_title("Latency");
+    /// assert_eq!(state.title(), Some("Latency"));
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
 
     /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BoxPlotState;
+    ///
+    /// let mut state = BoxPlotState::default();
+    /// state.set_title(Some("Response Times".to_string()));
+    /// assert_eq!(state.title(), Some("Response Times"));
+    /// ```
     pub fn set_title(&mut self, title: Option<String>) {
         self.title = title;
     }
 
     /// Returns whether outliers are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BoxPlotState;
+    ///
+    /// let state = BoxPlotState::default();
+    /// assert!(state.show_outliers());
+    /// ```
     pub fn show_outliers(&self) -> bool {
         self.show_outliers
     }
 
     /// Sets whether outliers are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BoxPlotState;
+    ///
+    /// let mut state = BoxPlotState::default();
+    /// state.set_show_outliers(false);
+    /// assert!(!state.show_outliers());
+    /// ```
     pub fn set_show_outliers(&mut self, show: bool) {
         self.show_outliers = show;
     }
 
     /// Returns the orientation.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{BoxPlotState, BoxPlotOrientation};
+    ///
+    /// let state = BoxPlotState::default().with_orientation(BoxPlotOrientation::Horizontal);
+    /// assert_eq!(state.orientation(), &BoxPlotOrientation::Horizontal);
+    /// ```
     pub fn orientation(&self) -> &BoxPlotOrientation {
         &self.orientation
     }
 
     /// Sets the orientation.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{BoxPlotState, BoxPlotOrientation};
+    ///
+    /// let mut state = BoxPlotState::default();
+    /// state.set_orientation(BoxPlotOrientation::Horizontal);
+    /// assert_eq!(state.orientation(), &BoxPlotOrientation::Horizontal);
+    /// ```
     pub fn set_orientation(&mut self, orientation: BoxPlotOrientation) {
         self.orientation = orientation;
     }
 
     /// Returns the currently selected dataset index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{BoxPlotState, BoxPlotData};
+    ///
+    /// let state = BoxPlotState::new(vec![
+    ///     BoxPlotData::new("A", 1.0, 2.0, 3.0, 4.0, 5.0),
+    /// ]);
+    /// assert_eq!(state.selected(), 0);
+    /// ```
     pub fn selected(&self) -> usize {
         self.selected
     }
 
     /// Sets the selected dataset index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{BoxPlotState, BoxPlotData};
+    ///
+    /// let mut state = BoxPlotState::new(vec![
+    ///     BoxPlotData::new("A", 1.0, 2.0, 3.0, 4.0, 5.0),
+    ///     BoxPlotData::new("B", 2.0, 3.0, 4.0, 5.0, 6.0),
+    /// ]);
+    /// state.set_selected(1);
+    /// assert_eq!(state.selected(), 1);
+    /// ```
     pub fn set_selected(&mut self, index: usize) {
         if !self.datasets.is_empty() {
             self.selected = index.min(self.datasets.len() - 1);
@@ -492,11 +665,31 @@ impl BoxPlotState {
     }
 
     /// Returns the number of datasets.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{BoxPlotState, BoxPlotData};
+    ///
+    /// let state = BoxPlotState::new(vec![
+    ///     BoxPlotData::new("A", 1.0, 2.0, 3.0, 4.0, 5.0),
+    ///     BoxPlotData::new("B", 2.0, 3.0, 4.0, 5.0, 6.0),
+    /// ]);
+    /// assert_eq!(state.dataset_count(), 2);
+    /// ```
     pub fn dataset_count(&self) -> usize {
         self.datasets.len()
     }
 
     /// Returns true if there are no datasets.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BoxPlotState;
+    ///
+    /// assert!(BoxPlotState::default().is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.datasets.is_empty()
     }

--- a/src/component/breadcrumb/mod.rs
+++ b/src/component/breadcrumb/mod.rs
@@ -244,52 +244,150 @@ impl BreadcrumbState {
     }
 
     /// Returns the breadcrumb segments.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BreadcrumbState;
+    ///
+    /// let state = BreadcrumbState::from_labels(vec!["Home", "Products"]);
+    /// assert_eq!(state.segments().len(), 2);
+    /// assert_eq!(state.segments()[0].label(), "Home");
+    /// ```
     pub fn segments(&self) -> &[BreadcrumbSegment] {
         &self.segments
     }
 
     /// Returns the number of segments.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BreadcrumbState;
+    ///
+    /// let state = BreadcrumbState::from_labels(vec!["Home", "Products", "Item"]);
+    /// assert_eq!(state.len(), 3);
+    /// ```
     pub fn len(&self) -> usize {
         self.segments.len()
     }
 
     /// Returns true if there are no segments.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BreadcrumbState;
+    ///
+    /// let empty = BreadcrumbState::default();
+    /// assert!(empty.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.segments.is_empty()
     }
 
     /// Returns the currently focused segment index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Breadcrumb, BreadcrumbMessage, BreadcrumbState, Component};
+    ///
+    /// let mut state = BreadcrumbState::from_labels(vec!["Home", "Products"]);
+    /// assert_eq!(state.focused_index(), 0);
+    /// Breadcrumb::update(&mut state, BreadcrumbMessage::Right);
+    /// assert_eq!(state.focused_index(), 1);
+    /// ```
     pub fn focused_index(&self) -> usize {
         self.focused_index
     }
 
     /// Returns the currently focused segment, if any.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BreadcrumbState;
+    ///
+    /// let state = BreadcrumbState::from_labels(vec!["Home", "Products"]);
+    /// assert_eq!(state.focused_segment().unwrap().label(), "Home");
+    /// ```
     pub fn focused_segment(&self) -> Option<&BreadcrumbSegment> {
         self.segments.get(self.focused_index)
     }
 
     /// Returns the separator used between segments.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BreadcrumbState;
+    ///
+    /// let state = BreadcrumbState::from_labels(vec!["A", "B"]).with_separator(" / ");
+    /// assert_eq!(state.separator(), " / ");
+    /// ```
     pub fn separator(&self) -> &str {
         &self.separator
     }
 
     /// Returns the maximum number of visible segments.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BreadcrumbState;
+    ///
+    /// let state = BreadcrumbState::from_labels(vec!["A", "B", "C", "D", "E"])
+    ///     .with_max_visible(Some(3));
+    /// assert_eq!(state.max_visible(), Some(3));
+    /// ```
     pub fn max_visible(&self) -> Option<usize> {
         self.max_visible
     }
 
     /// Returns the last segment (current location).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BreadcrumbState;
+    ///
+    /// let state = BreadcrumbState::from_labels(vec!["Home", "Products", "Item"]);
+    /// assert_eq!(state.current().unwrap().label(), "Item");
+    /// ```
     pub fn current(&self) -> Option<&BreadcrumbSegment> {
         self.segments.last()
     }
 
     /// Sets new segments, resetting the focused index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{BreadcrumbSegment, BreadcrumbState};
+    ///
+    /// let mut state = BreadcrumbState::from_labels(vec!["Home", "Old"]);
+    /// state.set_segments(vec![BreadcrumbSegment::new("New")]);
+    /// assert_eq!(state.len(), 1);
+    /// assert_eq!(state.focused_index(), 0);
+    /// ```
     pub fn set_segments(&mut self, segments: Vec<BreadcrumbSegment>) {
         self.segments = segments;
         self.focused_index = 0;
     }
 
     /// Adds a segment to the end.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{BreadcrumbSegment, BreadcrumbState};
+    ///
+    /// let mut state = BreadcrumbState::from_labels(vec!["Home"]);
+    /// state.push(BreadcrumbSegment::new("Products"));
+    /// assert_eq!(state.len(), 2);
+    /// assert_eq!(state.current().unwrap().label(), "Products");
+    /// ```
     pub fn push(&mut self, segment: BreadcrumbSegment) {
         self.segments.push(segment);
     }
@@ -297,6 +395,17 @@ impl BreadcrumbState {
     /// Removes and returns the last segment.
     ///
     /// Adjusts the focused index if necessary.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BreadcrumbState;
+    ///
+    /// let mut state = BreadcrumbState::from_labels(vec!["Home", "Products"]);
+    /// let removed = state.pop();
+    /// assert_eq!(removed.unwrap().label(), "Products");
+    /// assert_eq!(state.len(), 1);
+    /// ```
     pub fn pop(&mut self) -> Option<BreadcrumbSegment> {
         let result = self.segments.pop();
         if !self.segments.is_empty() && self.focused_index >= self.segments.len() {
@@ -376,6 +485,17 @@ impl BreadcrumbState {
     }
 
     /// Returns whether the breadcrumb is truncated.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BreadcrumbState;
+    ///
+    /// let mut state = BreadcrumbState::from_labels(vec!["A", "B", "C", "D"]);
+    /// assert!(!state.is_truncated());
+    /// state.set_max_visible(Some(2));
+    /// assert!(state.is_truncated());
+    /// ```
     pub fn is_truncated(&self) -> bool {
         match self.max_visible {
             Some(max) if max > 0 => self.segments.len() > max,
@@ -398,6 +518,19 @@ impl BreadcrumbState {
     ///
     /// When truncation is enabled and the number of segments exceeds
     /// `max_visible`, only the last `max_visible` segments are returned.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BreadcrumbState;
+    ///
+    /// let state = BreadcrumbState::from_labels(vec!["A", "B", "C", "D"])
+    ///     .with_max_visible(Some(2));
+    /// let visible = state.visible_segments();
+    /// assert_eq!(visible.len(), 2);
+    /// assert_eq!(visible[0].label(), "C");
+    /// assert_eq!(visible[1].label(), "D");
+    /// ```
     pub fn visible_segments(&self) -> &[BreadcrumbSegment] {
         let (start, end) = self.visible_range();
         &self.segments[start..end]

--- a/src/component/code_block/mod.rs
+++ b/src/component/code_block/mod.rs
@@ -267,11 +267,32 @@ impl CodeBlockState {
     // ---- Language accessors ----
 
     /// Returns the current language.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CodeBlockState;
+    /// use envision::component::code_block::highlight::Language;
+    ///
+    /// let state = CodeBlockState::new().with_language(Language::Python);
+    /// assert_eq!(state.language(), &Language::Python);
+    /// ```
     pub fn language(&self) -> &Language {
         &self.language
     }
 
     /// Sets the language.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CodeBlockState;
+    /// use envision::component::code_block::highlight::Language;
+    ///
+    /// let mut state = CodeBlockState::new();
+    /// state.set_language(Language::Go);
+    /// assert_eq!(state.language(), &Language::Go);
+    /// ```
     pub fn set_language(&mut self, language: Language) {
         self.language = language;
     }
@@ -279,11 +300,30 @@ impl CodeBlockState {
     // ---- Title accessors ----
 
     /// Returns the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CodeBlockState;
+    ///
+    /// let state = CodeBlockState::new().with_title("server.rs");
+    /// assert_eq!(state.title(), Some("server.rs"));
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
 
     /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CodeBlockState;
+    ///
+    /// let mut state = CodeBlockState::new();
+    /// state.set_title(Some("app.rs".to_string()));
+    /// assert_eq!(state.title(), Some("app.rs"));
+    /// ```
     pub fn set_title(&mut self, title: Option<String>) {
         self.title = title;
     }
@@ -291,11 +331,30 @@ impl CodeBlockState {
     // ---- Line number accessors ----
 
     /// Returns whether line numbers are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CodeBlockState;
+    ///
+    /// let state = CodeBlockState::new().with_line_numbers(true);
+    /// assert!(state.show_line_numbers());
+    /// ```
     pub fn show_line_numbers(&self) -> bool {
         self.show_line_numbers
     }
 
     /// Sets whether line numbers are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CodeBlockState;
+    ///
+    /// let mut state = CodeBlockState::new();
+    /// state.set_show_line_numbers(true);
+    /// assert!(state.show_line_numbers());
+    /// ```
     pub fn set_show_line_numbers(&mut self, show: bool) {
         self.show_line_numbers = show;
     }
@@ -303,26 +362,77 @@ impl CodeBlockState {
     // ---- Highlight line accessors ----
 
     /// Returns true if the given line (1-based) is highlighted.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CodeBlockState;
+    ///
+    /// let state = CodeBlockState::new().with_highlight_lines(vec![2, 4]);
+    /// assert!(state.is_line_highlighted(2));
+    /// assert!(!state.is_line_highlighted(3));
+    /// ```
     pub fn is_line_highlighted(&self, line: usize) -> bool {
         self.highlight_lines.contains(&line)
     }
 
     /// Adds a highlighted line (1-based).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CodeBlockState;
+    ///
+    /// let mut state = CodeBlockState::new();
+    /// state.add_highlight_line(3);
+    /// assert!(state.is_line_highlighted(3));
+    /// ```
     pub fn add_highlight_line(&mut self, line: usize) {
         self.highlight_lines.insert(line);
     }
 
     /// Removes a highlighted line (1-based).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CodeBlockState;
+    ///
+    /// let mut state = CodeBlockState::new().with_highlight_lines(vec![1, 2, 3]);
+    /// state.remove_highlight_line(2);
+    /// assert!(!state.is_line_highlighted(2));
+    /// assert!(state.is_line_highlighted(1));
+    /// ```
     pub fn remove_highlight_line(&mut self, line: usize) {
         self.highlight_lines.remove(&line);
     }
 
     /// Clears all highlighted lines.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CodeBlockState;
+    ///
+    /// let mut state = CodeBlockState::new().with_highlight_lines(vec![1, 2, 3]);
+    /// state.clear_highlights();
+    /// assert!(state.highlighted_lines().is_empty());
+    /// ```
     pub fn clear_highlights(&mut self) {
         self.highlight_lines.clear();
     }
 
     /// Returns the set of highlighted line numbers.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CodeBlockState;
+    ///
+    /// let state = CodeBlockState::new().with_highlight_lines(vec![1, 3]);
+    /// assert_eq!(state.highlighted_lines().len(), 2);
+    /// assert!(state.highlighted_lines().contains(&1));
+    /// ```
     pub fn highlighted_lines(&self) -> &HashSet<usize> {
         &self.highlight_lines
     }
@@ -330,21 +440,60 @@ impl CodeBlockState {
     // ---- Scroll accessors ----
 
     /// Returns the current scroll offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CodeBlockState;
+    ///
+    /// let state = CodeBlockState::new();
+    /// assert_eq!(state.scroll_offset(), 0);
+    /// ```
     pub fn scroll_offset(&self) -> usize {
         self.scroll.offset()
     }
 
     /// Sets the scroll offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CodeBlockState;
+    ///
+    /// let mut state = CodeBlockState::new()
+    ///     .with_code("line1\nline2\nline3\nline4\nline5");
+    /// state.set_scroll_offset(2);
+    /// assert_eq!(state.scroll_offset(), 2);
+    /// ```
     pub fn set_scroll_offset(&mut self, offset: usize) {
         self.scroll.set_offset(offset);
     }
 
     /// Returns the horizontal scroll offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CodeBlockState;
+    ///
+    /// let state = CodeBlockState::new();
+    /// assert_eq!(state.horizontal_offset(), 0);
+    /// ```
     pub fn horizontal_offset(&self) -> usize {
         self.horizontal_offset
     }
 
     /// Sets the horizontal scroll offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CodeBlockState;
+    ///
+    /// let mut state = CodeBlockState::new();
+    /// state.set_horizontal_offset(10);
+    /// assert_eq!(state.horizontal_offset(), 10);
+    /// ```
     pub fn set_horizontal_offset(&mut self, offset: usize) {
         self.horizontal_offset = offset;
     }

--- a/src/component/input_field/mod.rs
+++ b/src/component/input_field/mod.rs
@@ -270,31 +270,87 @@ impl InputFieldState {
     }
 
     /// Returns the cursor byte offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::InputFieldState;
+    ///
+    /// let state = InputFieldState::with_value("abc");
+    /// assert_eq!(state.cursor_byte_offset(), 3);
+    /// ```
     pub fn cursor_byte_offset(&self) -> usize {
         self.cursor
     }
 
     /// Sets the placeholder text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::InputFieldState;
+    ///
+    /// let mut state = InputFieldState::new();
+    /// state.set_placeholder("Search...");
+    /// assert_eq!(state.placeholder(), "Search...");
+    /// ```
     pub fn set_placeholder(&mut self, placeholder: impl Into<String>) {
         self.placeholder = placeholder.into();
     }
 
     /// Returns the placeholder text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::InputFieldState;
+    ///
+    /// let state = InputFieldState::with_placeholder("Type something");
+    /// assert_eq!(state.placeholder(), "Type something");
+    /// ```
     pub fn placeholder(&self) -> &str {
         &self.placeholder
     }
 
     /// Returns true if the input is empty.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::InputFieldState;
+    ///
+    /// assert!(InputFieldState::new().is_empty());
+    /// assert!(!InputFieldState::with_value("hi").is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.value.is_empty()
     }
 
     /// Returns the number of characters in the input.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::InputFieldState;
+    ///
+    /// let state = InputFieldState::with_value("hello");
+    /// assert_eq!(state.len(), 5);
+    /// ```
     pub fn len(&self) -> usize {
         self.value.chars().count()
     }
 
     /// Moves cursor to the given character position.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::InputFieldState;
+    ///
+    /// let mut state = InputFieldState::with_value("hello");
+    /// state.set_cursor_position(2);
+    /// assert_eq!(state.cursor_position(), 2);
+    /// ```
     pub fn set_cursor_position(&mut self, char_pos: usize) {
         let char_count = self.value.chars().count();
         let clamped = char_pos.min(char_count);
@@ -307,6 +363,17 @@ impl InputFieldState {
     }
 
     /// Returns true if there is an active text selection.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{InputField, InputFieldMessage, InputFieldState, Component};
+    ///
+    /// let mut state = InputFieldState::with_value("hello");
+    /// assert!(!state.has_selection());
+    /// InputField::update(&mut state, InputFieldMessage::SelectAll);
+    /// assert!(state.has_selection());
+    /// ```
     pub fn has_selection(&self) -> bool {
         self.selection_anchor.is_some() && self.selection_anchor != Some(self.cursor)
     }
@@ -314,6 +381,16 @@ impl InputFieldState {
     /// Returns the selected byte range as `(start, end)` where `start < end`.
     ///
     /// Returns `None` if there is no active selection or the selection is empty.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{InputField, InputFieldMessage, InputFieldState, Component};
+    ///
+    /// let mut state = InputFieldState::with_value("hello");
+    /// InputField::update(&mut state, InputFieldMessage::SelectAll);
+    /// assert_eq!(state.selection_range(), Some((0, 5)));
+    /// ```
     pub fn selection_range(&self) -> Option<(usize, usize)> {
         self.selection_anchor.and_then(|anchor| {
             if anchor == self.cursor {
@@ -327,12 +404,33 @@ impl InputFieldState {
     }
 
     /// Returns the currently selected text, or `None` if no selection.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{InputField, InputFieldMessage, InputFieldState, Component};
+    ///
+    /// let mut state = InputFieldState::with_value("hello world");
+    /// InputField::update(&mut state, InputFieldMessage::SelectAll);
+    /// assert_eq!(state.selected_text(), Some("hello world"));
+    /// ```
     pub fn selected_text(&self) -> Option<&str> {
         self.selection_range()
             .map(|(start, end)| &self.value[start..end])
     }
 
     /// Returns a reference to the internal clipboard contents.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{InputField, InputFieldMessage, InputFieldState, Component};
+    ///
+    /// let mut state = InputFieldState::with_value("hello");
+    /// InputField::update(&mut state, InputFieldMessage::SelectAll);
+    /// InputField::update(&mut state, InputFieldMessage::Copy);
+    /// assert_eq!(state.clipboard(), "hello");
+    /// ```
     pub fn clipboard(&self) -> &str {
         &self.clipboard
     }
@@ -363,11 +461,33 @@ impl InputFieldState {
     }
 
     /// Returns true if there are edits that can be undone.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{InputField, InputFieldMessage, InputFieldState, Component};
+    ///
+    /// let mut state = InputFieldState::new();
+    /// assert!(!state.can_undo());
+    /// InputField::update(&mut state, InputFieldMessage::Insert('a'));
+    /// assert!(state.can_undo());
+    /// ```
     pub fn can_undo(&self) -> bool {
         self.undo_stack.can_undo()
     }
 
     /// Returns true if there are edits that can be redone.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{InputField, InputFieldMessage, InputFieldState, Component};
+    ///
+    /// let mut state = InputFieldState::new();
+    /// InputField::update(&mut state, InputFieldMessage::Insert('a'));
+    /// InputField::update(&mut state, InputFieldMessage::Undo);
+    /// assert!(state.can_redo());
+    /// ```
     pub fn can_redo(&self) -> bool {
         self.undo_stack.can_redo()
     }

--- a/src/component/key_hints/mod.rs
+++ b/src/component/key_hints/mod.rs
@@ -150,21 +150,61 @@ impl KeyHint {
     }
 
     /// Sets the key string.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHint;
+    ///
+    /// let mut hint = KeyHint::new("Enter", "Select");
+    /// hint.set_key("Return");
+    /// assert_eq!(hint.key(), "Return");
+    /// ```
     pub fn set_key(&mut self, key: impl Into<String>) {
         self.key = key.into();
     }
 
     /// Sets the action description.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHint;
+    ///
+    /// let mut hint = KeyHint::new("q", "Quit");
+    /// hint.set_action("Exit");
+    /// assert_eq!(hint.action(), "Exit");
+    /// ```
     pub fn set_action(&mut self, action: impl Into<String>) {
         self.action = action.into();
     }
 
     /// Sets whether the hint is enabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHint;
+    ///
+    /// let mut hint = KeyHint::new("Delete", "Remove");
+    /// hint.set_enabled(false);
+    /// assert!(!hint.is_enabled());
+    /// ```
     pub fn set_enabled(&mut self, enabled: bool) {
         self.enabled = enabled;
     }
 
     /// Sets the priority.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHint;
+    ///
+    /// let mut hint = KeyHint::new("q", "Quit");
+    /// hint.set_priority(5);
+    /// assert_eq!(hint.priority(), 5);
+    /// ```
     pub fn set_priority(&mut self, priority: u8) {
         self.priority = priority;
     }
@@ -288,24 +328,67 @@ impl KeyHintsState {
     }
 
     /// Sets the separator between key and action.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHintsState;
+    ///
+    /// let state = KeyHintsState::new()
+    ///     .with_key_action_separator(": ")
+    ///     .hint("Enter", "Select");
+    /// assert_eq!(state.len(), 1);
+    /// ```
     pub fn with_key_action_separator(mut self, sep: impl Into<String>) -> Self {
         self.key_action_separator = sep.into();
         self
     }
 
     /// Sets the separator between hints.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHintsState;
+    ///
+    /// let state = KeyHintsState::new()
+    ///     .with_hint_separator(" | ")
+    ///     .hint("q", "Quit")
+    ///     .hint("Enter", "Select");
+    /// assert_eq!(state.len(), 2);
+    /// ```
     pub fn with_hint_separator(mut self, sep: impl Into<String>) -> Self {
         self.hint_separator = sep.into();
         self
     }
 
     /// Sets the style for keys.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHintsState;
+    /// use ratatui::style::{Style, Color};
+    ///
+    /// let state = KeyHintsState::new().with_key_style(Style::default().fg(Color::Yellow));
+    /// assert_eq!(state.key_style(), Style::default().fg(Color::Yellow));
+    /// ```
     pub fn with_key_style(mut self, style: Style) -> Self {
         self.key_style = style;
         self
     }
 
     /// Sets the style for actions.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHintsState;
+    /// use ratatui::style::{Style, Color};
+    ///
+    /// let state = KeyHintsState::new().with_action_style(Style::default().fg(Color::White));
+    /// assert_eq!(state.action_style(), Style::default().fg(Color::White));
+    /// ```
     pub fn with_action_style(mut self, style: Style) -> Self {
         self.action_style = style;
         self
@@ -331,6 +414,17 @@ impl KeyHintsState {
     }
 
     /// Adds a hint with priority using builder pattern.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHintsState;
+    ///
+    /// let state = KeyHintsState::new()
+    ///     .hint_with_priority("q", "Quit", 1)
+    ///     .hint_with_priority("Enter", "Select", 10);
+    /// assert_eq!(state.visible_hints()[0].key(), "q");
+    /// ```
     pub fn hint_with_priority(
         mut self,
         key: impl Into<String>,
@@ -343,11 +437,32 @@ impl KeyHintsState {
     }
 
     /// Returns all hints.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHintsState;
+    ///
+    /// let state = KeyHintsState::new().hint("q", "Quit").hint("Enter", "Select");
+    /// assert_eq!(state.hints().len(), 2);
+    /// ```
     pub fn hints(&self) -> &[KeyHint] {
         &self.hints
     }
 
     /// Returns only enabled hints, sorted by priority.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHintsState;
+    ///
+    /// let state = KeyHintsState::new()
+    ///     .hint("q", "Quit")
+    ///     .hint("Delete", "Remove")
+    ///     .with_disabled(false);
+    /// assert_eq!(state.visible_hints().len(), 2);
+    /// ```
     pub fn visible_hints(&self) -> Vec<&KeyHint> {
         let mut visible: Vec<_> = self.hints.iter().filter(|h| h.enabled).collect();
         visible.sort_by_key(|h| h.priority);
@@ -370,21 +485,64 @@ impl KeyHintsState {
     }
 
     /// Sets the hints.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{KeyHintsState, KeyHint};
+    ///
+    /// let mut state = KeyHintsState::new().hint("q", "Quit");
+    /// state.set_hints(vec![KeyHint::new("Enter", "Select"), KeyHint::new("Esc", "Cancel")]);
+    /// assert_eq!(state.len(), 2);
+    /// ```
     pub fn set_hints(&mut self, hints: Vec<KeyHint>) {
         self.hints = hints;
     }
 
     /// Adds a hint.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{KeyHintsState, KeyHint};
+    ///
+    /// let mut state = KeyHintsState::new();
+    /// state.add_hint(KeyHint::new("q", "Quit"));
+    /// assert_eq!(state.len(), 1);
+    /// ```
     pub fn add_hint(&mut self, hint: KeyHint) {
         self.hints.push(hint);
     }
 
     /// Removes a hint by key.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHintsState;
+    ///
+    /// let mut state = KeyHintsState::new().hint("q", "Quit").hint("Enter", "Select");
+    /// state.remove_hint("q");
+    /// assert_eq!(state.len(), 1);
+    /// assert_eq!(state.hints()[0].key(), "Enter");
+    /// ```
     pub fn remove_hint(&mut self, key: &str) {
         self.hints.retain(|h| h.key != key);
     }
 
     /// Enables a hint by key.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{KeyHintsState, KeyHint};
+    ///
+    /// let mut state = KeyHintsState::new()
+    ///     .hint("Delete", "Remove");
+    /// state.disable_hint("Delete");
+    /// state.enable_hint("Delete");
+    /// assert!(state.hints()[0].is_enabled());
+    /// ```
     pub fn enable_hint(&mut self, key: &str) {
         if let Some(hint) = self.hints.iter_mut().find(|h| h.key == key) {
             hint.enabled = true;
@@ -392,6 +550,16 @@ impl KeyHintsState {
     }
 
     /// Disables a hint by key.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHintsState;
+    ///
+    /// let mut state = KeyHintsState::new().hint("Delete", "Remove");
+    /// state.disable_hint("Delete");
+    /// assert!(!state.hints()[0].is_enabled());
+    /// ```
     pub fn disable_hint(&mut self, key: &str) {
         if let Some(hint) = self.hints.iter_mut().find(|h| h.key == key) {
             hint.enabled = false;
@@ -399,41 +567,122 @@ impl KeyHintsState {
     }
 
     /// Sets the layout.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{KeyHintsState, KeyHintsLayout};
+    ///
+    /// let mut state = KeyHintsState::new();
+    /// state.set_layout(KeyHintsLayout::Inline);
+    /// assert_eq!(state.layout(), KeyHintsLayout::Inline);
+    /// ```
     pub fn set_layout(&mut self, layout: KeyHintsLayout) {
         self.layout = layout;
     }
 
     /// Clears all hints.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHintsState;
+    ///
+    /// let mut state = KeyHintsState::new().hint("q", "Quit").hint("Enter", "Select");
+    /// state.clear();
+    /// assert!(state.is_empty());
+    /// ```
     pub fn clear(&mut self) {
         self.hints.clear();
     }
 
     /// Returns the key style.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHintsState;
+    /// use ratatui::style::{Style, Color};
+    ///
+    /// let state = KeyHintsState::new().with_key_style(Style::default().fg(Color::Blue));
+    /// assert_eq!(state.key_style(), Style::default().fg(Color::Blue));
+    /// ```
     pub fn key_style(&self) -> Style {
         self.key_style
     }
 
     /// Returns the action style.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHintsState;
+    /// use ratatui::style::Style;
+    ///
+    /// let state = KeyHintsState::new();
+    /// assert_eq!(state.action_style(), Style::default());
+    /// ```
     pub fn action_style(&self) -> Style {
         self.action_style
     }
 
     /// Sets the key style.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHintsState;
+    /// use ratatui::style::{Style, Color};
+    ///
+    /// let mut state = KeyHintsState::new();
+    /// state.set_key_style(Style::default().fg(Color::Cyan));
+    /// assert_eq!(state.key_style(), Style::default().fg(Color::Cyan));
+    /// ```
     pub fn set_key_style(&mut self, style: Style) {
         self.key_style = style;
     }
 
     /// Sets the action style.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHintsState;
+    /// use ratatui::style::{Style, Color};
+    ///
+    /// let mut state = KeyHintsState::new();
+    /// state.set_action_style(Style::default().fg(Color::Gray));
+    /// assert_eq!(state.action_style(), Style::default().fg(Color::Gray));
+    /// ```
     pub fn set_action_style(&mut self, style: Style) {
         self.action_style = style;
     }
 
     /// Returns true if the key hints are disabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHintsState;
+    ///
+    /// let state = KeyHintsState::new();
+    /// assert!(!state.is_disabled());
+    /// ```
     pub fn is_disabled(&self) -> bool {
         self.disabled
     }
 
     /// Sets the disabled state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHintsState;
+    ///
+    /// let mut state = KeyHintsState::new();
+    /// state.set_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn set_disabled(&mut self, disabled: bool) {
         self.disabled = disabled;
     }

--- a/src/component/radio_group/mod.rs
+++ b/src/component/radio_group/mod.rs
@@ -129,6 +129,15 @@ impl<T: Clone> RadioGroupState<T> {
     }
 
     /// Returns the available options.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::RadioGroupState;
+    ///
+    /// let state = RadioGroupState::new(vec!["Small", "Medium", "Large"]);
+    /// assert_eq!(state.options(), &["Small", "Medium", "Large"]);
+    /// ```
     pub fn options(&self) -> &[T] {
         &self.options
     }
@@ -166,11 +175,29 @@ impl<T: Clone> RadioGroupState<T> {
     /// Returns the currently selected index.
     ///
     /// Returns `None` if the options are empty.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::RadioGroupState;
+    ///
+    /// let state = RadioGroupState::new(vec!["A", "B", "C"]);
+    /// assert_eq!(state.selected_index(), Some(0));
+    /// ```
     pub fn selected_index(&self) -> Option<usize> {
         self.selected
     }
 
     /// Alias for [`selected_index()`](Self::selected_index).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::RadioGroupState;
+    ///
+    /// let state = RadioGroupState::with_selected(vec!["A", "B", "C"], 2);
+    /// assert_eq!(state.selected(), Some(2));
+    /// ```
     pub fn selected(&self) -> Option<usize> {
         self.selected_index()
     }
@@ -178,6 +205,15 @@ impl<T: Clone> RadioGroupState<T> {
     /// Returns a reference to the currently selected item.
     ///
     /// Returns `None` if the options are empty or no selection exists.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::RadioGroupState;
+    ///
+    /// let state = RadioGroupState::with_selected(vec!["Small", "Medium", "Large"], 1);
+    /// assert_eq!(state.selected_item(), Some(&"Medium"));
+    /// ```
     pub fn selected_item(&self) -> Option<&T> {
         self.options.get(self.selected?)
     }
@@ -186,6 +222,16 @@ impl<T: Clone> RadioGroupState<T> {
     ///
     /// Pass `Some(index)` to select an option (out-of-bounds indices are
     /// ignored), or `None` to clear the selection.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::RadioGroupState;
+    ///
+    /// let mut state = RadioGroupState::new(vec!["A", "B", "C"]);
+    /// state.set_selected(Some(2));
+    /// assert_eq!(state.selected_index(), Some(2));
+    /// ```
     pub fn set_selected(&mut self, index: Option<usize>) {
         match index {
             Some(i) if i < self.options.len() => self.selected = Some(i),
@@ -195,11 +241,32 @@ impl<T: Clone> RadioGroupState<T> {
     }
 
     /// Returns true if the options are empty.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::RadioGroupState;
+    ///
+    /// let empty: RadioGroupState<&str> = RadioGroupState::default();
+    /// assert!(empty.is_empty());
+    ///
+    /// let state = RadioGroupState::new(vec!["A"]);
+    /// assert!(!state.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.options.is_empty()
     }
 
     /// Returns the number of options.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::RadioGroupState;
+    ///
+    /// let state = RadioGroupState::new(vec!["Small", "Medium", "Large"]);
+    /// assert_eq!(state.len(), 3);
+    /// ```
     pub fn len(&self) -> usize {
         self.options.len()
     }

--- a/src/component/router/mod.rs
+++ b/src/component/router/mod.rs
@@ -202,37 +202,129 @@ impl<S: Clone + PartialEq> RouterState<S> {
     }
 
     /// Returns the current screen.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::RouterState;
+    ///
+    /// #[derive(Clone, Debug, PartialEq)]
+    /// enum Screen { Home, Settings }
+    ///
+    /// let state = RouterState::new(Screen::Home);
+    /// assert_eq!(state.current(), &Screen::Home);
+    /// ```
     pub fn current(&self) -> &S {
         &self.current
     }
 
     /// Returns true if we can navigate back.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Router, RouterState, RouterMessage};
+    ///
+    /// #[derive(Clone, Debug, PartialEq)]
+    /// enum Screen { Home, Settings }
+    ///
+    /// let mut state = RouterState::new(Screen::Home);
+    /// assert!(!state.can_go_back());
+    /// Router::update(&mut state, RouterMessage::Navigate(Screen::Settings));
+    /// assert!(state.can_go_back());
+    /// ```
     pub fn can_go_back(&self) -> bool {
         !self.history.is_empty()
     }
 
     /// Returns the number of screens in history.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Router, RouterState, RouterMessage};
+    ///
+    /// #[derive(Clone, Debug, PartialEq)]
+    /// enum Screen { Home, Settings, Profile }
+    ///
+    /// let mut state = RouterState::new(Screen::Home);
+    /// Router::update(&mut state, RouterMessage::Navigate(Screen::Settings));
+    /// Router::update(&mut state, RouterMessage::Navigate(Screen::Profile));
+    /// assert_eq!(state.history_len(), 2);
+    /// ```
     pub fn history_len(&self) -> usize {
         self.history.len()
     }
 
     /// Returns the history stack (oldest first).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Router, RouterState, RouterMessage};
+    ///
+    /// #[derive(Clone, Debug, PartialEq)]
+    /// enum Screen { Home, Settings }
+    ///
+    /// let mut state = RouterState::new(Screen::Home);
+    /// Router::update(&mut state, RouterMessage::Navigate(Screen::Settings));
+    /// assert_eq!(state.history(), &[Screen::Home]);
+    /// ```
     pub fn history(&self) -> &[S] {
         &self.history
     }
 
     /// Returns the maximum history size (0 = unlimited).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::RouterState;
+    ///
+    /// #[derive(Clone, Debug, PartialEq)]
+    /// enum Screen { Home }
+    ///
+    /// let state = RouterState::new(Screen::Home).with_max_history(10);
+    /// assert_eq!(state.max_history(), 10);
+    /// ```
     pub fn max_history(&self) -> usize {
         self.max_history
     }
 
     /// Sets the maximum history size.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::RouterState;
+    ///
+    /// #[derive(Clone, Debug, PartialEq)]
+    /// enum Screen { Home }
+    ///
+    /// let mut state = RouterState::new(Screen::Home);
+    /// state.set_max_history(5);
+    /// assert_eq!(state.max_history(), 5);
+    /// ```
     pub fn set_max_history(&mut self, max: usize) {
         self.max_history = max;
         self.enforce_history_limit();
     }
 
     /// Returns the previous screen if available.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Router, RouterState, RouterMessage};
+    ///
+    /// #[derive(Clone, Debug, PartialEq)]
+    /// enum Screen { Home, Settings }
+    ///
+    /// let mut state = RouterState::new(Screen::Home);
+    /// assert_eq!(state.previous(), None);
+    /// Router::update(&mut state, RouterMessage::Navigate(Screen::Settings));
+    /// assert_eq!(state.previous(), Some(&Screen::Home));
+    /// ```
     pub fn previous(&self) -> Option<&S> {
         self.history.last()
     }
@@ -256,6 +348,20 @@ impl<S: Clone + PartialEq> RouterState<S> {
     }
 
     /// Clears all navigation history.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Router, RouterState, RouterMessage};
+    ///
+    /// #[derive(Clone, Debug, PartialEq)]
+    /// enum Screen { Home, Settings }
+    ///
+    /// let mut state = RouterState::new(Screen::Home);
+    /// Router::update(&mut state, RouterMessage::Navigate(Screen::Settings));
+    /// state.clear_history();
+    /// assert!(!state.can_go_back());
+    /// ```
     pub fn clear_history(&mut self) {
         self.history.clear();
     }

--- a/src/component/spinner/mod.rs
+++ b/src/component/spinner/mod.rs
@@ -121,6 +121,15 @@ impl SpinnerStyle {
     }
 
     /// Returns the number of frames in this style.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SpinnerStyle;
+    ///
+    /// assert_eq!(SpinnerStyle::Line.frame_count(), 4);
+    /// assert_eq!(SpinnerStyle::Dots.frame_count(), 10);
+    /// ```
     pub fn frame_count(&self) -> usize {
         self.frames().len()
     }
@@ -223,32 +232,93 @@ impl SpinnerState {
     ///
     /// This is the character that should be displayed for the current
     /// animation state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Spinner, SpinnerMessage, SpinnerState, Component};
+    ///
+    /// let mut state = SpinnerState::new();
+    /// let first = state.current_frame();
+    /// Spinner::update(&mut state, SpinnerMessage::Tick);
+    /// let second = state.current_frame();
+    /// assert_ne!(first, second);
+    /// ```
     pub fn current_frame(&self) -> char {
         let frames = self.style.frames();
         frames[self.frame % frames.len()]
     }
 
     /// Returns true if the spinner is currently spinning.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Spinner, SpinnerMessage, SpinnerState, Component};
+    ///
+    /// let mut state = SpinnerState::new();
+    /// assert!(state.is_spinning());
+    /// Spinner::update(&mut state, SpinnerMessage::Stop);
+    /// assert!(!state.is_spinning());
+    /// ```
     pub fn is_spinning(&self) -> bool {
         self.spinning
     }
 
     /// Sets whether the spinner is spinning.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SpinnerState;
+    ///
+    /// let mut state = SpinnerState::new();
+    /// state.set_spinning(false);
+    /// assert!(!state.is_spinning());
+    /// ```
     pub fn set_spinning(&mut self, spinning: bool) {
         self.spinning = spinning;
     }
 
     /// Returns the label if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SpinnerState;
+    ///
+    /// let state = SpinnerState::with_label("Uploading...");
+    /// assert_eq!(state.label(), Some("Uploading..."));
+    /// ```
     pub fn label(&self) -> Option<&str> {
         self.label.as_deref()
     }
 
     /// Sets the label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SpinnerState;
+    ///
+    /// let mut state = SpinnerState::new();
+    /// state.set_label(Some("Processing...".to_string()));
+    /// assert_eq!(state.label(), Some("Processing..."));
+    /// ```
     pub fn set_label(&mut self, label: Option<String>) {
         self.label = label;
     }
 
     /// Returns the spinner style.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SpinnerState, SpinnerStyle};
+    ///
+    /// let state = SpinnerState::with_style(SpinnerStyle::Circle);
+    /// assert_eq!(state.style(), &SpinnerStyle::Circle);
+    /// ```
     pub fn style(&self) -> &SpinnerStyle {
         &self.style
     }
@@ -256,22 +326,63 @@ impl SpinnerState {
     /// Sets the spinner style.
     ///
     /// This resets the frame index to 0.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SpinnerState, SpinnerStyle};
+    ///
+    /// let mut state = SpinnerState::new();
+    /// state.set_style(SpinnerStyle::Bounce);
+    /// assert_eq!(state.style(), &SpinnerStyle::Bounce);
+    /// assert_eq!(state.frame_index(), 0);
+    /// ```
     pub fn set_style(&mut self, style: SpinnerStyle) {
         self.style = style;
         self.frame = 0;
     }
 
     /// Returns the current frame index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Spinner, SpinnerMessage, SpinnerState, Component};
+    ///
+    /// let mut state = SpinnerState::new();
+    /// assert_eq!(state.frame_index(), 0);
+    /// Spinner::update(&mut state, SpinnerMessage::Tick);
+    /// assert_eq!(state.frame_index(), 1);
+    /// ```
     pub fn frame_index(&self) -> usize {
         self.frame
     }
 
     /// Returns true if the spinner is disabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SpinnerState;
+    ///
+    /// let state = SpinnerState::new();
+    /// assert!(!state.is_disabled());
+    /// ```
     pub fn is_disabled(&self) -> bool {
         self.disabled
     }
 
     /// Sets the disabled state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SpinnerState;
+    ///
+    /// let mut state = SpinnerState::new();
+    /// state.set_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn set_disabled(&mut self, disabled: bool) {
         self.disabled = disabled;
     }

--- a/src/component/status_bar/mod.rs
+++ b/src/component/status_bar/mod.rs
@@ -256,31 +256,94 @@ impl StatusBarState {
     }
 
     /// Returns the left section items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{StatusBarState, StatusBarItem};
+    ///
+    /// let mut state = StatusBarState::new();
+    /// state.push_left(StatusBarItem::new("Mode"));
+    /// assert_eq!(state.left().len(), 1);
+    /// assert_eq!(state.left()[0].text(), "Mode");
+    /// ```
     pub fn left(&self) -> &[StatusBarItem] {
         &self.left
     }
 
     /// Returns the center section items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{StatusBarState, StatusBarItem};
+    ///
+    /// let mut state = StatusBarState::new();
+    /// state.push_center(StatusBarItem::new("main.rs"));
+    /// assert_eq!(state.center().len(), 1);
+    /// assert_eq!(state.center()[0].text(), "main.rs");
+    /// ```
     pub fn center(&self) -> &[StatusBarItem] {
         &self.center
     }
 
     /// Returns the right section items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{StatusBarState, StatusBarItem};
+    ///
+    /// let mut state = StatusBarState::new();
+    /// state.push_right(StatusBarItem::new("Ln 1"));
+    /// assert_eq!(state.right().len(), 1);
+    /// assert_eq!(state.right()[0].text(), "Ln 1");
+    /// ```
     pub fn right(&self) -> &[StatusBarItem] {
         &self.right
     }
 
     /// Sets the left section items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{StatusBarState, StatusBarItem};
+    ///
+    /// let mut state = StatusBarState::new();
+    /// state.set_left(vec![StatusBarItem::new("INSERT"), StatusBarItem::new("Git")]);
+    /// assert_eq!(state.left().len(), 2);
+    /// ```
     pub fn set_left(&mut self, items: Vec<StatusBarItem>) {
         self.left = items;
     }
 
     /// Sets the center section items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{StatusBarState, StatusBarItem};
+    ///
+    /// let mut state = StatusBarState::new();
+    /// state.set_center(vec![StatusBarItem::new("main.rs")]);
+    /// assert_eq!(state.center().len(), 1);
+    /// ```
     pub fn set_center(&mut self, items: Vec<StatusBarItem>) {
         self.center = items;
     }
 
     /// Sets the right section items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{StatusBarState, StatusBarItem};
+    ///
+    /// let mut state = StatusBarState::new();
+    /// state.set_right(vec![StatusBarItem::new("UTF-8"), StatusBarItem::new("Ln 1")]);
+    /// assert_eq!(state.right().len(), 2);
+    /// ```
     pub fn set_right(&mut self, items: Vec<StatusBarItem>) {
         self.right = items;
     }
@@ -331,6 +394,18 @@ impl StatusBarState {
     }
 
     /// Clears all sections.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{StatusBarState, StatusBarItem};
+    ///
+    /// let mut state = StatusBarState::new();
+    /// state.push_left(StatusBarItem::new("Mode"));
+    /// state.push_right(StatusBarItem::new("Ln 1"));
+    /// state.clear();
+    /// assert!(state.is_empty());
+    /// ```
     pub fn clear(&mut self) {
         self.left.clear();
         self.center.clear();
@@ -343,26 +418,76 @@ impl StatusBarState {
     }
 
     /// Sets the separator string.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarState;
+    ///
+    /// let mut state = StatusBarState::new();
+    /// state.set_separator(" :: ");
+    /// assert_eq!(state.separator(), " :: ");
+    /// ```
     pub fn set_separator(&mut self, separator: impl Into<String>) {
         self.separator = separator.into();
     }
 
     /// Returns the background color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarState;
+    /// use ratatui::style::Color;
+    ///
+    /// let state = StatusBarState::new();
+    /// assert_eq!(state.background(), Color::DarkGray);
+    /// ```
     pub fn background(&self) -> Color {
         self.background
     }
 
     /// Sets the background color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarState;
+    /// use ratatui::style::Color;
+    ///
+    /// let mut state = StatusBarState::new();
+    /// state.set_background(Color::Black);
+    /// assert_eq!(state.background(), Color::Black);
+    /// ```
     pub fn set_background(&mut self, color: Color) {
         self.background = color;
     }
 
     /// Returns true if the status bar is disabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarState;
+    ///
+    /// let state = StatusBarState::new();
+    /// assert!(!state.is_disabled());
+    /// ```
     pub fn is_disabled(&self) -> bool {
         self.disabled
     }
 
     /// Sets the disabled state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarState;
+    ///
+    /// let mut state = StatusBarState::new();
+    /// state.set_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn set_disabled(&mut self, disabled: bool) {
         self.disabled = disabled;
     }
@@ -384,16 +509,48 @@ impl StatusBarState {
     }
 
     /// Returns true if all sections are empty.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarState;
+    ///
+    /// let state = StatusBarState::new();
+    /// assert!(state.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.left.is_empty() && self.center.is_empty() && self.right.is_empty()
     }
 
     /// Returns the total number of items across all sections.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{StatusBarState, StatusBarItem};
+    ///
+    /// let mut state = StatusBarState::new();
+    /// state.push_left(StatusBarItem::new("A"));
+    /// state.push_center(StatusBarItem::new("B"));
+    /// state.push_right(StatusBarItem::new("C"));
+    /// assert_eq!(state.len(), 3);
+    /// ```
     pub fn len(&self) -> usize {
         self.left.len() + self.center.len() + self.right.len()
     }
 
     /// Returns the items in the specified section.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{StatusBarState, StatusBarItem, Section};
+    ///
+    /// let mut state = StatusBarState::new();
+    /// state.push_left(StatusBarItem::new("Mode"));
+    /// assert_eq!(state.section(Section::Left).len(), 1);
+    /// assert_eq!(state.section(Section::Right).len(), 0);
+    /// ```
     pub fn section(&self, section: Section) -> &[StatusBarItem] {
         match section {
             Section::Left => &self.left,

--- a/src/component/tabs/mod.rs
+++ b/src/component/tabs/mod.rs
@@ -137,11 +137,29 @@ impl<T: Clone> TabsState<T> {
     /// Returns the currently selected index.
     ///
     /// Returns `None` if there are no tabs.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TabsState;
+    ///
+    /// let state = TabsState::new(vec!["Home", "Settings"]);
+    /// assert_eq!(state.selected_index(), Some(0));
+    /// ```
     pub fn selected_index(&self) -> Option<usize> {
         self.selected
     }
 
     /// Alias for [`selected_index()`](Self::selected_index).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TabsState;
+    ///
+    /// let state = TabsState::with_selected(vec!["A", "B", "C"], 2);
+    /// assert_eq!(state.selected(), Some(2));
+    /// ```
     pub fn selected(&self) -> Option<usize> {
         self.selected_index()
     }
@@ -149,6 +167,15 @@ impl<T: Clone> TabsState<T> {
     /// Returns the currently selected item.
     ///
     /// Returns `None` if there are no tabs or no selection.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TabsState;
+    ///
+    /// let state = TabsState::with_selected(vec!["Home", "Settings", "Help"], 1);
+    /// assert_eq!(state.selected_item(), Some(&"Settings"));
+    /// ```
     pub fn selected_item(&self) -> Option<&T> {
         self.tabs.get(self.selected?)
     }
@@ -157,6 +184,16 @@ impl<T: Clone> TabsState<T> {
     ///
     /// Pass `Some(index)` to select a tab (clamped to valid range), or
     /// `None` to clear the selection.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TabsState;
+    ///
+    /// let mut state = TabsState::new(vec!["A", "B", "C"]);
+    /// state.set_selected(Some(2));
+    /// assert_eq!(state.selected_index(), Some(2));
+    /// ```
     pub fn set_selected(&mut self, index: Option<usize>) {
         match index {
             Some(i) => {
@@ -171,6 +208,15 @@ impl<T: Clone> TabsState<T> {
     }
 
     /// Returns all tabs.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TabsState;
+    ///
+    /// let state = TabsState::new(vec!["Home", "Settings", "Help"]);
+    /// assert_eq!(state.tabs(), &["Home", "Settings", "Help"]);
+    /// ```
     pub fn tabs(&self) -> &[T] {
         &self.tabs
     }
@@ -206,11 +252,32 @@ impl<T: Clone> TabsState<T> {
     }
 
     /// Returns the number of tabs.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TabsState;
+    ///
+    /// let state = TabsState::new(vec!["Tab1", "Tab2", "Tab3"]);
+    /// assert_eq!(state.len(), 3);
+    /// ```
     pub fn len(&self) -> usize {
         self.tabs.len()
     }
 
     /// Returns true if there are no tabs.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TabsState;
+    ///
+    /// let empty: TabsState<&str> = TabsState::default();
+    /// assert!(empty.is_empty());
+    ///
+    /// let state = TabsState::new(vec!["Tab1"]);
+    /// assert!(!state.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.tabs.is_empty()
     }

--- a/src/component/text_area/mod.rs
+++ b/src/component/text_area/mod.rs
@@ -349,26 +349,73 @@ impl TextAreaState {
     }
 
     /// Returns the cursor row.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TextArea, TextAreaMessage, TextAreaState, Component};
+    ///
+    /// let mut state = TextAreaState::new().with_value("Line 1\nLine 2");
+    /// assert_eq!(state.cursor_row(), 1);
+    /// ```
     pub fn cursor_row(&self) -> usize {
         self.cursor_row
     }
 
     /// Returns the cursor column (byte offset).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TextArea, TextAreaMessage, TextAreaState, Component};
+    ///
+    /// let state = TextAreaState::new().with_value("Hello");
+    /// assert_eq!(state.cursor_col(), 5);
+    /// ```
     pub fn cursor_col(&self) -> usize {
         self.cursor_col
     }
 
     /// Returns the number of lines.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TextAreaState;
+    ///
+    /// let state = TextAreaState::new().with_value("a\nb\nc");
+    /// assert_eq!(state.line_count(), 3);
+    /// ```
     pub fn line_count(&self) -> usize {
         self.lines.len()
     }
 
     /// Returns a specific line by index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TextAreaState;
+    ///
+    /// let state = TextAreaState::new().with_value("first\nsecond\nthird");
+    /// assert_eq!(state.line(0), Some("first"));
+    /// assert_eq!(state.line(1), Some("second"));
+    /// assert_eq!(state.line(99), None);
+    /// ```
     pub fn line(&self, index: usize) -> Option<&str> {
         self.lines.get(index).map(|s| s.as_str())
     }
 
     /// Returns the current line (at cursor row).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TextAreaState;
+    ///
+    /// let state = TextAreaState::new().with_value("first\nsecond");
+    /// assert_eq!(state.current_line(), "second");
+    /// ```
     pub fn current_line(&self) -> &str {
         &self.lines[self.cursor_row]
     }
@@ -390,16 +437,44 @@ impl TextAreaState {
     }
 
     /// Returns the placeholder text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TextAreaState;
+    ///
+    /// let state = TextAreaState::new().with_placeholder("Type here...");
+    /// assert_eq!(state.placeholder(), "Type here...");
+    /// ```
     pub fn placeholder(&self) -> &str {
         &self.placeholder
     }
 
     /// Sets the placeholder text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TextAreaState;
+    ///
+    /// let mut state = TextAreaState::new();
+    /// state.set_placeholder("Enter your text...");
+    /// assert_eq!(state.placeholder(), "Enter your text...");
+    /// ```
     pub fn set_placeholder(&mut self, placeholder: impl Into<String>) {
         self.placeholder = placeholder.into();
     }
 
     /// Returns the scroll offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TextAreaState;
+    ///
+    /// let state = TextAreaState::new();
+    /// assert_eq!(state.scroll_offset(), 0);
+    /// ```
     pub fn scroll_offset(&self) -> usize {
         self.scroll_offset
     }
@@ -407,6 +482,16 @@ impl TextAreaState {
     /// Sets the cursor position (row, char_column).
     ///
     /// Both row and column are clamped to valid ranges.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TextAreaState;
+    ///
+    /// let mut state = TextAreaState::new().with_value("Hello\nWorld");
+    /// state.set_cursor_position(0, 3);
+    /// assert_eq!(state.cursor_position(), (0, 3));
+    /// ```
     pub fn set_cursor_position(&mut self, row: usize, col: usize) {
         self.cursor_row = row.min(self.lines.len().saturating_sub(1));
         // Convert char position to byte offset
@@ -436,11 +521,33 @@ impl TextAreaState {
     }
 
     /// Returns true if there are edits that can be undone.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TextArea, TextAreaMessage, TextAreaState, Component};
+    ///
+    /// let mut state = TextAreaState::new();
+    /// assert!(!state.can_undo());
+    /// TextArea::update(&mut state, TextAreaMessage::Insert('a'));
+    /// assert!(state.can_undo());
+    /// ```
     pub fn can_undo(&self) -> bool {
         self.undo_stack.can_undo()
     }
 
     /// Returns true if there are edits that can be redone.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TextArea, TextAreaMessage, TextAreaState, Component};
+    ///
+    /// let mut state = TextAreaState::new();
+    /// TextArea::update(&mut state, TextAreaMessage::Insert('a'));
+    /// TextArea::update(&mut state, TextAreaMessage::Undo);
+    /// assert!(state.can_redo());
+    /// ```
     pub fn can_redo(&self) -> bool {
         self.undo_stack.can_redo()
     }
@@ -478,11 +585,30 @@ impl TextAreaState {
     }
 
     /// Returns whether line numbers are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TextAreaState;
+    ///
+    /// let state = TextAreaState::new().with_line_numbers(true);
+    /// assert!(state.show_line_numbers());
+    /// ```
     pub fn show_line_numbers(&self) -> bool {
         self.show_line_numbers
     }
 
     /// Sets whether line numbers are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TextAreaState;
+    ///
+    /// let mut state = TextAreaState::new();
+    /// state.set_show_line_numbers(true);
+    /// assert!(state.show_line_numbers());
+    /// ```
     pub fn set_show_line_numbers(&mut self, show: bool) {
         self.show_line_numbers = show;
     }

--- a/src/component/usage_display/mod.rs
+++ b/src/component/usage_display/mod.rs
@@ -162,21 +162,62 @@ impl UsageMetric {
     }
 
     /// Sets the metric label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::UsageMetric;
+    ///
+    /// let mut metric = UsageMetric::new("CPU", "45%");
+    /// metric.set_label("Processor");
+    /// assert_eq!(metric.label(), "Processor");
+    /// ```
     pub fn set_label(&mut self, label: impl Into<String>) {
         self.label = label.into();
     }
 
     /// Sets the metric value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::UsageMetric;
+    ///
+    /// let mut metric = UsageMetric::new("CPU", "45%");
+    /// metric.set_value("80%");
+    /// assert_eq!(metric.value(), "80%");
+    /// ```
     pub fn set_value(&mut self, value: impl Into<String>) {
         self.value = value.into();
     }
 
     /// Sets the optional color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::UsageMetric;
+    /// use ratatui::style::Color;
+    ///
+    /// let mut metric = UsageMetric::new("CPU", "45%");
+    /// metric.set_color(Some(Color::Red));
+    /// assert_eq!(metric.color(), Some(Color::Red));
+    /// ```
     pub fn set_color(&mut self, color: Option<Color>) {
         self.color = color;
     }
 
     /// Sets the optional icon.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::UsageMetric;
+    ///
+    /// let mut metric = UsageMetric::new("CPU", "45%");
+    /// metric.set_icon(Some("*".to_string()));
+    /// assert_eq!(metric.icon(), Some("*"));
+    /// ```
     pub fn set_icon(&mut self, icon: Option<String>) {
         self.icon = icon;
     }
@@ -379,51 +420,150 @@ impl UsageDisplayState {
     }
 
     /// Returns all metrics.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{UsageDisplayState, UsageMetric};
+    ///
+    /// let state = UsageDisplayState::new()
+    ///     .metric(UsageMetric::new("CPU", "45%"));
+    /// assert_eq!(state.metrics().len(), 1);
+    /// assert_eq!(state.metrics()[0].label(), "CPU");
+    /// ```
     pub fn metrics(&self) -> &[UsageMetric] {
         &self.metrics
     }
 
     /// Returns the layout style.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{UsageDisplayState, UsageLayout};
+    ///
+    /// let state = UsageDisplayState::new().with_layout(UsageLayout::Grid(2));
+    /// assert_eq!(state.layout(), UsageLayout::Grid(2));
+    /// ```
     pub fn layout(&self) -> UsageLayout {
         self.layout
     }
 
     /// Returns the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::UsageDisplayState;
+    ///
+    /// let state = UsageDisplayState::new().with_title("System");
+    /// assert_eq!(state.title(), Some("System"));
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
 
     /// Returns the separator.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::UsageDisplayState;
+    ///
+    /// let state = UsageDisplayState::new().with_separator(" / ");
+    /// assert_eq!(state.separator(), " / ");
+    /// ```
     pub fn separator(&self) -> &str {
         &self.separator
     }
 
     /// Returns the number of metrics.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{UsageDisplayState, UsageMetric};
+    ///
+    /// let state = UsageDisplayState::new()
+    ///     .metric(UsageMetric::new("CPU", "45%"))
+    ///     .metric(UsageMetric::new("Memory", "3.2 GB"));
+    /// assert_eq!(state.len(), 2);
+    /// ```
     pub fn len(&self) -> usize {
         self.metrics.len()
     }
 
     /// Returns true if there are no metrics.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::UsageDisplayState;
+    ///
+    /// assert!(UsageDisplayState::new().is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.metrics.is_empty()
     }
 
     /// Returns true if the component is disabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::UsageDisplayState;
+    ///
+    /// let state = UsageDisplayState::new().with_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn is_disabled(&self) -> bool {
         self.disabled
     }
 
     /// Sets the metrics.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{UsageDisplayState, UsageMetric};
+    ///
+    /// let mut state = UsageDisplayState::new();
+    /// state.set_metrics(vec![UsageMetric::new("CPU", "45%")]);
+    /// assert_eq!(state.len(), 1);
+    /// ```
     pub fn set_metrics(&mut self, metrics: Vec<UsageMetric>) {
         self.metrics = metrics;
     }
 
     /// Adds a metric.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{UsageDisplayState, UsageMetric};
+    ///
+    /// let mut state = UsageDisplayState::new();
+    /// state.add_metric(UsageMetric::new("Disk", "120 GB"));
+    /// assert_eq!(state.len(), 1);
+    /// ```
     pub fn add_metric(&mut self, metric: UsageMetric) {
         self.metrics.push(metric);
     }
 
     /// Removes a metric by label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{UsageDisplayState, UsageMetric};
+    ///
+    /// let mut state = UsageDisplayState::new()
+    ///     .metric(UsageMetric::new("CPU", "45%"))
+    ///     .metric(UsageMetric::new("Memory", "3.2 GB"));
+    /// state.remove_metric("CPU");
+    /// assert_eq!(state.len(), 1);
+    /// assert_eq!(state.metrics()[0].label(), "Memory");
+    /// ```
     pub fn remove_metric(&mut self, label: &str) {
         self.metrics.retain(|m| m.label != label);
     }
@@ -431,6 +571,17 @@ impl UsageDisplayState {
     /// Updates a metric's value by label.
     ///
     /// Returns true if the metric was found and updated.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{UsageDisplayState, UsageMetric};
+    ///
+    /// let mut state = UsageDisplayState::new()
+    ///     .metric(UsageMetric::new("CPU", "45%"));
+    /// assert!(state.update_value("CPU", "80%"));
+    /// assert_eq!(state.find("CPU").unwrap().value(), "80%");
+    /// ```
     pub fn update_value(&mut self, label: &str, value: impl Into<String>) -> bool {
         if let Some(metric) = self.metrics.iter_mut().find(|m| m.label == label) {
             metric.value = value.into();
@@ -443,6 +594,18 @@ impl UsageDisplayState {
     /// Updates a metric's color by label.
     ///
     /// Returns true if the metric was found and updated.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{UsageDisplayState, UsageMetric};
+    /// use ratatui::style::Color;
+    ///
+    /// let mut state = UsageDisplayState::new()
+    ///     .metric(UsageMetric::new("CPU", "45%"));
+    /// assert!(state.update_color("CPU", Some(Color::Red)));
+    /// assert_eq!(state.find("CPU").unwrap().color(), Some(Color::Red));
+    /// ```
     pub fn update_color(&mut self, label: &str, color: Option<Color>) -> bool {
         if let Some(metric) = self.metrics.iter_mut().find(|m| m.label == label) {
             metric.color = color;
@@ -453,36 +616,111 @@ impl UsageDisplayState {
     }
 
     /// Sets the layout.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{UsageDisplayState, UsageLayout};
+    ///
+    /// let mut state = UsageDisplayState::new();
+    /// state.set_layout(UsageLayout::Vertical);
+    /// assert_eq!(state.layout(), UsageLayout::Vertical);
+    /// ```
     pub fn set_layout(&mut self, layout: UsageLayout) {
         self.layout = layout;
     }
 
     /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::UsageDisplayState;
+    ///
+    /// let mut state = UsageDisplayState::new();
+    /// state.set_title(Some("Metrics".to_string()));
+    /// assert_eq!(state.title(), Some("Metrics"));
+    /// ```
     pub fn set_title(&mut self, title: Option<String>) {
         self.title = title;
     }
 
     /// Sets the separator.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::UsageDisplayState;
+    ///
+    /// let mut state = UsageDisplayState::new();
+    /// state.set_separator(" / ");
+    /// assert_eq!(state.separator(), " / ");
+    /// ```
     pub fn set_separator(&mut self, separator: impl Into<String>) {
         self.separator = separator.into();
     }
 
     /// Sets the disabled state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::UsageDisplayState;
+    ///
+    /// let mut state = UsageDisplayState::new();
+    /// state.set_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn set_disabled(&mut self, disabled: bool) {
         self.disabled = disabled;
     }
 
     /// Clears all metrics.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{UsageDisplayState, UsageMetric};
+    ///
+    /// let mut state = UsageDisplayState::new()
+    ///     .metric(UsageMetric::new("CPU", "45%"));
+    /// state.clear();
+    /// assert!(state.is_empty());
+    /// ```
     pub fn clear(&mut self) {
         self.metrics.clear();
     }
 
     /// Finds a metric by label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{UsageDisplayState, UsageMetric};
+    ///
+    /// let state = UsageDisplayState::new()
+    ///     .metric(UsageMetric::new("CPU", "45%"));
+    /// assert_eq!(state.find("CPU").unwrap().value(), "45%");
+    /// assert!(state.find("Disk").is_none());
+    /// ```
     pub fn find(&self, label: &str) -> Option<&UsageMetric> {
         self.metrics.iter().find(|m| m.label == label)
     }
 
     /// Finds a mutable metric by label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{UsageDisplayState, UsageMetric};
+    ///
+    /// let mut state = UsageDisplayState::new()
+    ///     .metric(UsageMetric::new("CPU", "45%"));
+    /// if let Some(metric) = state.find_mut("CPU") {
+    ///     metric.set_value("80%");
+    /// }
+    /// assert_eq!(state.find("CPU").unwrap().value(), "80%");
+    /// ```
     pub fn find_mut(&mut self, label: &str) -> Option<&mut UsageMetric> {
         self.metrics.iter_mut().find(|m| m.label == label)
     }


### PR DESCRIPTION
## Summary

- Adds doc tests to public methods on 12 components that were below 35% doc test coverage.
- Target components: key_hints, router, status_bar, spinner, radio_group, tabs, usage_display, text_area, input_field, box_plot, breadcrumb, code_block.
- Each component now has >50% doc test coverage.
- No behavioral changes — only documentation additions.

## Test plan

- [x] `cargo test --doc -p envision` — all doc tests pass (1814 total)
- [x] `cargo clippy -p envision -- -D warnings` — no warnings
- [x] `cargo fmt` — no diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)