### PR TITLE
Add doc tests to 9 components below 50% coverage

### DIFF
--- a/src/component/accordion/mod.rs
+++ b/src/component/accordion/mod.rs
@@ -107,16 +107,46 @@ impl AccordionPanel {
     }
 
     /// Returns the panel title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::AccordionPanel;
+    ///
+    /// let panel = AccordionPanel::new("Overview", "Details here");
+    /// assert_eq!(panel.title(), "Overview");
+    /// ```
     pub fn title(&self) -> &str {
         &self.title
     }
 
     /// Returns the panel content.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::AccordionPanel;
+    ///
+    /// let panel = AccordionPanel::new("Title", "My content");
+    /// assert_eq!(panel.content(), "My content");
+    /// ```
     pub fn content(&self) -> &str {
         &self.content
     }
 
     /// Returns whether the panel is expanded.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::AccordionPanel;
+    ///
+    /// let collapsed = AccordionPanel::new("Title", "Content");
+    /// assert!(!collapsed.is_expanded());
+    ///
+    /// let expanded = AccordionPanel::new("Title", "Content").expanded();
+    /// assert!(expanded.is_expanded());
+    /// ```
     pub fn is_expanded(&self) -> bool {
         self.expanded
     }
@@ -233,21 +263,57 @@ impl AccordionState {
     }
 
     /// Returns the number of panels.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::AccordionState;
+    ///
+    /// let state = AccordionState::from_pairs(vec![("A", "1"), ("B", "2")]);
+    /// assert_eq!(state.len(), 2);
+    /// ```
     pub fn len(&self) -> usize {
         self.panels.len()
     }
 
     /// Returns true if there are no panels.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::AccordionState;
+    ///
+    /// let empty = AccordionState::new(vec![]);
+    /// assert!(empty.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.panels.is_empty()
     }
 
     /// Returns the currently focused panel index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::AccordionState;
+    ///
+    /// let state = AccordionState::from_pairs(vec![("A", "1"), ("B", "2")]).with_focused_index(1);
+    /// assert_eq!(state.focused_index(), 1);
+    /// ```
     pub fn focused_index(&self) -> usize {
         self.focused_index
     }
 
     /// Returns the currently focused panel.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::AccordionState;
+    ///
+    /// let state = AccordionState::from_pairs(vec![("Intro", "Introduction text")]);
+    /// assert_eq!(state.focused_panel().unwrap().title(), "Intro");
+    /// ```
     pub fn focused_panel(&self) -> Option<&AccordionPanel> {
         self.panels.get(self.focused_index)
     }
