### PR TITLE
Add doc tests to 9 components between 50-60% coverage

### DIFF
--- a/src/component/conversation_view/mod.rs
+++ b/src/component/conversation_view/mod.rs
@@ -257,11 +257,30 @@ impl ConversationViewState {
     }
 
     /// Returns whether markdown rendering is enabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ConversationViewState;
+    ///
+    /// let state = ConversationViewState::new().with_markdown(true);
+    /// assert!(state.markdown_enabled());
+    /// ```
     pub fn markdown_enabled(&self) -> bool {
         self.markdown_enabled
     }
 
     /// Sets whether markdown rendering is enabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ConversationViewState;
+    ///
+    /// let mut state = ConversationViewState::new();
+    /// state.set_markdown_enabled(true);
+    /// assert!(state.markdown_enabled());
+    /// ```
     pub fn set_markdown_enabled(&mut self, enabled: bool) {
         self.markdown_enabled = enabled;
     }
@@ -542,6 +561,16 @@ impl ConversationViewState {
     // ---- Accessors ----
 
     /// Returns the messages.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ConversationViewState, ConversationMessage, ConversationRole};
+    ///
+    /// let mut state = ConversationViewState::new();
+    /// state.push_user("Hello");
+    /// assert_eq!(state.messages().len(), 1);
+    /// ```
     pub fn messages(&self) -> &[ConversationMessage] {
         &self.messages
     }

--- a/src/component/dialog/mod.rs
+++ b/src/component/dialog/mod.rs
@@ -295,21 +295,60 @@ impl DialogState {
     }
 
     /// Returns the index of the primary button.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DialogState;
+    ///
+    /// let state = DialogState::confirm("Delete?", "Are you sure?");
+    /// assert_eq!(state.primary_button(), 1);
+    /// ```
     pub fn primary_button(&self) -> usize {
         self.primary_button
     }
 
     /// Returns the index of the currently focused button.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DialogState;
+    ///
+    /// let state = DialogState::confirm("Delete?", "Are you sure?");
+    /// // Starts at primary button index
+    /// assert_eq!(state.focused_button(), state.primary_button());
+    /// ```
     pub fn focused_button(&self) -> usize {
         self.focused_button
     }
 
     /// Sets the dialog title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DialogState;
+    ///
+    /// let mut state = DialogState::alert("Old Title", "Message");
+    /// state.set_title("New Title");
+    /// assert_eq!(state.title(), "New Title");
+    /// ```
     pub fn set_title(&mut self, title: impl Into<String>) {
         self.title = title.into();
     }
 
     /// Sets the dialog message.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DialogState;
+    ///
+    /// let mut state = DialogState::alert("Title", "Old message");
+    /// state.set_message("New message");
+    /// assert_eq!(state.message(), "New message");
+    /// ```
     pub fn set_message(&mut self, message: impl Into<String>) {
         self.message = message.into();
     }
@@ -331,6 +370,19 @@ impl DialogState {
     /// Sets the primary button index.
     ///
     /// The index is clamped to the valid range.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{DialogButton, DialogState};
+    ///
+    /// let mut state = DialogState::new("T", "M", vec![
+    ///     DialogButton::new("cancel", "Cancel"),
+    ///     DialogButton::new("ok", "OK"),
+    /// ]);
+    /// state.set_primary_button(1);
+    /// assert_eq!(state.primary_button(), 1);
+    /// ```
     pub fn set_primary_button(&mut self, index: usize) {
         if self.buttons.is_empty() {
             self.primary_button = 0;
@@ -454,16 +506,52 @@ impl DialogState {
     }
 
     /// Maps an input event to a dialog message.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{DialogMessage, DialogState, Toggleable, Dialog};
+    /// use envision::input::{Event, KeyCode};
+    ///
+    /// let mut state = DialogState::alert("Info", "Done.");
+    /// Dialog::show(&mut state);
+    /// let event = Event::key(KeyCode::Enter);
+    /// assert_eq!(state.handle_event(&event), Some(DialogMessage::Press));
+    /// ```
     pub fn handle_event(&self, event: &Event) -> Option<DialogMessage> {
         Dialog::handle_event(self, event, &ViewContext::default())
     }
 
     /// Dispatches an event, updating state and returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{DialogOutput, DialogState, Toggleable, Dialog};
+    /// use envision::input::{Event, KeyCode};
+    ///
+    /// let mut state = DialogState::alert("Info", "Done.");
+    /// Dialog::show(&mut state);
+    /// let event = Event::key(KeyCode::Enter);
+    /// let output = state.dispatch_event(&event);
+    /// assert_eq!(output, Some(DialogOutput::ButtonPressed("ok".into())));
+    /// ```
     pub fn dispatch_event(&mut self, event: &Event) -> Option<DialogOutput> {
         Dialog::dispatch_event(self, event, &ViewContext::default())
     }
 
     /// Updates the dialog state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{DialogMessage, DialogOutput, DialogState, Toggleable, Dialog};
+    ///
+    /// let mut state = DialogState::alert("Info", "Done.");
+    /// Dialog::show(&mut state);
+    /// let output = state.update(DialogMessage::Close);
+    /// assert_eq!(output, Some(DialogOutput::Closed));
+    /// ```
     pub fn update(&mut self, msg: DialogMessage) -> Option<DialogOutput> {
         Dialog::update(self, msg)
     }

--- a/src/component/file_browser/mod.rs
+++ b/src/component/file_browser/mod.rs
@@ -361,6 +361,18 @@ impl FileBrowserState {
     }
 
     /// Returns all entries (unfiltered).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState};
+    ///
+    /// let state = FileBrowserState::new("/", vec![
+    ///     FileEntry::file("a.txt", "/a.txt"),
+    ///     FileEntry::directory("src", "/src"),
+    /// ]);
+    /// assert_eq!(state.entries().len(), 2);
+    /// ```
     pub fn entries(&self) -> &[FileEntry] {
         &self.entries
     }
@@ -410,6 +422,18 @@ impl FileBrowserState {
     }
 
     /// Returns the selected index within the filtered list.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState};
+    ///
+    /// let state = FileBrowserState::new("/", vec![FileEntry::file("a.txt", "/a.txt")]);
+    /// assert_eq!(state.selected_index(), Some(0));
+    ///
+    /// let empty = FileBrowserState::new("/", vec![]);
+    /// assert_eq!(empty.selected_index(), None);
+    /// ```
     pub fn selected_index(&self) -> Option<usize> {
         self.selected_index
     }
@@ -459,11 +483,30 @@ impl FileBrowserState {
     }
 
     /// Returns the selection mode.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState, SelectionMode};
+    ///
+    /// let state = FileBrowserState::new("/", vec![])
+    ///     .with_selection_mode(SelectionMode::Multiple);
+    /// assert_eq!(state.selection_mode(), &SelectionMode::Multiple);
+    /// ```
     pub fn selection_mode(&self) -> &SelectionMode {
         &self.selection_mode
     }
 
     /// Returns the sort field.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState, FileSortField};
+    ///
+    /// let state = FileBrowserState::new("/", vec![]);
+    /// assert_eq!(state.sort_field(), &FileSortField::Name);
+    /// ```
     pub fn sort_field(&self) -> &FileSortField {
         &self.sort_field
     }
@@ -513,6 +556,20 @@ impl FileBrowserState {
     // ---- Instance methods ----
 
     /// Updates the state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState};
+    /// use envision::component::{FileBrowserMessage, FileBrowserOutput};
+    ///
+    /// let mut state = FileBrowserState::new("/", vec![
+    ///     FileEntry::file("a.txt", "/a.txt"),
+    ///     FileEntry::file("b.txt", "/b.txt"),
+    /// ]);
+    /// let output = state.update(FileBrowserMessage::Down);
+    /// assert_eq!(output, Some(FileBrowserOutput::SelectionChanged(1)));
+    /// ```
     pub fn update(&mut self, msg: FileBrowserMessage) -> Option<FileBrowserOutput> {
         FileBrowser::update(self, msg)
     }

--- a/src/component/help_panel/mod.rs
+++ b/src/component/help_panel/mod.rs
@@ -427,11 +427,32 @@ impl HelpPanelState {
     // ---- Title accessors ----
 
     /// Returns the panel title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HelpPanelState;
+    ///
+    /// let state = HelpPanelState::new();
+    /// assert_eq!(state.title(), Some("Help"));
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
 
     /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HelpPanelState;
+    ///
+    /// let mut state = HelpPanelState::new();
+    /// state.set_title(Some("Shortcuts".to_string()));
+    /// assert_eq!(state.title(), Some("Shortcuts"));
+    /// state.set_title(None);
+    /// assert_eq!(state.title(), None);
+    /// ```
     pub fn set_title(&mut self, title: Option<String>) {
         self.title = title;
     }
@@ -439,16 +460,44 @@ impl HelpPanelState {
     // ---- State accessors ----
 
     /// Returns true if the component is visible.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HelpPanelState;
+    ///
+    /// let state = HelpPanelState::new();
+    /// assert!(state.is_visible()); // visible by default
+    /// ```
     pub fn is_visible(&self) -> bool {
         self.visible
     }
 
     /// Sets the visibility state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HelpPanelState;
+    ///
+    /// let mut state = HelpPanelState::new();
+    /// state.set_visible(false);
+    /// assert!(!state.is_visible());
+    /// ```
     pub fn set_visible(&mut self, visible: bool) {
         self.visible = visible;
     }
 
     /// Returns the current scroll offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HelpPanelState;
+    ///
+    /// let state = HelpPanelState::new();
+    /// assert_eq!(state.scroll_offset(), 0);
+    /// ```
     pub fn scroll_offset(&self) -> usize {
         self.scroll.offset()
     }

--- a/src/component/loading_list/mod.rs
+++ b/src/component/loading_list/mod.rs
@@ -203,11 +203,30 @@ impl<T: Clone> LoadingListItem<T> {
     }
 
     /// Returns a mutable reference to the data.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListItem;
+    ///
+    /// let mut item = LoadingListItem::new(42u32, "Answer");
+    /// *item.data_mut() = 99;
+    /// assert_eq!(*item.data(), 99);
+    /// ```
     pub fn data_mut(&mut self) -> &mut T {
         &mut self.data
     }
 
     /// Returns the label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListItem;
+    ///
+    /// let item = LoadingListItem::new("x", "Display Name");
+    /// assert_eq!(item.label(), "Display Name");
+    /// ```
     pub fn label(&self) -> &str {
         &self.label
     }
@@ -218,11 +237,30 @@ impl<T: Clone> LoadingListItem<T> {
     }
 
     /// Returns the current state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ItemState, LoadingListItem};
+    ///
+    /// let item = LoadingListItem::new("x", "Item");
+    /// assert_eq!(item.state(), &ItemState::Ready);
+    /// ```
     pub fn state(&self) -> &ItemState {
         &self.state
     }
 
     /// Sets the state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ItemState, LoadingListItem};
+    ///
+    /// let mut item = LoadingListItem::new("x", "Item");
+    /// item.set_state(ItemState::Loading);
+    /// assert!(item.is_loading());
+    /// ```
     pub fn set_state(&mut self, state: ItemState) {
         self.state = state;
     }

--- a/src/component/log_correlation/mod.rs
+++ b/src/component/log_correlation/mod.rs
@@ -443,36 +443,105 @@ impl LogCorrelationState {
     // ---- Accessors ----
 
     /// Returns all streams.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{LogCorrelationState, LogStream};
+    ///
+    /// let state = LogCorrelationState::new()
+    ///     .with_streams(vec![LogStream::new("API"), LogStream::new("DB")]);
+    /// assert_eq!(state.streams().len(), 2);
+    /// assert_eq!(state.streams()[0].name, "API");
+    /// ```
     pub fn streams(&self) -> &[LogStream] {
         &self.streams
     }
 
     /// Returns the number of streams.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{LogCorrelationState, LogStream};
+    ///
+    /// let state = LogCorrelationState::new()
+    ///     .with_streams(vec![LogStream::new("A"), LogStream::new("B")]);
+    /// assert_eq!(state.stream_count(), 2);
+    /// ```
     pub fn stream_count(&self) -> usize {
         self.streams.len()
     }
 
     /// Returns the index of the active (focused) stream.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogCorrelationState;
+    ///
+    /// let state = LogCorrelationState::new();
+    /// assert_eq!(state.active_stream(), 0);
+    /// ```
     pub fn active_stream(&self) -> usize {
         self.active_stream
     }
 
     /// Returns whether synchronized scrolling is enabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogCorrelationState;
+    ///
+    /// let state = LogCorrelationState::new();
+    /// assert!(state.sync_scroll()); // enabled by default
+    /// ```
     pub fn sync_scroll(&self) -> bool {
         self.sync_scroll
     }
 
     /// Returns the scroll offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogCorrelationState;
+    ///
+    /// let state = LogCorrelationState::new();
+    /// assert_eq!(state.scroll_offset(), 0);
+    /// ```
     pub fn scroll_offset(&self) -> usize {
         self.scroll.offset()
     }
 
     /// Returns the current scroll timestamp.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogCorrelationState;
+    ///
+    /// let state = LogCorrelationState::new();
+    /// assert_eq!(state.scroll_timestamp(), 0.0);
+    /// ```
     pub fn scroll_timestamp(&self) -> f64 {
         self.scroll_timestamp
     }
 
     /// Returns the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogCorrelationState;
+    ///
+    /// let state = LogCorrelationState::new().with_title("Logs");
+    /// assert_eq!(state.title(), Some("Logs"));
+    ///
+    /// let no_title = LogCorrelationState::new();
+    /// assert_eq!(no_title.title(), None);
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
@@ -613,6 +682,19 @@ impl LogCorrelationState {
     // ---- Instance methods ----
 
     /// Updates the state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{
+    ///     LogCorrelationState, LogCorrelationMessage, LogCorrelationOutput, LogStream,
+    /// };
+    ///
+    /// let mut state = LogCorrelationState::new()
+    ///     .with_streams(vec![LogStream::new("A"), LogStream::new("B")]);
+    /// let output = state.update(LogCorrelationMessage::FocusNextStream);
+    /// assert_eq!(output, Some(LogCorrelationOutput::StreamFocused(1)));
+    /// ```
     pub fn update(&mut self, msg: LogCorrelationMessage) -> Option<LogCorrelationOutput> {
         LogCorrelation::update(self, msg)
     }

--- a/src/component/scrollable_text/mod.rs
+++ b/src/component/scrollable_text/mod.rs
@@ -130,6 +130,15 @@ impl ScrollableTextState {
     // ---- Content accessors ----
 
     /// Returns the text content.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ScrollableTextState;
+    ///
+    /// let state = ScrollableTextState::new().with_content("Hello, world!");
+    /// assert_eq!(state.content(), "Hello, world!");
+    /// ```
     pub fn content(&self) -> &str {
         &self.content
     }
@@ -170,11 +179,35 @@ impl ScrollableTextState {
     }
 
     /// Returns the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ScrollableTextState;
+    ///
+    /// let state = ScrollableTextState::new().with_title("My Panel");
+    /// assert_eq!(state.title(), Some("My Panel"));
+    ///
+    /// let empty = ScrollableTextState::new();
+    /// assert_eq!(empty.title(), None);
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
 
     /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ScrollableTextState;
+    ///
+    /// let mut state = ScrollableTextState::new();
+    /// state.set_title(Some("Updated Title".to_string()));
+    /// assert_eq!(state.title(), Some("Updated Title"));
+    /// state.set_title(None);
+    /// assert_eq!(state.title(), None);
+    /// ```
     pub fn set_title(&mut self, title: Option<String>) {
         self.title = title;
     }
@@ -191,6 +224,17 @@ impl ScrollableTextState {
     /// The offset is clamped to the valid range based on the current
     /// content length estimate. The precise clamping to wrapped line
     /// count happens during rendering.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ScrollableTextState;
+    ///
+    /// let mut state = ScrollableTextState::new()
+    ///     .with_content("Line 1\nLine 2\nLine 3\nLine 4\nLine 5");
+    /// state.set_scroll_offset(2);
+    /// assert_eq!(state.scroll_offset(), 2);
+    /// ```
     pub fn set_scroll_offset(&mut self, offset: usize) {
         self.scroll.set_offset(offset);
     }

--- a/src/component/step_indicator/mod.rs
+++ b/src/component/step_indicator/mod.rs
@@ -353,6 +353,17 @@ impl StepIndicatorState {
     }
 
     /// Returns a specific step, if it exists.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::Step;
+    /// use envision::component::StepIndicatorState;
+    ///
+    /// let state = StepIndicatorState::new(vec![Step::new("Build"), Step::new("Test")]);
+    /// assert_eq!(state.step(0).unwrap().label(), "Build");
+    /// assert!(state.step(99).is_none());
+    /// ```
     pub fn step(&self, index: usize) -> Option<&Step> {
         self.steps.get(index)
     }
@@ -363,6 +374,16 @@ impl StepIndicatorState {
     }
 
     /// Returns the focused step index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::Step;
+    /// use envision::component::StepIndicatorState;
+    ///
+    /// let state = StepIndicatorState::new(vec![Step::new("A"), Step::new("B")]);
+    /// assert_eq!(state.focused_index(), 0);
+    /// ```
     pub fn focused_index(&self) -> usize {
         self.focused_index
     }
@@ -437,6 +458,15 @@ impl StepIndicatorState {
     }
 
     /// Returns whether descriptions are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StepIndicatorState;
+    ///
+    /// let state = StepIndicatorState::default();
+    /// assert!(!state.show_descriptions());
+    /// ```
     pub fn show_descriptions(&self) -> bool {
         self.show_descriptions
     }
@@ -507,6 +537,21 @@ impl StepIndicatorState {
     }
 
     /// Updates the state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{StepIndicatorState, StepIndicatorMessage, StepIndicatorOutput};
+    /// use envision::component::step_indicator::{Step, StepStatus};
+    ///
+    /// let steps = vec![
+    ///     Step::new("Build").with_status(StepStatus::Active),
+    ///     Step::new("Test"),
+    /// ];
+    /// let mut state = StepIndicatorState::new(steps);
+    /// let output = state.update(StepIndicatorMessage::CompleteActive);
+    /// assert!(matches!(output, Some(StepIndicatorOutput::StatusChanged { .. })));
+    /// ```
     pub fn update(&mut self, msg: StepIndicatorMessage) -> Option<StepIndicatorOutput> {
         StepIndicator::update(self, msg)
     }

--- a/src/component/terminal_output/mod.rs
+++ b/src/component/terminal_output/mod.rs
@@ -365,6 +365,20 @@ impl TerminalOutputState {
     }
 
     /// Returns the number of output lines.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "display-components")]
+    /// # {
+    /// use envision::component::TerminalOutputState;
+    ///
+    /// let mut state = TerminalOutputState::new();
+    /// assert_eq!(state.line_count(), 0);
+    /// state.push_line("hello");
+    /// assert_eq!(state.line_count(), 1);
+    /// # }
+    /// ```
     pub fn line_count(&self) -> usize {
         self.lines.len()
     }
@@ -372,11 +386,39 @@ impl TerminalOutputState {
     // ---- Scroll accessors ----
 
     /// Returns the current scroll offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "display-components")]
+    /// # {
+    /// use envision::component::TerminalOutputState;
+    ///
+    /// let state = TerminalOutputState::new();
+    /// assert_eq!(state.scroll_offset(), 0);
+    /// # }
+    /// ```
     pub fn scroll_offset(&self) -> usize {
         self.scroll.offset()
     }
 
     /// Sets the scroll offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "display-components")]
+    /// # {
+    /// use envision::component::TerminalOutputState;
+    ///
+    /// let mut state = TerminalOutputState::new();
+    /// for i in 0..20 {
+    ///     state.push_line(format!("line {}", i));
+    /// }
+    /// state.set_scroll_offset(5);
+    /// assert_eq!(state.scroll_offset(), 5);
+    /// # }
+    /// ```
     pub fn set_scroll_offset(&mut self, offset: usize) {
         self.scroll.set_offset(offset);
     }
@@ -408,31 +450,108 @@ impl TerminalOutputState {
     }
 
     /// Returns whether auto-scroll is enabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "display-components")]
+    /// # {
+    /// use envision::component::TerminalOutputState;
+    ///
+    /// let state = TerminalOutputState::new();
+    /// assert!(state.auto_scroll()); // enabled by default
+    /// # }
+    /// ```
     pub fn auto_scroll(&self) -> bool {
         self.auto_scroll
     }
 
     /// Sets the auto-scroll state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "display-components")]
+    /// # {
+    /// use envision::component::TerminalOutputState;
+    ///
+    /// let mut state = TerminalOutputState::new();
+    /// state.set_auto_scroll(false);
+    /// assert!(!state.auto_scroll());
+    /// # }
+    /// ```
     pub fn set_auto_scroll(&mut self, auto_scroll: bool) {
         self.auto_scroll = auto_scroll;
     }
 
     /// Returns whether line numbers are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "display-components")]
+    /// # {
+    /// use envision::component::TerminalOutputState;
+    ///
+    /// let state = TerminalOutputState::new();
+    /// assert!(!state.show_line_numbers());
+    /// # }
+    /// ```
     pub fn show_line_numbers(&self) -> bool {
         self.show_line_numbers
     }
 
     /// Sets whether to show line numbers.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "display-components")]
+    /// # {
+    /// use envision::component::TerminalOutputState;
+    ///
+    /// let mut state = TerminalOutputState::new();
+    /// state.set_show_line_numbers(true);
+    /// assert!(state.show_line_numbers());
+    /// # }
+    /// ```
     pub fn set_show_line_numbers(&mut self, show: bool) {
         self.show_line_numbers = show;
     }
 
     /// Returns the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "display-components")]
+    /// # {
+    /// use envision::component::TerminalOutputState;
+    ///
+    /// let state = TerminalOutputState::new().with_title("Build");
+    /// assert_eq!(state.title(), Some("Build"));
+    /// # }
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
 
     /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "display-components")]
+    /// # {
+    /// use envision::component::TerminalOutputState;
+    ///
+    /// let mut state = TerminalOutputState::new();
+    /// state.set_title(Some("Output".to_string()));
+    /// assert_eq!(state.title(), Some("Output"));
+    /// state.set_title(None);
+    /// assert_eq!(state.title(), None);
+    /// # }
+    /// ```
     pub fn set_title(&mut self, title: Option<String>) {
         self.title = title;
     }
@@ -501,6 +620,21 @@ impl TerminalOutputState {
     }
 
     /// Sets the running state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "display-components")]
+    /// # {
+    /// use envision::component::TerminalOutputState;
+    ///
+    /// let mut state = TerminalOutputState::new();
+    /// state.set_running(true);
+    /// assert!(state.running());
+    /// state.set_running(false);
+    /// assert!(!state.running());
+    /// # }
+    /// ```
     pub fn set_running(&mut self, running: bool) {
         self.running = running;
     }


### PR DESCRIPTION
## Summary

- Adds doc tests to 9 components between 50-60% doc test coverage.
- Targets 70%+ per component.
- Documentation only — no behavioral changes.

## Components Updated

| Component | Before | Added |
|---|---|---|
| `scrollable_text` | 7/12 (58.3%) | `content()`, `title()`, `set_title()`, `set_scroll_offset()` |
| `dialog` | 15/26 (57.7%) | `primary_button()`, `focused_button()`, `set_title()`, `set_message()`, `set_primary_button()`, `handle_event()`, `dispatch_event()`, `update()` |
| `terminal_output` | 15/26 (57.7%) | `line_count()`, `scroll_offset()`, `set_scroll_offset()`, `auto_scroll()`, `set_auto_scroll()`, `show_line_numbers()`, `set_show_line_numbers()`, `title()`, `set_title()`, `set_running()` |
| `help_panel` | 12/21 (57.1%) | `title()`, `set_title()`, `is_visible()`, `set_visible()`, `scroll_offset()` |
| `step_indicator` | 15/27 (55.6%) | `step()`, `focused_index()`, `show_descriptions()`, `update()` |
| `log_correlation` | 12/22 (54.5%) | `streams()`, `stream_count()`, `active_stream()`, `sync_scroll()`, `scroll_offset()`, `scroll_timestamp()`, `title()`, `update()` |
| `conversation_view` | 23/44 (52.3%) | `markdown_enabled()`, `set_markdown_enabled()`, `messages()` (size-limited) |
| `loading_list` | 24/46 (52.2%) | `data_mut()`, `label()`, `state()`, `set_state()` (size-limited) |
| `file_browser` | 12/24 (50.0%) | `entries()`, `selected_index()`, `selection_mode()`, `sort_field()`, `update()` |

## Size Constraints

- `conversation_view/mod.rs`: 955 → 984 lines (size-limited; added 3 doc tests)
- `loading_list/mod.rs`: 960 → 998 lines (size-limited; added 4 doc tests)
- `file_browser/mod.rs`: 939 → 996 lines (stayed under 1000; added 5 doc tests)

## Test plan

- [x] `cargo test --doc -p envision` — all 1977 pass
- [x] `cargo clippy -p envision -- -D warnings` — no warnings
- [x] `cargo fmt` — applied
- [x] No files over 1000 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)