### PR TITLE
Add missing PartialEq derives to state types

### DIFF
--- a/src/component/dependency_graph/mod.rs
+++ b/src/component/dependency_graph/mod.rs
@@ -148,7 +148,7 @@ pub enum DependencyGraphOutput {
 /// assert_eq!(state.edges().len(), 1);
 /// assert_eq!(state.title(), Some("Service Topology"));
 /// ```
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 #[cfg_attr(
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)

--- a/src/component/flame_graph/mod.rs
+++ b/src/component/flame_graph/mod.rs
@@ -140,7 +140,7 @@ pub enum FlameGraphOutput {
 /// assert_eq!(state.selected_depth(), 0);
 /// assert_eq!(state.selected_index(), 0);
 /// ```
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 #[cfg_attr(
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)

--- a/src/component/focus_manager/mod.rs
+++ b/src/component/focus_manager/mod.rs
@@ -50,7 +50,7 @@
 /// - `focus_next()` moves focus forward, wrapping from last to first
 /// - `focus_prev()` moves focus backward, wrapping from first to last
 /// - When unfocused, `focus_next()` focuses the first item, `focus_prev()` focuses the last
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct FocusManager<Id> {
     order: Vec<Id>,
     focused: Option<usize>,

--- a/src/component/span_tree/mod.rs
+++ b/src/component/span_tree/mod.rs
@@ -130,7 +130,7 @@ pub enum SpanTreeOutput {
 /// assert_eq!(state.global_end(), 1000.0);
 /// assert_eq!(state.selected_index(), Some(0));
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)


### PR DESCRIPTION
## Summary

- Adds `PartialEq` to `DependencyGraphState`, `FlameGraphState`, `SpanTreeState`, and `FocusManager<Id>` — four types that were missing the derive and had no manual `PartialEq` implementation.
- Purely additive — no existing behavior changes.
- All field types for each of these structs already implement `PartialEq`, so the derive compiles cleanly.

## Audit findings

After a complete audit of all 73+ component state types, the vast majority already have `PartialEq` either via derive or via a manual impl (for types with fields like `Arc<dyn Trait>`, `f64`, `ListState`, or `ScrollState` that warranted custom logic). Only these 4 genuinely lacked any `PartialEq` support.

**Skipped types (already have manual PartialEq impls — no derive needed):**
- `CodeBlockState` — manual impl (skips HashSet field comparison details)
- `CommandPaletteState` — manual impl (skips `scroll: ScrollState`)
- `ConversationViewState` — manual impl (skips `HashMap<Role, Style>` field)
- `DataGridState<T>` — manual impl with `T: PartialEq` bound
- `DiffViewerState` — manual impl
- `EventStreamState` — manual impl (skips search `InputFieldState` field)
- `FileBrowserState` — manual impl (skips `Arc<dyn DirectoryProvider>` field)
- `LoadingListState<T>` — manual impl with `T: PartialEq` bound
- `LogCorrelationState` — manual impl (uses epsilon comparison for `f64` field)
- `LogViewerState` — manual impl
- `RadioGroupState<T>` — manual impl with `T: PartialEq` bound
- `RouterState<S>` — manual impl
- `SearchableListState<T>` — manual impl (skips `Arc<MatcherFn>` field)
- `SelectableListState<T>` — manual impl (handles `ListState` comparison)
- `SplitPanelState` — manual impl
- `TabBarState` — manual impl
- `TableState<T>` — manual impl with `T: PartialEq` bound
- `TabsState<T>` — manual impl with `T: PartialEq` bound
- `TreeState<T>` — manual impl with `T: PartialEq` bound

**Debug / Clone:** All state types already have `Debug` and `Clone` (either derived or manual implementations where field types require it — e.g., `FileBrowserState` has a manual `Debug` impl to handle the `Arc<dyn DirectoryProvider>` field).

**Default:** Not added — all types that could sensibly derive `Default` already do so.

## Test plan

- [x] `cargo check -p envision` — compiles clean
- [x] `cargo nextest run -p envision` — all 7155 tests pass
- [x] `cargo clippy -p envision -- -D warnings` — no warnings
- [x] `cargo fmt` — no formatting changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)