### PR TITLE
Add missing getters for accessor symmetry

### DIFF
--- a/src/component/flame_graph/mod.rs
+++ b/src/component/flame_graph/mod.rs
@@ -387,6 +387,28 @@ impl FlameGraphState {
         &self.search_query
     }
 
+    /// Returns the search query as an `Option<&str>`, or `None` if empty.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{FlameGraphState, FlameNode};
+    ///
+    /// let state = FlameGraphState::new();
+    /// assert_eq!(state.search(), None);
+    ///
+    /// let mut state = FlameGraphState::with_root(FlameNode::new("main()", 500));
+    /// state.set_search("compute".to_string());
+    /// assert_eq!(state.search(), Some("compute"));
+    /// ```
+    pub fn search(&self) -> Option<&str> {
+        if self.search_query.is_empty() {
+            None
+        } else {
+            Some(&self.search_query)
+        }
+    }
+
     /// Sets the search query.
     ///
     /// # Example

--- a/src/component/tab_bar/mod.rs
+++ b/src/component/tab_bar/mod.rs
@@ -298,6 +298,31 @@ impl TabBarState {
         self.active
     }
 
+    /// Returns the active tab index, or `None` if the tab bar is empty.
+    ///
+    /// This is the getter counterpart to [`set_active`](Self::set_active).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tab, TabBarState};
+    ///
+    /// let mut state = TabBarState::new(vec![
+    ///     Tab::new("a", "A"),
+    ///     Tab::new("b", "B"),
+    /// ]);
+    /// assert_eq!(state.active(), Some(0));
+    ///
+    /// state.set_active(Some(1));
+    /// assert_eq!(state.active(), Some(1));
+    ///
+    /// state.set_active(None);
+    /// assert_eq!(state.active(), None);
+    /// ```
+    pub fn active(&self) -> Option<usize> {
+        self.active
+    }
+
     /// Returns the currently active tab, or `None` if empty.
     ///
     /// # Example

--- a/src/component/tooltip/mod.rs
+++ b/src/component/tooltip/mod.rs
@@ -285,6 +285,25 @@ impl TooltipState {
         self.duration_ms
     }
 
+    /// Returns the auto-hide duration in milliseconds.
+    ///
+    /// This is the getter counterpart to [`set_duration`](Self::set_duration).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TooltipState;
+    ///
+    /// let state = TooltipState::new("Help text");
+    /// assert_eq!(state.duration(), None);
+    ///
+    /// let state = TooltipState::new("Help text").with_duration(5000);
+    /// assert_eq!(state.duration(), Some(5000));
+    /// ```
+    pub fn duration(&self) -> Option<u64> {
+        self.duration_ms
+    }
+
     /// Returns the remaining time before auto-hide.
     pub fn remaining_ms(&self) -> Option<u64> {
         self.remaining_ms

--- a/src/component/treemap/mod.rs
+++ b/src/component/treemap/mod.rs
@@ -136,6 +136,26 @@ impl TreemapNode {
         self.color = color;
     }
 
+    /// Returns the color of this node.
+    ///
+    /// This is the getter counterpart to [`set_color`](Self::set_color).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TreemapNode;
+    /// use ratatui::style::Color;
+    ///
+    /// let node = TreemapNode::new("data", 100.0);
+    /// assert_eq!(node.color(), Color::Gray);
+    ///
+    /// let node = TreemapNode::new("data", 100.0).with_color(Color::Cyan);
+    /// assert_eq!(node.color(), Color::Cyan);
+    /// ```
+    pub fn color(&self) -> Color {
+        self.color
+    }
+
     /// Adds a single child node (builder pattern).
     ///
     /// # Example


### PR DESCRIPTION
## Summary

- Adds 4 missing getters to match existing setters:
  - `FlameGraphState::search()` → matches `set_search()`, returns `Option<&str>` (None when query is empty)
  - `TabBarState::active()` → matches `set_active()`, returns `Option<usize>`
  - `TooltipState::duration()` → matches `set_duration()`, returns `Option<u64>`
  - `TreemapNode::color()` → matches `set_color()`, returns `Color`
- Purely additive — no existing API changes.
- Each getter has a doc test following the project style.

## Test plan

- [x] Doc tests on all 4 new getters
- [x] `cargo test --doc -p envision` — 1820 passed, 0 failed
- [x] `cargo nextest run -p envision` — 7155 passed, 0 skipped
- [x] `cargo clippy -p envision -- -D warnings` — no warnings
- [x] `cargo fmt` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)