### PR TITLE
Eliminate remaining clippy suppressions in component code

### DIFF
--- a/src/component/code_block/render.rs
+++ b/src/component/code_block/render.rs
@@ -18,7 +18,6 @@ use crate::theme::Theme;
 const GUTTER_WIDTH: u16 = 7;
 
 /// Renders the CodeBlock in the given area.
-#[allow(clippy::too_many_lines)]
 pub(super) fn render(
     state: &CodeBlockState,
     frame: &mut Frame,

--- a/src/component/gauge/mod.rs
+++ b/src/component/gauge/mod.rs
@@ -381,7 +381,6 @@ impl GaugeState {
     /// let state = GaugeState::new(33.3, 100.0);
     /// assert_eq!(state.display_percentage(), 33);
     /// ```
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     pub fn display_percentage(&self) -> u16 {
         (self.percentage() * 100.0) as u16
     }

--- a/src/component/number_input/mod.rs
+++ b/src/component/number_input/mod.rs
@@ -564,7 +564,6 @@ impl Component for NumberInput {
         }
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
         if area.width == 0 || area.height == 0 {
             return;

--- a/src/component/progress_bar/mod.rs
+++ b/src/component/progress_bar/mod.rs
@@ -162,7 +162,6 @@ impl ProgressBarState {
     }
 
     /// Returns the progress as a percentage (0 to 100).
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     pub fn percentage(&self) -> u16 {
         (self.progress * 100.0).round() as u16
     }

--- a/src/component/slider/mod.rs
+++ b/src/component/slider/mod.rs
@@ -488,7 +488,6 @@ impl Component for Slider {
 }
 
 /// Renders the slider in horizontal orientation.
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn view_horizontal(
     state: &SliderState,
     frame: &mut Frame,
@@ -547,7 +546,6 @@ fn view_horizontal(
 }
 
 /// Renders the slider in vertical orientation.
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn view_vertical(
     state: &SliderState,
     frame: &mut Frame,


### PR DESCRIPTION
## Summary

- Removes all 6 remaining `#[allow(clippy::...)]` from `src/component/`.
- `code_block/render.rs`: stale `too_many_lines` suppression — the function was already well split and no longer exceeds the limit.
- `progress_bar/mod.rs`: stale `cast_possible_truncation` / `cast_sign_loss` on `percentage()` — these lints are not enabled in the project clippy profile.
- `gauge/mod.rs`: same stale suppression on `display_percentage()`.
- `slider/mod.rs` (×2): same stale suppressions on `view_horizontal()` and `view_vertical()`.
- `number_input/mod.rs`: vestigial `cast_possible_truncation` on `view()` — no cast exists in the function body at all.

Zero `#[allow(clippy::...)]` remain in `src/component/` outside of test code.

## Test plan

- [x] `cargo nextest run -p envision` — 7155 tests, all pass
- [x] `cargo clippy -p envision --all-targets -- -D warnings` — no warnings
- [x] `cargo fmt --check` — clean
- [x] `grep -rn "allow(clippy::" src/component/ | grep -v test` — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)