### PR TITLE
Also recolor markdown spans with fg: None

### DIFF
--- a/src/component/conversation_view/render.rs
+++ b/src/component/conversation_view/render.rs
@@ -327,7 +327,7 @@ fn format_text_block<'a>(
         );
         for mut md_line in md_lines {
             for span in md_line.spans.iter_mut() {
-                if span.style.fg == Some(theme.foreground) {
+                if span.style.fg.is_none() || span.style.fg == Some(theme.foreground) {
                     span.style.fg = style.fg;
                 }
             }


### PR DESCRIPTION
## Summary

- The markdown role color fix (#389) only caught spans with `fg == Some(theme.foreground)`. If the markdown renderer ever emits a plain-text span with `fg: None`, that span would not receive the role color.
- Adds `span.style.fg.is_none()` to the condition, handling both cases defensively.
- One-line change. Existing test still passes.

Customer Claude feedback on v0.13.0.

## Test plan

- [x] `test_markdown_role_style_propagation` — passes
- [x] `cargo clippy -p envision -- -D warnings` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)