### PR TITLE
Extract render parameter structs to eliminate clippy suppressions

### DIFF
--- a/src/component/alert_panel/render.rs
+++ b/src/component/alert_panel/render.rs
@@ -88,8 +88,10 @@ pub(super) fn render_alert_panel(
             if let Some(metric) = state.metrics().get(metric_idx) {
                 let is_selected = state.selected() == Some(metric_idx);
                 render_metric_card(
-                    metric,
-                    is_selected,
+                    MetricCardInput {
+                        metric,
+                        is_selected,
+                    },
                     state,
                     frame,
                     *col_area,
@@ -102,11 +104,15 @@ pub(super) fn render_alert_panel(
     }
 }
 
-/// Renders a single metric card within the grid.
-#[allow(clippy::too_many_arguments)]
-fn render_metric_card(
-    metric: &super::AlertMetric,
+/// Selection and focus state for a single metric card.
+struct MetricCardInput<'a> {
+    metric: &'a super::AlertMetric,
     is_selected: bool,
+}
+
+/// Renders a single metric card within the grid.
+fn render_metric_card(
+    card: MetricCardInput<'_>,
     state: &AlertPanelState,
     frame: &mut Frame,
     area: Rect,
@@ -114,6 +120,8 @@ fn render_metric_card(
     focused: bool,
     disabled: bool,
 ) {
+    let metric = card.metric;
+    let is_selected = card.is_selected;
     let border_style = if disabled {
         theme.disabled_style()
     } else if is_selected && focused {

--- a/src/component/chart/annotations.rs
+++ b/src/component/chart/annotations.rs
@@ -67,6 +67,15 @@ impl ChartAnnotation {
     }
 }
 
+/// Axis bounds and scale information used for coordinate mapping.
+pub(super) struct AxisBounds {
+    pub(super) x_min: f64,
+    pub(super) x_max: f64,
+    pub(super) y_min: f64,
+    pub(super) y_max: f64,
+    pub(super) is_log: bool,
+}
+
 /// Renders text annotations at data coordinates on the chart surface.
 ///
 /// Each annotation's (x, y) data coordinates are converted to screen positions
@@ -74,18 +83,13 @@ impl ChartAnnotation {
 /// one column to the right and one row above the data point to avoid overlapping
 /// the plotted data. Only empty or space cells are overwritten, preserving
 /// existing chart content.
-#[allow(clippy::too_many_arguments)]
 pub(super) fn render_annotations(
     state: &ChartState,
     frame: &mut Frame,
     area: Rect,
     y_labels: &[String],
     x_labels: &[String],
-    x_bound_min: f64,
-    x_bound_max: f64,
-    y_axis_min: f64,
-    y_axis_max: f64,
-    is_log: bool,
+    bounds: AxisBounds,
 ) {
     if state.annotations.is_empty() {
         return;
@@ -96,8 +100,8 @@ pub(super) fn render_annotations(
         return;
     }
 
-    let x_range = x_bound_max - x_bound_min;
-    let y_range = y_axis_max - y_axis_min;
+    let x_range = bounds.x_max - bounds.x_min;
+    let y_range = bounds.y_max - bounds.y_min;
     if x_range <= 0.0 || y_range <= 0.0 {
         return;
     }
@@ -105,14 +109,14 @@ pub(super) fn render_annotations(
     let buf = frame.buffer_mut();
 
     for ann in &state.annotations {
-        let ann_y = if is_log {
+        let ann_y = if bounds.is_log {
             state.y_scale.transform(ann.y.max(f64::MIN_POSITIVE))
         } else {
             ann.y
         };
 
-        let x_frac = (ann.x - x_bound_min) / x_range;
-        let y_frac = (ann_y - y_axis_min) / y_range;
+        let x_frac = (ann.x - bounds.x_min) / x_range;
+        let y_frac = (ann_y - bounds.y_min) / y_range;
 
         // Skip annotations outside the visible graph area
         if !(0.0..=1.0).contains(&x_frac) || !(0.0..=1.0).contains(&y_frac) {

--- a/src/component/chart/error_bands.rs
+++ b/src/component/chart/error_bands.rs
@@ -3,25 +3,21 @@
 use ratatui::prelude::*;
 
 use super::ChartState;
+use super::annotations::AxisBounds;
 use super::render::interpolate_y;
 use crate::theme::Theme;
 
 /// Fills the shaded region between upper and lower bounds for error bands.
-#[allow(clippy::too_many_arguments)]
 pub(super) fn fill_error_bands(
     state: &ChartState,
     frame: &mut Frame,
     graph_area: Rect,
-    x_min: f64,
-    x_max: f64,
-    y_min: f64,
-    y_max: f64,
+    bounds: AxisBounds,
     disabled: bool,
     theme: &Theme,
-    is_log: bool,
 ) {
-    let x_range = x_max - x_min;
-    let y_range = y_max - y_min;
+    let x_range = bounds.x_max - bounds.x_min;
+    let y_range = bounds.y_max - bounds.y_min;
     if x_range <= 0.0 || y_range <= 0.0 {
         return;
     }
@@ -38,17 +34,17 @@ pub(super) fn fill_error_bands(
             dim_color(series.color())
         };
         let upper_data: Vec<(f64, f64)> = upper.map_or_else(Vec::new, |ub| {
-            build_bound_data(series, ub, is_log, &state.y_scale)
+            build_bound_data(series, ub, bounds.is_log, &state.y_scale)
         });
         let lower_data: Vec<(f64, f64)> = lower.map_or_else(Vec::new, |lb| {
-            build_bound_data(series, lb, is_log, &state.y_scale)
+            build_bound_data(series, lb, bounds.is_log, &state.y_scale)
         });
         let main_data: Vec<(f64, f64)> =
-            build_bound_data(series, series.values(), is_log, &state.y_scale);
+            build_bound_data(series, series.values(), bounds.is_log, &state.y_scale);
         for screen_x in graph_area.x..graph_area.right() {
             let x_frac =
                 (screen_x - graph_area.x) as f64 / (graph_area.width as f64 - 1.0).max(1.0);
-            let data_x = x_min + x_frac * x_range;
+            let data_x = bounds.x_min + x_frac * x_range;
             let upper_y = if !upper_data.is_empty() {
                 interpolate_y(&upper_data, data_x)
             } else {
@@ -74,8 +70,8 @@ pub(super) fn fill_error_bands(
             if band_upper <= band_lower {
                 continue;
             }
-            let upper_frac = f64::clamp((band_upper - y_min) / y_range, 0.0, 1.0);
-            let lower_frac = f64::clamp((band_lower - y_min) / y_range, 0.0, 1.0);
+            let upper_frac = f64::clamp((band_upper - bounds.y_min) / y_range, 0.0, 1.0);
+            let lower_frac = f64::clamp((band_lower - bounds.y_min) / y_range, 0.0, 1.0);
             let upper_screen_y = graph_area
                 .bottom()
                 .saturating_sub(1)

--- a/src/component/chart/render.rs
+++ b/src/component/chart/render.rs
@@ -695,13 +695,15 @@ pub(super) fn render_shared_axis_chart(
                 state,
                 frame,
                 graph_area,
-                x_bound_min,
-                x_bound_max,
-                y_axis_min,
-                y_axis_max,
+                super::annotations::AxisBounds {
+                    x_min: x_bound_min,
+                    x_max: x_bound_max,
+                    y_min: y_axis_min,
+                    y_max: y_axis_max,
+                    is_log,
+                },
                 disabled,
                 theme,
-                is_log,
             );
         }
     }
@@ -715,10 +717,13 @@ pub(super) fn render_shared_axis_chart(
                 frame,
                 graph_area,
                 &series_data,
-                x_bound_min,
-                x_bound_max,
-                y_axis_min,
-                y_axis_max,
+                super::annotations::AxisBounds {
+                    x_min: x_bound_min,
+                    x_max: x_bound_max,
+                    y_min: y_axis_min,
+                    y_max: y_axis_max,
+                    is_log,
+                },
                 disabled,
                 theme,
             );
@@ -736,11 +741,13 @@ pub(super) fn render_shared_axis_chart(
         area,
         &y_labels_for_layout,
         &x_labels_for_layout,
-        x_bound_min,
-        x_bound_max,
-        y_axis_min,
-        y_axis_max,
-        is_log,
+        super::annotations::AxisBounds {
+            x_min: x_bound_min,
+            x_max: x_bound_max,
+            y_min: y_axis_min,
+            y_max: y_axis_max,
+            is_log,
+        },
     );
 }
 
@@ -815,21 +822,17 @@ pub(super) fn compute_graph_area(area: Rect, y_labels: &[String], x_labels: &[St
 }
 
 /// Fills the area below each series curve for area charts.
-#[allow(clippy::too_many_arguments)]
 fn fill_area_below_curve(
     state: &ChartState,
     frame: &mut Frame,
     graph_area: Rect,
     series_data: &[Vec<(f64, f64)>],
-    x_min: f64,
-    x_max: f64,
-    y_min: f64,
-    y_max: f64,
+    bounds: super::annotations::AxisBounds,
     disabled: bool,
     theme: &Theme,
 ) {
-    let x_range = x_max - x_min;
-    let y_range = y_max - y_min;
+    let x_range = bounds.x_max - bounds.x_min;
+    let y_range = bounds.y_max - bounds.y_min;
     if x_range <= 0.0 || y_range <= 0.0 {
         return;
     }
@@ -843,9 +846,9 @@ fn fill_area_below_curve(
         let data = &series_data[series_idx];
         if data.len() < 2 {
             if let Some(&(dx, dy)) = data.first() {
-                let x_frac = (dx - x_min) / x_range;
+                let x_frac = (dx - bounds.x_min) / x_range;
                 let screen_x = graph_area.x + (x_frac * (graph_area.width as f64 - 1.0)) as u16;
-                let y_frac = (dy - y_min) / y_range;
+                let y_frac = (dy - bounds.y_min) / y_range;
                 let line_y = graph_area
                     .bottom()
                     .saturating_sub(1)
@@ -857,10 +860,10 @@ fn fill_area_below_curve(
         for screen_x in graph_area.x..graph_area.right() {
             let x_frac =
                 (screen_x - graph_area.x) as f64 / (graph_area.width as f64 - 1.0).max(1.0);
-            let data_x = x_min + x_frac * x_range;
+            let data_x = bounds.x_min + x_frac * x_range;
             let data_y = interpolate_y(data, data_x);
             if let Some(dy) = data_y {
-                let y_frac = ((dy - y_min) / y_range).clamp(0.0, 1.0);
+                let y_frac = ((dy - bounds.y_min) / y_range).clamp(0.0, 1.0);
                 let line_y = graph_area
                     .bottom()
                     .saturating_sub(1)

--- a/src/component/code_block/render.rs
+++ b/src/component/code_block/render.rs
@@ -107,13 +107,15 @@ pub(super) fn render(
         let code_line_area = Rect::new(code_x, y, code_area_width, 1);
         render_code_line(
             line_text,
-            is_highlighted,
+            LineRenderConfig {
+                is_highlighted,
+                horizontal_offset: state.horizontal_offset,
+            },
             state,
             frame,
             code_line_area,
             theme,
             disabled,
-            state.horizontal_offset,
         );
     }
 
@@ -193,18 +195,24 @@ fn apply_horizontal_offset<'a>(spans: Vec<Span<'a>>, offset: usize) -> Vec<Span<
     result
 }
 
+/// Display configuration for a single code line.
+struct LineRenderConfig {
+    is_highlighted: bool,
+    horizontal_offset: usize,
+}
+
 /// Renders a single line of highlighted code.
-#[allow(clippy::too_many_arguments)]
 fn render_code_line(
     line_text: &str,
-    is_highlighted: bool,
+    config: LineRenderConfig,
     state: &CodeBlockState,
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
     disabled: bool,
-    horizontal_offset: usize,
 ) {
+    let is_highlighted = config.is_highlighted;
+    let horizontal_offset = config.horizontal_offset;
     if disabled {
         let visible: String = line_text.chars().skip(horizontal_offset).collect();
         let paragraph = Paragraph::new(visible).style(theme.disabled_style());

--- a/src/component/dependency_graph/render.rs
+++ b/src/component/dependency_graph/render.rs
@@ -130,12 +130,14 @@ pub(super) fn render_dependency_graph(
                 frame,
                 node,
                 layout_node,
-                is_selected,
+                NodeRenderState {
+                    is_selected,
+                    focused,
+                    disabled,
+                },
                 state,
                 inner,
                 theme,
-                focused,
-                disabled,
             );
         }
     }
@@ -161,20 +163,26 @@ fn render_empty_state(
     frame.render_widget(Paragraph::new(msg).style(style), msg_area);
 }
 
+/// Selection and focus state for rendering a graph node.
+struct NodeRenderState {
+    is_selected: bool,
+    focused: bool,
+    disabled: bool,
+}
+
 /// Renders a single graph node as a bordered box with label and status.
-#[allow(clippy::too_many_arguments)]
 fn render_node(
     frame: &mut Frame,
     node: &super::GraphNode,
     layout_node: &LayoutNode,
-    is_selected: bool,
+    render_state: NodeRenderState,
     _state: &DependencyGraphState,
     clip: Rect,
     theme: &Theme,
-
-    focused: bool,
-    disabled: bool,
 ) {
+    let is_selected = render_state.is_selected;
+    let focused = render_state.focused;
+    let disabled = render_state.disabled;
     // Clip node to inner area
     let node_area = clip_rect(
         Rect::new(

--- a/src/component/flame_graph/render.rs
+++ b/src/component/flame_graph/render.rs
@@ -84,7 +84,19 @@ pub(super) fn render_flame_graph(
         }
         let row_area = Rect::new(inner.x, y, inner.width, 1);
         render_depth_row(
-            state, frame, view_root, root_total, depth, row_area, theme, focused, disabled,
+            state,
+            frame,
+            FlameRootInfo {
+                view_root,
+                root_total,
+            },
+            depth,
+            row_area,
+            RowStyleContext {
+                theme,
+                focused,
+                disabled,
+            },
         );
     }
 
@@ -108,20 +120,33 @@ pub(super) fn render_flame_graph(
     }
 }
 
+/// Root node information needed to compute proportional widths.
+struct FlameRootInfo<'a> {
+    view_root: &'a FlameNode,
+    root_total: u64,
+}
+
+/// Style context for rendering a flame graph row.
+struct RowStyleContext<'a> {
+    theme: &'a Theme,
+    focused: bool,
+    disabled: bool,
+}
+
 /// Renders a single depth row of the flame graph.
-#[allow(clippy::too_many_arguments)]
 fn render_depth_row(
     state: &FlameGraphState,
     frame: &mut Frame,
-    view_root: &FlameNode,
-    root_total: u64,
+    root: FlameRootInfo<'_>,
     depth: usize,
     area: Rect,
-    theme: &Theme,
-
-    focused: bool,
-    disabled: bool,
+    style_ctx: RowStyleContext<'_>,
 ) {
+    let view_root = root.view_root;
+    let root_total = root.root_total;
+    let theme = style_ctx.theme;
+    let focused = style_ctx.focused;
+    let disabled = style_ctx.disabled;
     let width = area.width as usize;
     if width == 0 {
         return;

--- a/src/component/heatmap/render.rs
+++ b/src/component/heatmap/render.rs
@@ -74,9 +74,11 @@ pub(super) fn render_heatmap(
             render_row_label(
                 state,
                 frame,
-                area.x,
-                y,
-                row_label_width,
+                LabelPosition {
+                    x: area.x,
+                    y,
+                    width: row_label_width,
+                },
                 ri,
                 theme,
                 disabled,
@@ -88,13 +90,15 @@ pub(super) fn render_heatmap(
             state,
             frame,
             ri,
-            grid_x,
-            y,
-            cell_width,
-            cell_height,
-            area,
-            min_val,
-            max_val,
+            CellRenderParams {
+                grid_x,
+                y,
+                cell_width,
+                cell_height,
+                area,
+                min_val,
+                max_val,
+            },
             theme,
             focused,
             disabled,
@@ -135,21 +139,25 @@ fn render_col_labels(
     }
 }
 
-/// Renders a single row label.
-#[allow(clippy::too_many_arguments)]
-fn render_row_label(
-    state: &HeatmapState,
-    frame: &mut Frame,
+/// Position and dimensions for rendering a row label.
+struct LabelPosition {
     x: u16,
     y: u16,
     width: u16,
+}
+
+/// Renders a single row label.
+fn render_row_label(
+    state: &HeatmapState,
+    frame: &mut Frame,
+    pos: LabelPosition,
     row_index: usize,
     theme: &Theme,
     disabled: bool,
 ) {
     if let Some(label) = state.row_labels().get(row_index) {
-        let label_area = Rect::new(x, y, width, 1);
-        let truncated = truncate_str(label, width as usize);
+        let label_area = Rect::new(pos.x, pos.y, pos.width, 1);
+        let truncated = truncate_str(label, pos.width as usize);
         let style = if disabled {
             theme.disabled_style()
         } else {
@@ -160,12 +168,8 @@ fn render_row_label(
     }
 }
 
-/// Renders all cells in a single row.
-#[allow(clippy::too_many_arguments)]
-fn render_row_cells(
-    state: &HeatmapState,
-    frame: &mut Frame,
-    ri: usize,
+/// Layout and value range parameters for rendering a row of heatmap cells.
+struct CellRenderParams {
     grid_x: u16,
     y: u16,
     cell_width: u16,
@@ -173,6 +177,14 @@ fn render_row_cells(
     area: Rect,
     min_val: f64,
     max_val: f64,
+}
+
+/// Renders all cells in a single row.
+fn render_row_cells(
+    state: &HeatmapState,
+    frame: &mut Frame,
+    ri: usize,
+    params: CellRenderParams,
     theme: &Theme,
     focused: bool,
     disabled: bool,
@@ -180,20 +192,20 @@ fn render_row_cells(
     let _ = theme; // reserved for future style customization
     let row_data = &state.data()[ri];
     for (ci, &value) in row_data.iter().enumerate() {
-        let x = grid_x + (ci as u16) * cell_width;
-        if x >= area.right() {
+        let x = params.grid_x + (ci as u16) * params.cell_width;
+        if x >= params.area.right() {
             break;
         }
-        let available_w = cell_width.min(area.right().saturating_sub(x));
+        let available_w = params.cell_width.min(params.area.right().saturating_sub(x));
         if available_w == 0 {
             continue;
         }
-        let cell_area = Rect::new(x, y, available_w, cell_height);
+        let cell_area = Rect::new(x, params.y, available_w, params.cell_height);
 
         let bg_color = if disabled {
             Color::DarkGray
         } else {
-            value_to_color(value, min_val, max_val, state.color_scale())
+            value_to_color(value, params.min_val, params.max_val, state.color_scale())
         };
 
         let is_selected = state.selected() == Some((ri, ci));

--- a/src/component/log_correlation/render.rs
+++ b/src/component/log_correlation/render.rs
@@ -128,34 +128,50 @@ fn render_streams(
         render_single_stream(
             state,
             stream,
-            i,
-            is_active,
-            &aligned_rows,
-            &filtered[i],
+            StreamViewState {
+                is_active,
+                focused,
+                disabled,
+            },
+            StreamViewData {
+                aligned_rows: &aligned_rows,
+                filtered_entries: &filtered[i],
+                stream_idx: i,
+            },
             frame,
             stream_area,
             theme,
-            focused,
-            disabled,
         );
     }
 }
 
+/// Focus and active state for rendering a stream panel.
+struct StreamViewState {
+    is_active: bool,
+    focused: bool,
+    disabled: bool,
+}
+
+/// Pre-computed view data for a stream panel.
+struct StreamViewData<'a> {
+    aligned_rows: &'a [super::AlignedRow],
+    filtered_entries: &'a [&'a super::CorrelationEntry],
+    stream_idx: usize,
+}
+
 /// Renders a single stream panel.
-#[allow(clippy::too_many_arguments)]
 fn render_single_stream(
     state: &LogCorrelationState,
     stream: &super::LogStream,
-    _stream_idx: usize,
-    is_active: bool,
-    aligned_rows: &[super::AlignedRow],
-    filtered_entries: &[&super::CorrelationEntry],
+    view_state: StreamViewState,
+    data: StreamViewData<'_>,
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
-    focused: bool,
-    disabled: bool,
 ) {
+    let is_active = view_state.is_active;
+    let focused = view_state.focused;
+    let disabled = view_state.disabled;
     if area.width < 2 || area.height < 2 {
         return;
     }
@@ -189,8 +205,8 @@ fn render_single_stream(
     // Build display lines from aligned rows
     let mut lines: Vec<Line<'_>> = Vec::new();
 
-    for row in aligned_rows {
-        let indices = &row.stream_entries[_stream_idx];
+    for row in data.aligned_rows {
+        let indices = &row.stream_entries[data.stream_idx];
         let max_across_streams = row
             .stream_entries
             .iter()
@@ -205,8 +221,8 @@ fn render_single_stream(
             }
         } else {
             for &idx in indices {
-                if idx < filtered_entries.len() {
-                    let entry = filtered_entries[idx];
+                if idx < data.filtered_entries.len() {
+                    let entry = data.filtered_entries[idx];
                     let line = format_entry(entry, inner.width as usize);
                     let style = if disabled {
                         theme.disabled_style()


### PR DESCRIPTION
## Summary

- Refactors render helper functions to use parameter structs instead of 8–13 argument lists.
- Removes all 10 `#[allow(clippy::too_many_arguments)]` suppressions from `src/component/` render code.
- Internal-only change — no public API modifications.
- All existing tests pass unchanged.

### Structs introduced (all private to their modules)

| File | Struct | Params absorbed |
|------|--------|----------------|
| `alert_panel/render.rs` | `MetricCardInput` | `metric`, `is_selected` |
| `chart/annotations.rs` | `AxisBounds` | `x_min`, `x_max`, `y_min`, `y_max`, `is_log` |
| `chart/error_bands.rs` | reuses `AxisBounds` | same 5 |
| `chart/render.rs` | reuses `AxisBounds` | same 5 (for area fill) |
| `code_block/render.rs` | `LineRenderConfig` | `is_highlighted`, `horizontal_offset` |
| `dependency_graph/render.rs` | `NodeRenderState` | `is_selected`, `focused`, `disabled` |
| `flame_graph/render.rs` | `FlameRootInfo` | `view_root`, `root_total` |
| `flame_graph/render.rs` | `RowStyleContext` | `theme`, `focused`, `disabled` |
| `heatmap/render.rs` | `LabelPosition` | `x`, `y`, `width` |
| `heatmap/render.rs` | `CellRenderParams` | `grid_x`, `y`, `cell_width`, `cell_height`, `area`, `min_val`, `max_val` |
| `log_correlation/render.rs` | `StreamViewState` | `is_active`, `focused`, `disabled` |
| `log_correlation/render.rs` | `StreamViewData` | `aligned_rows`, `filtered_entries`, `stream_idx` |

## Test plan

- [x] `cargo nextest run -p envision` — all 7,155 tests pass
- [x] `cargo test --doc -p envision` — all 1,820 doc tests pass
- [x] `cargo clippy -p envision -- -D warnings` — no warnings, no suppressions
- [x] `cargo fmt` — no diffs
- [x] Zero `too_many_arguments` suppressions remaining in `src/component/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)