### PR TITLE
Add # Errors and # Panics documentation to public methods

### DIFF
--- a/src/app/command/mod.rs
+++ b/src/app/command/mod.rs
@@ -532,7 +532,7 @@ impl<M> Command<M> {
     ///
     /// If JSON serialization fails, returns [`Command::none`] silently (no
     /// error is reported). If the file write fails, the error is reported to
-    /// the runtime's error channel as [`EnvisionError::Io`]; retrieve it
+    /// the runtime's error channel as `EnvisionError::Io`; retrieve it
     /// with [`Runtime::take_errors`](crate::Runtime::take_errors).
     ///
     /// # Example

--- a/src/app/command/mod.rs
+++ b/src/app/command/mod.rs
@@ -526,9 +526,14 @@ impl<M> Command<M> {
     /// Creates a command that saves application state to a JSON file.
     ///
     /// Serializes the state to JSON synchronously, then writes the file
-    /// asynchronously via `tokio::fs::write`. If serialization fails,
-    /// returns [`Command::none`]. File write errors are reported to the
-    /// runtime's error channel (see [`Runtime::take_errors`](crate::Runtime::take_errors)).
+    /// asynchronously via `tokio::fs::write`.
+    ///
+    /// # Errors
+    ///
+    /// If JSON serialization fails, returns [`Command::none`] silently (no
+    /// error is reported). If the file write fails, the error is reported to
+    /// the runtime's error channel as [`EnvisionError::Io`]; retrieve it
+    /// with [`Runtime::take_errors`](crate::Runtime::take_errors).
     ///
     /// # Example
     ///

--- a/src/app/model/mod.rs
+++ b/src/app/model/mod.rs
@@ -202,10 +202,10 @@ pub trait App: Sized {
     /// [`Runtime::virtual_terminal_with_state()`]), this method is **not
     /// called** — the provided state is used directly instead.
     ///
-    /// # Default Implementation
+    /// # Panics
     ///
-    /// The default implementation panics with a descriptive message. This
-    /// allows applications that exclusively use `with_state` constructors
+    /// The default implementation panics if called without being overridden.
+    /// This allows applications that exclusively use `with_state` constructors
     /// to omit `init()` entirely, since it will never be called. If you
     /// use [`Runtime::new_terminal()`] or [`Runtime::virtual_terminal()`],
     /// you **must** override this method to provide valid initial state.

--- a/src/app/worker/mod.rs
+++ b/src/app/worker/mod.rs
@@ -108,6 +108,11 @@ impl ProgressSender {
     }
 
     /// Sends a progress update with just a percentage.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the progress channel is closed, which occurs when the
+    /// worker has been cancelled or the runtime has shut down.
     pub async fn send_percentage(
         &self,
         percentage: f32,
@@ -116,6 +121,11 @@ impl ProgressSender {
     }
 
     /// Sends a progress update with a percentage and status message.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the progress channel is closed, which occurs when the
+    /// worker has been cancelled or the runtime has shut down.
     pub async fn send_status(
         &self,
         percentage: f32,


### PR DESCRIPTION
## Summary

- Adds a formal `# Panics` section to `App::init()` — the default implementation panics when called without being overridden. Previously the panic was described in a non-standard `# Default Implementation` section; this change uses the conventional Rustdoc heading.
- Adds a `# Errors` section to `Command::save_state` documenting its two distinct failure modes: serialization failures silently return `Command::none()` (no error), while file-write failures are reported to the runtime's error channel. This behavior is non-obvious from the signature.
- Adds `# Errors` sections to `ProgressSender::send_percentage` and `ProgressSender::send_status`, consistent with the already-documented `send()` method on the same type.

No behavioral changes — documentation only.

## Test plan

- [x] `cargo test --doc -p envision` — all 1648 doc tests pass
- [x] `cargo clippy -p envision -- -D warnings` — no warnings
- [x] `cargo fmt --check` — no diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)