@@ -282,6 +348,18 @@ impl AccordionState {
     ///
     /// This is an alias for [`selected_index()`](Self::selected_index) that provides a
     /// consistent accessor name across all selection-based components.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::AccordionState;
+    ///
+    /// let state = AccordionState::from_pairs(vec![("A", "1"), ("B", "2")]);
+    /// assert_eq!(state.selected(), Some(0));
+    ///
+    /// let empty = AccordionState::new(vec![]);
+    /// assert_eq!(empty.selected(), None);
+    /// ```
     pub fn selected(&self) -> Option<usize> {
         self.selected_index()
     }
@@ -309,6 +387,19 @@ impl AccordionState {
     }
 
     /// Sets new panels, resetting the focused index if needed.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{AccordionPanel, AccordionState};
+    ///
+    /// let mut state = AccordionState::from_pairs(vec![("A", "1")]);
+    /// state.set_panels(vec![
+    ///     AccordionPanel::new("X", "10"),
+    ///     AccordionPanel::new("Y", "20"),
+    /// ]);
+    /// assert_eq!(state.len(), 2);
+    /// ```
     pub fn set_panels(&mut self, panels: Vec<AccordionPanel>) {
         self.panels = panels;
         if self.focused_index >= self.panels.len() && !self.panels.is_empty() {
@@ -317,6 +408,16 @@ impl AccordionState {
     }
 
     /// Adds a panel to the accordion.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{AccordionPanel, AccordionState};
+    ///
+    /// let mut state = AccordionState::from_pairs(vec![("A", "1")]);
+    /// state.add_panel(AccordionPanel::new("B", "2"));
+    /// assert_eq!(state.len(), 2);
+    /// ```
     pub fn add_panel(&mut self, panel: AccordionPanel) {
         self.panels.push(panel);
     }
@@ -326,6 +427,16 @@ impl AccordionState {
     /// If the index is out of bounds, this is a no-op.
     /// Adjusts the focused index after removal so it remains valid.
     /// If the accordion becomes empty, the focused index is reset to 0.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::AccordionState;
+    ///
+    /// let mut state = AccordionState::from_pairs(vec![("A", "1"), ("B", "2"), ("C", "3")]);
+    /// state.remove_panel(1);
+    /// assert_eq!(state.len(), 2);
+    /// ```
     pub fn remove_panel(&mut self, index: usize) {
         if index >= self.panels.len() {
             return;
@@ -414,6 +525,17 @@ impl AccordionState {
     }
 
     /// Updates the accordion state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{AccordionMessage, AccordionOutput, AccordionState};
+    ///
+    /// let mut state = AccordionState::from_pairs(vec![("A", "1"), ("B", "2")]);
+    /// let output = state.update(AccordionMessage::Toggle);
+    /// assert_eq!(output, Some(AccordionOutput::Expanded(0)));
+    /// assert!(state.panels()[0].is_expanded());
+    /// ```
     pub fn update(&mut self, msg: AccordionMessage) -> Option<AccordionOutput> {
         Accordion::update(self, msg)
     }

--- a/src/component/data_grid/mod.rs
+++ b/src/component/data_grid/mod.rs
@@ -267,16 +267,73 @@ impl<T: TableRow> DataGridState<T> {
     }
 
     /// Alias for [`selected_index()`](Self::selected_index).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{DataGridState, TableRow, Column};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = DataGridState::new(
+    ///     vec![Item { name: "A".into() }],
+    ///     vec![Column::new("Name", Constraint::Min(10))],
+    /// );
+    /// assert_eq!(state.selected(), Some(0));
+    /// ```
     pub fn selected(&self) -> Option<usize> {
         self.selected_index()
     }
 
     /// Returns a reference to the currently selected row.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{DataGridState, TableRow, Column};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = DataGridState::new(
+    ///     vec![Item { name: "Alice".into() }],
+    ///     vec![Column::new("Name", Constraint::Min(10))],
+    /// );
+    /// assert_eq!(state.selected_row().unwrap().name, "Alice");
+    /// ```
     pub fn selected_row(&self) -> Option<&T> {
         self.selected_row.and_then(|i| self.rows.get(i))
     }
 
     /// Returns a reference to the currently selected item.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{DataGridState, TableRow, Column};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = DataGridState::new(
+    ///     vec![Item { name: "Bob".into() }],
+    ///     vec![Column::new("Name", Constraint::Min(10))],
+    /// );
+    /// assert_eq!(state.selected_item().unwrap().name, "Bob");
+    /// ```
     pub fn selected_item(&self) -> Option<&T> {
         self.selected_row()
     }
@@ -351,11 +408,49 @@ impl<T: TableRow> DataGridState<T> {
     }
 
     /// Returns the current editor value (while editing).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{DataGridState, TableRow, Column};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = DataGridState::new(
+    ///     vec![Item { name: "A".into() }],
+    ///     vec![Column::new("Name", Constraint::Min(10))],
+    /// );
+    /// assert_eq!(state.editor_value(), "");
+    /// ```
     pub fn editor_value(&self) -> &str {
         self.editor.value()
     }
 
     /// Returns the value of the currently selected cell.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{DataGridState, TableRow, Column};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = DataGridState::new(
+    ///     vec![Item { name: "Alice".into() }],
+    ///     vec![Column::new("Name", Constraint::Min(10))],
+    /// );
+    /// assert_eq!(state.current_cell_value(), Some("Alice".to_string()));
+    /// ```
     pub fn current_cell_value(&self) -> Option<String> {
         self.selected_row
             .and_then(|ri| self.rows.get(ri))
@@ -437,6 +532,26 @@ impl<T: TableRow> DataGridState<T> {
     }
 
     /// Sets the rows, resetting selection and cancelling any edit.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{DataGridState, TableRow, Column};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let mut state = DataGridState::new(
+    ///     vec![Item { name: "A".into() }],
+    ///     vec![Column::new("Name", Constraint::Min(10))],
+    /// );
+    /// state.set_rows(vec![Item { name: "X".into() }, Item { name: "Y".into() }]);
+    /// assert_eq!(state.row_count(), 2);
+    /// ```
     pub fn set_rows(&mut self, rows: Vec<T>) {
         self.editing = false;
         self.rows = rows;

--- a/src/component/line_input/mod.rs
+++ b/src/component/line_input/mod.rs
@@ -159,6 +159,15 @@ impl LineInputState {
     }
 
     /// Sets the maximum number of history entries (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LineInputState;
+    ///
+    /// let state = LineInputState::new().with_max_history(20);
+    /// assert_eq!(state.max_history(), 20);
+    /// ```
     pub fn with_max_history(mut self, max: usize) -> Self {
         self.history = History::new(max);
         self
@@ -247,6 +256,15 @@ impl LineInputState {
     }
 
     /// Returns the cursor byte offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LineInputState;
+    ///
+    /// let state = LineInputState::with_value("hello");
+    /// assert_eq!(state.cursor_byte_offset(), 5);
+    /// ```
     pub fn cursor_byte_offset(&self) -> usize {
         self.cursor
     }
@@ -254,6 +272,17 @@ impl LineInputState {
     /// Returns the cursor as a (row, col) visual position.
     ///
     /// Uses the last known display width from the parent layout.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LineInputState;
+    ///
+    /// let state = LineInputState::with_value("hi");
+    /// let (row, col) = state.cursor_visual_position();
+    /// assert_eq!(row, 0);
+    /// assert_eq!(col, 2);
+    /// ```
     pub fn cursor_visual_position(&self) -> (usize, usize) {
         cursor_to_visual(&self.buffer, self.cursor, self.last_display_width)
     }
@@ -262,11 +291,30 @@ impl LineInputState {
     ///
     /// The parent layout should call this before event dispatch so that
     /// Up/Down navigation and rendering use the correct width.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LineInputState;
+    ///
+    /// let mut state = LineInputState::new();
+    /// state.set_display_width(40);
+    /// assert_eq!(state.display_width(), 40);
+    /// ```
     pub fn set_display_width(&mut self, width: usize) {
         self.last_display_width = width;
     }
 
     /// Returns the current display width.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LineInputState;
+    ///
+    /// let state = LineInputState::new();
+    /// assert_eq!(state.display_width(), 80);
+    /// ```
     pub fn display_width(&self) -> usize {
         self.last_display_width
     }
@@ -311,16 +359,45 @@ impl LineInputState {
     /// Sets the maximum character length. `None` means unlimited.
     ///
     /// Does not truncate existing content -- only constrains future edits.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LineInputState;
+    ///
+    /// let mut state = LineInputState::new();
+    /// state.set_max_length(Some(25));
+    /// assert_eq!(state.max_length(), Some(25));
+    /// ```
     pub fn set_max_length(&mut self, max: Option<usize>) {
         self.max_length = max;
     }
 
     /// Returns the placeholder text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LineInputState;
+    ///
+    /// let state = LineInputState::new().with_placeholder("Search...");
+    /// assert_eq!(state.placeholder(), "Search...");
+    /// ```
     pub fn placeholder(&self) -> &str {
         &self.placeholder
     }
 
     /// Sets the placeholder text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LineInputState;
+    ///
+    /// let mut state = LineInputState::new();
+    /// state.set_placeholder("Enter your name");
+    /// assert_eq!(state.placeholder(), "Enter your name");
+    /// ```
     pub fn set_placeholder(&mut self, placeholder: impl Into<String>) {
         self.placeholder = placeholder.into();
     }
@@ -357,26 +434,80 @@ impl LineInputState {
     }
 
     /// Returns the history entries.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{LineInputState, LineInputMessage};
+    ///
+    /// let mut state = LineInputState::new();
+    /// state.update(LineInputMessage::SetValue("command one".into()));
+    /// state.update(LineInputMessage::Submit);
+    /// assert_eq!(state.history_entries(), &["command one"]);
+    /// ```
     pub fn history_entries(&self) -> &[String] {
         self.history.entries()
     }
 
     /// Returns the number of history entries.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{LineInputState, LineInputMessage};
+    ///
+    /// let mut state = LineInputState::new();
+    /// assert_eq!(state.history_count(), 0);
+    /// state.update(LineInputMessage::SetValue("cmd".into()));
+    /// state.update(LineInputMessage::Submit);
+    /// assert_eq!(state.history_count(), 1);
+    /// ```
     pub fn history_count(&self) -> usize {
         self.history.count()
     }
 
     /// Returns true if currently browsing history.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LineInputState;
+    ///
+    /// let state = LineInputState::new();
+    /// assert!(!state.is_browsing_history());
+    /// ```
     pub fn is_browsing_history(&self) -> bool {
         self.history.is_browsing()
     }
 
     /// Returns true if there are entries to undo.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{LineInputState, LineInputMessage};
+    ///
+    /// let mut state = LineInputState::new();
+    /// assert!(!state.can_undo());
+    /// state.update(LineInputMessage::Insert('a'));
+    /// assert!(state.can_undo());
+    /// ```
     pub fn can_undo(&self) -> bool {
         self.undo_stack.can_undo()
     }
 
     /// Returns true if there are entries to redo.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{LineInputState, LineInputMessage};
+    ///
+    /// let mut state = LineInputState::new();
+    /// state.update(LineInputMessage::Insert('a'));
+    /// state.update(LineInputMessage::Undo);
+    /// assert!(state.can_redo());
+    /// ```
     pub fn can_redo(&self) -> bool {
         self.undo_stack.can_redo()
     }
@@ -396,6 +527,16 @@ impl LineInputState {
     }
 
     /// Returns the selected byte range `(start, end)`, or `None`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{LineInputState, LineInputMessage};
+    ///
+    /// let mut state = LineInputState::with_value("hello");
+    /// state.update(LineInputMessage::SelectAll);
+    /// assert_eq!(state.selection_range(), Some((0, 5)));
+    /// ```
     pub fn selection_range(&self) -> Option<(usize, usize)> {
         let anchor = self.selection_anchor?;
         let start = anchor.min(self.cursor);
@@ -408,12 +549,33 @@ impl LineInputState {
     }
 
     /// Returns the selected text, or `None` if no selection.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{LineInputState, LineInputMessage};
+    ///
+    /// let mut state = LineInputState::with_value("hello");
+    /// state.update(LineInputMessage::SelectAll);
+    /// assert_eq!(state.selected_text(), Some("hello"));
+    /// ```
     pub fn selected_text(&self) -> Option<&str> {
         let (start, end) = self.selection_range()?;
         Some(&self.buffer[start..end])
     }
 
     /// Returns the internal clipboard contents.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{LineInputState, LineInputMessage};
+    ///
+    /// let mut state = LineInputState::with_value("hello");
+    /// state.update(LineInputMessage::SelectAll);
+    /// state.update(LineInputMessage::Copy);
+    /// assert_eq!(state.clipboard(), "hello");
+    /// ```
     pub fn clipboard(&self) -> &str {
         &self.clipboard
     }

--- a/src/component/menu/mod.rs
+++ b/src/component/menu/mod.rs
@@ -43,16 +43,47 @@ pub struct MenuItem {
 
 impl MenuItem {
     /// Returns the item label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MenuItem;
+    ///
+    /// let item = MenuItem::new("Edit");
+    /// assert_eq!(item.label(), "Edit");
+    /// ```
     pub fn label(&self) -> &str {
         &self.label
     }
 
     /// Returns whether the item is enabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MenuItem;
+    ///
+    /// let enabled = MenuItem::new("File");
+    /// assert!(enabled.is_enabled());
+    ///
+    /// let disabled = MenuItem::disabled("Save");
+    /// assert!(!disabled.is_enabled());
+    /// ```
     pub fn is_enabled(&self) -> bool {
         self.enabled
     }
 
     /// Sets the item label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MenuItem;
+    ///
+    /// let mut item = MenuItem::new("File");
+    /// item.set_label("Edit");
+    /// assert_eq!(item.label(), "Edit");
+    /// ```
     pub fn set_label(&mut self, label: impl Into<String>) {
         self.label = label.into();
     }
@@ -93,6 +124,16 @@ impl MenuItem {
     }
 
     /// Sets whether this item is enabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MenuItem;
+    ///
+    /// let mut item = MenuItem::new("Save");
+    /// item.set_enabled(false);
+    /// assert!(!item.is_enabled());
+    /// ```
     pub fn set_enabled(&mut self, enabled: bool) {
         self.enabled = enabled;
     }
@@ -177,6 +218,16 @@ impl MenuState {
     ///
     /// Resets selection to the first item if the current selection is out of bounds.
     /// Sets selection to `None` if the new items list is empty.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{MenuState, MenuItem};
+    ///
+    /// let mut state = MenuState::new(vec![MenuItem::new("File")]);
+    /// state.set_items(vec![MenuItem::new("A"), MenuItem::new("B"), MenuItem::new("C")]);
+    /// assert_eq!(state.items().len(), 3);
+    /// ```
     pub fn set_items(&mut self, items: Vec<MenuItem>) {
         self.items = items;
         if self.items.is_empty() {
@@ -189,6 +240,16 @@ impl MenuState {
     /// Adds a menu item.
     ///
     /// If this is the first item, it becomes selected.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{MenuState, MenuItem};
+    ///
+    /// let mut state = MenuState::new(vec![MenuItem::new("File")]);
+    /// state.add_item(MenuItem::new("Edit"));
+    /// assert_eq!(state.items().len(), 2);
+    /// ```
     pub fn add_item(&mut self, item: MenuItem) {
         self.items.push(item);
         if self.selected_index.is_none() {
@@ -203,6 +264,20 @@ impl MenuState {
     /// - If the removed item was the selected item, selects the previous item
     ///   (or the first if at the beginning).
     /// - If the menu becomes empty, selection becomes `None`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{MenuState, MenuItem};
+    ///
+    /// let mut state = MenuState::new(vec![
+    ///     MenuItem::new("File"),
+    ///     MenuItem::new("Edit"),
+    ///     MenuItem::new("View"),
+    /// ]);
+    /// state.remove_item(1);
+    /// assert_eq!(state.items().len(), 2);
+    /// ```
     pub fn remove_item(&mut self, index: usize) {
         if index >= self.items.len() {
             return;
@@ -237,6 +312,15 @@ impl MenuState {
     }
 
     /// Alias for [`selected_index()`](Self::selected_index).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{MenuState, MenuItem};
+    ///
+    /// let state = MenuState::new(vec![MenuItem::new("File"), MenuItem::new("Edit")]);
+    /// assert_eq!(state.selected(), Some(0));
+    /// ```
     pub fn selected(&self) -> Option<usize> {
         self.selected_index()
     }
@@ -246,6 +330,20 @@ impl MenuState {
     /// Pass `Some(index)` to select an item (clamped to valid range), or
     /// `None` to clear the selection. Has no effect on an empty menu when
     /// selecting.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{MenuState, MenuItem};
+    ///
+    /// let mut state = MenuState::new(vec![
+    ///     MenuItem::new("File"),
+    ///     MenuItem::new("Edit"),
+    ///     MenuItem::new("View"),
+    /// ]);
+    /// state.set_selected(Some(2));
+    /// assert_eq!(state.selected_index(), Some(2));
+    /// ```
     pub fn set_selected(&mut self, index: Option<usize>) {
         match index {
             Some(i) => {
@@ -294,6 +392,19 @@ impl MenuState {
     }
 
     /// Updates the menu state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{MenuMessage, MenuOutput, MenuState, MenuItem};
+    ///
+    /// let mut state = MenuState::new(vec![
+    ///     MenuItem::new("File"),
+    ///     MenuItem::new("Edit"),
+    /// ]);
+    /// let output = state.update(MenuMessage::Right);
+    /// assert_eq!(output, Some(MenuOutput::SelectionChanged(1)));
+    /// ```
     pub fn update(&mut self, msg: MenuMessage) -> Option<MenuOutput> {
         Menu::update(self, msg)
     }

--- a/src/component/progress_bar/mod.rs
+++ b/src/component/progress_bar/mod.rs
@@ -157,6 +157,15 @@ impl ProgressBarState {
     }
 
     /// Returns the current progress value (0.0 to 1.0).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressBarState;
+    ///
+    /// let state = ProgressBarState::with_progress(0.75);
+    /// assert_eq!(state.progress(), 0.75);
+    /// ```
     pub fn progress(&self) -> f32 {
         self.progress
     }
@@ -170,31 +179,94 @@ impl ProgressBarState {
     /// Sets the progress value.
     ///
     /// The value is clamped to the range 0.0..=1.0.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressBarState;
+    ///
+    /// let mut state = ProgressBarState::new();
+    /// state.set_progress(0.6);
+    /// assert_eq!(state.percentage(), 60);
+    /// ```
     pub fn set_progress(&mut self, progress: f32) {
         self.progress = progress.clamp(0.0, 1.0);
     }
 
     /// Returns true if the progress is complete (>= 1.0).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressBarState;
+    ///
+    /// let mut state = ProgressBarState::with_progress(1.0);
+    /// assert!(state.is_complete());
+    ///
+    /// let partial = ProgressBarState::with_progress(0.5);
+    /// assert!(!partial.is_complete());
+    /// ```
     pub fn is_complete(&self) -> bool {
         self.progress >= 1.0
     }
 
     /// Returns the label if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressBarState;
+    ///
+    /// let state = ProgressBarState::with_label("Uploading...");
+    /// assert_eq!(state.label(), Some("Uploading..."));
+    ///
+    /// let unlabeled = ProgressBarState::new();
+    /// assert_eq!(unlabeled.label(), None);
+    /// ```
     pub fn label(&self) -> Option<&str> {
         self.label.as_deref()
     }
 
     /// Sets the label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressBarState;
+    ///
+    /// let mut state = ProgressBarState::new();
+    /// state.set_label(Some("Loading...".to_string()));
+    /// assert_eq!(state.label(), Some("Loading..."));
+    /// ```
     pub fn set_label(&mut self, label: Option<String>) {
         self.label = label;
     }
 
     /// Returns true if the progress bar is disabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressBarState;
+    ///
+    /// let state = ProgressBarState::new();
+    /// assert!(!state.is_disabled());
+    /// ```
     pub fn is_disabled(&self) -> bool {
         self.disabled
     }
 
     /// Sets the disabled state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressBarState;
+    ///
+    /// let mut state = ProgressBarState::new();
+    /// state.set_disabled(true);
+    /// assert!(state.is_disabled());
+    /// ```
     pub fn set_disabled(&mut self, disabled: bool) {
         self.disabled = disabled;
     }
@@ -327,26 +399,79 @@ impl ProgressBarState {
     }
 
     /// Returns the ETA as a `Duration`, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use std::time::Duration;
+    /// use envision::component::ProgressBarState;
+    ///
+    /// let mut state = ProgressBarState::new();
+    /// state.set_eta(Some(Duration::from_secs(30)));
+    /// assert_eq!(state.eta(), Some(Duration::from_secs(30)));
+    /// ```
     pub fn eta(&self) -> Option<Duration> {
         self.eta_millis.map(Duration::from_millis)
     }
 
     /// Returns the ETA in milliseconds, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use std::time::Duration;
+    /// use envision::component::ProgressBarState;
+    ///
+    /// let mut state = ProgressBarState::new();
+    /// state.set_eta(Some(Duration::from_millis(5000)));
+    /// assert_eq!(state.eta_millis(), Some(5000));
+    /// ```
     pub fn eta_millis(&self) -> Option<u64> {
         self.eta_millis
     }
 
     /// Returns the rate text, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressBarState;
+    ///
+    /// let mut state = ProgressBarState::new();
+    /// state.set_rate_text(Some("5.2 MB/s".to_string()));
+    /// assert_eq!(state.rate_text(), Some("5.2 MB/s"));
+    /// ```
     pub fn rate_text(&self) -> Option<&str> {
         self.rate_text.as_deref()
     }
 
     /// Sets the ETA.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use std::time::Duration;
+    /// use envision::component::ProgressBarState;
+    ///
+    /// let mut state = ProgressBarState::new();
+    /// state.set_eta(Some(Duration::from_secs(60)));
+    /// assert_eq!(state.eta_millis(), Some(60_000));
+    /// ```
     pub fn set_eta(&mut self, eta: Option<Duration>) {
         self.eta_millis = eta.map(|d| d.as_millis() as u64);
     }
 
     /// Sets the rate text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressBarState;
+    ///
+    /// let mut state = ProgressBarState::new();
+    /// state.set_rate_text(Some("100 items/s".to_string()));
+    /// assert_eq!(state.rate_text(), Some("100 items/s"));
+    /// ```
     pub fn set_rate_text(&mut self, rate_text: Option<String>) {
         self.rate_text = rate_text;
     }

--- a/src/component/table/mod.rs
+++ b/src/component/table/mod.rs
@@ -163,6 +163,26 @@ impl<T: TableRow> TableState<T> {
     /// Creates a table state with a specific row selected.
     ///
     /// The index is clamped to the valid range.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Column, TableRow, TableState};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = TableState::with_selected(
+    ///     vec![Item { name: "A".into() }, Item { name: "B".into() }],
+    ///     vec![Column::new("Name", Constraint::Length(10))],
+    ///     1,
+    /// );
+    /// assert_eq!(state.selected_index(), Some(1));
+    /// ```
     pub fn with_selected(rows: Vec<T>, columns: Vec<Column>, selected: usize) -> Self {
         let display_order: Vec<usize> = (0..rows.len()).collect();
         let selected = if rows.is_empty() {
@@ -238,6 +258,25 @@ impl<T: TableRow> TableState<T> {
     }
 
     /// Alias for [`selected_index()`](Self::selected_index).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Column, TableRow, TableState};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = TableState::new(
+    ///     vec![Item { name: "A".into() }],
+    ///     vec![Column::fixed("Name", 10)],
+    /// );
+    /// assert_eq!(state.selected(), Some(0));
+    /// ```
     pub fn selected(&self) -> Option<usize> {
         self.selected_index()
     }
@@ -273,6 +312,24 @@ impl<T: TableRow> TableState<T> {
     ///
     /// This is an alias for [`selected_row()`](Self::selected_row) that provides a
     /// consistent accessor name across all selection-based components.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Column, TableRow, TableState};
+    ///
+    /// #[derive(Clone, Debug, PartialEq)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = TableState::new(
+    ///     vec![Item { name: "First".into() }],
+    ///     vec![Column::fixed("Name", 10)],
+    /// );
+    /// assert_eq!(state.selected_item().unwrap().name, "First");
+    /// ```
     pub fn selected_item(&self) -> Option<&T> {
         self.selected_row()
     }
@@ -311,6 +368,25 @@ impl<T: TableRow> TableState<T> {
     ///
     /// The first element is the primary sort, the second is the
     /// first tiebreaker, and so on.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Column, Table, TableMessage, TableRow, TableState, Component};
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let mut state = TableState::new(
+    ///     vec![Item { name: "B".into() }, Item { name: "A".into() }],
+    ///     vec![Column::fixed("Name", 10).sortable()],
+    /// );
+    /// Table::<Item>::update(&mut state, TableMessage::SortBy(0));
+    /// assert_eq!(state.sort_columns().len(), 1);
+    /// ```
     pub fn sort_columns(&self) -> &[(usize, SortDirection)] {
         &self.sort_columns
     }
@@ -340,6 +416,21 @@ impl<T: TableRow> TableState<T> {
     }
 
     /// Returns `true` if the table has no rows.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Column, TableRow, TableState};
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let empty: TableState<Item> = TableState::default();
+    /// assert!(empty.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.rows.is_empty()
     }
@@ -348,6 +439,25 @@ impl<T: TableRow> TableState<T> {
     ///
     /// If there were rows selected, the selection is preserved if valid,
     /// otherwise clamped to the last row.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Column, TableRow, TableState};
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let mut state = TableState::new(
+    ///     vec![Item { name: "A".into() }],
+    ///     vec![Column::fixed("Name", 10)],
+    /// );
+    /// state.set_rows(vec![Item { name: "X".into() }, Item { name: "Y".into() }]);
+    /// assert_eq!(state.len(), 2);
+    /// ```
     pub fn set_rows(&mut self, rows: Vec<T>) {
         self.rows = rows;
         self.filter_text.clear();
@@ -457,6 +567,27 @@ impl<T: TableRow> TableState<T> {
     }
 
     /// Clears the filter, showing all rows.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Column, TableRow, TableState};
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let mut state = TableState::new(
+    ///     vec![Item { name: "Alice".into() }, Item { name: "Bob".into() }],
+    ///     vec![Column::fixed("Name", 10)],
+    /// );
+    /// state.set_filter_text("Alice");
+    /// assert_eq!(state.visible_count(), 1);
+    /// state.clear_filter();
+    /// assert_eq!(state.visible_count(), 2);
+    /// ```
     pub fn clear_filter(&mut self) {
         self.filter_text.clear();
         self.rebuild_display_order();

--- a/src/component/toast/mod.rs
+++ b/src/component/toast/mod.rs
@@ -81,26 +81,76 @@ pub struct ToastItem {
 
 impl ToastItem {
     /// Returns the toast's unique identifier.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ToastState;
+    ///
+    /// let mut state = ToastState::new();
+    /// let id = state.info("Hello");
+    /// assert_eq!(state.toasts()[0].id(), id);
+    /// ```
     pub fn id(&self) -> u64 {
         self.id
     }
 
     /// Returns the toast message.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ToastState;
+    ///
+    /// let mut state = ToastState::new();
+    /// state.info("Hello, world!");
+    /// assert_eq!(state.toasts()[0].message(), "Hello, world!");
+    /// ```
     pub fn message(&self) -> &str {
         &self.message
     }
 
     /// Returns the severity level.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ToastState, ToastLevel};
+    ///
+    /// let mut state = ToastState::new();
+    /// state.error("Something went wrong");
+    /// assert_eq!(state.toasts()[0].level(), ToastLevel::Error);
+    /// ```
     pub fn level(&self) -> ToastLevel {
         self.level
     }
 
     /// Returns true if this toast is persistent (no auto-dismiss).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ToastState;
+    ///
+    /// let mut state = ToastState::new();
+    /// state.info("Persistent toast");
+    /// assert!(state.toasts()[0].is_persistent());
+    /// ```
     pub fn is_persistent(&self) -> bool {
         self.remaining_ms.is_none()
     }
 
     /// Returns the remaining duration in milliseconds, if any.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ToastState;
+    ///
+    /// let mut state = ToastState::with_duration(5000);
+    /// state.info("Timed toast");
+    /// assert_eq!(state.toasts()[0].remaining_ms(), Some(5000));
+    /// ```
     pub fn remaining_ms(&self) -> Option<u64> {
         self.remaining_ms
     }
@@ -221,36 +271,107 @@ impl ToastState {
     }
 
     /// Returns all active toasts.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ToastState;
+    ///
+    /// let mut state = ToastState::new();
+    /// state.info("First");
+    /// state.error("Second");
+    /// assert_eq!(state.toasts().len(), 2);
+    /// ```
     pub fn toasts(&self) -> &[ToastItem] {
         &self.toasts
     }
 
     /// Returns the number of active toasts.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ToastState;
+    ///
+    /// let mut state = ToastState::new();
+    /// assert_eq!(state.len(), 0);
+    /// state.info("Hello");
+    /// assert_eq!(state.len(), 1);
+    /// ```
     pub fn len(&self) -> usize {
         self.toasts.len()
     }
 
     /// Returns true if there are no active toasts.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ToastState;
+    ///
+    /// let mut state = ToastState::new();
+    /// assert!(state.is_empty());
+    /// state.success("Done!");
+    /// assert!(!state.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.toasts.is_empty()
     }
 
     /// Returns the default duration for new toasts.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ToastState;
+    ///
+    /// let state = ToastState::new();
+    /// assert_eq!(state.default_duration(), None);
+    /// ```
     pub fn default_duration(&self) -> Option<u64> {
         self.default_duration_ms
     }
 
     /// Returns the maximum number of visible toasts.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ToastState;
+    ///
+    /// let state = ToastState::new();
+    /// assert_eq!(state.max_visible(), 5);
+    /// ```
     pub fn max_visible(&self) -> usize {
         self.max_visible
     }
 
     /// Sets the default duration for new toasts.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ToastState;
+    ///
+    /// let mut state = ToastState::new();
+    /// state.set_default_duration(Some(2000));
+    /// assert_eq!(state.default_duration(), Some(2000));
+    /// ```
     pub fn set_default_duration(&mut self, duration_ms: Option<u64>) {
         self.default_duration_ms = duration_ms;
     }
 
     /// Sets the maximum number of visible toasts.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ToastState;
+    ///
+    /// let mut state = ToastState::new();
+    /// state.set_max_visible(3);
+    /// assert_eq!(state.max_visible(), 3);
+    /// ```
     pub fn set_max_visible(&mut self, max: usize) {
         self.max_visible = max;
     }

--- a/src/component/tooltip/mod.rs
+++ b/src/component/tooltip/mod.rs
@@ -276,11 +276,32 @@ impl TooltipState {
     }
 
     /// Returns whether the tooltip is visible.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TooltipState;
+    ///
+    /// let state = TooltipState::new("Help text");
+    /// assert!(!state.is_visible());
+    ///
+    /// let visible = TooltipState::new("Help text").with_visible(true);
+    /// assert!(visible.is_visible());
+    /// ```
     pub fn is_visible(&self) -> bool {
         self.visible
     }
 
     /// Returns the auto-hide duration in milliseconds.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TooltipState;
+    ///
+    /// let state = TooltipState::new("Content").with_duration(2000);
+    /// assert_eq!(state.duration_ms(), Some(2000));
+    /// ```
     pub fn duration_ms(&self) -> Option<u64> {
         self.duration_ms
     }
@@ -305,56 +326,169 @@ impl TooltipState {
     }
 
     /// Returns the remaining time before auto-hide.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Tooltip, TooltipMessage, TooltipState, Component};
+    ///
+    /// let mut state = TooltipState::new("Content").with_duration(5000);
+    /// Tooltip::update(&mut state, TooltipMessage::Show);
+    /// assert_eq!(state.remaining_ms(), Some(5000));
+    /// ```
     pub fn remaining_ms(&self) -> Option<u64> {
         self.remaining_ms
     }
 
     /// Returns the foreground color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TooltipState;
+    /// use ratatui::style::Color;
+    ///
+    /// let state = TooltipState::new("Content").with_fg_color(Color::Cyan);
+    /// assert_eq!(state.fg_color(), Color::Cyan);
+    /// ```
     pub fn fg_color(&self) -> Color {
         self.fg_color
     }
 
     /// Returns the background color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TooltipState;
+    /// use ratatui::style::Color;
+    ///
+    /// let state = TooltipState::new("Content").with_bg_color(Color::Blue);
+    /// assert_eq!(state.bg_color(), Color::Blue);
+    /// ```
     pub fn bg_color(&self) -> Color {
         self.bg_color
     }
 
     /// Returns the border color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TooltipState;
+    /// use ratatui::style::Color;
+    ///
+    /// let state = TooltipState::new("Content").with_border_color(Color::Green);
+    /// assert_eq!(state.border_color(), Color::Green);
+    /// ```
     pub fn border_color(&self) -> Color {
         self.border_color
     }
 
     /// Sets the tooltip content.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TooltipState;
+    ///
+    /// let mut state = TooltipState::new("Old content");
+    /// state.set_content("New content");
+    /// assert_eq!(state.content(), "New content");
+    /// ```
     pub fn set_content(&mut self, content: impl Into<String>) {
         self.content = content.into();
     }
 
     /// Sets the tooltip title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TooltipState;
+    ///
+    /// let mut state = TooltipState::new("Content");
+    /// state.set_title(Some("Hint".to_string()));
+    /// assert_eq!(state.title(), Some("Hint"));
+    /// ```
     pub fn set_title(&mut self, title: Option<String>) {
         self.title = title;
     }
 
     /// Sets the preferred position.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TooltipState, TooltipPosition};
+    ///
+    /// let mut state = TooltipState::new("Content");
+    /// state.set_position(TooltipPosition::Right);
+    /// assert_eq!(state.position(), TooltipPosition::Right);
+    /// ```
     pub fn set_position(&mut self, position: TooltipPosition) {
         self.position = position;
     }
 
     /// Sets the auto-hide duration.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TooltipState;
+    ///
+    /// let mut state = TooltipState::new("Content");
+    /// state.set_duration(Some(3000));
+    /// assert_eq!(state.duration_ms(), Some(3000));
+    /// ```
     pub fn set_duration(&mut self, duration_ms: Option<u64>) {
         self.duration_ms = duration_ms;
     }
 
     /// Sets the foreground color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TooltipState;
+    /// use ratatui::style::Color;
+    ///
+    /// let mut state = TooltipState::new("Content");
+    /// state.set_fg_color(Color::Red);
+    /// assert_eq!(state.fg_color(), Color::Red);
+    /// ```
     pub fn set_fg_color(&mut self, color: Color) {
         self.fg_color = color;
     }
 
     /// Sets the background color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TooltipState;
+    /// use ratatui::style::Color;
+    ///
+    /// let mut state = TooltipState::new("Content");
+    /// state.set_bg_color(Color::DarkGray);
+    /// assert_eq!(state.bg_color(), Color::DarkGray);
+    /// ```
     pub fn set_bg_color(&mut self, color: Color) {
         self.bg_color = color;
     }
 
     /// Sets the border color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TooltipState;
+    /// use ratatui::style::Color;
+    ///
+    /// let mut state = TooltipState::new("Content");
+    /// state.set_border_color(Color::Yellow);
+    /// assert_eq!(state.border_color(), Color::Yellow);
+    /// ```
     pub fn set_border_color(&mut self, color: Color) {
         self.border_color = color;
     }

--- a/src/component/tree/mod.rs
+++ b/src/component/tree/mod.rs
@@ -107,26 +107,75 @@ impl<T: Clone> TreeNode<T> {
     }
 
     /// Sets the node's label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TreeNode;
+    ///
+    /// let mut node = TreeNode::new("Old", ());
+    /// node.set_label("New");
+    /// assert_eq!(node.label(), "New");
+    /// ```
     pub fn set_label(&mut self, label: impl Into<String>) {
         self.label = label.into();
     }
 
     /// Returns a reference to the node's data.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TreeNode;
+    ///
+    /// let node = TreeNode::new("Root", 42u32);
+    /// assert_eq!(node.data(), &42u32);
+    /// ```
     pub fn data(&self) -> &T {
         &self.data
     }
 
     /// Returns a mutable reference to the node's data.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TreeNode;
+    ///
+    /// let mut node = TreeNode::new("Root", 0u32);
+    /// *node.data_mut() = 99;
+    /// assert_eq!(node.data(), &99u32);
+    /// ```
     pub fn data_mut(&mut self) -> &mut T {
         &mut self.data
     }
 
     /// Returns the children of this node.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TreeNode;
+    ///
+    /// let mut parent = TreeNode::new("Parent", ());
+    /// parent.add_child(TreeNode::new("Child", ()));
+    /// assert_eq!(parent.children().len(), 1);
+    /// ```
     pub fn children(&self) -> &[TreeNode<T>] {
         &self.children
     }
 
     /// Returns a mutable reference to the children.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TreeNode;
+    ///
+    /// let mut node = TreeNode::new("Root", ());
+    /// node.children_mut().push(TreeNode::new("Child", ()));
+    /// assert_eq!(node.children().len(), 1);
+    /// ```
     pub fn children_mut(&mut self) -> &mut Vec<TreeNode<T>> {
         &mut self.children
     }
@@ -147,31 +196,93 @@ impl<T: Clone> TreeNode<T> {
     }
 
     /// Returns true if this node has children.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TreeNode;
+    ///
+    /// let mut parent = TreeNode::new("Parent", ());
+    /// assert!(!parent.has_children());
+    /// parent.add_child(TreeNode::new("Child", ()));
+    /// assert!(parent.has_children());
+    /// ```
     pub fn has_children(&self) -> bool {
         !self.children.is_empty()
     }
 
     /// Returns true if this node is expanded.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TreeNode;
+    ///
+    /// let node = TreeNode::new("Root", ());
+    /// assert!(!node.is_expanded());
+    /// ```
     pub fn is_expanded(&self) -> bool {
         self.expanded
     }
 
     /// Sets the expanded state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TreeNode;
+    ///
+    /// let mut node = TreeNode::new("Root", ());
+    /// node.set_expanded(true);
+    /// assert!(node.is_expanded());
+    /// ```
     pub fn set_expanded(&mut self, expanded: bool) {
         self.expanded = expanded;
     }
 
     /// Expands this node.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TreeNode;
+    ///
+    /// let mut node = TreeNode::new("Root", ());
+    /// node.expand();
+    /// assert!(node.is_expanded());
+    /// ```
     pub fn expand(&mut self) {
         self.expanded = true;
     }
 
     /// Collapses this node.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TreeNode;
+    ///
+    /// let mut node = TreeNode::new_expanded("Root", ());
+    /// node.collapse();
+    /// assert!(!node.is_expanded());
+    /// ```
     pub fn collapse(&mut self) {
         self.expanded = false;
     }
 
     /// Toggles the expanded state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TreeNode;
+    ///
+    /// let mut node = TreeNode::new("Root", ());
+    /// node.toggle();
+    /// assert!(node.is_expanded());
+    /// node.toggle();
+    /// assert!(!node.is_expanded());
+    /// ```
     pub fn toggle(&mut self) {
         self.expanded = !self.expanded;
     }
@@ -319,6 +430,16 @@ impl<T: Clone> TreeState<T> {
     }
 
     /// Returns a mutable reference to the root nodes.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TreeState, TreeNode};
+    ///
+    /// let mut state = TreeState::new(vec![TreeNode::new("Root", ())]);
+    /// state.roots_mut().push(TreeNode::new("Another Root", ()));
+    /// assert_eq!(state.roots().len(), 2);
+    /// ```
     pub fn roots_mut(&mut self) -> &mut Vec<TreeNode<T>> {
         &mut self.roots
     }
@@ -389,6 +510,15 @@ impl<T: Clone> TreeState<T> {
     }
 
     /// Alias for [`selected_index()`](Self::selected_index).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TreeState, TreeNode};
+    ///
+    /// let state = TreeState::new(vec![TreeNode::new("Root", ())]);
+    /// assert_eq!(state.selected(), Some(0));
+    /// ```
     pub fn selected(&self) -> Option<usize> {
         self.selected_index()
     }
@@ -425,11 +555,29 @@ impl<T: Clone> TreeState<T> {
     }
 
     /// Returns true if the tree is empty.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TreeState;
+    ///
+    /// let empty: TreeState<()> = TreeState::new(vec![]);
+    /// assert!(empty.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.roots.is_empty()
     }
 
     /// Returns the path of the currently selected node.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TreeState, TreeNode};
+    ///
+    /// let state = TreeState::new(vec![TreeNode::new("Root", ())]);
+    /// assert_eq!(state.selected_path(), Some(vec![0]));
+    /// ```
     pub fn selected_path(&self) -> Option<Vec<usize>> {
         let flat = self.flatten();
         flat.get(self.selected_index?).map(|n| n.path.clone())
@@ -530,6 +678,15 @@ impl<T: Clone> TreeState<T> {
     }
 
     /// Returns the current filter text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TreeState;
+    ///
+    /// let state: TreeState<()> = TreeState::new(vec![]);
+    /// assert_eq!(state.filter_text(), "");
+    /// ```
     pub fn filter_text(&self) -> &str {
         &self.filter_text
     }
@@ -542,6 +699,20 @@ impl<T: Clone> TreeState<T> {
     ///
     /// Selection is preserved if the selected node remains visible,
     /// otherwise it moves to the first visible node.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TreeState, TreeNode};
+    ///
+    /// let mut state = TreeState::new(vec![
+    ///     TreeNode::new("Alpha", ()),
+    ///     TreeNode::new("Beta", ()),
+    /// ]);
+    /// state.set_filter_text("alpha");
+    /// assert_eq!(state.filter_text(), "alpha");
+    /// assert_eq!(state.visible_count(), 1);
+    /// ```
     pub fn set_filter_text(&mut self, text: &str) {
         let prev_path = self.selected_path();
         self.filter_text = text.to_string();
@@ -550,6 +721,22 @@ impl<T: Clone> TreeState<T> {
     }
 
     /// Clears the filter, showing all nodes with their original expanded state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TreeState, TreeNode};
+    ///
+    /// let mut state = TreeState::new(vec![
+    ///     TreeNode::new("Alpha", ()),
+    ///     TreeNode::new("Beta", ()),
+    /// ]);
+    /// state.set_filter_text("alpha");
+    /// assert_eq!(state.visible_count(), 1);
+    /// state.clear_filter();
+    /// assert_eq!(state.filter_text(), "");
+    /// assert_eq!(state.visible_count(), 2);
+    /// ```
     pub fn clear_filter(&mut self) {
         let prev_path = self.selected_path();
         self.filter_text.clear();


### PR DESCRIPTION
## Summary

- Adds doc tests to public methods on 9 components below 50% doc test coverage.
- Target: toast, progress_bar, tooltip, menu, tree, line_input, data_grid, table, accordion.
- All components now above 50% doc test coverage.

## Test plan

- [x] `cargo test --doc -p envision` — all 1926 pass
- [x] `cargo clippy -p envision -- -D warnings` — no warnings
- [x] `cargo fmt` — no diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)