### PR TITLE
Refactor Component::view to use RenderContext (BREAKING, 0.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+
+- **`Component::view` signature changed** from
+  `(state, frame, area, theme, ctx)` to `(state, ctx)`. The new
+  `ctx: &mut RenderContext<'_, '_>` bundles `frame`, `area`, `theme`,
+  `focused`, and `disabled` into a single value. This is a large,
+  cascading breakage: every component, every custom component
+  implementation, every direct call to `Component::view`, and every
+  test that renders a component through the public API must be
+  updated. See MIGRATION.md for the upgrade path.
+- **`ViewContext` renamed to `EventContext`.** It is now used only by
+  `Component::handle_event`, not by `Component::view`. The fields and
+  builder methods are unchanged.
+- **`Component::handle_event` signature changed** from
+  `(state, event, ctx: &ViewContext)` to
+  `(state, event, ctx: &EventContext)`. Pure type rename.
+- **`Component::traced_view` signature changed** to match the new
+  `view` signature: `(state, ctx: &mut RenderContext<'_, '_>)`.
+- **`Component::dispatch_event` now takes `&EventContext`** (not
+  `&ViewContext`). Pure type rename.
+- **`ChartGrid::render` signature changed** to take
+  `&mut RenderContext<'_, '_>` as the sole non-`self` argument
+  (previously took `frame`, `area`, `theme`, `ctx`).
+- **`Router::view` signature changed** to take
+  `(state, ctx: &mut RenderContext<'_, '_>)`.
+- **`ConversationView::view_from` signature changed** to take
+  `(source, state, ctx: &mut RenderContext<'_, '_>)`.
+
+### Added
+
+- `RenderContext<'frame, 'buf>` type in `envision::component`
+  that bundles `frame`, `area`, `theme`, `focused`, and `disabled`.
+  Provides builder methods (`focused`, `disabled`), sub-area reborrow
+  (`with_area`), a `render_widget` convenience method, and an
+  `event_context()` slice method for calls that need an
+  `EventContext`.
+- `EventContext` type (renamed from `ViewContext`) in
+  `envision::component`, now used exclusively by
+  `Component::handle_event`. `From<&RenderContext<'_, '_>>` impl is
+  provided so `(&render_ctx).into()` yields an `EventContext`.
+
 ## [0.13.1] - 2026-04-11
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,8 +78,8 @@ Every interactive component should have:
 1. **State struct** with domain-specific fields (no `focused`/`disabled` fields)
 2. **Instance method**: `update()` on the State type
 3. **`selected_item()`** accessor if the component has selection
-4. **Event guards**: `handle_event` checks `ctx.focused && !ctx.disabled` via `ViewContext`
-5. **View style**: Uses `ViewContext` to determine focused/disabled rendering
+4. **Event guards**: `handle_event` checks `ctx.focused && !ctx.disabled` via `EventContext`
+5. **View style**: Uses `RenderContext` to determine focused/disabled rendering
 
 ## Testing
 
@@ -108,7 +108,8 @@ fn test_view_focused() {
     let theme = Theme::default();
 
     terminal.draw(|frame| {
-        MyComponent::view(&state, frame, area, &theme, &ViewContext::new().focused(true));
+        let mut ctx = RenderContext::new(frame, area, &theme).focused(true);
+        MyComponent::view(&state, &mut ctx);
     }).unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -124,7 +125,8 @@ use crate::input::{Event, KeyCode};
 fn test_handle_event_focused() {
     let state = MyState::new();
     let event = Event::key(KeyCode::Enter);
-    let msg = MyComponent::handle_event(&state, &event, &ViewContext::new().focused(true));
+    let ctx = EventContext::new().focused(true);
+    let msg = MyComponent::handle_event(&state, &event, &ctx);
     assert_eq!(msg, Some(MyMessage::Confirm));
 }
 ```

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,196 @@
 # Migration Guide
 
+## v0.13.x to v0.14.0
+
+0.14.0 introduces a large, cascading breakage around component rendering.
+`Component::view` now takes a single `&mut RenderContext<'_, '_>` argument
+instead of five separate arguments, and `ViewContext` has been renamed to
+`EventContext` and is now used only for `handle_event`. The upside is that
+component signatures are stable: adding a new render-time field (e.g.
+scaling factor, accessibility hint) is a non-breaking change because callers
+never name those fields explicitly.
+
+### 1. Component `view` implementations
+
+```rust
+// Before (v0.13.x)
+use envision::component::{Component, ViewContext};
+use envision::theme::Theme;
+use ratatui::prelude::*;
+
+impl Component for MyButton {
+    // ...
+    fn view(
+        state: &Self::State,
+        frame: &mut Frame,
+        area: Rect,
+        theme: &Theme,
+        ctx: &ViewContext,
+    ) {
+        let style = if ctx.focused {
+            theme.focused_style()
+        } else {
+            theme.normal_style()
+        };
+        frame.render_widget(Paragraph::new("Hello").style(style), area);
+    }
+}
+```
+
+```rust
+// After (v0.14.0)
+use envision::component::{Component, RenderContext};
+use ratatui::prelude::*;
+
+impl Component for MyButton {
+    // ...
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        let style = if ctx.focused {
+            ctx.theme.focused_style()
+        } else {
+            ctx.theme.normal_style()
+        };
+        ctx.frame.render_widget(Paragraph::new("Hello").style(style), ctx.area);
+        // Or equivalently:
+        // ctx.render_widget(Paragraph::new("Hello").style(style));
+    }
+}
+```
+
+Mechanical steps:
+- Replace the parameter list with `ctx: &mut RenderContext<'_, '_>`.
+- Replace `theme` with `ctx.theme`.
+- Replace `frame` with `ctx.frame` (or use `ctx.render_widget(...)` when
+  the widget fills the entire `area`).
+- Replace `area` with `ctx.area`.
+- `ctx.focused` and `ctx.disabled` continue to work unchanged.
+
+### 2. Component `handle_event` implementations
+
+```rust
+// Before
+fn handle_event(
+    state: &Self::State,
+    event: &Event,
+    ctx: &ViewContext,
+) -> Option<Self::Message> { /* ... */ }
+```
+
+```rust
+// After
+fn handle_event(
+    state: &Self::State,
+    event: &Event,
+    ctx: &EventContext,
+) -> Option<Self::Message> { /* ... */ }
+```
+
+This is a pure type rename. Field access (`ctx.focused`, `ctx.disabled`) is
+unchanged. The same applies to `Component::dispatch_event`.
+
+### 3. Sub-area rendering: `RenderContext::with_area`
+
+When a parent component lays out sub-areas and delegates to child
+components:
+
+```rust
+// Before
+fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    let chunks = Layout::vertical([Constraint::Length(3), Constraint::Min(0)]).split(area);
+    Header::view(&state.header, frame, chunks[0], theme, ctx);
+    Body::view(&state.body, frame, chunks[1], theme, ctx);
+}
+```
+
+```rust
+// After
+fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+    let chunks = Layout::vertical([Constraint::Length(3), Constraint::Min(0)]).split(ctx.area);
+    Header::view(&state.header, &mut ctx.with_area(chunks[0]));
+    Body::view(&state.body, &mut ctx.with_area(chunks[1]));
+}
+```
+
+`ctx.with_area(new_area)` returns a `RenderContext` that borrows `frame`
+for a shorter lifetime, reborrows the theme, and preserves `focused` and
+`disabled`. When the child context goes out of scope, the parent `ctx` is
+usable again.
+
+If a child needs different focus/disabled state, mutate the fields on the
+returned context:
+
+```rust
+let mut child_ctx = ctx.with_area(chunks[0]);
+child_ctx.focused = state.current_focus == FocusTarget::Header;
+Header::view(&state.header, &mut child_ctx);
+```
+
+### 4. Test code calling `Component::view` directly
+
+```rust
+// Before
+terminal.draw(|frame| {
+    Button::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+}).unwrap();
+```
+
+```rust
+// After
+terminal.draw(|frame| {
+    Button::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
+}).unwrap();
+```
+
+For focused or disabled rendering:
+
+```rust
+// Before
+Button::view(&state, frame, frame.area(), &theme, &ViewContext::new().focused(true));
+
+// After
+Button::view(
+    &state,
+    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
+);
+```
+
+### 5. Test code calling `Component::handle_event` / `dispatch_event`
+
+Pure type rename:
+
+```rust
+// Before
+Button::handle_event(&state, &event, &ViewContext::new().focused(true));
+Button::dispatch_event(&mut state, &event, &ViewContext::default());
+```
+
+```rust
+// After
+Button::handle_event(&state, &event, &EventContext::new().focused(true));
+Button::dispatch_event(&mut state, &event, &EventContext::default());
+```
+
+### 6. `App::view` is unchanged
+
+`App::view` still has signature `(state, frame)` — the `App` trait is not
+affected by the `Component::view` change. Only `Component::view` (and its
+helpers like `traced_view`) moved to `RenderContext`.
+
+### 7. `ChartGrid::render` and other inherent methods
+
+A small number of inherent methods (as opposed to trait methods) also
+migrated to `&mut RenderContext<'_, '_>`:
+
+- `ChartGrid::render(&self, frame, area, theme, ctx)` →
+  `ChartGrid::render(&self, ctx: &mut RenderContext<'_, '_>)`
+- `ConversationView::view_from(source, state, frame, area, theme, ctx)` →
+  `ConversationView::view_from(source, state, ctx: &mut RenderContext<'_, '_>)`
+- `Router::view(state, frame, area, theme, ctx)` →
+  `Router::view(state, ctx: &mut RenderContext<'_, '_>)`
+
+Call sites need the same `&mut RenderContext::new(...)` treatment as
+`Component::view` call sites.
+
 ## v0.6.0 to v0.7.0
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ cargo run --example component_showcase
 
 ## Components
 
-Envision provides a comprehensive library of 73 reusable UI components, all following the TEA (The Elm Architecture) pattern with `Component`, `ViewContext`, and `Toggleable` traits.
+Envision provides a comprehensive library of 73 reusable UI components, all following the TEA (The Elm Architecture) pattern with `Component` and `Toggleable` traits.
 
 ### Input Components
 
@@ -277,7 +277,7 @@ Envision follows The Elm Architecture (TEA) pattern:
 
 | Module | Description |
 |--------|-------------|
-| `component` | 73 reusable UI components with `Component`, `ViewContext`, `Toggleable` traits |
+| `component` | 73 reusable UI components with `Component`, `Toggleable` traits |
 | `backend` | `CaptureBackend` for headless rendering |
 | `app` | TEA architecture: `App`, `Runtime`, `Command`, subscriptions |
 | `harness` | `TestHarness` and `AppHarness` for testing |

--- a/benches/component_events.rs
+++ b/benches/component_events.rs
@@ -6,8 +6,8 @@
 
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use envision::component::{
-    Column, Component, InputField, InputFieldState, SelectableList, SelectableListState, Table,
-    TableRow, TableState, TextArea, TextAreaState, ViewContext,
+    Column, Component, EventContext, InputField, InputFieldState, SelectableList,
+    SelectableListState, Table, TableRow, TableState, TextArea, TextAreaState,
 };
 use envision::input::{Event, KeyCode};
 use ratatui::layout::Constraint;
@@ -69,7 +69,7 @@ fn bench_handle_event(c: &mut Criterion) {
                     SelectableList::<String>::handle_event(
                         black_box(&state),
                         black_box(&event),
-                        &ViewContext::new().focused(true),
+                        &EventContext::new().focused(true),
                     )
                 })
             },
@@ -84,7 +84,7 @@ fn bench_handle_event(c: &mut Criterion) {
                     SelectableList::<String>::handle_event(
                         black_box(&state),
                         black_box(&event),
-                        &ViewContext::default(),
+                        &EventContext::default(),
                     )
                 })
             },
@@ -102,7 +102,7 @@ fn bench_handle_event(c: &mut Criterion) {
                 Table::<BenchRow>::handle_event(
                     black_box(&state),
                     black_box(&event),
-                    &ViewContext::new().focused(true),
+                    &EventContext::new().focused(true),
                 )
             })
         });
@@ -113,7 +113,7 @@ fn bench_handle_event(c: &mut Criterion) {
                 Table::<BenchRow>::handle_event(
                     black_box(&state),
                     black_box(&event),
-                    &ViewContext::default(),
+                    &EventContext::default(),
                 )
             })
         });
@@ -136,7 +136,7 @@ fn bench_handle_event(c: &mut Criterion) {
                     TextArea::handle_event(
                         black_box(&state),
                         black_box(&event),
-                        &ViewContext::new().focused(true),
+                        &EventContext::new().focused(true),
                     )
                 })
             },
@@ -151,7 +151,7 @@ fn bench_handle_event(c: &mut Criterion) {
                     TextArea::handle_event(
                         black_box(&state),
                         black_box(&event),
-                        &ViewContext::default(),
+                        &EventContext::default(),
                     )
                 })
             },
@@ -176,7 +176,7 @@ fn bench_handle_event(c: &mut Criterion) {
                     InputField::handle_event(
                         black_box(&state),
                         black_box(&event_insert),
-                        &ViewContext::new().focused(true),
+                        &EventContext::new().focused(true),
                     )
                 })
             },
@@ -192,7 +192,7 @@ fn bench_handle_event(c: &mut Criterion) {
                     InputField::handle_event(
                         black_box(&state),
                         black_box(&event_backspace),
-                        &ViewContext::new().focused(true),
+                        &EventContext::new().focused(true),
                     )
                 })
             },
@@ -207,7 +207,7 @@ fn bench_handle_event(c: &mut Criterion) {
                     InputField::handle_event(
                         black_box(&state),
                         black_box(&event_insert),
-                        &ViewContext::default(),
+                        &EventContext::default(),
                     )
                 })
             },
@@ -238,7 +238,7 @@ fn bench_dispatch_event(c: &mut Criterion) {
                     SelectableList::<String>::dispatch_event(
                         black_box(&mut state),
                         black_box(&event),
-                        &ViewContext::new().focused(true),
+                        &EventContext::new().focused(true),
                     )
                 })
             },
@@ -255,7 +255,7 @@ fn bench_dispatch_event(c: &mut Criterion) {
                 Table::<BenchRow>::dispatch_event(
                     black_box(&mut state),
                     black_box(&event),
-                    &ViewContext::new().focused(true),
+                    &EventContext::new().focused(true),
                 )
             })
         });
@@ -278,7 +278,7 @@ fn bench_dispatch_event(c: &mut Criterion) {
                     TextArea::dispatch_event(
                         black_box(&mut state),
                         black_box(&event_down),
-                        &ViewContext::new().focused(true),
+                        &EventContext::new().focused(true),
                     )
                 })
             },
@@ -301,7 +301,7 @@ fn bench_dispatch_event(c: &mut Criterion) {
                     InputField::dispatch_event(
                         black_box(&mut state),
                         black_box(&event_insert),
-                        &ViewContext::new().focused(true),
+                        &EventContext::new().focused(true),
                     )
                 })
             },
@@ -319,7 +319,7 @@ fn bench_dispatch_event(c: &mut Criterion) {
                     InputField::dispatch_event(
                         black_box(&mut state),
                         black_box(&event_backspace),
-                        &ViewContext::new().focused(true),
+                        &EventContext::new().focused(true),
                     )
                 })
             },

--- a/benches/component_view.rs
+++ b/benches/component_view.rs
@@ -5,7 +5,7 @@
 
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use envision::backend::CaptureBackend;
-use envision::component::ViewContext;
+use envision::component::RenderContext;
 use envision::component::{
     Column, Component, SelectableList, SelectableListState, Table, TableRow, TableState, Tree,
     TreeNode, TreeState,
@@ -41,10 +41,7 @@ fn bench_selectable_list_view(c: &mut Criterion) {
                             .draw(|frame| {
                                 SelectableList::<String>::view(
                                     black_box(&state),
-                                    frame,
-                                    frame.area(),
-                                    &theme,
-                                    &ViewContext::default(),
+                                    &mut RenderContext::new(frame, frame.area(), &theme),
                                 );
                             })
                             .unwrap();
@@ -109,10 +106,7 @@ fn bench_table_view(c: &mut Criterion) {
                             .draw(|frame| {
                                 Table::<BenchRow>::view(
                                     black_box(&state),
-                                    frame,
-                                    frame.area(),
-                                    &theme,
-                                    &ViewContext::default(),
+                                    &mut RenderContext::new(frame, frame.area(), &theme),
                                 );
                             })
                             .unwrap();
@@ -181,10 +175,7 @@ fn bench_tree_view(c: &mut Criterion) {
                             .draw(|frame| {
                                 Tree::<String>::view(
                                     black_box(&state),
-                                    frame,
-                                    frame.area(),
-                                    &theme,
-                                    &ViewContext::default(),
+                                    &mut RenderContext::new(frame, frame.area(), &theme),
                                 );
                             })
                             .unwrap();
@@ -210,10 +201,7 @@ fn bench_tree_view(c: &mut Criterion) {
                     .draw(|frame| {
                         Tree::<String>::view(
                             black_box(&state),
-                            frame,
-                            frame.area(),
-                            &theme,
-                            &ViewContext::default(),
+                            &mut RenderContext::new(frame, frame.area(), &theme),
                         );
                     })
                     .unwrap();

--- a/benches/memory.rs
+++ b/benches/memory.rs
@@ -31,7 +31,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use envision::backend::CaptureBackend;
-use envision::component::ViewContext;
+use envision::component::RenderContext;
 use envision::component::{
     Column, Component, SelectableList, SelectableListState, Table, TableRow, TableState, Tree,
     TreeNode, TreeState,
@@ -137,10 +137,7 @@ fn bench_selectable_list_1000_view_allocs(c: &mut Criterion) {
                 .draw(|frame| {
                     SelectableList::<String>::view(
                         black_box(&state),
-                        frame,
-                        frame.area(),
-                        &theme,
-                        &ViewContext::default(),
+                        &mut RenderContext::new(frame, frame.area(), &theme),
                     );
                 })
                 .unwrap();
@@ -172,10 +169,7 @@ fn bench_table_1000_view_allocs(c: &mut Criterion) {
                 .draw(|frame| {
                     Table::<BenchRow>::view(
                         black_box(&state),
-                        frame,
-                        frame.area(),
-                        &theme,
-                        &ViewContext::default(),
+                        &mut RenderContext::new(frame, frame.area(), &theme),
                     );
                 })
                 .unwrap();
@@ -200,10 +194,7 @@ fn bench_tree_1000_view_allocs(c: &mut Criterion) {
                 .draw(|frame| {
                     Tree::<String>::view(
                         black_box(&state),
-                        frame,
-                        frame.area(),
-                        &theme,
-                        &ViewContext::default(),
+                        &mut RenderContext::new(frame, frame.area(), &theme),
                     );
                 })
                 .unwrap();

--- a/docs/superpowers/plans/2026-04-11-render-context-refactor.md
+++ b/docs/superpowers/plans/2026-04-11-render-context-refactor.md
@@ -1,0 +1,1138 @@
+# RenderContext Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor `Component::view()` from 5 parameters to 2 by introducing `RenderContext` (a wrapper for frame/area/theme/focus state) and renaming `ViewContext` → `EventContext`.
+
+**Architecture:** Pure refactor with no behavioral changes. Add two new types in `src/component/mod.rs`. Change the `Component` trait signature. Cascade updates through all 73 components, all examples, all tests, and all integration code in a single atomic PR. Existing snapshot tests must produce byte-identical output.
+
+**Tech Stack:** Rust (edition 2024), ratatui (Frame/Rect), cargo-nextest, insta snapshots.
+
+**Spec:** `docs/superpowers/specs/2026-04-11-render-context-design.md`
+
+**Target version:** 0.14.0 (breaking)
+
+---
+
+## Project Context
+
+- **Working branch:** `render-context-refactor` (already created from main, spec already committed at `c9003d6`).
+- **Atomic strategy:** This is one giant PR. The trait signature change cannot be done incrementally because all 73 components implement `view()` and the signature is part of the trait. Phase 1 adds types non-atomically; Phase 2 is the atomic switch.
+- **Snapshot tests are the canary:** all 179 `.snap` files under `src/component/*/snapshots/` must produce byte-identical output after the migration. Any snapshot diff is a regression bug, NOT something to accept with `cargo insta accept`.
+- **Test runner:** `cargo nextest run -p envision` (faster than `cargo test`).
+- **Doc tests:** run via `cargo test --doc -p envision` (separate from nextest).
+- **Signed commits required.** Git config has `commit.gpgsign=true`.
+- **No warnings allowed:** `cargo clippy --all-targets -- -D warnings` must be clean.
+
+---
+
+## File Structure
+
+This is a refactor across many files, but the file structure itself doesn't change. Files affected:
+
+**Modified (no new files in src/):**
+- `src/component/mod.rs` — type definitions, trait signature
+- `src/component/test_utils.rs` — test helper signatures
+- 73 component modules under `src/component/*/mod.rs` and their test files
+- `src/app/mod.rs` and runtime code that calls `Component::view()`
+- `src/harness/app_harness/mod.rs` — AppHarness component view calls
+- 88 example files under `examples/*.rs`
+- `tests/*.rs` — integration tests calling Component::view directly
+- `benches/component_view.rs`, `benches/component_events.rs`, `benches/memory.rs`
+- `CHANGELOG.md`
+- `MIGRATION.md`
+
+**New files:**
+- `src/component/tests/render_context.rs` — unit tests for the new types (or inline in existing tests file)
+
+---
+
+## Task 1: Add `EventContext` and `RenderContext` types (TDD)
+
+**Goal:** Introduce both types without yet changing the `Component` trait. Compiles cleanly. The new types coexist with the old `ViewContext` temporarily.
+
+**Files:**
+- Modify: `src/component/mod.rs` — add types
+- Modify: `src/component/tests.rs` — add unit tests (or wherever component-level tests live)
+
+---
+
+- [ ] **Step 1.1: Verify the current state of `src/component/mod.rs`**
+
+```bash
+grep -n "ViewContext" src/component/mod.rs | head -10
+```
+
+Confirm `ViewContext` is defined at lines ~523-548 and the `Component::view` signature uses it at line ~611.
+
+- [ ] **Step 1.2: Write failing unit tests for `RenderContext` and `EventContext`**
+
+Create `src/component/tests/render_context.rs` (new file). If `src/component/tests/` doesn't exist as a directory yet, create it and ensure `src/component/mod.rs` declares `#[cfg(test)] mod tests;` somewhere.
+
+Actually, check first whether `src/component/tests.rs` exists or `src/component/tests/` directory exists. If neither, write tests inline in `src/component/mod.rs` under `#[cfg(test)] mod render_context_tests { ... }`.
+
+```bash
+ls src/component/tests* 2>&1
+```
+
+If you see a file or directory, add tests there. Otherwise, add an inline test module at the end of `src/component/mod.rs` (just before any existing `#[cfg(test)]` block).
+
+Add these tests:
+
+```rust
+#[cfg(test)]
+mod render_context_tests {
+    use super::*;
+    use crate::component::test_utils::setup_render;
+
+    #[test]
+    fn test_event_context_default() {
+        let ctx = EventContext::default();
+        assert!(!ctx.focused);
+        assert!(!ctx.disabled);
+    }
+
+    #[test]
+    fn test_event_context_builder() {
+        let ctx = EventContext::new().focused(true);
+        assert!(ctx.focused);
+        assert!(!ctx.disabled);
+
+        let ctx = EventContext::new().focused(true).disabled(true);
+        assert!(ctx.focused);
+        assert!(ctx.disabled);
+    }
+
+    #[test]
+    fn test_render_context_construction() {
+        let (mut terminal, theme) = setup_render(60, 5);
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                let ctx = RenderContext::new(frame, area, &theme);
+                assert!(!ctx.focused);
+                assert!(!ctx.disabled);
+                assert_eq!(ctx.area, area);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn test_render_context_builder() {
+        let (mut terminal, theme) = setup_render(60, 5);
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                let ctx = RenderContext::new(frame, area, &theme)
+                    .focused(true)
+                    .disabled(true);
+                assert!(ctx.focused);
+                assert!(ctx.disabled);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn test_render_context_with_area() {
+        let (mut terminal, theme) = setup_render(60, 10);
+        terminal
+            .draw(|frame| {
+                let parent_area = frame.area();
+                let mut ctx = RenderContext::new(frame, parent_area, &theme).focused(true);
+                let child_area = ratatui::layout::Rect::new(5, 2, 20, 3);
+                {
+                    let child_ctx = ctx.with_area(child_area);
+                    assert_eq!(child_ctx.area, child_area);
+                    assert!(child_ctx.focused);
+                    assert_eq!(child_ctx.theme as *const _, ctx.theme as *const _);
+                }
+                // Parent context is valid again here
+                assert_eq!(ctx.area, parent_area);
+                assert!(ctx.focused);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn test_render_context_render_widget() {
+        use ratatui::widgets::Paragraph;
+        let (mut terminal, theme) = setup_render(60, 5);
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                let mut ctx = RenderContext::new(frame, area, &theme);
+                ctx.render_widget(Paragraph::new("hello"));
+            })
+            .unwrap();
+
+        let display = terminal.backend().to_string();
+        assert!(display.contains("hello"));
+    }
+
+    #[test]
+    fn test_event_context_from_render_context() {
+        let (mut terminal, theme) = setup_render(60, 5);
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                let ctx = RenderContext::new(frame, area, &theme)
+                    .focused(true)
+                    .disabled(false);
+                let event_ctx: EventContext = (&ctx).into();
+                assert!(event_ctx.focused);
+                assert!(!event_ctx.disabled);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn test_render_context_event_context_method() {
+        let (mut terminal, theme) = setup_render(60, 5);
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                let ctx = RenderContext::new(frame, area, &theme)
+                    .focused(true)
+                    .disabled(true);
+                let event_ctx = ctx.event_context();
+                assert!(event_ctx.focused);
+                assert!(event_ctx.disabled);
+            })
+            .unwrap();
+    }
+}
+```
+
+- [ ] **Step 1.3: Run the tests and verify they fail to compile**
+
+```bash
+cargo nextest run -p envision render_context_tests 2>&1 | tail -20
+```
+
+Expected: compilation errors about `EventContext` and `RenderContext` not existing.
+
+- [ ] **Step 1.4: Add `EventContext` to `src/component/mod.rs`**
+
+In `src/component/mod.rs`, just before the existing `pub struct ViewContext` at line ~523, add the new `EventContext`:
+
+```rust
+/// Context passed to [`Component::handle_event`].
+///
+/// Carries focus and disabled state from the parent so the component
+/// can decide whether and how to handle events. Use [`RenderContext`]
+/// for `view()`.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::component::EventContext;
+///
+/// let ctx = EventContext::default();
+/// assert!(!ctx.focused);
+///
+/// let ctx = EventContext::new().focused(true).disabled(false);
+/// assert!(ctx.focused);
+/// ```
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct EventContext {
+    /// Whether this component currently has keyboard focus.
+    pub focused: bool,
+    /// Whether this component is currently disabled.
+    pub disabled: bool,
+}
+
+impl EventContext {
+    /// Creates a new default EventContext (unfocused, enabled).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the focused state (builder pattern).
+    pub fn focused(mut self, focused: bool) -> Self {
+        self.focused = focused;
+        self
+    }
+
+    /// Sets the disabled state (builder pattern).
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+}
+```
+
+Leave the existing `ViewContext` definition untouched for now.
+
+- [ ] **Step 1.5: Add `RenderContext` to `src/component/mod.rs`**
+
+After the `EventContext` definition, add:
+
+```rust
+/// Context passed to [`Component::view`].
+///
+/// Bundles the frame, area, theme, and focus/disabled state into a
+/// single value so component view signatures stay short and adding
+/// new render-time fields is non-breaking.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use envision::component::{Component, RenderContext};
+/// use envision::theme::Theme;
+/// use envision::backend::CaptureBackend;
+/// use ratatui::Terminal;
+///
+/// let backend = CaptureBackend::new(80, 24);
+/// let mut terminal = Terminal::new(backend).unwrap();
+/// let theme = Theme::default();
+/// terminal.draw(|frame| {
+///     let area = frame.area();
+///     let mut ctx = RenderContext::new(frame, area, &theme).focused(true);
+///     // Pass `&mut ctx` to a component's `view` method.
+/// }).unwrap();
+/// ```
+pub struct RenderContext<'a> {
+    /// The ratatui frame to render into.
+    pub frame: &'a mut Frame<'a>,
+    /// The area within the frame to render to.
+    pub area: Rect,
+    /// The theme to use for styling.
+    pub theme: &'a Theme,
+    /// Whether the component currently has keyboard focus.
+    pub focused: bool,
+    /// Whether the component is currently disabled.
+    pub disabled: bool,
+}
+
+impl<'a> RenderContext<'a> {
+    /// Constructs a new RenderContext with `focused` and `disabled` both `false`.
+    pub fn new(frame: &'a mut Frame<'a>, area: Rect, theme: &'a Theme) -> Self {
+        Self {
+            frame,
+            area,
+            theme,
+            focused: false,
+            disabled: false,
+        }
+    }
+
+    /// Sets the focused state (builder pattern).
+    pub fn focused(mut self, focused: bool) -> Self {
+        self.focused = focused;
+        self
+    }
+
+    /// Sets the disabled state (builder pattern).
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    /// Returns a context with the same frame, theme, and focus state but
+    /// a different area.
+    ///
+    /// The returned context borrows the frame for a shorter lifetime, so
+    /// the parent context becomes valid again after the child context
+    /// goes out of scope.
+    pub fn with_area(&mut self, area: Rect) -> RenderContext<'_> {
+        RenderContext {
+            frame: self.frame,
+            area,
+            theme: self.theme,
+            focused: self.focused,
+            disabled: self.disabled,
+        }
+    }
+
+    /// Convenience: render a widget into this context's area.
+    ///
+    /// Equivalent to `self.frame.render_widget(widget, self.area)`.
+    pub fn render_widget<W: ratatui::widgets::Widget>(&mut self, widget: W) {
+        self.frame.render_widget(widget, self.area);
+    }
+
+    /// Returns the [`EventContext`] slice of this RenderContext.
+    pub fn event_context(&self) -> EventContext {
+        EventContext {
+            focused: self.focused,
+            disabled: self.disabled,
+        }
+    }
+}
+
+impl From<&RenderContext<'_>> for EventContext {
+    fn from(ctx: &RenderContext<'_>) -> Self {
+        EventContext {
+            focused: ctx.focused,
+            disabled: ctx.disabled,
+        }
+    }
+}
+```
+
+- [ ] **Step 1.6: Re-export the new types from lib.rs**
+
+In `src/lib.rs`, find the line that re-exports `ViewContext`:
+
+```bash
+grep -n "ViewContext" src/lib.rs
+```
+
+There should be a line like `pub use component::{Component, FocusManager, Toggleable, ViewContext};`. Update it to also export the new types:
+
+```rust
+pub use component::{Component, EventContext, FocusManager, RenderContext, Toggleable, ViewContext};
+```
+
+(Keep `ViewContext` in the export for now — Task 2 will remove it.)
+
+- [ ] **Step 1.7: Verify the new types compile and tests pass**
+
+```bash
+cargo check -p envision 2>&1 | tail -10
+```
+
+Expected: clean compile. If there are lifetime errors on `RenderContext`, the most likely culprit is the `&'a mut Frame<'a>` self-referential lifetime. If `cargo check` fails, escalate — DO NOT try to bypass the lifetime issue. The trait change in Task 2 won't work without this.
+
+Then run the new tests:
+
+```bash
+cargo nextest run -p envision render_context_tests 2>&1 | tail -10
+```
+
+Expected: all 8 tests pass.
+
+Then run the doc test on the new `RenderContext`:
+
+```bash
+cargo test --doc -p envision RenderContext 2>&1 | tail -10
+```
+
+Expected: doc test passes.
+
+- [ ] **Step 1.8: Run the full test suite to confirm no regressions**
+
+```bash
+cargo nextest run -p envision 2>&1 | tail -5
+```
+
+Expected: all existing tests pass (16,136+ tests) plus the 8 new ones. If any existing test fails, the type additions broke something — investigate.
+
+- [ ] **Step 1.9: Format and lint**
+
+```bash
+cargo fmt
+cargo clippy -p envision -- -D warnings 2>&1 | tail -3
+```
+
+Expected: no formatting diffs, no clippy warnings.
+
+- [ ] **Step 1.10: Commit (signed)**
+
+```bash
+git add src/component/mod.rs src/lib.rs
+git commit -S -m "$(cat <<'EOF'
+Add RenderContext and EventContext types (foundation for 0.14.0)
+
+Introduces RenderContext bundling frame/area/theme/focus state, and
+EventContext as the renamed-soon successor to ViewContext for use in
+handle_event. The Component trait still uses the old (frame, area,
+theme, ctx) signature; the next commit makes the breaking switch.
+
+Adds 8 unit tests covering construction, builder, with_area reborrow,
+render_widget shortcut, and From conversion.
+
+Part of docs/superpowers/specs/2026-04-11-render-context-design.md
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Switch the `Component` trait + cascade through all callers (atomic)
+
+**Goal:** Atomic change that updates the `Component` trait, removes `ViewContext`, and migrates every component, every test, every example, and every internal call site to use `RenderContext` and `EventContext`.
+
+**Files:** Many. The expected change is roughly ~5000 lines across ~150 files. The transformation is mechanical pattern-substitution.
+
+**This is the largest single task in the project's history. Work methodically.**
+
+---
+
+- [ ] **Step 2.1: Update the `Component` trait in `src/component/mod.rs`**
+
+Change the trait method signatures:
+
+```rust
+// FROM
+fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext);
+
+// TO
+fn view(state: &Self::State, ctx: &mut RenderContext<'_>);
+```
+
+```rust
+// FROM
+fn handle_event(state: &Self::State, event: &Event, ctx: &ViewContext) -> Option<Self::Message> {
+    let _ = (state, event, ctx);
+    None
+}
+
+// TO
+fn handle_event(state: &Self::State, event: &Event, ctx: &EventContext) -> Option<Self::Message> {
+    let _ = (state, event, ctx);
+    None
+}
+```
+
+```rust
+// FROM
+fn traced_view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    #[cfg(feature = "tracing")]
+    let _span = tracing::trace_span!(
+        "component_view",
+        component = std::any::type_name::<Self>(),
+        area.x = area.x,
+        area.y = area.y,
+        area.width = area.width,
+        area.height = area.height,
+    )
+    .entered();
+    Self::view(state, frame, area, theme, ctx);
+}
+
+// TO
+fn traced_view(state: &Self::State, ctx: &mut RenderContext<'_>) {
+    #[cfg(feature = "tracing")]
+    let _span = tracing::trace_span!(
+        "component_view",
+        component = std::any::type_name::<Self>(),
+        area.x = ctx.area.x,
+        area.y = ctx.area.y,
+        area.width = ctx.area.width,
+        area.height = ctx.area.height,
+    )
+    .entered();
+    Self::view(state, ctx);
+}
+```
+
+Also update the `dispatch_event` function (search for it in `src/component/mod.rs` — it currently takes a `ViewContext`):
+
+```bash
+grep -n "dispatch_event\|fn dispatch_event" src/component/mod.rs
+```
+
+Update its signature: any `&ViewContext` parameter becomes `&EventContext`.
+
+- [ ] **Step 2.2: Remove `ViewContext` definition and re-export**
+
+In `src/component/mod.rs`, delete the existing `pub struct ViewContext` definition (was around line 523-548 before Task 1's additions). It's been replaced by `EventContext`.
+
+In `src/lib.rs`, remove `ViewContext` from the re-export:
+
+```rust
+// Before
+pub use component::{Component, EventContext, FocusManager, RenderContext, Toggleable, ViewContext};
+
+// After
+pub use component::{Component, EventContext, FocusManager, RenderContext, Toggleable};
+```
+
+Also check `src/lib.rs` for any prelude module that re-exports `ViewContext`:
+
+```bash
+grep -n "ViewContext" src/lib.rs
+```
+
+Replace all occurrences with `EventContext` and `RenderContext` (or just `EventContext` if the prelude doesn't include rendering primitives).
+
+- [ ] **Step 2.3: Run cargo check to discover the cascade**
+
+```bash
+cargo check -p envision 2>&1 | head -100
+```
+
+Expected: many compile errors, all of them in component implementations and call sites that use the old `view()` signature or `ViewContext`.
+
+Save the error list to a file for tracking:
+
+```bash
+cargo check -p envision 2>&1 > /tmp/render-context-errors.txt
+```
+
+Count the errors:
+
+```bash
+grep -c "^error" /tmp/render-context-errors.txt
+```
+
+This gives a rough sense of how many call sites need updating. Expect 200-500 errors initially.
+
+- [ ] **Step 2.4: Update `src/component/test_utils.rs`**
+
+```bash
+grep -n "ViewContext\|fn view" src/component/test_utils.rs
+```
+
+Update any helper functions that:
+- Take a `ViewContext` parameter → take an `EventContext` parameter
+- Construct a `ViewContext` → construct a `RenderContext` if for view, `EventContext` if for event handling
+
+If there's a `setup_render` helper or similar, it likely doesn't need changes (it returns `(terminal, theme)` and the caller does the rest).
+
+- [ ] **Step 2.5: Update `src/component/mod.rs` `dispatch_event`**
+
+The `dispatch_event` function takes `&ViewContext` and needs to take `&EventContext`. Update it.
+
+- [ ] **Step 2.6: Update each component's `view()` and `handle_event()` impls**
+
+This is the bulk of the work. For each of the 73 components under `src/component/*/`, update:
+
+1. The `Component` trait impl's `view()` signature and body
+2. The `Component` trait impl's `handle_event()` signature
+3. Any internal helper functions that take `frame`/`area`/`theme`/`ViewContext` parameters
+4. Any tests in that component's test files that call `view()` or `handle_event()` directly
+
+The transformation pattern (apply mechanically):
+
+```rust
+// view() — BEFORE
+fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    // body uses: frame, area, theme, ctx.focused, ctx.disabled
+}
+
+// view() — AFTER
+fn view(state: &Self::State, ctx: &mut RenderContext<'_>) {
+    // body uses: ctx.frame, ctx.area, ctx.theme, ctx.focused, ctx.disabled
+}
+```
+
+```rust
+// handle_event() — BEFORE
+fn handle_event(state: &Self::State, event: &Event, ctx: &ViewContext) -> Option<Self::Message> {
+    // ...
+}
+
+// handle_event() — AFTER (only the type name changes)
+fn handle_event(state: &Self::State, event: &Event, ctx: &EventContext) -> Option<Self::Message> {
+    // ...
+}
+```
+
+For internal render helper functions that take separate frame/area/theme:
+
+```rust
+// BEFORE
+fn render_header(frame: &mut Frame, area: Rect, theme: &Theme, focused: bool) { ... }
+
+// Caller
+render_header(frame, header_area, theme, ctx.focused);
+```
+
+You have two choices:
+- **A.** Keep the helper signature as-is, just update the caller to pass `ctx.frame, header_area, ctx.theme, ctx.focused`. This is the path of least resistance and preserves internal API.
+- **B.** Update the helper to take `&mut RenderContext` and use `ctx.with_area(header_area)` at the call site.
+
+**Use approach A** for this PR. The goal is the trait surface change, not internal refactoring. We can revisit internal helpers in a follow-up.
+
+For sub-area rendering when calling another Component's `view()`:
+
+```rust
+// BEFORE
+SomeComponent::view(&state.child, frame, child_area, theme, &child_ctx);
+
+// AFTER
+let mut child_render_ctx = ctx.with_area(child_area);
+child_render_ctx.focused = child_ctx.focused;
+child_render_ctx.disabled = child_ctx.disabled;
+SomeComponent::view(&state.child, &mut child_render_ctx);
+```
+
+Or more concisely if focused/disabled match the parent:
+
+```rust
+let mut child_render_ctx = ctx.with_area(child_area);
+SomeComponent::view(&state.child, &mut child_render_ctx);
+```
+
+**Strategy:** work alphabetically. After updating each component, run:
+
+```bash
+cargo check -p envision -- --bin envision 2>&1 | grep "error\[" | wc -l
+```
+
+The error count should go down. When it hits zero, the migration is structurally complete.
+
+**Components to update (alphabetical, all 73):**
+
+accordion, alert_panel, big_text, box_plot, breadcrumb, button, calendar,
+canvas, chart, checkbox, code_block, collapsible, command_palette,
+confirm_dialog, conversation_view, data_grid, dependency_graph, dialog,
+diff_viewer, divider, dropdown, event_stream, file_browser, flame_graph,
+focus_manager, form, gauge, heatmap, help_panel, histogram, input_field,
+key_hints, line_input, loading_list, log_correlation, log_viewer,
+markdown_renderer, menu, metrics_dashboard, multi_progress, number_input,
+paginator, pane_layout, progress_bar, radio_group, router, scroll_view,
+scrollable_text, searchable_list, select, selectable_list, slider,
+span_tree, sparkline, spinner, split_panel, status_bar, status_log,
+step_indicator, styled_text, switch, tab_bar, table, tabs, terminal_output,
+text_area, timeline, title_card, toast, tooltip, tree, treemap,
+usage_display
+
+Track progress in a checklist if helpful:
+
+```bash
+echo "=== Component migration progress ==="
+for comp in accordion alert_panel big_text ...; do
+    if grep -q "ctx: &mut RenderContext" src/component/$comp/mod.rs 2>/dev/null; then
+        echo "✓ $comp"
+    else
+        echo "✗ $comp"
+    fi
+done
+```
+
+- [ ] **Step 2.7: Update `src/app/` runtime call sites**
+
+The runtime is what eventually calls `Component::view()` for the App's view tree. Find call sites:
+
+```bash
+grep -rn "::view(" src/app/ | head -20
+```
+
+Most relevant: `App::view()` is implemented by users, but the runtime calls it. Check `src/app/runtime/mod.rs` and related files for any internal `view()` calls.
+
+The `App` trait itself has a `view()` method too — check its signature:
+
+```bash
+grep -n "fn view" src/app/model/mod.rs
+```
+
+If `App::view()` takes the same 5-arg signature, update it to match the new pattern:
+
+```rust
+// BEFORE (if applicable)
+fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme);
+
+// AFTER
+fn view(state: &Self::State, ctx: &mut RenderContext<'_>);
+```
+
+The `App::view()` doesn't currently have a `ViewContext` because the App is at the root (always focused). Decide whether the App should also use RenderContext for consistency. **Recommended: yes.** Apps benefit from the same `render_widget` shortcut and the future-proof signature.
+
+Update the runtime to construct a `RenderContext` and call `App::view()`:
+
+```rust
+// In the runtime's draw closure
+terminal.draw(|frame| {
+    let area = frame.area();
+    let mut ctx = RenderContext::new(frame, area, &theme);
+    A::view(&state, &mut ctx);
+})?;
+```
+
+- [ ] **Step 2.8: Update `src/harness/app_harness/mod.rs`**
+
+```bash
+grep -n "::view(\|ViewContext" src/harness/app_harness/mod.rs
+```
+
+Update any call sites to use the new API. AppHarness likely has internal `view()` calls for testing.
+
+- [ ] **Step 2.9: Run cargo check until clean**
+
+```bash
+cargo check -p envision 2>&1 | tail -10
+```
+
+Expected: clean compile. If errors remain, address them one at a time. Common remaining issues:
+- A test file you forgot to update
+- A doc test in a comment that uses the old API
+- An internal helper function that still takes `&ViewContext`
+
+For doc tests inside source files (not separate test files), search for them:
+
+```bash
+grep -rn "ViewContext::default\(\)\|frame: &mut Frame" src/ | grep -v test
+```
+
+- [ ] **Step 2.10: Update all examples**
+
+```bash
+ls examples/*.rs | wc -l  # should be 89
+```
+
+For each example file, update:
+- `App::view()` impl (if it implements App and has the old signature)
+- Any `Component::view()` direct calls
+- Any `ViewContext` references → `EventContext` for handle_event, `RenderContext` for view
+
+```bash
+for ex in examples/*.rs; do
+    echo "=== $ex ==="
+    grep -l "ViewContext\|fn view" "$ex" 2>/dev/null
+done
+```
+
+Verify all examples compile:
+
+```bash
+cargo build --examples --all-features 2>&1 | tail -10
+```
+
+Expected: clean build of all 89 examples.
+
+- [ ] **Step 2.11: Update integration tests**
+
+```bash
+grep -rn "ViewContext\|::view(" tests/ | head -20
+```
+
+For each integration test file in `tests/`, update:
+- `ViewContext` references → `EventContext`
+- `Component::view(state, frame, area, theme, &ctx)` → construct a `RenderContext` and pass it
+
+```bash
+cargo nextest run -p envision --tests 2>&1 | tail -10
+```
+
+Expected: all integration tests pass.
+
+- [ ] **Step 2.12: Update benchmarks**
+
+```bash
+grep -rn "ViewContext\|::view(" benches/ | head -20
+```
+
+Three benchmark files likely need updates:
+- `benches/component_view.rs`
+- `benches/component_events.rs`
+- `benches/memory.rs`
+
+Update each to construct a `RenderContext` instead of passing 5 separate args.
+
+Verify benchmarks compile (without running them):
+
+```bash
+cargo bench --no-run 2>&1 | tail -10
+```
+
+- [ ] **Step 2.13: Update doc tests**
+
+Doc tests embedded in `///` comments throughout `src/` need updating. They're the easiest to forget.
+
+```bash
+cargo test --doc -p envision 2>&1 | tail -20
+```
+
+Expected: all doc tests pass. If any fail with "no method named X" or "expected ViewContext, found EventContext" errors, find the failing doc test and update it.
+
+The most common pattern in doc tests:
+
+```rust
+/// ```rust
+/// use envision::component::{Component, Button, ButtonState, ViewContext};
+/// // ... old call ...
+/// ```
+```
+
+Becomes:
+
+```rust
+/// ```rust
+/// use envision::component::{Component, Button, ButtonState, RenderContext, EventContext};
+/// // ... new call ...
+/// ```
+```
+
+Many doc tests don't actually call `view()` and only need the import update.
+
+- [ ] **Step 2.14: Run the full test suite — snapshot equality is critical**
+
+```bash
+cargo nextest run -p envision 2>&1 | tail -10
+```
+
+Expected: ALL tests pass. Specifically, the 179 snapshot tests must produce byte-identical output.
+
+If any snapshot test fails, do **NOT** run `cargo insta accept`. A snapshot diff means the rendering output changed, which is a regression bug introduced during the migration. Investigate the failing component.
+
+Check for unexpected snapshot changes:
+
+```bash
+git diff --stat src/component/*/snapshots/ | tail -5
+```
+
+Expected: zero changes to snapshot files.
+
+- [ ] **Step 2.15: Format and lint**
+
+```bash
+cargo fmt
+cargo clippy -p envision --all-targets -- -D warnings 2>&1 | tail -3
+```
+
+Expected: no formatting diffs, no clippy warnings.
+
+- [ ] **Step 2.16: Final cargo check across all targets**
+
+```bash
+cargo check -p envision --all-targets --all-features 2>&1 | tail -3
+```
+
+Expected: clean.
+
+- [ ] **Step 2.17: Update CHANGELOG.md**
+
+Under `## [Unreleased]`, add a `### Breaking` section (or append to an existing one):
+
+```markdown
+### Breaking
+
+- **`Component::view` signature changed** from
+  `(state, frame, area, theme, ctx)` to `(state, ctx)`. The new
+  `ctx: &mut RenderContext<'_>` bundles `frame`, `area`, `theme`,
+  `focused`, and `disabled` into a single value. See MIGRATION.md
+  for the upgrade path.
+
+- **`ViewContext` renamed to `EventContext`.** It is now used only
+  by `Component::handle_event`, not by `Component::view`. The fields
+  and builder methods are unchanged.
+
+- **`Component::handle_event` signature changed** from
+  `(state, event, ctx: &ViewContext)` to
+  `(state, event, ctx: &EventContext)`. Pure type rename.
+
+- **`Component::traced_view` signature changed** to match the new
+  `view` signature.
+```
+
+- [ ] **Step 2.18: Update MIGRATION.md**
+
+Add a new section for 0.14.0:
+
+```markdown
+## Migrating from 0.13.x to 0.14.0
+
+### `Component::view` signature change
+
+The `view()` method on the `Component` trait now takes a single
+`RenderContext` parameter instead of five separate parameters.
+
+**Before (0.13.x):**
+
+\```rust
+fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    let style = if ctx.focused { theme.focused_style() } else { theme.normal_style() };
+    frame.render_widget(Paragraph::new("hello").style(style), area);
+}
+\```
+
+**After (0.14.0):**
+
+\```rust
+fn view(state: &Self::State, ctx: &mut RenderContext<'_>) {
+    let style = if ctx.focused { ctx.theme.focused_style() } else { ctx.theme.normal_style() };
+    ctx.render_widget(Paragraph::new("hello").style(style));
+}
+\```
+
+**Substitution rules:**
+
+1. Replace the parameter list `frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext` with `ctx: &mut RenderContext<'_>`.
+2. Replace `theme.X` with `ctx.theme.X`.
+3. Replace `frame.render_widget(widget, area)` with `ctx.render_widget(widget)` (or equivalent `ctx.frame.render_widget(widget, ctx.area)`).
+4. `ctx.focused` and `ctx.disabled` are still accessed directly — they're now fields on `RenderContext`.
+
+### `ViewContext` renamed to `EventContext`
+
+The type previously used by both `view()` and `handle_event()` is now
+called `EventContext` and is used only by `handle_event()`. The fields
+(`focused`, `disabled`) and builder methods are unchanged.
+
+**Before:**
+
+\```rust
+fn handle_event(state: &Self::State, event: &Event, ctx: &ViewContext) -> Option<Self::Message> { ... }
+\```
+
+**After:**
+
+\```rust
+fn handle_event(state: &Self::State, event: &Event, ctx: &EventContext) -> Option<Self::Message> { ... }
+\```
+
+### Sub-area rendering for nested components
+
+If your component renders a child into a sub-area, use `ctx.with_area`:
+
+\```rust
+// Before
+SomeChild::view(&state.child, frame, child_area, theme, &ctx);
+
+// After
+let mut child_ctx = ctx.with_area(child_area);
+SomeChild::view(&state.child, &mut child_ctx);
+\```
+
+The returned `child_ctx` borrows the frame for a shorter lifetime so
+the parent context becomes valid again after the child render returns.
+
+### Test code calling `Component::view` directly
+
+**Before:**
+
+\```rust
+let (mut terminal, theme) = setup_render(60, 5);
+terminal.draw(|frame| {
+    Button::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+}).unwrap();
+\```
+
+**After:**
+
+\```rust
+let (mut terminal, theme) = setup_render(60, 5);
+terminal.draw(|frame| {
+    let mut ctx = RenderContext::new(frame, frame.area(), &theme);
+    Button::view(&state, &mut ctx);
+}).unwrap();
+\```
+```
+
+- [ ] **Step 2.19: Final full verification**
+
+```bash
+cargo nextest run -p envision 2>&1 | tail -3
+cargo test --doc -p envision 2>&1 | tail -3
+cargo build --examples --all-features 2>&1 | tail -3
+cargo clippy -p envision --all-targets -- -D warnings 2>&1 | tail -3
+cargo fmt --check
+```
+
+All five must succeed.
+
+- [ ] **Step 2.20: Commit (signed) — the atomic migration**
+
+```bash
+git add -A
+git commit -S -m "$(cat <<'EOF'
+Migrate Component::view to RenderContext, rename ViewContext
+
+BREAKING CHANGE for 0.14.0.
+
+Changes Component::view from:
+    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext)
+to:
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_>)
+
+Renames ViewContext -> EventContext (used only by handle_event now,
+not by view). Updates Component::handle_event to take &EventContext.
+Updates Component::traced_view to match the new view signature.
+
+Cascade through all 73 components, all 89 examples, all integration
+tests, all benchmarks, all doc tests, the runtime, and the AppHarness.
+
+Snapshot tests verify byte-identical rendering output — no behavioral
+changes, only signature changes.
+
+CHANGELOG and MIGRATION.md updated with upgrade path.
+
+Part of docs/superpowers/specs/2026-04-11-render-context-design.md
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Push and open PR
+
+- [ ] **Step 3.1: Push the branch**
+
+```bash
+git push -u origin render-context-refactor 2>&1 | tail -5
+```
+
+- [ ] **Step 3.2: Open the PR**
+
+```bash
+gh pr create --title "Refactor Component::view to use RenderContext (BREAKING, 0.14.0)" --body "$(cat <<'EOF'
+## Summary
+
+**Breaking change for 0.14.0.** Refactors `Component::view` from 5 parameters to 2 by introducing `RenderContext`, which bundles `frame`, `area`, `theme`, `focused`, and `disabled` into a single value.
+
+**Before:**
+\`\`\`rust
+fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext);
+\`\`\`
+
+**After:**
+\`\`\`rust
+fn view(state: &Self::State, ctx: &mut RenderContext<'_>);
+\`\`\`
+
+Also renames \`ViewContext\` -> \`EventContext\` since it is now used only by \`handle_event\`, not by \`view\`.
+
+## What changed
+
+- New types: \`RenderContext<'a>\` and \`EventContext\` in \`src/component/mod.rs\`
+- \`Component::view\` and \`Component::traced_view\` use \`&mut RenderContext<'_>\`
+- \`Component::handle_event\` uses \`&EventContext\` (renamed from \`ViewContext\`)
+- All 73 components migrated to the new signatures
+- All 89 examples updated
+- All integration tests, doc tests, benchmarks, and the AppHarness updated
+- CHANGELOG.md and MIGRATION.md updated with upgrade path
+
+## Why
+
+The 5-parameter \`view()\` signature was the audit's #1 trust-eroding finding for the library: users implementing custom components had to understand and propagate ratatui's \`Frame\` and \`Rect\` types plus the framework's \`Theme\` and \`ViewContext\`. The new \`RenderContext\` simplifies the signature, provides a place for future render-time fields without breaking changes, and matches how mature TUI/UI frameworks bundle render state.
+
+Design spec: \`docs/superpowers/specs/2026-04-11-render-context-design.md\`
+
+## Test plan
+
+- [x] All 16,000+ existing tests pass without modification beyond signature updates
+- [x] All 179 snapshot tests produce byte-identical output (no \`cargo insta accept\` allowed)
+- [x] 8 new unit tests for \`RenderContext\` and \`EventContext\`
+- [x] All 89 examples compile
+- [x] \`cargo doc --no-deps --all-features\` succeeds
+- [x] \`cargo clippy --all-targets -- -D warnings\` clean
+- [x] \`cargo fmt\` clean
+
+## Migration
+
+See MIGRATION.md for the 0.14.0 upgrade path with before/after code samples.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3.3: Check CI**
+
+```bash
+gh pr checks $(gh pr view --json number -q .number)
+```
+
+Wait for all required checks to pass before merging.
+
+---
+
+## Definition of done
+
+- [ ] `RenderContext` and `EventContext` types exist in `src/component/mod.rs`
+- [ ] `Component::view`, `Component::handle_event`, and `Component::traced_view` use the new types
+- [ ] `ViewContext` is removed from the codebase (no occurrences in `grep -r "ViewContext" src/`)
+- [ ] All 73 components compile and pass tests
+- [ ] All 89 examples compile
+- [ ] All snapshot tests produce byte-identical output (zero `.snap` file changes in the diff)
+- [ ] All doc tests pass
+- [ ] CHANGELOG.md has the breaking change entry under `[Unreleased]`
+- [ ] MIGRATION.md has a 0.14.0 section with upgrade examples
+- [ ] PR opened, CI green
+- [ ] PR will be squash-merged

--- a/docs/superpowers/specs/2026-04-11-render-context-design.md
+++ b/docs/superpowers/specs/2026-04-11-render-context-design.md
@@ -1,0 +1,317 @@
+# RenderContext refactor — design
+
+**Status:** approved
+**Date:** 2026-04-11
+**Target version:** 0.14.0 (breaking)
+**Source:** library audit finding #1 (Complexity Hiding B+ → A-)
+
+## Problem
+
+The `Component::view()` trait method takes 5 parameters:
+
+```rust
+fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext);
+```
+
+Every Component impl signature carries this verbosity. Adding a new
+render-time concern (e.g., a new render-time configuration value)
+requires touching every component's signature — a breaking change.
+
+The audit's #1 trust-eroding finding for the library: users
+implementing custom components must understand and propagate ratatui's
+`Frame` and `Rect` types, plus the framework's `Theme` and
+`ViewContext`. A wrapper that bundles these into one value would:
+
+1. Shorten every `view()` signature to two parameters
+2. Make adding new render-time fields non-breaking
+3. Provide a single place to put convenience methods like `render_widget`
+4. Match how mature TUI/UI frameworks (e.g., GPUI, Iced) wrap render context
+
+## Goal
+
+Introduce `RenderContext` bundling the rendering machinery, simplify
+`Component::view()` to two parameters, and rename `ViewContext` →
+`EventContext` since it is no longer the context passed to `view()`.
+
+Non-goals:
+- Changing component rendering behavior. This is a pure refactor.
+- Adding new render-time fields. The struct gives us room to grow,
+  but the initial fields exactly mirror today's parameters.
+- Touching `Component::handle_event` semantics. Only the parameter
+  type name changes (`ViewContext` → `EventContext`).
+
+## Design
+
+### New types in `src/component/mod.rs`
+
+```rust
+/// Context passed to [`Component::handle_event`].
+///
+/// Carries focus and disabled state from the parent so the component
+/// can decide whether and how to handle events.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct EventContext {
+    /// Whether this component currently has keyboard focus.
+    pub focused: bool,
+    /// Whether this component is currently disabled.
+    pub disabled: bool,
+}
+
+impl EventContext {
+    pub fn new() -> Self { Self::default() }
+    pub fn focused(mut self, focused: bool) -> Self { self.focused = focused; self }
+    pub fn disabled(mut self, disabled: bool) -> Self { self.disabled = disabled; self }
+}
+
+/// Context passed to [`Component::view`].
+///
+/// Bundles the frame, area, theme, and focus/disabled state into a
+/// single value so component view signatures stay short and adding
+/// new render-time fields is non-breaking.
+pub struct RenderContext<'a> {
+    pub frame: &'a mut Frame<'a>,
+    pub area: Rect,
+    pub theme: &'a Theme,
+    pub focused: bool,
+    pub disabled: bool,
+}
+
+impl<'a> RenderContext<'a> {
+    /// Constructs a new RenderContext with focused/disabled both `false`.
+    pub fn new(frame: &'a mut Frame<'a>, area: Rect, theme: &'a Theme) -> Self {
+        Self { frame, area, theme, focused: false, disabled: false }
+    }
+
+    pub fn focused(mut self, focused: bool) -> Self { self.focused = focused; self }
+    pub fn disabled(mut self, disabled: bool) -> Self { self.disabled = disabled; self }
+
+    /// Returns a context with the same frame/theme/focus state but a
+    /// different area. The returned context borrows the frame for a
+    /// shorter lifetime, so the parent context becomes valid again
+    /// after the child context is dropped.
+    pub fn with_area(&mut self, area: Rect) -> RenderContext<'_> {
+        RenderContext {
+            frame: self.frame,
+            area,
+            theme: self.theme,
+            focused: self.focused,
+            disabled: self.disabled,
+        }
+    }
+
+    /// Convenience: render a widget into this context's area.
+    ///
+    /// Equivalent to `self.frame.render_widget(widget, self.area)`.
+    pub fn render_widget<W: Widget>(&mut self, widget: W) {
+        self.frame.render_widget(widget, self.area);
+    }
+
+    /// Returns the [`EventContext`] slice of this RenderContext.
+    pub fn event_context(&self) -> EventContext {
+        EventContext { focused: self.focused, disabled: self.disabled }
+    }
+}
+
+impl From<&RenderContext<'_>> for EventContext {
+    fn from(ctx: &RenderContext<'_>) -> Self {
+        EventContext { focused: ctx.focused, disabled: ctx.disabled }
+    }
+}
+```
+
+### Updated `Component` trait
+
+```rust
+pub trait Component: Sized {
+    type State;
+    type Message: Clone;
+    type Output: Clone;
+
+    fn init() -> Self::State;
+    fn update(state: &mut Self::State, msg: Self::Message) -> Option<Self::Output>;
+
+    /// Render the component using the given context.
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_>);
+
+    /// Map an input event to a component message.
+    fn handle_event(
+        state: &Self::State,
+        event: &Event,
+        ctx: &EventContext,
+    ) -> Option<Self::Message> {
+        let _ = (state, event, ctx);
+        None
+    }
+
+    /// Renders the component with optional tracing instrumentation.
+    fn traced_view(state: &Self::State, ctx: &mut RenderContext<'_>) {
+        #[cfg(feature = "tracing")]
+        let _span = tracing::trace_span!(
+            "component_view",
+            component = std::any::type_name::<Self>(),
+            area.x = ctx.area.x,
+            area.y = ctx.area.y,
+            area.width = ctx.area.width,
+            area.height = ctx.area.height,
+        ).entered();
+        Self::view(state, ctx);
+    }
+}
+```
+
+### Migration pattern
+
+Every component's `view()` impl follows this mechanical transformation:
+
+```rust
+// Before
+fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    let style = if ctx.focused { theme.focused_style() } else { theme.normal_style() };
+    let widget = Paragraph::new(state.label.as_str()).style(style);
+    frame.render_widget(widget, area);
+}
+
+// After
+fn view(state: &Self::State, ctx: &mut RenderContext<'_>) {
+    let style = if ctx.focused { ctx.theme.focused_style() } else { ctx.theme.normal_style() };
+    let widget = Paragraph::new(state.label.as_str()).style(style);
+    ctx.render_widget(widget);
+}
+```
+
+Substitution rules:
+1. `frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext` → `ctx: &mut RenderContext<'_>`
+2. `theme.X` → `ctx.theme.X`
+3. `frame.render_widget(w, area)` → `ctx.render_widget(w)` (preferred) or `ctx.frame.render_widget(w, ctx.area)`
+4. `frame.render_stateful_widget(w, area, &mut state)` → `ctx.frame.render_stateful_widget(w, ctx.area, &mut state)` (no shortcut)
+5. Sub-area rendering: `frame.render_widget(w, sub_area)` → `let mut sub = ctx.with_area(sub_area); sub.render_widget(w);` OR keep explicit form
+6. `ViewContext` references in `handle_event` signatures → `EventContext`
+
+Components that subdivide their area for child components use `ctx.with_area(child_area)` to construct a child context that borrows the same frame for a shorter lifetime, then pass it to the child component's view.
+
+### Files affected
+
+- `src/component/mod.rs` — trait definition, type definitions, ViewContext rename
+- 73 component modules under `src/component/*/` — every `view()` impl, every `handle_event` impl
+- `src/component/test_utils.rs` — test helper signatures
+- `src/app/` — `App::view()` impl signatures and runtime call sites that invoke `Component::view`
+- `src/harness/` — AppHarness component view calls
+- 88 example files under `examples/` — most call `Component::view` or implement `App::view`
+- `tests/` integration tests — any test that calls `Component::view` directly
+- `benches/component_view.rs` and `benches/component_events.rs` — benchmark call sites
+- `benches/memory.rs` — same
+- `CHANGELOG.md` — breaking change entry under `[0.14.0]`
+- `MIGRATION.md` — new section explaining the upgrade path
+
+### PR strategy
+
+**One atomic PR.** Partial updates won't compile because the trait
+signature change is atomic. Splitting would require deprecation
+shims that don't work for trait method signatures.
+
+The PR will be large (estimated ~5000 lines changed across ~150 files)
+but **mechanically reviewable**: most changes are pattern-substitution.
+Reviewers can spot-check a few representative components and trust
+the rest.
+
+## Testing
+
+### Regression coverage
+
+The existing 16,136 tests must all pass after the migration. Component
+behavior is unchanged — only signatures change. Specifically:
+
+- **179 snapshot tests** must produce byte-identical output. Any
+  snapshot diff is a bug.
+- **1978 doc tests** must all pass. Doc test code blocks need updating
+  to use the new API.
+- **All unit tests** must pass without modification beyond signature
+  updates at the call sites.
+
+### New tests for `RenderContext` and `EventContext`
+
+In `src/component/tests/render_context.rs` (new file):
+
+1. `test_render_context_construction` — `RenderContext::new(frame, area, theme)` produces a context with focused=false, disabled=false.
+2. `test_render_context_builder` — `.focused(true).disabled(true)` chain produces the expected values.
+3. `test_render_context_with_area` — `with_area(child_area)` returns a context with the new area, same frame/theme/focus, and the parent context is valid again after the child context goes out of scope.
+4. `test_render_context_render_widget` — calling `ctx.render_widget(widget)` produces the same rendered output as `frame.render_widget(widget, area)`.
+5. `test_event_context_from_render_context` — the `From<&RenderContext<'_>>` impl produces matching focused/disabled fields.
+6. `test_render_context_event_context_method` — `ctx.event_context()` matches the `From` impl.
+7. `test_event_context_default` — `EventContext::default()` is `{ focused: false, disabled: false }`.
+8. `test_event_context_builder` — `.focused(true)` and `.disabled(true)` work.
+
+### Verification gates (in order)
+
+1. `cargo check` — compiles
+2. `cargo nextest run -p envision` — all 16,136 existing tests pass
+3. `cargo test --doc -p envision` — all doc tests pass
+4. **Snapshot byte-identical check**: `git diff -- src/**/snapshots/` after running tests should be empty. If any `.snap` file changed, that's a behavioral regression.
+5. `cargo build --examples --all-features` — all 88 examples compile
+6. `cargo clippy -p envision --all-targets -- -D warnings` — no warnings
+7. `cargo fmt --check` — formatted
+8. New `RenderContext` unit tests pass
+
+## Risk and rollback
+
+**Risk: medium-high.** This is the largest atomic refactor in the
+project's history. Risks:
+
+1. **Compile errors during migration** — partial updates won't compile.
+   Mitigation: do all the work on a feature branch, only merge when
+   the entire build is green.
+
+2. **Lifetime issues with `Frame<'a>`** — `&'a mut Frame<'a>` is a
+   self-referential lifetime that can be tricky. Mitigation: prototype
+   the trait change with one or two components first to confirm the
+   lifetime works, then cascade.
+
+3. **`with_area` lifetime gymnastics** — the reborrow pattern needs
+   careful annotation. Mitigation: write the unit test first to verify
+   the borrow checker accepts the pattern.
+
+4. **Snapshot test regressions** — any byte-level rendering difference
+   indicates a bug introduced during migration. Mitigation: the
+   snapshot equality check is the canary. No `cargo insta accept`
+   allowed during this PR.
+
+5. **Reviewer fatigue** — 150+ files in one PR. Mitigation: make the
+   changes mechanical and pattern-based so spot-checking is enough.
+
+**Rollback:** revert the single PR. Because the change is atomic, the
+revert is also atomic.
+
+## CHANGELOG / MIGRATION entries
+
+### CHANGELOG (under `[0.14.0]` → `### Breaking`)
+
+```markdown
+- **`Component::view` signature changed** from
+  `(state, frame, area, theme, ctx)` to `(state, ctx)`. The new
+  `ctx: &mut RenderContext<'_>` bundles `frame`, `area`, `theme`,
+  `focused`, and `disabled` into a single value. See MIGRATION.md
+  for the upgrade path.
+
+- **`ViewContext` renamed to `EventContext`.** It is now used only by
+  `Component::handle_event`, not by `Component::view`. The fields
+  and builder methods are unchanged.
+
+- **`Component::handle_event` signature changed** from
+  `(state, event, ctx: &ViewContext)` to
+  `(state, event, ctx: &EventContext)`. Pure type rename.
+
+- **`Component::traced_view` signature changed** to match the new
+  `view` signature.
+```
+
+### MIGRATION.md
+
+A new section explaining the upgrade path with before/after code
+samples for the most common patterns:
+
+1. Simple component view (Button-style)
+2. Component view that uses theme heavily
+3. Component view with sub-area rendering
+4. App::view implementation
+5. Test code that calls Component::view directly
+6. Custom Component implementations

--- a/examples/accordion.rs
+++ b/examples/accordion.rs
@@ -77,10 +77,7 @@ impl App for AccordionApp {
 
         Accordion::view(
             &state.accordion,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let panel_idx = state
@@ -110,7 +107,7 @@ impl App for AccordionApp {
                 return Some(Msg::Quit);
             }
         }
-        Accordion::handle_event(&state.accordion, event, &ViewContext::new().focused(true))
+        Accordion::handle_event(&state.accordion, event, &EventContext::new().focused(true))
             .map(Msg::Accordion)
     }
 }

--- a/examples/alert_panel.rs
+++ b/examples/alert_panel.rs
@@ -71,10 +71,7 @@ impl App for AlertPanelApp {
 
         AlertPanel::view(
             &state.panel,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let selected = state
@@ -98,7 +95,7 @@ impl App for AlertPanelApp {
                 return Some(Msg::Quit);
             }
         }
-        AlertPanel::handle_event(&state.panel, event, &ViewContext::new().focused(true))
+        AlertPanel::handle_event(&state.panel, event, &EventContext::new().focused(true))
             .map(Msg::Panel)
     }
 }

--- a/examples/beautiful_dashboard.rs
+++ b/examples/beautiful_dashboard.rs
@@ -289,7 +289,7 @@ impl App for DashboardApp {
             Msg::ChartNextSeries => {
                 // Toggle active series via chart message
                 let event = Event::key(KeyCode::Tab);
-                Chart::dispatch_event(&mut state.chart, &event, &ViewContext::default());
+                Chart::dispatch_event(&mut state.chart, &event, &EventContext::default());
             }
             Msg::Quit => {
                 return Command::quit();
@@ -331,14 +331,11 @@ impl App for DashboardApp {
         // ── Key Hints ──
         KeyHints::view(
             &state.hints,
-            frame,
-            main[4],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, main[4], &theme),
         );
 
         // ── Toast overlay (renders on top) ──
-        Toast::view(&state.toasts, frame, area, &theme, &ViewContext::default());
+        Toast::view(&state.toasts, &mut RenderContext::new(frame, area, &theme));
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {
@@ -366,7 +363,7 @@ impl App for DashboardApp {
 // =============================================================================
 
 fn sync_focus(_state: &mut State) {
-    // No-op: focused/disabled state is passed via ViewContext, not stored in component state.
+    // No-op: focused/disabled state is passed via EventContext, not stored in component state.
 }
 
 fn render_title_bar(state: &State, frame: &mut Frame, area: Rect, _theme: &Theme) {
@@ -438,7 +435,7 @@ fn render_navigation(state: &State, frame: &mut Frame, area: Rect, theme: &Theme
     frame.render_widget(block, area);
 
     // Render menu inside the block
-    Menu::view(&state.menu, frame, inner, theme, &ViewContext::default());
+    Menu::view(&state.menu, &mut RenderContext::new(frame, inner, theme));
 }
 
 fn render_content(state: &State, frame: &mut Frame, area: Rect, theme: &Theme) {
@@ -476,10 +473,7 @@ fn render_content(state: &State, frame: &mut Frame, area: Rect, theme: &Theme) {
     frame.render_widget(chart_block, content[0]);
     Chart::view(
         &state.chart,
-        frame,
-        chart_inner,
-        theme,
-        &ViewContext::default(),
+        &mut RenderContext::new(frame, chart_inner, theme),
     );
 
     // ── Metrics Panel ──
@@ -510,10 +504,7 @@ fn render_content(state: &State, frame: &mut Frame, area: Rect, theme: &Theme) {
     frame.render_widget(metrics_block, content[1]);
     MetricsDashboard::view(
         &state.metrics,
-        frame,
-        metrics_inner,
-        theme,
-        &ViewContext::default(),
+        &mut RenderContext::new(frame, metrics_inner, theme),
     );
 }
 
@@ -542,24 +533,15 @@ fn render_progress(state: &State, frame: &mut Frame, area: Rect, theme: &Theme) 
 
     ProgressBar::view(
         &state.progress_cpu,
-        frame,
-        cols[0],
-        theme,
-        &ViewContext::default(),
+        &mut RenderContext::new(frame, cols[0], theme),
     );
     ProgressBar::view(
         &state.progress_mem,
-        frame,
-        cols[1],
-        theme,
-        &ViewContext::default(),
+        &mut RenderContext::new(frame, cols[1], theme),
     );
     ProgressBar::view(
         &state.progress_disk,
-        frame,
-        cols[2],
-        theme,
-        &ViewContext::default(),
+        &mut RenderContext::new(frame, cols[2], theme),
     );
 }
 

--- a/examples/big_text.rs
+++ b/examples/big_text.rs
@@ -81,10 +81,7 @@ impl App for BigTextApp {
         frame.render_widget(clock_label, chunks[0]);
         BigText::view(
             &state.clock,
-            frame,
-            chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[1], &theme),
         );
 
         let metric_label =
@@ -92,20 +89,14 @@ impl App for BigTextApp {
         frame.render_widget(metric_label, chunks[2]);
         BigText::view(
             &state.metric,
-            frame,
-            chunks[3],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[3], &theme),
         );
 
         let pct_label = Paragraph::new(" Uptime").style(Style::default().fg(Color::DarkGray));
         frame.render_widget(pct_label, chunks[4]);
         BigText::view(
             &state.percentage,
-            frame,
-            chunks[5],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[5], &theme),
         );
 
         let footer = Paragraph::new(" BigText dashboard metrics | Esc to quit")

--- a/examples/box_plot.rs
+++ b/examples/box_plot.rs
@@ -61,10 +61,7 @@ impl App for BoxPlotApp {
         let area = frame.area();
         BoxPlot::view(
             &state.box_plot,
-            frame,
-            area,
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, area, &theme),
         );
     }
 

--- a/examples/breadcrumb.rs
+++ b/examples/breadcrumb.rs
@@ -78,10 +78,7 @@ impl App for BreadcrumbApp {
 
         Breadcrumb::view(
             &state.breadcrumb,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         // Show selection history
@@ -114,7 +111,7 @@ impl App for BreadcrumbApp {
                 return Some(Msg::Quit);
             }
         }
-        Breadcrumb::handle_event(&state.breadcrumb, event, &ViewContext::new().focused(true))
+        Breadcrumb::handle_event(&state.breadcrumb, event, &EventContext::new().focused(true))
             .map(Msg::Breadcrumb)
     }
 }

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -104,24 +104,15 @@ impl App for ButtonApp {
 
         Button::view(
             &state.save,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
         Button::view(
             &state.cancel,
-            frame,
-            chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[1], &theme),
         );
         Button::view(
             &state.submit,
-            frame,
-            chunks[2],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[2], &theme),
         );
 
         // Last pressed info
@@ -157,11 +148,11 @@ impl App for ButtonApp {
         }
         // Route event to focused button
         match state.focus_index {
-            0 => Button::handle_event(&state.save, event, &ViewContext::new().focused(true))
+            0 => Button::handle_event(&state.save, event, &EventContext::new().focused(true))
                 .map(Msg::Save),
-            1 => Button::handle_event(&state.cancel, event, &ViewContext::new().focused(true))
+            1 => Button::handle_event(&state.cancel, event, &EventContext::new().focused(true))
                 .map(Msg::Cancel),
-            _ => Button::handle_event(&state.submit, event, &ViewContext::new().focused(true))
+            _ => Button::handle_event(&state.submit, event, &EventContext::new().focused(true))
                 .map(Msg::Submit),
         }
     }

--- a/examples/calendar.rs
+++ b/examples/calendar.rs
@@ -55,10 +55,7 @@ impl App for CalendarApp {
 
         Calendar::view(
             &state.calendar,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let selected_info = match state.calendar.selected_day() {
@@ -86,7 +83,7 @@ impl App for CalendarApp {
                 return Some(Msg::Quit);
             }
         }
-        Calendar::handle_event(&state.calendar, event, &ViewContext::new().focused(true))
+        Calendar::handle_event(&state.calendar, event, &EventContext::new().focused(true))
             .map(Msg::Calendar)
     }
 }

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -95,10 +95,7 @@ impl App for CanvasApp {
         let theme = Theme::default();
         Canvas::view(
             &state.canvas,
-            frame,
-            frame.area(),
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, frame.area(), &theme),
         );
     }
 

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -68,17 +68,11 @@ impl App for ChartApp {
 
         Chart::view(
             &state.line_chart,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
         Chart::view(
             &state.bar_chart,
-            frame,
-            chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[1], &theme),
         );
     }
 

--- a/examples/chart_enhanced.rs
+++ b/examples/chart_enhanced.rs
@@ -80,17 +80,11 @@ impl App for ChartEnhancedApp {
 
         Chart::view(
             &state.area_chart,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
         Chart::view(
             &state.scatter_chart,
-            frame,
-            chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[1], &theme),
         );
     }
 

--- a/examples/chat_client.rs
+++ b/examples/chat_client.rs
@@ -336,47 +336,32 @@ impl App for ChatClient {
         // Tab bar
         TabBar::view(
             &state.tab_bar,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::new().focused(true),
+            &mut RenderContext::new(frame, chunks[0], &theme).focused(true),
         );
 
         // Conversation
         ConversationView::view(
             &state.active_conv().view,
-            frame,
-            chunks[1],
-            &theme,
-            &ViewContext::new().focused(conv_focused),
+            &mut RenderContext::new(frame, chunks[1], &theme).focused(conv_focused),
         );
 
         // Input
         TextArea::view(
             &state.input,
-            frame,
-            chunks[2],
-            &theme,
-            &ViewContext::new().focused(input_focused),
+            &mut RenderContext::new(frame, chunks[2], &theme).focused(input_focused),
         );
 
         // Status
         StatusBar::view(
             &state.status,
-            frame,
-            chunks[3],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[3], &theme),
         );
 
         // Command palette overlay (render last)
         if state.palette.is_visible() {
             CommandPalette::view(
                 &state.palette,
-                frame,
-                area,
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, area, &theme).focused(true),
             );
         }
     }
@@ -391,7 +376,7 @@ impl App for ChatClient {
 
         // Command palette gets priority
         if state.palette.is_visible() {
-            return CommandPalette::handle_event(&state.palette, event, &ViewContext::default())
+            return CommandPalette::handle_event(&state.palette, event, &EventContext::default())
                 .map(Msg::Palette);
         }
 
@@ -417,7 +402,7 @@ impl App for ChatClient {
             if ctrl && key.code == KeyCode::Enter {
                 return Some(Msg::SubmitInput);
             }
-            return TextArea::handle_event(&state.input, event, &ViewContext::default())
+            return TextArea::handle_event(&state.input, event, &EventContext::default())
                 .map(Msg::Input);
         }
 
@@ -426,13 +411,13 @@ impl App for ChatClient {
             return ConversationView::handle_event(
                 &state.active_conv().view,
                 event,
-                &ViewContext::default(),
+                &EventContext::default(),
             )
             .map(Msg::Conv);
         }
 
         // Fall through: route to TabBar for left/right tab switching
-        TabBar::handle_event(&state.tab_bar, event, &ViewContext::default()).map(Msg::TabBar)
+        TabBar::handle_event(&state.tab_bar, event, &EventContext::default()).map(Msg::TabBar)
     }
 }
 
@@ -493,7 +478,7 @@ fn main() -> envision::Result<()> {
     println!("  - TabBar with closable conversation tabs");
     println!("  - TextArea multi-line input");
     println!("  - CommandPalette for slash commands");
-    println!("  - FocusManager + ViewContext focus routing");
+    println!("  - FocusManager + EventContext focus routing");
     println!("  - StatusBar with message count");
 
     Ok(())

--- a/examples/checkbox.rs
+++ b/examples/checkbox.rs
@@ -87,24 +87,15 @@ impl App for CheckboxApp {
 
         Checkbox::view(
             &state.notifications,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
         Checkbox::view(
             &state.dark_mode,
-            frame,
-            chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[1], &theme),
         );
         Checkbox::view(
             &state.auto_save,
-            frame,
-            chunks[2],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[2], &theme),
         );
 
         // Summary
@@ -157,13 +148,17 @@ impl App for CheckboxApp {
             0 => Checkbox::handle_event(
                 &state.notifications,
                 event,
-                &ViewContext::new().focused(true),
+                &EventContext::new().focused(true),
             )
             .map(Msg::Notifications),
-            1 => Checkbox::handle_event(&state.dark_mode, event, &ViewContext::new().focused(true))
-                .map(Msg::DarkMode),
-            _ => Checkbox::handle_event(&state.auto_save, event, &ViewContext::new().focused(true))
-                .map(Msg::AutoSave),
+            1 => {
+                Checkbox::handle_event(&state.dark_mode, event, &EventContext::new().focused(true))
+                    .map(Msg::DarkMode)
+            }
+            _ => {
+                Checkbox::handle_event(&state.auto_save, event, &EventContext::new().focused(true))
+                    .map(Msg::AutoSave)
+            }
         }
     }
 }

--- a/examples/code_block.rs
+++ b/examples/code_block.rs
@@ -97,10 +97,7 @@ fn main() {
         let theme = Theme::default();
         CodeBlock::view(
             &state.code,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let status = Paragraph::new(format!(
@@ -120,7 +117,7 @@ fn main() {
             }
         }
 
-        CodeBlock::handle_event(&state.code, event, &ViewContext::new().focused(true))
+        CodeBlock::handle_event(&state.code, event, &EventContext::new().focused(true))
             .map(Msg::Code)
     }
 }

--- a/examples/collapsible.rs
+++ b/examples/collapsible.rs
@@ -51,10 +51,7 @@ impl App for CollapsibleApp {
         // Render the collapsible header and border
         Collapsible::view(
             &state.collapsible,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         // Render content inside the content area when expanded
@@ -97,8 +94,12 @@ impl App for CollapsibleApp {
                 return Some(Msg::Quit);
             }
         }
-        Collapsible::handle_event(&state.collapsible, event, &ViewContext::new().focused(true))
-            .map(Msg::Collapsible)
+        Collapsible::handle_event(
+            &state.collapsible,
+            event,
+            &EventContext::new().focused(true),
+        )
+        .map(Msg::Collapsible)
     }
 }
 

--- a/examples/command_palette.rs
+++ b/examples/command_palette.rs
@@ -126,10 +126,7 @@ impl App for CommandPaletteApp {
         // Main area: render the command palette overlay
         CommandPalette::view(
             &state.palette,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         // Show selection history
@@ -170,7 +167,7 @@ impl App for CommandPaletteApp {
 
         // Delegate to palette when visible
         if state.palette.is_visible() {
-            CommandPalette::handle_event(&state.palette, event, &ViewContext::new().focused(true))
+            CommandPalette::handle_event(&state.palette, event, &EventContext::new().focused(true))
                 .map(Msg::Palette)
         } else {
             None

--- a/examples/component_showcase.rs
+++ b/examples/component_showcase.rs
@@ -4,7 +4,7 @@
 //! application using The Elm Architecture (TEA) pattern. It demonstrates:
 //!
 //! - **Event dispatch**: Using `dispatch_event` to route events to the focused component
-//! - **ViewContext**: Using `ViewContext::new().focused(true)` to pass focus state
+//! - **EventContext**: Using `EventContext::new().focused(true)` to pass focus state
 //! - **Simplified messages**: Global hotkeys only; component events dispatched directly
 //! - **Focus management**: Using `FocusManager` to coordinate keyboard focus
 //! - **Output handling**: Reacting to component outputs (selections, confirmations)
@@ -370,7 +370,7 @@ impl App for ShowcaseApp {
                     if let Some(output) = Dialog::dispatch_event(
                         &mut state.dialog,
                         &event,
-                        &ViewContext::new().focused(true),
+                        &EventContext::new().focused(true),
                     ) {
                         handle_dialog_output(state, output);
                     }
@@ -384,7 +384,7 @@ impl App for ShowcaseApp {
                         if let Some(MenuOutput::Selected(idx)) = Menu::dispatch_event(
                             &mut state.menu,
                             &event,
-                            &ViewContext::new().focused(true),
+                            &EventContext::new().focused(true),
                         ) {
                             let label = state.menu.items()[idx].label();
                             push_toast(
@@ -398,35 +398,35 @@ impl App for ShowcaseApp {
                         Tabs::dispatch_event(
                             &mut state.tabs,
                             &event,
-                            &ViewContext::new().focused(true),
+                            &EventContext::new().focused(true),
                         );
                     }
                     Some(FocusId::Input) => {
                         InputField::dispatch_event(
                             &mut state.input,
                             &event,
-                            &ViewContext::new().focused(true),
+                            &EventContext::new().focused(true),
                         );
                     }
                     Some(FocusId::Checkbox) => {
                         Checkbox::dispatch_event(
                             &mut state.checkbox,
                             &event,
-                            &ViewContext::new().focused(true),
+                            &EventContext::new().focused(true),
                         );
                     }
                     Some(FocusId::Radio) => {
                         RadioGroup::<String>::dispatch_event(
                             &mut state.radio,
                             &event,
-                            &ViewContext::new().focused(true),
+                            &EventContext::new().focused(true),
                         );
                     }
                     Some(FocusId::SubmitButton) => {
                         if Button::dispatch_event(
                             &mut state.submit_button,
                             &event,
-                            &ViewContext::new().focused(true),
+                            &EventContext::new().focused(true),
                         )
                         .is_some()
                         {
@@ -437,14 +437,14 @@ impl App for ShowcaseApp {
                         SelectableList::dispatch_event(
                             &mut state.list,
                             &event,
-                            &ViewContext::new().focused(true),
+                            &EventContext::new().focused(true),
                         );
                     }
                     Some(FocusId::Table) => {
                         if let Some(TableOutput::Selected(row)) = Table::dispatch_event(
                             &mut state.table,
                             &event,
-                            &ViewContext::new().focused(true),
+                            &EventContext::new().focused(true),
                         ) {
                             push_toast(
                                 &mut state.toast,
@@ -461,28 +461,28 @@ impl App for ShowcaseApp {
                         Heatmap::dispatch_event(
                             &mut state.heatmap,
                             &event,
-                            &ViewContext::new().focused(true),
+                            &EventContext::new().focused(true),
                         );
                     }
                     Some(FocusId::Timeline) => {
                         Timeline::dispatch_event(
                             &mut state.timeline,
                             &event,
-                            &ViewContext::new().focused(true),
+                            &EventContext::new().focused(true),
                         );
                     }
                     Some(FocusId::CommandPalette) => {
                         CommandPalette::dispatch_event(
                             &mut state.command_palette,
                             &event,
-                            &ViewContext::new().focused(true),
+                            &EventContext::new().focused(true),
                         );
                     }
                     Some(FocusId::CodeBlock) => {
                         CodeBlock::dispatch_event(
                             &mut state.code_block,
                             &event,
-                            &ViewContext::new().focused(true),
+                            &EventContext::new().focused(true),
                         );
                     }
                     None => {}
@@ -515,19 +515,13 @@ impl App for ShowcaseApp {
         // Menu bar
         envision::component::Menu::view(
             &state.menu,
-            frame,
-            main_chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, main_chunks[0], &theme),
         );
 
         // Tabs
         Tabs::view(
             &state.tabs,
-            frame,
-            main_chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, main_chunks[1], &theme),
         );
 
         // Content panel based on selected tab
@@ -565,10 +559,7 @@ impl App for ShowcaseApp {
             let dialog_area = centered_rect(40, 8, area);
             Dialog::view(
                 &state.dialog,
-                frame,
-                dialog_area,
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, dialog_area, &theme),
             );
         }
     }
@@ -643,31 +634,19 @@ fn render_form_panel(state: &State, frame: &mut Frame, area: Rect, theme: &Theme
 
     envision::component::InputField::view(
         &state.input,
-        frame,
-        chunks[0],
-        theme,
-        &ViewContext::default(),
+        &mut RenderContext::new(frame, chunks[0], theme),
     );
     envision::component::Checkbox::view(
         &state.checkbox,
-        frame,
-        chunks[1],
-        theme,
-        &ViewContext::default(),
+        &mut RenderContext::new(frame, chunks[1], theme),
     );
     envision::component::RadioGroup::view(
         &state.radio,
-        frame,
-        chunks[2],
-        theme,
-        &ViewContext::default(),
+        &mut RenderContext::new(frame, chunks[2], theme),
     );
     envision::component::Button::view(
         &state.submit_button,
-        frame,
-        chunks[3],
-        theme,
-        &ViewContext::default(),
+        &mut RenderContext::new(frame, chunks[3], theme),
     );
 }
 
@@ -691,19 +670,13 @@ fn render_data_panel(state: &State, frame: &mut Frame, area: Rect, theme: &Theme
     frame.render_widget(list_block, chunks[0]);
     envision::component::SelectableList::view(
         &state.list,
-        frame,
-        list_inner,
-        theme,
-        &ViewContext::default(),
+        &mut RenderContext::new(frame, list_inner, theme),
     );
 
     // Table
     Table::view(
         &state.table,
-        frame,
-        chunks[1],
-        theme,
-        &ViewContext::default(),
+        &mut RenderContext::new(frame, chunks[1], theme),
     );
 }
 
@@ -724,24 +697,15 @@ fn render_status_panel(state: &State, frame: &mut Frame, area: Rect, theme: &The
 
     envision::component::ProgressBar::view(
         &state.progress,
-        frame,
-        chunks[0],
-        theme,
-        &ViewContext::default(),
+        &mut RenderContext::new(frame, chunks[0], theme),
     );
     Spinner::view(
         &state.spinner,
-        frame,
-        chunks[1],
-        theme,
-        &ViewContext::default(),
+        &mut RenderContext::new(frame, chunks[1], theme),
     );
     Toast::view(
         &state.toast,
-        frame,
-        chunks[2],
-        theme,
-        &ViewContext::default(),
+        &mut RenderContext::new(frame, chunks[2], theme),
     );
 }
 
@@ -767,35 +731,23 @@ fn render_viz_panel(state: &State, frame: &mut Frame, area: Rect, theme: &Theme)
         Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)]).split(rows[0]);
     Sparkline::view(
         &state.sparkline,
-        frame,
-        top_cols[0],
-        theme,
-        &ViewContext::default(),
+        &mut RenderContext::new(frame, top_cols[0], theme),
     );
     Gauge::view(
         &state.gauge,
-        frame,
-        top_cols[1],
-        theme,
-        &ViewContext::default(),
+        &mut RenderContext::new(frame, top_cols[1], theme),
     );
 
     // Row 2: Heatmap (full width)
     Heatmap::view(
         &state.heatmap,
-        frame,
-        rows[1],
-        theme,
-        &ViewContext::default(),
+        &mut RenderContext::new(frame, rows[1], theme),
     );
 
     // Row 3: Timeline (full width)
     Timeline::view(
         &state.timeline,
-        frame,
-        rows[2],
-        theme,
-        &ViewContext::default(),
+        &mut RenderContext::new(frame, rows[2], theme),
     );
 
     // Row 4: CommandPalette (left) + CodeBlock (right)
@@ -803,17 +755,11 @@ fn render_viz_panel(state: &State, frame: &mut Frame, area: Rect, theme: &Theme)
         Layout::horizontal([Constraint::Percentage(40), Constraint::Percentage(60)]).split(rows[3]);
     CommandPalette::view(
         &state.command_palette,
-        frame,
-        bottom_cols[0],
-        theme,
-        &ViewContext::default(),
+        &mut RenderContext::new(frame, bottom_cols[0], theme),
     );
     CodeBlock::view(
         &state.code_block,
-        frame,
-        bottom_cols[1],
-        theme,
-        &ViewContext::default(),
+        &mut RenderContext::new(frame, bottom_cols[1], theme),
     );
 }
 
@@ -821,9 +767,9 @@ fn render_viz_panel(state: &State, frame: &mut Frame, area: Rect, theme: &Theme)
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Focus synchronization is now handled via ViewContext in view() and handle_event().
+/// Focus synchronization is now handled via EventContext in view() and handle_event().
 fn sync_focus(_state: &mut State) {
-    // No-op: focused/disabled state is passed via ViewContext, not stored in component state.
+    // No-op: focused/disabled state is passed via EventContext, not stored in component state.
 }
 
 /// Creates a centered rectangle for dialog overlays.

--- a/examples/confirm_dialog.rs
+++ b/examples/confirm_dialog.rs
@@ -116,7 +116,7 @@ impl App for ConfirmDialogApp {
 
         // Overlay dialog when visible
         if ConfirmDialog::is_visible(&state.dialog) {
-            ConfirmDialog::view(&state.dialog, frame, area, &theme, &ViewContext::default());
+            ConfirmDialog::view(&state.dialog, &mut RenderContext::new(frame, area, &theme));
         }
 
         let status = " d: delete dialog | s: save dialog | q: quit";
@@ -132,7 +132,7 @@ impl App for ConfirmDialogApp {
             return ConfirmDialog::handle_event(
                 &state.dialog,
                 event,
-                &ViewContext::new().focused(true),
+                &EventContext::new().focused(true),
             )
             .map(Msg::Dialog);
         }

--- a/examples/conversation_view.rs
+++ b/examples/conversation_view.rs
@@ -149,10 +149,7 @@ impl App for ConversationApp {
         let theme = Theme::default();
         ConversationView::view(
             &state.conversation,
-            frame,
-            frame.area(),
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, frame.area(), &theme),
         );
     }
 
@@ -166,7 +163,7 @@ impl App for ConversationApp {
         ConversationView::handle_event(
             &state.conversation,
             event,
-            &ViewContext::new().focused(true),
+            &EventContext::new().focused(true),
         )
         .map(Msg::Conversation)
     }

--- a/examples/dashboard_builder.rs
+++ b/examples/dashboard_builder.rs
@@ -242,10 +242,7 @@ impl App for Dashboard {
         // Tab bar
         Tabs::<DashTab>::view(
             &state.tabs,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::new().focused(true),
+            &mut RenderContext::new(frame, chunks[0], &theme).focused(true),
         );
 
         // Main content based on active tab
@@ -254,37 +251,25 @@ impl App for Dashboard {
             Some(DashTab::Overview) => {
                 MetricsDashboard::view(
                     &state.metrics,
-                    frame,
-                    chunks[1],
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, chunks[1], &theme).focused(true),
                 );
             }
             Some(DashTab::Alerts) => {
                 AlertPanel::view(
                     &state.alerts,
-                    frame,
-                    chunks[1],
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, chunks[1], &theme).focused(true),
                 );
             }
             Some(DashTab::Heatmap) => {
                 Heatmap::view(
                     &state.heatmap,
-                    frame,
-                    chunks[1],
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, chunks[1], &theme).focused(true),
                 );
             }
             None => {
                 MetricsDashboard::view(
                     &state.metrics,
-                    frame,
-                    chunks[1],
-                    &theme,
-                    &ViewContext::default(),
+                    &mut RenderContext::new(frame, chunks[1], &theme),
                 );
             }
         }
@@ -300,40 +285,25 @@ impl App for Dashboard {
 
         Sparkline::view(
             &state.cpu_spark,
-            frame,
-            gauge_chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, gauge_chunks[0], &theme),
         );
         Gauge::view(
             &state.cpu_gauge,
-            frame,
-            gauge_chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, gauge_chunks[1], &theme),
         );
         Gauge::view(
             &state.mem_gauge,
-            frame,
-            gauge_chunks[2],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, gauge_chunks[2], &theme),
         );
         Gauge::view(
             &state.disk_gauge,
-            frame,
-            gauge_chunks[3],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, gauge_chunks[3], &theme),
         );
 
         // Status bar
         StatusBar::view(
             &state.status,
-            frame,
-            chunks[3],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[3], &theme),
         );
     }
 
@@ -351,15 +321,15 @@ impl App for Dashboard {
                     Some(DashTab::Overview) => MetricsDashboard::handle_event(
                         &state.metrics,
                         event,
-                        &ViewContext::default(),
+                        &EventContext::default(),
                     )
                     .map(Msg::Metrics),
                     Some(DashTab::Alerts) => {
-                        AlertPanel::handle_event(&state.alerts, event, &ViewContext::default())
+                        AlertPanel::handle_event(&state.alerts, event, &EventContext::default())
                             .map(Msg::Alert)
                     }
                     Some(DashTab::Heatmap) => {
-                        Heatmap::handle_event(&state.heatmap, event, &ViewContext::default())
+                        Heatmap::handle_event(&state.heatmap, event, &EventContext::default())
                             .map(Msg::Heatmap)
                     }
                     None => None,

--- a/examples/dashboard_demo.rs
+++ b/examples/dashboard_demo.rs
@@ -348,38 +348,26 @@ impl App for DashboardApp {
 
         Chart::view(
             &state.chart,
-            frame,
-            left_chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, left_chunks[0], &theme),
         );
         MultiProgress::view(
             &state.multi_progress,
-            frame,
-            left_chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, left_chunks[1], &theme),
         );
 
         // Right column: status log
         StatusLog::view(
             &state.status_log,
-            frame,
-            content_chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, content_chunks[1], &theme),
         );
 
         // Toast overlay (renders on top of everything)
-        Toast::view(&state.toasts, frame, area, &theme, &ViewContext::default());
+        Toast::view(&state.toasts, &mut RenderContext::new(frame, area, &theme));
 
         // Status bar
         StatusBar::view(
             &state.status_bar,
-            frame,
-            main_chunks[2],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, main_chunks[2], &theme),
         );
 
         // Key hints
@@ -402,7 +390,7 @@ impl App for DashboardApp {
             }
         }
         // Delegate scroll to status log
-        StatusLog::handle_event(&state.status_log, event, &ViewContext::new().focused(true))
+        StatusLog::handle_event(&state.status_log, event, &EventContext::new().focused(true))
             .map(Msg::Log)
     }
 

--- a/examples/data_grid.rs
+++ b/examples/data_grid.rs
@@ -92,10 +92,7 @@ impl App for DataGridApp {
 
         DataGrid::view(
             &state.grid,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let selected = state
@@ -118,7 +115,8 @@ impl App for DataGridApp {
                 }
             }
         }
-        DataGrid::handle_event(&state.grid, event, &ViewContext::new().focused(true)).map(Msg::Grid)
+        DataGrid::handle_event(&state.grid, event, &EventContext::new().focused(true))
+            .map(Msg::Grid)
     }
 }
 

--- a/examples/dependency_graph.rs
+++ b/examples/dependency_graph.rs
@@ -97,10 +97,7 @@ impl App for DependencyGraphApp {
 
         DependencyGraph::view(
             &state.graph,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let selected_info = state
@@ -139,7 +136,7 @@ impl App for DependencyGraphApp {
                 return Some(Msg::Quit);
             }
         }
-        DependencyGraph::handle_event(&state.graph, event, &ViewContext::new().focused(true))
+        DependencyGraph::handle_event(&state.graph, event, &EventContext::new().focused(true))
             .map(Msg::Graph)
     }
 }

--- a/examples/dialog.rs
+++ b/examples/dialog.rs
@@ -84,7 +84,7 @@ impl App for DialogApp {
         frame.render_widget(content, chunks[0]);
 
         if Dialog::is_visible(&state.dialog) {
-            Dialog::view(&state.dialog, frame, area, &theme, &ViewContext::default());
+            Dialog::view(&state.dialog, &mut RenderContext::new(frame, area, &theme));
         }
 
         let status = " d: show dialog, q: quit";
@@ -96,7 +96,7 @@ impl App for DialogApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if Dialog::is_visible(&state.dialog) {
-            return Dialog::handle_event(&state.dialog, event, &ViewContext::new().focused(true))
+            return Dialog::handle_event(&state.dialog, event, &EventContext::new().focused(true))
                 .map(Msg::Dialog);
         }
         if let Some(key) = event.as_key() {

--- a/examples/diff_viewer.rs
+++ b/examples/diff_viewer.rs
@@ -79,10 +79,7 @@ fn main() {
         let theme = Theme::default();
         DiffViewer::view(
             &state.viewer,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let mode_str = match state.viewer.mode() {
@@ -109,7 +106,7 @@ fn main() {
             }
         }
 
-        DiffViewer::handle_event(&state.viewer, event, &ViewContext::new().focused(true))
+        DiffViewer::handle_event(&state.viewer, event, &EventContext::new().focused(true))
             .map(Msg::Viewer)
     }
 }

--- a/examples/divider.rs
+++ b/examples/divider.rs
@@ -62,17 +62,11 @@ impl App for DividerApp {
 
         Divider::view(
             &state.horizontal,
-            frame,
-            main_chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, main_chunks[0], &theme),
         );
         Divider::view(
             &state.horizontal_labeled,
-            frame,
-            main_chunks[2],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, main_chunks[2], &theme),
         );
 
         // Bottom section: vertical dividers side by side
@@ -86,17 +80,11 @@ impl App for DividerApp {
 
         Divider::view(
             &state.vertical,
-            frame,
-            vertical_chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, vertical_chunks[0], &theme),
         );
         Divider::view(
             &state.vertical_labeled,
-            frame,
-            vertical_chunks[2],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, vertical_chunks[2], &theme),
         );
     }
 

--- a/examples/dropdown.rs
+++ b/examples/dropdown.rs
@@ -62,10 +62,7 @@ impl App for DropdownApp {
 
         Dropdown::view(
             &state.language,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let selected = state.language.selected_value().unwrap_or("None");
@@ -82,7 +79,7 @@ impl App for DropdownApp {
                 return Some(Msg::Quit);
             }
         }
-        Dropdown::handle_event(&state.language, event, &ViewContext::new().focused(true))
+        Dropdown::handle_event(&state.language, event, &EventContext::new().focused(true))
             .map(Msg::Language)
     }
 }

--- a/examples/event_stream.rs
+++ b/examples/event_stream.rs
@@ -166,10 +166,7 @@ impl App for EventStreamApp {
 
         EventStream::view(
             &state.stream,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let visible = state.stream.visible_events().len();
@@ -190,7 +187,7 @@ impl App for EventStreamApp {
                 return Some(Msg::Quit);
             }
         }
-        EventStream::handle_event(&state.stream, event, &ViewContext::new().focused(true))
+        EventStream::handle_event(&state.stream, event, &EventContext::new().focused(true))
             .map(Msg::Stream)
     }
 }

--- a/examples/file_browser.rs
+++ b/examples/file_browser.rs
@@ -74,10 +74,7 @@ impl App for FileBrowserApp {
 
         FileBrowser::view(
             &state.browser,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let selected = state
@@ -111,7 +108,7 @@ impl App for FileBrowserApp {
                 return Some(Msg::Quit);
             }
         }
-        FileBrowser::handle_event(&state.browser, event, &ViewContext::new().focused(true))
+        FileBrowser::handle_event(&state.browser, event, &EventContext::new().focused(true))
             .map(Msg::Browser)
     }
 }

--- a/examples/file_manager.rs
+++ b/examples/file_manager.rs
@@ -258,10 +258,7 @@ impl App for FileManager {
         // Breadcrumb
         Breadcrumb::view(
             &state.breadcrumb,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::new().focused(browser_focused),
+            &mut RenderContext::new(frame, chunks[0], &theme).focused(browser_focused),
         );
 
         // Split panel: browser (left) + preview (right)
@@ -269,29 +266,20 @@ impl App for FileManager {
 
         FileBrowser::view(
             &state.browser,
-            frame,
-            left,
-            &theme,
-            &ViewContext::new().focused(browser_focused),
+            &mut RenderContext::new(frame, left, &theme).focused(browser_focused),
         );
 
         match state.preview_mode {
             PreviewMode::Code => {
                 CodeBlock::view(
                     &state.code,
-                    frame,
-                    right,
-                    &theme,
-                    &ViewContext::new().focused(preview_focused),
+                    &mut RenderContext::new(frame, right, &theme).focused(preview_focused),
                 );
             }
             PreviewMode::Diff => {
                 DiffViewer::view(
                     &state.diff,
-                    frame,
-                    right,
-                    &theme,
-                    &ViewContext::new().focused(preview_focused),
+                    &mut RenderContext::new(frame, right, &theme).focused(preview_focused),
                 );
             }
         }
@@ -299,20 +287,14 @@ impl App for FileManager {
         // Status bar
         StatusBar::view(
             &state.status,
-            frame,
-            chunks[2],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[2], &theme),
         );
 
         // Command palette overlay
         if state.palette.is_visible() {
             CommandPalette::view(
                 &state.palette,
-                frame,
-                area,
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, area, &theme).focused(true),
             );
         }
     }
@@ -327,7 +309,7 @@ impl App for FileManager {
 
         // Command palette gets priority
         if state.palette.is_visible() {
-            return CommandPalette::handle_event(&state.palette, event, &ViewContext::default())
+            return CommandPalette::handle_event(&state.palette, event, &EventContext::default())
                 .map(Msg::Palette);
         }
 
@@ -346,7 +328,7 @@ impl App for FileManager {
 
         // Browser-focused
         if state.focus.is_focused(&Focus::Browser) {
-            return FileBrowser::handle_event(&state.browser, event, &ViewContext::default())
+            return FileBrowser::handle_event(&state.browser, event, &EventContext::default())
                 .map(Msg::Browser);
         }
 
@@ -354,21 +336,21 @@ impl App for FileManager {
         if state.focus.is_focused(&Focus::Preview) {
             return match state.preview_mode {
                 PreviewMode::Code => {
-                    CodeBlock::handle_event(&state.code, event, &ViewContext::default())
+                    CodeBlock::handle_event(&state.code, event, &EventContext::default())
                         .map(Msg::Code)
                 }
                 PreviewMode::Diff => {
-                    DiffViewer::handle_event(&state.diff, event, &ViewContext::default())
+                    DiffViewer::handle_event(&state.diff, event, &EventContext::default())
                         .map(Msg::Diff)
                 }
             };
         }
 
         // Fall through: split panel resize and breadcrumb navigation
-        if let Some(m) = SplitPanel::handle_event(&state.split, event, &ViewContext::default()) {
+        if let Some(m) = SplitPanel::handle_event(&state.split, event, &EventContext::default()) {
             return Some(Msg::Split(m));
         }
-        Breadcrumb::handle_event(&state.breadcrumb, event, &ViewContext::default()).map(Msg::Crumb)
+        Breadcrumb::handle_event(&state.breadcrumb, event, &EventContext::default()).map(Msg::Crumb)
     }
 }
 
@@ -543,7 +525,7 @@ fn main() -> envision::Result<()> {
     println!("  - SplitPanel with resizable panes");
     println!("  - Breadcrumb path navigation");
     println!("  - CommandPalette for quick actions");
-    println!("  - FocusManager + ViewContext focus routing");
+    println!("  - FocusManager + EventContext focus routing");
     println!("  - StatusBar with file info");
 
     Ok(())

--- a/examples/flame_graph.rs
+++ b/examples/flame_graph.rs
@@ -80,10 +80,7 @@ impl App for FlameGraphApp {
 
         FlameGraph::view(
             &state.graph,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let selected = state
@@ -116,7 +113,7 @@ impl App for FlameGraphApp {
                 return Some(Msg::Quit);
             }
         }
-        FlameGraph::handle_event(&state.graph, event, &ViewContext::new().focused(true))
+        FlameGraph::handle_event(&state.graph, event, &EventContext::new().focused(true))
             .map(Msg::FlameGraph)
     }
 }

--- a/examples/form.rs
+++ b/examples/form.rs
@@ -90,10 +90,7 @@ impl App for FormApp {
         } else {
             Form::view(
                 &state.form,
-                frame,
-                chunks[0],
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, chunks[0], &theme),
             );
         }
 
@@ -111,7 +108,7 @@ impl App for FormApp {
                 return Some(Msg::Quit);
             }
         }
-        Form::handle_event(&state.form, event, &ViewContext::new().focused(true)).map(Msg::Form)
+        Form::handle_event(&state.form, event, &EventContext::new().focused(true)).map(Msg::Form)
     }
 }
 

--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -93,31 +93,19 @@ impl App for GaugeApp {
 
         Gauge::view(
             &state.cpu,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
         Gauge::view(
             &state.memory,
-            frame,
-            chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[1], &theme),
         );
         Gauge::view(
             &state.disk,
-            frame,
-            chunks[2],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[2], &theme),
         );
         Gauge::view(
             &state.network,
-            frame,
-            chunks[3],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[3], &theme),
         );
     }
 

--- a/examples/heatmap.rs
+++ b/examples/heatmap.rs
@@ -64,7 +64,7 @@ impl App for HeatmapApp {
     fn view(state: &State, frame: &mut Frame) {
         let theme = Theme::default();
         let area = frame.area();
-        Heatmap::view(&state.heatmap, frame, area, &theme, &ViewContext::default());
+        Heatmap::view(&state.heatmap, &mut RenderContext::new(frame, area, &theme));
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {

--- a/examples/help_panel.rs
+++ b/examples/help_panel.rs
@@ -96,10 +96,7 @@ impl App for HelpPanelApp {
         let theme = Theme::default();
         HelpPanel::view(
             &state.help,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let status = Paragraph::new(format!(
@@ -117,7 +114,7 @@ impl App for HelpPanelApp {
             }
         }
 
-        HelpPanel::handle_event(&state.help, event, &ViewContext::new().focused(true))
+        HelpPanel::handle_event(&state.help, event, &EventContext::new().focused(true))
             .map(Msg::Help)
     }
 }

--- a/examples/histogram.rs
+++ b/examples/histogram.rs
@@ -56,10 +56,7 @@ impl App for HistogramApp {
         let area = frame.area();
         Histogram::view(
             &state.histogram,
-            frame,
-            area,
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, area, &theme),
         );
     }
 

--- a/examples/input_field.rs
+++ b/examples/input_field.rs
@@ -68,10 +68,7 @@ impl App for InputFieldApp {
 
         InputField::view(
             &state.input,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         // Show submitted values
@@ -110,7 +107,7 @@ impl App for InputFieldApp {
                 return Some(Msg::Quit);
             }
         }
-        InputField::handle_event(&state.input, event, &ViewContext::new().focused(true))
+        InputField::handle_event(&state.input, event, &EventContext::new().focused(true))
             .map(Msg::Input)
     }
 }

--- a/examples/key_hints.rs
+++ b/examples/key_hints.rs
@@ -100,10 +100,7 @@ impl App for KeyHintsApp {
         // Key hints bar at the bottom
         KeyHints::view(
             &state.hints,
-            frame,
-            chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[1], &theme),
         );
     }
 

--- a/examples/line_input.rs
+++ b/examples/line_input.rs
@@ -65,10 +65,7 @@ impl App for LineInputApp {
         let theme = Theme::default();
         LineInput::view(
             &state.input,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         // Show submissions log
@@ -99,7 +96,7 @@ impl App for LineInputApp {
             }
         }
 
-        LineInput::handle_event(&state.input, event, &ViewContext::new().focused(true))
+        LineInput::handle_event(&state.input, event, &EventContext::new().focused(true))
             .map(Msg::Input)
     }
 }

--- a/examples/loading_list.rs
+++ b/examples/loading_list.rs
@@ -74,10 +74,7 @@ impl App for LoadingListApp {
 
         LoadingList::view(
             &state.list,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let selected = state
@@ -98,7 +95,7 @@ impl App for LoadingListApp {
                 return Some(Msg::Quit);
             }
         }
-        LoadingList::<Task>::handle_event(&state.list, event, &ViewContext::new().focused(true))
+        LoadingList::<Task>::handle_event(&state.list, event, &EventContext::new().focused(true))
             .map(Msg::List)
     }
 }

--- a/examples/log_correlation.rs
+++ b/examples/log_correlation.rs
@@ -144,10 +144,7 @@ impl App for LogCorrelationApp {
 
         LogCorrelation::view(
             &state.correlation,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let status = " Tab: switch stream | j/k: scroll | s: toggle sync | q: quit";
@@ -163,8 +160,12 @@ impl App for LogCorrelationApp {
                 return Some(Msg::Quit);
             }
         }
-        LogCorrelation::handle_event(&state.correlation, event, &ViewContext::new().focused(true))
-            .map(Msg::Correlation)
+        LogCorrelation::handle_event(
+            &state.correlation,
+            event,
+            &EventContext::new().focused(true),
+        )
+        .map(Msg::Correlation)
     }
 }
 

--- a/examples/log_explorer.rs
+++ b/examples/log_explorer.rs
@@ -12,7 +12,7 @@
 //
 // - **SplitPanel**: Side-by-side LogViewer + EventStream
 // - **FocusManager**: Tab-key focus cycling between panes
-// - **ViewContext**: Parent controls focus rendering per component
+// - **EventContext**: Parent controls focus rendering per component
 // - **CommandPalette**: Ctrl+P for action picker (overlay)
 // - **StatusBar**: Live counters and mode indicators
 // - **Async data**: Tick-driven simulated log stream
@@ -298,44 +298,32 @@ impl App for LogExplorer {
         // Get the two pane areas from SplitPanel
         let (left_area, right_area) = state.split.layout(chunks[0]);
 
-        // Determine focus for ViewContext
+        // Determine focus for EventContext
         let log_focused = state.focus.is_focused(&Pane::LogViewer);
         let event_focused = state.focus.is_focused(&Pane::EventStream);
 
-        // Render components with ViewContext carrying focus state
+        // Render components with EventContext carrying focus state
         LogViewer::view(
             &state.log,
-            frame,
-            left_area,
-            &theme,
-            &ViewContext::new().focused(log_focused),
+            &mut RenderContext::new(frame, left_area, &theme).focused(log_focused),
         );
 
         EventStream::view(
             &state.events,
-            frame,
-            right_area,
-            &theme,
-            &ViewContext::new().focused(event_focused),
+            &mut RenderContext::new(frame, right_area, &theme).focused(event_focused),
         );
 
         // Status bar (never focused)
         StatusBar::view(
             &state.status,
-            frame,
-            chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[1], &theme),
         );
 
         // Command palette renders last (overlay)
         if state.palette.is_visible() {
             CommandPalette::view(
                 &state.palette,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         }
     }
@@ -349,7 +337,7 @@ impl App for LogExplorer {
 
         // Command palette gets priority when visible
         if state.palette.is_visible() {
-            return CommandPalette::handle_event(&state.palette, event, &ViewContext::default())
+            return CommandPalette::handle_event(&state.palette, event, &EventContext::default())
                 .map(Msg::Palette);
         }
 
@@ -371,14 +359,15 @@ impl App for LogExplorer {
 
         // Route to focused component
         if state.focus.is_focused(&Pane::LogViewer) {
-            if let Some(msg) = LogViewer::handle_event(&state.log, event, &ViewContext::default()) {
+            if let Some(msg) = LogViewer::handle_event(&state.log, event, &EventContext::default())
+            {
                 return Some(Msg::Log(msg));
             }
         }
 
         if state.focus.is_focused(&Pane::EventStream) {
             if let Some(msg) =
-                EventStream::handle_event(&state.events, event, &ViewContext::default())
+                EventStream::handle_event(&state.events, event, &EventContext::default())
             {
                 return Some(Msg::Event(msg));
             }
@@ -515,7 +504,7 @@ fn main() -> envision::Result<()> {
     println!();
     println!("This demonstrates:");
     println!("  - SplitPanel with LogViewer + EventStream");
-    println!("  - FocusManager + ViewContext for focus routing");
+    println!("  - FocusManager + EventContext for focus routing");
     println!("  - CommandPalette overlay (Ctrl+P)");
     println!("  - StatusBar with live counters");
     println!("  - Async simulated data via on_tick");

--- a/examples/log_viewer.rs
+++ b/examples/log_viewer.rs
@@ -72,10 +72,7 @@ impl App for LogViewerApp {
 
         LogViewer::view(
             &state.viewer,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let visible = state.viewer.visible_entries().len();
@@ -101,7 +98,7 @@ impl App for LogViewerApp {
                 return Some(Msg::Quit);
             }
         }
-        LogViewer::handle_event(&state.viewer, event, &ViewContext::new().focused(true))
+        LogViewer::handle_event(&state.viewer, event, &EventContext::new().focused(true))
             .map(Msg::Viewer)
     }
 }

--- a/examples/markdown_renderer.rs
+++ b/examples/markdown_renderer.rs
@@ -105,10 +105,7 @@ impl App for MarkdownRendererApp {
         let theme = Theme::default();
         MarkdownRenderer::view(
             &state.renderer,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let mode = if state.renderer.show_source() {
@@ -132,7 +129,7 @@ impl App for MarkdownRendererApp {
             }
         }
 
-        MarkdownRenderer::handle_event(&state.renderer, event, &ViewContext::new().focused(true))
+        MarkdownRenderer::handle_event(&state.renderer, event, &EventContext::new().focused(true))
             .map(Msg::Renderer)
     }
 }

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -70,10 +70,7 @@ impl App for MenuApp {
 
         Menu::view(
             &state.menu,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let selected_text = state.last_selected.as_deref().unwrap_or("None");
@@ -98,7 +95,7 @@ impl App for MenuApp {
                 return Some(Msg::Quit);
             }
         }
-        Menu::handle_event(&state.menu, event, &ViewContext::new().focused(true)).map(Msg::Menu)
+        Menu::handle_event(&state.menu, event, &EventContext::new().focused(true)).map(Msg::Menu)
     }
 }
 

--- a/examples/metrics_dashboard.rs
+++ b/examples/metrics_dashboard.rs
@@ -61,10 +61,7 @@ impl App for MetricsDashboardApp {
 
         MetricsDashboard::view(
             &state.dashboard,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let selected = state
@@ -85,7 +82,7 @@ impl App for MetricsDashboardApp {
                 return Some(Msg::Quit);
             }
         }
-        MetricsDashboard::handle_event(&state.dashboard, event, &ViewContext::new().focused(true))
+        MetricsDashboard::handle_event(&state.dashboard, event, &EventContext::new().focused(true))
             .map(Msg::Dashboard)
     }
 }

--- a/examples/multi_progress.rs
+++ b/examples/multi_progress.rs
@@ -55,10 +55,7 @@ impl App for MultiProgressApp {
 
         MultiProgress::view(
             &state.progress,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let completed = state.progress.completed_count();
@@ -81,7 +78,7 @@ impl App for MultiProgressApp {
                 return Some(Msg::Quit);
             }
         }
-        MultiProgress::handle_event(&state.progress, event, &ViewContext::new().focused(true))
+        MultiProgress::handle_event(&state.progress, event, &EventContext::new().focused(true))
             .map(Msg::Progress)
     }
 }

--- a/examples/number_input.rs
+++ b/examples/number_input.rs
@@ -100,24 +100,15 @@ impl App for NumberInputApp {
 
         NumberInput::view(
             &state.quantity,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
         NumberInput::view(
             &state.price,
-            frame,
-            chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[1], &theme),
         );
         NumberInput::view(
             &state.temperature,
-            frame,
-            chunks[2],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[2], &theme),
         );
 
         let status = format!(
@@ -151,16 +142,18 @@ impl App for NumberInputApp {
 
         // Route event to focused input
         match state.focus_index {
-            0 => {
-                NumberInput::handle_event(&state.quantity, event, &ViewContext::new().focused(true))
-                    .map(Msg::Quantity)
-            }
-            1 => NumberInput::handle_event(&state.price, event, &ViewContext::new().focused(true))
+            0 => NumberInput::handle_event(
+                &state.quantity,
+                event,
+                &EventContext::new().focused(true),
+            )
+            .map(Msg::Quantity),
+            1 => NumberInput::handle_event(&state.price, event, &EventContext::new().focused(true))
                 .map(Msg::Price),
             _ => NumberInput::handle_event(
                 &state.temperature,
                 event,
-                &ViewContext::new().focused(true),
+                &EventContext::new().focused(true),
             )
             .map(Msg::Temperature),
         }

--- a/examples/paginator.rs
+++ b/examples/paginator.rs
@@ -94,10 +94,7 @@ impl App for PaginatorApp {
         );
         Paginator::view(
             &state.page_of_total,
-            frame,
-            chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[1], &theme),
         );
 
         frame.render_widget(
@@ -106,10 +103,7 @@ impl App for PaginatorApp {
         );
         Paginator::view(
             &state.range_of_total,
-            frame,
-            chunks[4],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[4], &theme),
         );
 
         frame.render_widget(
@@ -118,10 +112,7 @@ impl App for PaginatorApp {
         );
         Paginator::view(
             &state.dots,
-            frame,
-            chunks[7],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[7], &theme),
         );
 
         frame.render_widget(
@@ -130,10 +121,7 @@ impl App for PaginatorApp {
         );
         Paginator::view(
             &state.compact,
-            frame,
-            chunks[10],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[10], &theme),
         );
     }
 

--- a/examples/pane_layout.rs
+++ b/examples/pane_layout.rs
@@ -75,10 +75,7 @@ impl App for PaneLayoutApp {
         // Render pane borders
         PaneLayout::view(
             &state.layout,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         // Render content in each pane
@@ -120,7 +117,7 @@ impl App for PaneLayoutApp {
                 _ => {}
             }
         }
-        PaneLayout::handle_event(&state.layout, event, &ViewContext::new().focused(true))
+        PaneLayout::handle_event(&state.layout, event, &EventContext::new().focused(true))
             .map(Msg::Layout)
     }
 }

--- a/examples/production_app.rs
+++ b/examples/production_app.rs
@@ -209,10 +209,7 @@ impl App for ProcessorApp {
         frame.render_widget(progress_block, sections[1]);
         ProgressBar::view(
             &state.progress,
-            frame,
-            progress_inner,
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, progress_inner, &theme),
         );
 
         // -- Current file indicator --
@@ -239,10 +236,7 @@ impl App for ProcessorApp {
         // -- Status log --
         StatusLog::view(
             &state.log,
-            frame,
-            sections[3],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, sections[3], &theme),
         );
 
         // -- Bottom status bar --
@@ -266,7 +260,7 @@ impl App for ProcessorApp {
             }
         }
         // Delegate to the status log for scroll events (Up/Down keys).
-        StatusLog::handle_event(&state.log, event, &ViewContext::new().focused(true))
+        StatusLog::handle_event(&state.log, event, &EventContext::new().focused(true))
             .map(ProcessorMsg::Log)
     }
 }

--- a/examples/progress_bar.rs
+++ b/examples/progress_bar.rs
@@ -70,24 +70,15 @@ impl App for ProgressBarApp {
 
         ProgressBar::view(
             &state.download,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
         ProgressBar::view(
             &state.install,
-            frame,
-            chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[1], &theme),
         );
         ProgressBar::view(
             &state.verify,
-            frame,
-            chunks[2],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[2], &theme),
         );
     }
 

--- a/examples/radio_group.rs
+++ b/examples/radio_group.rs
@@ -61,10 +61,7 @@ impl App for RadioGroupApp {
 
         RadioGroup::<String>::view(
             &state.size,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let selected = state
@@ -93,7 +90,7 @@ impl App for RadioGroupApp {
                 return Some(Msg::Quit);
             }
         }
-        RadioGroup::<String>::handle_event(&state.size, event, &ViewContext::new().focused(true))
+        RadioGroup::<String>::handle_event(&state.size, event, &EventContext::new().focused(true))
             .map(Msg::Size)
     }
 }

--- a/examples/scroll_view.rs
+++ b/examples/scroll_view.rs
@@ -61,10 +61,7 @@ impl App for ScrollViewApp {
         // Render the scroll view (border + scrollbar)
         ScrollView::view(
             &state.scroll_view,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         // Render content inside the content area
@@ -98,8 +95,12 @@ impl App for ScrollViewApp {
                 return Some(Msg::Quit);
             }
         }
-        ScrollView::handle_event(&state.scroll_view, event, &ViewContext::new().focused(true))
-            .map(Msg::ScrollView)
+        ScrollView::handle_event(
+            &state.scroll_view,
+            event,
+            &EventContext::new().focused(true),
+        )
+        .map(Msg::ScrollView)
     }
 }
 

--- a/examples/scrollable_text.rs
+++ b/examples/scrollable_text.rs
@@ -64,10 +64,7 @@ impl App for ScrollableTextApp {
         let theme = Theme::default();
         ScrollableText::view(
             &state.text,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let status = Paragraph::new(format!(
@@ -85,7 +82,7 @@ impl App for ScrollableTextApp {
             }
         }
 
-        ScrollableText::handle_event(&state.text, event, &ViewContext::new().focused(true))
+        ScrollableText::handle_event(&state.text, event, &EventContext::new().focused(true))
             .map(Msg::Text)
     }
 }

--- a/examples/searchable_list.rs
+++ b/examples/searchable_list.rs
@@ -83,10 +83,7 @@ impl App for SearchableListApp {
 
         SearchableList::view(
             &state.list,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         // Show selection history
@@ -119,7 +116,7 @@ impl App for SearchableListApp {
                 return Some(Msg::Quit);
             }
         }
-        SearchableList::handle_event(&state.list, event, &ViewContext::new().focused(true))
+        SearchableList::handle_event(&state.list, event, &EventContext::new().focused(true))
             .map(Msg::List)
     }
 }

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -88,17 +88,11 @@ impl App for SelectApp {
 
         Select::view(
             &state.color,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::new().focused(state.focus_index == 0),
+            &mut RenderContext::new(frame, chunks[0], &theme).focused(state.focus_index == 0),
         );
         Select::view(
             &state.size,
-            frame,
-            chunks[1],
-            &theme,
-            &ViewContext::new().focused(state.focus_index == 1),
+            &mut RenderContext::new(frame, chunks[1], &theme).focused(state.focus_index == 1),
         );
 
         // Summary
@@ -137,9 +131,9 @@ impl App for SelectApp {
         }
         // Route event to focused select
         match state.focus_index {
-            0 => Select::handle_event(&state.color, event, &ViewContext::new().focused(true))
+            0 => Select::handle_event(&state.color, event, &EventContext::new().focused(true))
                 .map(Msg::Color),
-            _ => Select::handle_event(&state.size, event, &ViewContext::new().focused(true))
+            _ => Select::handle_event(&state.size, event, &EventContext::new().focused(true))
                 .map(Msg::Size),
         }
     }

--- a/examples/selectable_list.rs
+++ b/examples/selectable_list.rs
@@ -59,10 +59,7 @@ impl App for SelectableListApp {
 
         SelectableList::<String>::view(
             &state.list,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let selected = state
@@ -86,7 +83,7 @@ impl App for SelectableListApp {
                 return Some(Msg::Quit);
             }
         }
-        SelectableList::handle_event(&state.list, event, &ViewContext::new().focused(true))
+        SelectableList::handle_event(&state.list, event, &EventContext::new().focused(true))
             .map(Msg::List)
     }
 }

--- a/examples/slider.rs
+++ b/examples/slider.rs
@@ -109,31 +109,19 @@ impl App for SliderApp {
 
         Slider::view(
             &state.volume,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
         Slider::view(
             &state.brightness,
-            frame,
-            chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[1], &theme),
         );
         Slider::view(
             &state.temperature,
-            frame,
-            chunks[2],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[2], &theme),
         );
         Slider::view(
             &state.vertical,
-            frame,
-            chunks[3],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[3], &theme),
         );
 
         let status = format!(
@@ -160,13 +148,17 @@ impl App for SliderApp {
         }
         // Route event to focused slider
         match state.focus_index {
-            0 => Slider::handle_event(&state.volume, event, &ViewContext::new().focused(true))
+            0 => Slider::handle_event(&state.volume, event, &EventContext::new().focused(true))
                 .map(Msg::Volume),
-            1 => Slider::handle_event(&state.brightness, event, &ViewContext::new().focused(true))
+            1 => Slider::handle_event(&state.brightness, event, &EventContext::new().focused(true))
                 .map(Msg::Brightness),
-            2 => Slider::handle_event(&state.temperature, event, &ViewContext::new().focused(true))
-                .map(Msg::Temperature),
-            _ => Slider::handle_event(&state.vertical, event, &ViewContext::new().focused(true))
+            2 => Slider::handle_event(
+                &state.temperature,
+                event,
+                &EventContext::new().focused(true),
+            )
+            .map(Msg::Temperature),
+            _ => Slider::handle_event(&state.vertical, event, &EventContext::new().focused(true))
                 .map(Msg::Vertical),
         }
     }

--- a/examples/span_tree.rs
+++ b/examples/span_tree.rs
@@ -83,10 +83,7 @@ impl App for SpanTreeApp {
 
         SpanTree::view(
             &state.tree,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let selected = state
@@ -107,7 +104,7 @@ impl App for SpanTreeApp {
                 return Some(Msg::Quit);
             }
         }
-        SpanTree::handle_event(&state.tree, event, &ViewContext::new().focused(true))
+        SpanTree::handle_event(&state.tree, event, &EventContext::new().focused(true))
             .map(Msg::SpanTree)
     }
 }

--- a/examples/sparkline.rs
+++ b/examples/sparkline.rs
@@ -65,31 +65,19 @@ impl App for SparklineApp {
 
         Sparkline::view(
             &state.basic,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
         Sparkline::view(
             &state.titled,
-            frame,
-            chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[1], &theme),
         );
         Sparkline::view(
             &state.rtl,
-            frame,
-            chunks[2],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[2], &theme),
         );
         Sparkline::view(
             &state.limited,
-            frame,
-            chunks[3],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[3], &theme),
         );
     }
 

--- a/examples/spinner.rs
+++ b/examples/spinner.rs
@@ -72,31 +72,19 @@ impl App for SpinnerApp {
 
         Spinner::view(
             &state.dots,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
         Spinner::view(
             &state.line,
-            frame,
-            chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[1], &theme),
         );
         Spinner::view(
             &state.circle,
-            frame,
-            chunks[2],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[2], &theme),
         );
         Spinner::view(
             &state.stopped,
-            frame,
-            chunks[3],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[3], &theme),
         );
     }
 

--- a/examples/split_panel.rs
+++ b/examples/split_panel.rs
@@ -54,10 +54,7 @@ impl App for SplitPanelApp {
         let theme = Theme::default();
         SplitPanel::view(
             &state.split,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         // Render content inside each pane
@@ -107,7 +104,7 @@ impl App for SplitPanelApp {
                 return Some(Msg::Quit);
             }
         }
-        SplitPanel::handle_event(&state.split, event, &ViewContext::new().focused(true))
+        SplitPanel::handle_event(&state.split, event, &EventContext::new().focused(true))
             .map(Msg::Split)
     }
 }

--- a/examples/status_bar.rs
+++ b/examples/status_bar.rs
@@ -104,10 +104,7 @@ impl App for StatusBarApp {
         // Status bar
         StatusBar::view(
             &state.status,
-            frame,
-            chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[1], &theme),
         );
 
         // Help line

--- a/examples/status_log.rs
+++ b/examples/status_log.rs
@@ -58,10 +58,7 @@ impl App for StatusLogApp {
 
         StatusLog::view(
             &state.log,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let status = format!(" Entries: {} | Up/Down: scroll, q: quit", state.log.len());
@@ -77,7 +74,7 @@ impl App for StatusLogApp {
                 return Some(Msg::Quit);
             }
         }
-        StatusLog::handle_event(&state.log, event, &ViewContext::new().focused(true)).map(Msg::Log)
+        StatusLog::handle_event(&state.log, event, &EventContext::new().focused(true)).map(Msg::Log)
     }
 }
 

--- a/examples/step_indicator.rs
+++ b/examples/step_indicator.rs
@@ -88,10 +88,7 @@ impl App for StepIndicatorApp {
 
         StepIndicator::view(
             &state.pipeline,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         // Info panel
@@ -144,7 +141,7 @@ impl App for StepIndicatorApp {
                 _ => {}
             }
         }
-        StepIndicator::handle_event(&state.pipeline, event, &ViewContext::new().focused(true))
+        StepIndicator::handle_event(&state.pipeline, event, &EventContext::new().focused(true))
             .map(Msg::Step)
     }
 }

--- a/examples/styled_text.rs
+++ b/examples/styled_text.rs
@@ -134,10 +134,7 @@ impl App for StyledTextApp {
 
         StyledText::view(
             &state.text,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let status = format!(
@@ -156,7 +153,7 @@ impl App for StyledTextApp {
                 return Some(Msg::Quit);
             }
         }
-        StyledText::handle_event(&state.text, event, &ViewContext::new().focused(true))
+        StyledText::handle_event(&state.text, event, &EventContext::new().focused(true))
             .map(Msg::StyledText)
     }
 }

--- a/examples/styling_showcase.rs
+++ b/examples/styling_showcase.rs
@@ -304,10 +304,7 @@ impl App for StylingShowcaseApp {
         // Right panel: Rich Text
         StyledText::view(
             &state.styled_text,
-            frame,
-            panels[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, panels[1], &theme),
         );
 
         // Footer — key hints
@@ -326,8 +323,12 @@ impl App for StylingShowcaseApp {
             }
         }
         if state.panel == Panel::RichText {
-            StyledText::handle_event(&state.styled_text, event, &ViewContext::new().focused(true))
-                .map(Msg::StyledText)
+            StyledText::handle_event(
+                &state.styled_text,
+                event,
+                &EventContext::new().focused(true),
+            )
+            .map(Msg::StyledText)
         } else {
             None
         }

--- a/examples/switch.rs
+++ b/examples/switch.rs
@@ -119,31 +119,19 @@ impl App for SwitchApp {
         // Switches
         Switch::view(
             &state.wifi,
-            frame,
-            chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[1], &theme),
         );
         Switch::view(
             &state.bluetooth,
-            frame,
-            chunks[2],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[2], &theme),
         );
         Switch::view(
             &state.dark_mode,
-            frame,
-            chunks[3],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[3], &theme),
         );
         Switch::view(
             &state.notifications,
-            frame,
-            chunks[4],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[4], &theme),
         );
 
         // Summary
@@ -190,16 +178,16 @@ impl App for SwitchApp {
         }
         // Route event to focused switch
         match state.focus_index {
-            0 => Switch::handle_event(&state.wifi, event, &ViewContext::new().focused(true))
+            0 => Switch::handle_event(&state.wifi, event, &EventContext::new().focused(true))
                 .map(Msg::Wifi),
-            1 => Switch::handle_event(&state.bluetooth, event, &ViewContext::new().focused(true))
+            1 => Switch::handle_event(&state.bluetooth, event, &EventContext::new().focused(true))
                 .map(Msg::Bluetooth),
-            2 => Switch::handle_event(&state.dark_mode, event, &ViewContext::new().focused(true))
+            2 => Switch::handle_event(&state.dark_mode, event, &EventContext::new().focused(true))
                 .map(Msg::DarkMode),
             _ => Switch::handle_event(
                 &state.notifications,
                 event,
-                &ViewContext::new().focused(true),
+                &EventContext::new().focused(true),
             )
             .map(Msg::Notifications),
         }

--- a/examples/tab_bar.rs
+++ b/examples/tab_bar.rs
@@ -84,10 +84,7 @@ impl App for TabBarApp {
 
         TabBar::view(
             &state.tab_bar,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let tab_name = state
@@ -124,7 +121,7 @@ impl App for TabBarApp {
                 return Some(Msg::AddNewTab);
             }
         }
-        TabBar::handle_event(&state.tab_bar, event, &ViewContext::new().focused(true))
+        TabBar::handle_event(&state.tab_bar, event, &EventContext::new().focused(true))
             .map(Msg::TabBar)
     }
 }

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -98,10 +98,7 @@ impl App for TableApp {
 
         Table::<Language>::view(
             &state.table,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let selected = state
@@ -127,7 +124,7 @@ impl App for TableApp {
                 _ => {}
             }
         }
-        Table::handle_event(&state.table, event, &ViewContext::new().focused(true)).map(Msg::Table)
+        Table::handle_event(&state.table, event, &EventContext::new().focused(true)).map(Msg::Table)
     }
 }
 

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -60,10 +60,7 @@ impl App for TabsApp {
 
         Tabs::<String>::view(
             &state.tabs,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let tab_name = state
@@ -98,7 +95,7 @@ impl App for TabsApp {
                 return Some(Msg::Quit);
             }
         }
-        Tabs::handle_event(&state.tabs, event, &ViewContext::new().focused(true)).map(Msg::Tabs)
+        Tabs::handle_event(&state.tabs, event, &EventContext::new().focused(true)).map(Msg::Tabs)
     }
 }
 

--- a/examples/terminal_output.rs
+++ b/examples/terminal_output.rs
@@ -79,10 +79,7 @@ impl App for TerminalOutputApp {
         let theme = Theme::default();
         TerminalOutput::view(
             &state.output,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let status = Paragraph::new(
@@ -100,7 +97,7 @@ impl App for TerminalOutputApp {
             }
         }
 
-        TerminalOutput::handle_event(&state.output, event, &ViewContext::new().focused(true))
+        TerminalOutput::handle_event(&state.output, event, &EventContext::new().focused(true))
             .map(Msg::Output)
     }
 }

--- a/examples/text_area.rs
+++ b/examples/text_area.rs
@@ -51,10 +51,7 @@ impl App for TextAreaApp {
 
         TextArea::view(
             &state.editor,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let (row, col) = state.editor.cursor_position();
@@ -72,7 +69,7 @@ impl App for TextAreaApp {
                 return Some(Msg::Quit);
             }
         }
-        TextArea::handle_event(&state.editor, event, &ViewContext::new().focused(true))
+        TextArea::handle_event(&state.editor, event, &EventContext::new().focused(true))
             .map(Msg::Editor)
     }
 }

--- a/examples/themed_app.rs
+++ b/examples/themed_app.rs
@@ -208,28 +208,19 @@ impl App for ThemedApp {
         // Render button using Component trait
         Button::view(
             &state.button_state,
-            frame,
-            button_checkbox_chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, button_checkbox_chunks[0], &theme),
         );
 
         // Render checkbox using Component trait
         Checkbox::view(
             &state.checkbox_state,
-            frame,
-            button_checkbox_chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, button_checkbox_chunks[1], &theme),
         );
 
         // Progress bar
         ProgressBar::view(
             &state.progress_state,
-            frame,
-            chunks[3],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[3], &theme),
         );
 
         // Selectable list with block wrapper
@@ -242,10 +233,7 @@ impl App for ThemedApp {
         frame.render_widget(list_block, list_area);
         SelectableList::view(
             &state.list_state,
-            frame,
-            inner_area,
-            &theme,
-            &ViewContext::new().focused(true),
+            &mut RenderContext::new(frame, inner_area, &theme).focused(true),
         );
 
         // Controls help

--- a/examples/timeline.rs
+++ b/examples/timeline.rs
@@ -80,10 +80,7 @@ impl App for TimelineApp {
         let theme = Theme::default();
         Timeline::view(
             &state.timeline,
-            frame,
-            frame.area(),
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, frame.area(), &theme),
         );
     }
 

--- a/examples/title_card.rs
+++ b/examples/title_card.rs
@@ -85,24 +85,15 @@ impl App for TitleCardApp {
 
         TitleCard::view(
             &state.plain,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
         TitleCard::view(
             &state.decorated,
-            frame,
-            chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[1], &theme),
         );
         TitleCard::view(
             &state.styled,
-            frame,
-            chunks[2],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[2], &theme),
         );
 
         let footer = Paragraph::new(" TitleCard configurations | Esc to quit")

--- a/examples/toast.rs
+++ b/examples/toast.rs
@@ -68,7 +68,7 @@ impl App for ToastApp {
                 );
         frame.render_widget(content, chunks[0]);
 
-        Toast::view(&state.toasts, frame, area, &theme, &ViewContext::default());
+        Toast::view(&state.toasts, &mut RenderContext::new(frame, area, &theme));
 
         let status = " s: success, w: warning, e: error, q: quit";
         frame.render_widget(

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -70,10 +70,7 @@ impl App for TreeApp {
 
         Tree::view(
             &state.tree,
-            frame,
-            chunks[0],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
         let selected = state
@@ -94,7 +91,7 @@ impl App for TreeApp {
                 return Some(Msg::Quit);
             }
         }
-        Tree::handle_event(&state.tree, event, &ViewContext::new().focused(true)).map(Msg::Tree)
+        Tree::handle_event(&state.tree, event, &EventContext::new().focused(true)).map(Msg::Tree)
     }
 }
 

--- a/examples/treemap.rs
+++ b/examples/treemap.rs
@@ -84,7 +84,7 @@ impl App for TreemapApp {
     fn view(state: &State, frame: &mut Frame) {
         let theme = Theme::default();
         let area = frame.area();
-        Treemap::view(&state.treemap, frame, area, &theme, &ViewContext::default());
+        Treemap::view(&state.treemap, &mut RenderContext::new(frame, area, &theme));
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {
@@ -98,7 +98,7 @@ impl App for TreemapApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(msg) =
-            Treemap::handle_event(&state.treemap, event, &ViewContext::new().focused(true))
+            Treemap::handle_event(&state.treemap, event, &EventContext::new().focused(true))
         {
             return Some(Msg::Treemap(msg));
         }

--- a/examples/usage_display.rs
+++ b/examples/usage_display.rs
@@ -82,19 +82,13 @@ impl App for UsageDisplayApp {
         // Horizontal layout
         UsageDisplay::view(
             &state.horizontal,
-            frame,
-            chunks[1],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[1], &theme),
         );
 
         // Vertical layout
         UsageDisplay::view(
             &state.vertical,
-            frame,
-            chunks[2],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[2], &theme),
         );
 
         // Spacer line
@@ -104,10 +98,7 @@ impl App for UsageDisplayApp {
         // Grid layout
         UsageDisplay::view(
             &state.grid,
-            frame,
-            chunks[4],
-            &theme,
-            &ViewContext::default(),
+            &mut RenderContext::new(frame, chunks[4], &theme),
         );
     }
 

--- a/src/component/accordion/mod.rs
+++ b/src/component/accordion/mod.rs
@@ -35,9 +35,8 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 /// A single accordion panel with a title and content.
 ///
@@ -734,7 +733,7 @@ impl Component for Accordion {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -753,24 +752,24 @@ impl Component for Accordion {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         if state.panels.is_empty() {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::accordion("accordion")
                     .with_focus(ctx.focused)
                     .with_disabled(ctx.disabled),
             );
         });
 
-        let mut y = area.y;
+        let mut y = ctx.area.y;
 
         for (i, panel) in state.panels.iter().enumerate() {
-            if y >= area.bottom() {
+            if y >= ctx.area.bottom() {
                 break;
             }
 
@@ -780,32 +779,37 @@ impl Component for Accordion {
             let header = format!("{} {}", icon, panel.title);
 
             let header_style = if ctx.disabled {
-                theme.disabled_style()
+                ctx.theme.disabled_style()
             } else if is_focused_panel {
-                theme.focused_bold_style()
+                ctx.theme.focused_bold_style()
             } else {
-                theme.normal_style()
+                ctx.theme.normal_style()
             };
 
-            let header_area = Rect::new(area.x, y, area.width, 1);
-            frame.render_widget(Paragraph::new(header).style(header_style), header_area);
+            let header_area = Rect::new(ctx.area.x, y, ctx.area.width, 1);
+            ctx.frame
+                .render_widget(Paragraph::new(header).style(header_style), header_area);
             y += 1;
 
             // Content (if expanded)
-            if panel.expanded && y < area.bottom() {
+            if panel.expanded && y < ctx.area.bottom() {
                 let content_lines = panel.content.lines().count().max(1) as u16;
-                let available_height = area.bottom().saturating_sub(y);
+                let available_height = ctx.area.bottom().saturating_sub(y);
                 let content_height = content_lines.min(available_height);
 
                 if content_height > 0 {
-                    let content_area =
-                        Rect::new(area.x + 2, y, area.width.saturating_sub(2), content_height);
+                    let content_area = Rect::new(
+                        ctx.area.x + 2,
+                        y,
+                        ctx.area.width.saturating_sub(2),
+                        content_height,
+                    );
                     let content_style = if ctx.disabled {
-                        theme.disabled_style()
+                        ctx.theme.disabled_style()
                     } else {
-                        theme.placeholder_style()
+                        ctx.theme.placeholder_style()
                     };
-                    frame.render_widget(
+                    ctx.frame.render_widget(
                         Paragraph::new(panel.content.as_str()).style(content_style),
                         content_area,
                     );

--- a/src/component/accordion/tests.rs
+++ b/src/component/accordion/tests.rs
@@ -424,7 +424,7 @@ fn test_view_empty() {
 
     terminal
         .draw(|frame| {
-            Accordion::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Accordion::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -438,7 +438,7 @@ fn test_view_collapsed() {
 
     terminal
         .draw(|frame| {
-            Accordion::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Accordion::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -454,7 +454,7 @@ fn test_view_expanded() {
 
     terminal
         .draw(|frame| {
-            Accordion::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Accordion::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -471,7 +471,7 @@ fn test_view_mixed() {
 
     terminal
         .draw(|frame| {
-            Accordion::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Accordion::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -487,10 +487,7 @@ fn test_view_focused_highlight() {
         .draw(|frame| {
             Accordion::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -507,7 +504,7 @@ fn test_view_long_content() {
 
     terminal
         .draw(|frame| {
-            Accordion::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Accordion::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -567,7 +564,7 @@ fn test_handle_event_up_when_focused() {
     let msg = Accordion::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(AccordionMessage::Up));
 }
@@ -579,7 +576,7 @@ fn test_handle_event_down_when_focused() {
     let msg = Accordion::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(AccordionMessage::Down));
 }
@@ -591,7 +588,7 @@ fn test_handle_event_toggle_when_focused() {
     let msg = Accordion::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(AccordionMessage::Toggle));
 }
@@ -603,7 +600,7 @@ fn test_handle_event_first_when_focused() {
     let msg = Accordion::handle_event(
         &state,
         &Event::key(KeyCode::Home),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(AccordionMessage::First));
 }
@@ -615,7 +612,7 @@ fn test_handle_event_last_when_focused() {
     let msg = Accordion::handle_event(
         &state,
         &Event::key(KeyCode::End),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(AccordionMessage::Last));
 }
@@ -624,12 +621,18 @@ fn test_handle_event_last_when_focused() {
 fn test_handle_event_vim_keys() {
     let state = AccordionState::from_pairs(vec![("A", "1"), ("B", "2")]);
 
-    let msg_k =
-        Accordion::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true));
+    let msg_k = Accordion::handle_event(
+        &state,
+        &Event::char('k'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg_k, Some(AccordionMessage::Up));
 
-    let msg_j =
-        Accordion::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true));
+    let msg_j = Accordion::handle_event(
+        &state,
+        &Event::char('j'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg_j, Some(AccordionMessage::Down));
 }
 
@@ -637,7 +640,11 @@ fn test_handle_event_vim_keys() {
 fn test_handle_event_space_toggle() {
     let state = AccordionState::from_pairs(vec![("A", "1"), ("B", "2")]);
 
-    let msg = Accordion::handle_event(&state, &Event::char(' '), &ViewContext::new().focused(true));
+    let msg = Accordion::handle_event(
+        &state,
+        &Event::char(' '),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(AccordionMessage::Toggle));
 }
 
@@ -646,13 +653,17 @@ fn test_handle_event_ignored_when_unfocused() {
     let state = AccordionState::from_pairs(vec![("A", "1"), ("B", "2")]);
     // Not focused by default
 
-    let msg = Accordion::handle_event(&state, &Event::key(KeyCode::Down), &ViewContext::default());
+    let msg = Accordion::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
     assert_eq!(msg, None);
 
-    let msg = Accordion::handle_event(&state, &Event::key(KeyCode::Enter), &ViewContext::default());
+    let msg = Accordion::handle_event(
+        &state,
+        &Event::key(KeyCode::Enter),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 
-    let msg = Accordion::handle_event(&state, &Event::char('j'), &ViewContext::default());
+    let msg = Accordion::handle_event(&state, &Event::char('j'), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -663,14 +674,14 @@ fn test_handle_event_ignored_when_disabled() {
     let msg = Accordion::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Accordion::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -685,7 +696,7 @@ fn test_dispatch_event() {
     let output = Accordion::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(AccordionOutput::FocusChanged(1)));
     assert_eq!(state.focused_index(), 1);
@@ -694,7 +705,7 @@ fn test_dispatch_event() {
     let output = Accordion::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(AccordionOutput::Expanded(1)));
     assert!(state.panels()[1].is_expanded());
@@ -710,7 +721,7 @@ fn test_instance_update() {
     let output = Accordion::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(AccordionOutput::FocusChanged(1)));
     assert_eq!(state.focused_index(), 1);
@@ -760,7 +771,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Accordion::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Accordion::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/alert_panel/mod.rs
+++ b/src/component/alert_panel/mod.rs
@@ -42,11 +42,8 @@ pub use metric::{AlertMetric, AlertState, AlertThreshold};
 
 use std::marker::PhantomData;
 
-use ratatui::prelude::*;
-
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 /// Messages that can be sent to an AlertPanel.
 ///
@@ -690,7 +687,7 @@ impl Component for AlertPanel {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -822,8 +819,15 @@ impl Component for AlertPanel {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        render::render_alert_panel(state, frame, area, theme, ctx.focused, ctx.disabled);
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        render::render_alert_panel(
+            state,
+            ctx.frame,
+            ctx.area,
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
     }
 }
 

--- a/src/component/alert_panel/snapshot_tests.rs
+++ b/src/component/alert_panel/snapshot_tests.rs
@@ -28,7 +28,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(80, 25);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            AlertPanel::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -43,7 +43,7 @@ fn test_snapshot_with_metrics() {
     let (mut terminal, theme) = test_utils::setup_render(80, 25);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            AlertPanel::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -60,10 +60,7 @@ fn test_snapshot_focused() {
         .draw(|frame| {
             AlertPanel::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -80,10 +77,7 @@ fn test_snapshot_disabled() {
         .draw(|frame| {
             AlertPanel::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -106,7 +100,7 @@ fn test_snapshot_all_ok() {
     let (mut terminal, theme) = test_utils::setup_render(80, 15);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            AlertPanel::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -128,7 +122,7 @@ fn test_snapshot_all_critical() {
     let (mut terminal, theme) = test_utils::setup_render(80, 15);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            AlertPanel::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -153,7 +147,7 @@ fn test_snapshot_with_sparklines() {
     let (mut terminal, theme) = test_utils::setup_render(80, 15);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            AlertPanel::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -171,7 +165,7 @@ fn test_snapshot_single_metric() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            AlertPanel::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -193,7 +187,7 @@ fn test_snapshot_with_thresholds() {
     let (mut terminal, theme) = test_utils::setup_render(80, 15);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            AlertPanel::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/alert_panel/tests.rs
+++ b/src/component/alert_panel/tests.rs
@@ -566,7 +566,7 @@ fn test_key_maps() {
         AlertPanel::handle_event(
             &state,
             &Event::key(KeyCode::Left),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(AlertPanelMessage::SelectPrev)
     );
@@ -574,7 +574,7 @@ fn test_key_maps() {
         AlertPanel::handle_event(
             &state,
             &Event::key(KeyCode::Right),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(AlertPanelMessage::SelectNext)
     );
@@ -582,7 +582,7 @@ fn test_key_maps() {
         AlertPanel::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(AlertPanelMessage::SelectUp)
     );
@@ -590,7 +590,7 @@ fn test_key_maps() {
         AlertPanel::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(AlertPanelMessage::SelectDown)
     );
@@ -598,7 +598,7 @@ fn test_key_maps() {
         AlertPanel::handle_event(
             &state,
             &Event::key(KeyCode::Enter),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(AlertPanelMessage::Select)
     );
@@ -608,19 +608,35 @@ fn test_key_maps() {
 fn test_vim_key_maps() {
     let state = focused_state();
     assert_eq!(
-        AlertPanel::handle_event(&state, &Event::char('h'), &ViewContext::new().focused(true)),
+        AlertPanel::handle_event(
+            &state,
+            &Event::char('h'),
+            &EventContext::new().focused(true)
+        ),
         Some(AlertPanelMessage::SelectPrev)
     );
     assert_eq!(
-        AlertPanel::handle_event(&state, &Event::char('l'), &ViewContext::new().focused(true)),
+        AlertPanel::handle_event(
+            &state,
+            &Event::char('l'),
+            &EventContext::new().focused(true)
+        ),
         Some(AlertPanelMessage::SelectNext)
     );
     assert_eq!(
-        AlertPanel::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true)),
+        AlertPanel::handle_event(
+            &state,
+            &Event::char('k'),
+            &EventContext::new().focused(true)
+        ),
         Some(AlertPanelMessage::SelectUp)
     );
     assert_eq!(
-        AlertPanel::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true)),
+        AlertPanel::handle_event(
+            &state,
+            &Event::char('j'),
+            &EventContext::new().focused(true)
+        ),
         Some(AlertPanelMessage::SelectDown)
     );
 }
@@ -635,7 +651,7 @@ fn test_disabled_ignores_events() {
     let msg = AlertPanel::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -647,8 +663,11 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = AlertPanelState::new().with_metrics(sample_metrics());
-    let msg =
-        AlertPanel::handle_event(&state, &Event::key(KeyCode::Right), &ViewContext::default());
+    let msg = AlertPanel::handle_event(
+        &state,
+        &Event::key(KeyCode::Right),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 }
 
@@ -673,7 +692,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            AlertPanel::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -684,7 +703,7 @@ fn test_render_with_metrics() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            AlertPanel::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -697,10 +716,7 @@ fn test_render_disabled() {
         .draw(|frame| {
             AlertPanel::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -712,7 +728,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(60, 2);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            AlertPanel::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -729,7 +745,7 @@ fn test_render_with_history() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            AlertPanel::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -857,7 +873,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                AlertPanel::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/big_text/mod.rs
+++ b/src/component/big_text/mod.rs
@@ -24,8 +24,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, ViewContext};
-use crate::theme::Theme;
+use super::{Component, EventContext, RenderContext};
 
 /// Returns the 3-row block representation of a character.
 ///
@@ -327,7 +326,7 @@ impl BigTextState {
     /// assert_eq!(state.handle_event(&Event::key(KeyCode::Enter)), None);
     /// ```
     pub fn handle_event(&self, event: &crate::input::Event) -> Option<BigTextMessage> {
-        BigText::handle_event(self, event, &ViewContext::default())
+        BigText::handle_event(self, event, &EventContext::default())
     }
 
     /// Updates the state with a message, returning any output (instance method).
@@ -361,7 +360,7 @@ impl BigTextState {
     /// assert_eq!(state.dispatch_event(&Event::key(KeyCode::Enter)), None);
     /// ```
     pub fn dispatch_event(&mut self, event: &crate::input::Event) -> Option<()> {
-        BigText::dispatch_event(self, event, &ViewContext::default())
+        BigText::dispatch_event(self, event, &EventContext::default())
     }
 }
 
@@ -420,26 +419,26 @@ impl Component for BigText {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::big_text("big_text")
                     .with_label(&state.text)
                     .with_disabled(ctx.disabled),
             );
         });
 
-        if area.height == 0 || area.width == 0 {
+        if ctx.area.height == 0 || ctx.area.width == 0 {
             return;
         }
 
         let style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if let Some(color) = state.color {
             Style::default().fg(color)
         } else {
-            theme.normal_style()
+            ctx.theme.normal_style()
         };
 
         // Build the 3 rows of big text
@@ -450,20 +449,20 @@ impl Component for BigText {
             })
             .collect();
 
-        // Vertically center within the available area
+        // Vertically center within the available ctx.area
         let content_height: u16 = 3;
-        let vertical_offset = area.height.saturating_sub(content_height) / 2;
+        let vertical_offset = ctx.area.height.saturating_sub(content_height) / 2;
 
         let render_area = Rect::new(
-            area.x,
-            area.y + vertical_offset,
-            area.width,
-            content_height.min(area.height.saturating_sub(vertical_offset)),
+            ctx.area.x,
+            ctx.area.y + vertical_offset,
+            ctx.area.width,
+            content_height.min(ctx.area.height.saturating_sub(vertical_offset)),
         );
 
         if render_area.height > 0 {
             let paragraph = Paragraph::new(lines).alignment(state.alignment);
-            frame.render_widget(paragraph, render_area);
+            ctx.frame.render_widget(paragraph, render_area);
         }
     }
 }

--- a/src/component/big_text/tests.rs
+++ b/src/component/big_text/tests.rs
@@ -133,15 +133,19 @@ fn test_instance_update() {
 fn test_handle_event_returns_none() {
     let state = BigTextState::new("42");
     assert_eq!(
-        BigText::handle_event(&state, &Event::key(KeyCode::Up), &ViewContext::default()),
+        BigText::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default()),
         None
     );
     assert_eq!(
-        BigText::handle_event(&state, &Event::key(KeyCode::Enter), &ViewContext::default()),
+        BigText::handle_event(
+            &state,
+            &Event::key(KeyCode::Enter),
+            &EventContext::default()
+        ),
         None
     );
     assert_eq!(
-        BigText::handle_event(&state, &Event::char('a'), &ViewContext::default()),
+        BigText::handle_event(&state, &Event::char('a'), &EventContext::default()),
         None
     );
 }
@@ -276,7 +280,7 @@ fn test_empty_text() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BigText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -288,7 +292,7 @@ fn test_unsupported_characters() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BigText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -301,7 +305,7 @@ fn test_zero_height_area() {
     terminal
         .draw(|frame| {
             let area = Rect::new(0, 0, 40, 0);
-            BigText::view(&state, frame, area, &theme, &ViewContext::default());
+            BigText::view(&state, &mut RenderContext::new(frame, area, &theme));
         })
         .unwrap();
     // Should not panic
@@ -314,7 +318,7 @@ fn test_zero_width_area() {
     terminal
         .draw(|frame| {
             let area = Rect::new(0, 0, 0, 5);
-            BigText::view(&state, frame, area, &theme, &ViewContext::default());
+            BigText::view(&state, &mut RenderContext::new(frame, area, &theme));
         })
         .unwrap();
     // Should not panic
@@ -330,7 +334,7 @@ fn test_view_digits() {
     let (mut terminal, theme) = test_utils::setup_render(60, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BigText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -342,7 +346,7 @@ fn test_view_clock() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BigText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -354,7 +358,7 @@ fn test_view_percentage() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BigText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -366,7 +370,7 @@ fn test_view_with_color() {
     let (mut terminal, theme) = test_utils::setup_render(30, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BigText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -378,7 +382,7 @@ fn test_view_left_aligned() {
     let (mut terminal, theme) = test_utils::setup_render(30, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BigText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -390,7 +394,7 @@ fn test_view_right_aligned() {
     let (mut terminal, theme) = test_utils::setup_render(30, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BigText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -404,10 +408,7 @@ fn test_view_disabled() {
         .draw(|frame| {
             BigText::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -420,7 +421,7 @@ fn test_view_letters() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BigText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -433,7 +434,7 @@ fn test_view_lowercase_converted() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BigText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -445,7 +446,7 @@ fn test_view_single_char() {
     let (mut terminal, theme) = test_utils::setup_render(20, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BigText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -457,7 +458,7 @@ fn test_view_dash() {
     let (mut terminal, theme) = test_utils::setup_render(30, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BigText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -469,7 +470,7 @@ fn test_view_date() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BigText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -487,7 +488,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                BigText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                BigText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -508,10 +509,7 @@ fn test_annotation_disabled() {
             .draw(|frame| {
                 BigText::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().disabled(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
                 );
             })
             .unwrap();

--- a/src/component/box_plot/mod.rs
+++ b/src/component/box_plot/mod.rs
@@ -24,9 +24,8 @@ use std::marker::PhantomData;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 mod render;
 
@@ -831,7 +830,7 @@ impl Component for BoxPlot {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -884,14 +883,14 @@ impl Component for BoxPlot {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        if area.height < 3 || area.width < 3 {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        if ctx.area.height < 3 || ctx.area.width < 3 {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::container("box_plot")
                     .with_focus(ctx.focused)
                     .with_disabled(ctx.disabled),
@@ -899,11 +898,11 @@ impl Component for BoxPlot {
         });
 
         let border_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let mut block = Block::default()
@@ -914,8 +913,8 @@ impl Component for BoxPlot {
             block = block.title(title.as_str());
         }
 
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
+        let inner = block.inner(ctx.area);
+        ctx.frame.render_widget(block, ctx.area);
 
         if inner.height == 0 || inner.width == 0 || state.datasets.is_empty() {
             return;
@@ -923,10 +922,24 @@ impl Component for BoxPlot {
 
         match state.orientation {
             BoxPlotOrientation::Vertical => {
-                render::render_vertical(state, frame, inner, theme, ctx.focused, ctx.disabled);
+                render::render_vertical(
+                    state,
+                    ctx.frame,
+                    inner,
+                    ctx.theme,
+                    ctx.focused,
+                    ctx.disabled,
+                );
             }
             BoxPlotOrientation::Horizontal => {
-                render::render_horizontal(state, frame, inner, theme, ctx.focused, ctx.disabled);
+                render::render_horizontal(
+                    state,
+                    ctx.frame,
+                    inner,
+                    ctx.theme,
+                    ctx.focused,
+                    ctx.disabled,
+                );
             }
         }
     }

--- a/src/component/box_plot/snapshot_tests.rs
+++ b/src/component/box_plot/snapshot_tests.rs
@@ -11,7 +11,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BoxPlot::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -24,7 +24,7 @@ fn test_snapshot_single_vertical() {
     let (mut terminal, theme) = test_utils::setup_render(40, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BoxPlot::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -41,7 +41,7 @@ fn test_snapshot_multiple_vertical() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BoxPlot::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -58,7 +58,7 @@ fn test_snapshot_horizontal() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BoxPlot::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -74,7 +74,7 @@ fn test_snapshot_with_outliers() {
     let (mut terminal, theme) = test_utils::setup_render(40, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BoxPlot::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -91,10 +91,7 @@ fn test_snapshot_disabled() {
         .draw(|frame| {
             BoxPlot::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -113,7 +110,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                BoxPlot::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -130,10 +127,7 @@ fn test_annotation_with_focus() {
             .draw(|frame| {
                 BoxPlot::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
                 );
             })
             .unwrap();
@@ -152,10 +146,7 @@ fn test_annotation_with_disabled() {
             .draw(|frame| {
                 BoxPlot::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().disabled(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
                 );
             })
             .unwrap();

--- a/src/component/box_plot/tests.rs
+++ b/src/component/box_plot/tests.rs
@@ -413,7 +413,7 @@ fn test_handle_event_not_focused() {
     let msg = BoxPlot::handle_event(
         &state,
         &Event::key(crate::input::KeyCode::Right),
-        &ViewContext::default(),
+        &EventContext::default(),
     );
     assert!(msg.is_none());
 }
@@ -424,7 +424,7 @@ fn test_handle_event_disabled() {
     let msg = BoxPlot::handle_event(
         &state,
         &Event::key(crate::input::KeyCode::Right),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert!(msg.is_none());
 }
@@ -438,7 +438,7 @@ fn test_handle_event_right_arrow() {
     let msg = BoxPlot::handle_event(
         &state,
         &Event::key(crate::input::KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(BoxPlotMessage::NextDataset));
 }
@@ -452,7 +452,7 @@ fn test_handle_event_left_arrow() {
     let msg = BoxPlot::handle_event(
         &state,
         &Event::key(crate::input::KeyCode::Left),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(BoxPlotMessage::PrevDataset));
 }
@@ -460,28 +460,44 @@ fn test_handle_event_left_arrow() {
 #[test]
 fn test_handle_event_l_key() {
     let state = BoxPlotState::default();
-    let msg = BoxPlot::handle_event(&state, &Event::char('l'), &ViewContext::new().focused(true));
+    let msg = BoxPlot::handle_event(
+        &state,
+        &Event::char('l'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(BoxPlotMessage::NextDataset));
 }
 
 #[test]
 fn test_handle_event_h_key() {
     let state = BoxPlotState::default();
-    let msg = BoxPlot::handle_event(&state, &Event::char('h'), &ViewContext::new().focused(true));
+    let msg = BoxPlot::handle_event(
+        &state,
+        &Event::char('h'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(BoxPlotMessage::PrevDataset));
 }
 
 #[test]
 fn test_handle_event_o_key() {
     let state = BoxPlotState::default();
-    let msg = BoxPlot::handle_event(&state, &Event::char('o'), &ViewContext::new().focused(true));
+    let msg = BoxPlot::handle_event(
+        &state,
+        &Event::char('o'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(BoxPlotMessage::ToggleOutliers));
 }
 
 #[test]
 fn test_handle_event_unhandled_key() {
     let state = BoxPlotState::default();
-    let msg = BoxPlot::handle_event(&state, &Event::char('z'), &ViewContext::new().focused(true));
+    let msg = BoxPlot::handle_event(
+        &state,
+        &Event::char('z'),
+        &EventContext::new().focused(true),
+    );
     assert!(msg.is_none());
 }
 
@@ -676,7 +692,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BoxPlot::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -690,7 +706,7 @@ fn test_render_single_dataset() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BoxPlot::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -706,7 +722,7 @@ fn test_render_multiple_datasets() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BoxPlot::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -720,7 +736,7 @@ fn test_render_with_outliers() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BoxPlot::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -734,7 +750,7 @@ fn test_render_without_outliers() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BoxPlot::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -748,10 +764,7 @@ fn test_render_focused() {
         .draw(|frame| {
             BoxPlot::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -765,10 +778,7 @@ fn test_render_disabled() {
         .draw(|frame| {
             BoxPlot::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -780,7 +790,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(60, 2);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BoxPlot::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -791,7 +801,7 @@ fn test_render_very_small_width() {
     let (mut terminal, theme) = test_utils::setup_render(4, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BoxPlot::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -810,7 +820,7 @@ fn test_render_horizontal_single() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BoxPlot::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -825,7 +835,7 @@ fn test_render_horizontal_multiple() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BoxPlot::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -839,7 +849,7 @@ fn test_render_horizontal_with_outliers() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BoxPlot::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -853,10 +863,7 @@ fn test_render_horizontal_disabled() {
         .draw(|frame| {
             BoxPlot::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -875,7 +882,7 @@ fn test_render_zero_range() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            BoxPlot::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            BoxPlot::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }

--- a/src/component/breadcrumb/mod.rs
+++ b/src/component/breadcrumb/mod.rs
@@ -36,9 +36,8 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 /// A single breadcrumb segment.
 ///
@@ -643,7 +642,7 @@ impl Component for Breadcrumb {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -662,7 +661,7 @@ impl Component for Breadcrumb {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         if state.segments.is_empty() {
             return;
         }
@@ -672,7 +671,7 @@ impl Component for Breadcrumb {
 
         // Add ellipsis if truncated
         if state.is_truncated() {
-            spans.push(Span::styled("…", theme.disabled_style()));
+            spans.push(Span::styled("…", ctx.theme.disabled_style()));
             spans.push(Span::raw(&state.separator));
         }
 
@@ -682,9 +681,9 @@ impl Component for Breadcrumb {
             let is_focused_segment = ctx.focused && seg_idx == state.focused_index;
 
             let style = if ctx.disabled {
-                theme.disabled_style()
+                ctx.theme.disabled_style()
             } else if is_focused_segment {
-                theme
+                ctx.theme
                     .focused_style()
                     .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
             } else if is_last {
@@ -692,7 +691,7 @@ impl Component for Breadcrumb {
                 Style::default().add_modifier(Modifier::BOLD)
             } else {
                 // Navigable segments
-                theme.info_style()
+                ctx.theme.info_style()
             };
 
             spans.push(Span::styled(segment.label(), style));
@@ -708,7 +707,7 @@ impl Component for Breadcrumb {
             .with_focus(ctx.focused)
             .with_disabled(ctx.disabled);
         let annotated = crate::annotation::Annotate::new(Paragraph::new(line), annotation);
-        frame.render_widget(annotated, area);
+        ctx.frame.render_widget(annotated, ctx.area);
     }
 }
 

--- a/src/component/breadcrumb/tests.rs
+++ b/src/component/breadcrumb/tests.rs
@@ -400,7 +400,7 @@ fn test_view_empty() {
 
     terminal
         .draw(|frame| {
-            Breadcrumb::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Breadcrumb::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -415,7 +415,7 @@ fn test_view_single() {
 
     terminal
         .draw(|frame| {
-            Breadcrumb::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Breadcrumb::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -430,7 +430,7 @@ fn test_view_multiple() {
 
     terminal
         .draw(|frame| {
-            Breadcrumb::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Breadcrumb::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -448,10 +448,7 @@ fn test_view_focused_highlight() {
         .draw(|frame| {
             Breadcrumb::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -469,7 +466,7 @@ fn test_view_truncated() {
 
     terminal
         .draw(|frame| {
-            Breadcrumb::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Breadcrumb::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -485,7 +482,7 @@ fn test_view_custom_separator() {
 
     terminal
         .draw(|frame| {
-            Breadcrumb::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Breadcrumb::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -502,10 +499,7 @@ fn test_view_disabled() {
         .draw(|frame| {
             Breadcrumb::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -567,7 +561,7 @@ fn test_handle_event_left_when_focused() {
     let msg = Breadcrumb::handle_event(
         &state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(BreadcrumbMessage::Left));
 }
@@ -579,7 +573,7 @@ fn test_handle_event_right_when_focused() {
     let msg = Breadcrumb::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(BreadcrumbMessage::Right));
 }
@@ -591,7 +585,7 @@ fn test_handle_event_first_when_focused() {
     let msg = Breadcrumb::handle_event(
         &state,
         &Event::key(KeyCode::Home),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(BreadcrumbMessage::First));
 }
@@ -603,7 +597,7 @@ fn test_handle_event_last_when_focused() {
     let msg = Breadcrumb::handle_event(
         &state,
         &Event::key(KeyCode::End),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(BreadcrumbMessage::Last));
 }
@@ -615,7 +609,7 @@ fn test_handle_event_select_when_focused() {
     let msg = Breadcrumb::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(BreadcrumbMessage::Select));
 }
@@ -624,12 +618,18 @@ fn test_handle_event_select_when_focused() {
 fn test_handle_event_vim_keys() {
     let state = BreadcrumbState::from_labels(vec!["A", "B", "C"]);
 
-    let msg_h =
-        Breadcrumb::handle_event(&state, &Event::char('h'), &ViewContext::new().focused(true));
+    let msg_h = Breadcrumb::handle_event(
+        &state,
+        &Event::char('h'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg_h, Some(BreadcrumbMessage::Left));
 
-    let msg_l =
-        Breadcrumb::handle_event(&state, &Event::char('l'), &ViewContext::new().focused(true));
+    let msg_l = Breadcrumb::handle_event(
+        &state,
+        &Event::char('l'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg_l, Some(BreadcrumbMessage::Right));
 }
 
@@ -638,15 +638,21 @@ fn test_handle_event_ignored_when_unfocused() {
     let state = BreadcrumbState::from_labels(vec!["A", "B", "C"]);
     // Not focused by default
 
-    let msg =
-        Breadcrumb::handle_event(&state, &Event::key(KeyCode::Right), &ViewContext::default());
+    let msg = Breadcrumb::handle_event(
+        &state,
+        &Event::key(KeyCode::Right),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 
-    let msg =
-        Breadcrumb::handle_event(&state, &Event::key(KeyCode::Enter), &ViewContext::default());
+    let msg = Breadcrumb::handle_event(
+        &state,
+        &Event::key(KeyCode::Enter),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 
-    let msg = Breadcrumb::handle_event(&state, &Event::char('l'), &ViewContext::default());
+    let msg = Breadcrumb::handle_event(&state, &Event::char('l'), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -657,14 +663,14 @@ fn test_handle_event_ignored_when_disabled() {
     let msg = Breadcrumb::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Breadcrumb::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -679,7 +685,7 @@ fn test_dispatch_event() {
     let output = Breadcrumb::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(BreadcrumbOutput::FocusChanged(1)));
     assert_eq!(state.focused_index(), 1);
@@ -688,7 +694,7 @@ fn test_dispatch_event() {
     let output = Breadcrumb::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(BreadcrumbOutput::Selected(1)));
 }
@@ -763,7 +769,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Breadcrumb::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Breadcrumb::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/button/mod.rs
+++ b/src/component/button/mod.rs
@@ -23,9 +23,8 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 /// Messages that can be sent to a Button.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -178,7 +177,7 @@ impl Component for Button {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -193,19 +192,19 @@ impl Component for Button {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         let style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_style()
+            ctx.theme.focused_style()
         } else {
-            theme.normal_style()
+            ctx.theme.normal_style()
         };
 
         let border_style = if ctx.focused && !ctx.disabled {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let paragraph = Paragraph::new(state.label.as_str())
@@ -222,7 +221,7 @@ impl Component for Button {
         let annotated = crate::annotation::Annotate::new(paragraph, annotation)
             .focused(ctx.focused)
             .disabled(ctx.disabled);
-        frame.render_widget(annotated, area);
+        ctx.frame.render_widget(annotated, ctx.area);
     }
 }
 

--- a/src/component/button/tests.rs
+++ b/src/component/button/tests.rs
@@ -34,7 +34,7 @@ fn test_view() {
 
     terminal
         .draw(|frame| {
-            Button::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Button::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -50,10 +50,7 @@ fn test_view_focused() {
         .draw(|frame| {
             Button::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -70,10 +67,7 @@ fn test_view_disabled() {
         .draw(|frame| {
             Button::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -89,7 +83,7 @@ fn test_handle_event_enter_when_focused() {
     let msg = Button::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(ButtonMessage::Press));
 }
@@ -97,14 +91,22 @@ fn test_handle_event_enter_when_focused() {
 #[test]
 fn test_handle_event_space_when_focused() {
     let state = ButtonState::new("OK");
-    let msg = Button::handle_event(&state, &Event::char(' '), &ViewContext::new().focused(true));
+    let msg = Button::handle_event(
+        &state,
+        &Event::char(' '),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(ButtonMessage::Press));
 }
 
 #[test]
 fn test_handle_event_ignored_when_unfocused() {
     let state = ButtonState::new("OK");
-    let msg = Button::handle_event(&state, &Event::key(KeyCode::Enter), &ViewContext::default());
+    let msg = Button::handle_event(
+        &state,
+        &Event::key(KeyCode::Enter),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 }
 
@@ -114,7 +116,7 @@ fn test_handle_event_ignored_when_disabled() {
     let msg = Button::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -122,7 +124,11 @@ fn test_handle_event_ignored_when_disabled() {
 #[test]
 fn test_handle_event_irrelevant_key() {
     let state = ButtonState::new("OK");
-    let msg = Button::handle_event(&state, &Event::char('x'), &ViewContext::new().focused(true));
+    let msg = Button::handle_event(
+        &state,
+        &Event::char('x'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, None);
 }
 
@@ -132,7 +138,7 @@ fn test_dispatch_event() {
     let output = Button::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(ButtonOutput::Pressed));
 }
@@ -154,7 +160,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Button::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Button::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -176,10 +182,7 @@ fn test_annotation_focused() {
             .draw(|frame| {
                 Button::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
                 );
             })
             .unwrap();

--- a/src/component/calendar/mod.rs
+++ b/src/component/calendar/mod.rs
@@ -42,9 +42,8 @@ use std::collections::HashMap;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 // ---------------------------------------------------------------------------
 // Date math helpers (private)
@@ -678,7 +677,7 @@ impl Component for Calendar {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -700,14 +699,14 @@ impl Component for Calendar {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        if area.height == 0 || area.width == 0 {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        if ctx.area.height == 0 || ctx.area.width == 0 {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::new(crate::annotation::WidgetType::Custom(
                     "Calendar".to_string(),
                 ))
@@ -719,34 +718,34 @@ impl Component for Calendar {
 
         // Determine styles
         let border_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let normal_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else {
-            theme.normal_style()
+            ctx.theme.normal_style()
         };
 
         let header_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_bold_style()
+            ctx.theme.focused_bold_style()
         } else {
             Style::default()
-                .fg(theme.foreground)
+                .fg(ctx.theme.foreground)
                 .add_modifier(Modifier::BOLD)
         };
 
         let day_header_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else {
             Style::default()
-                .fg(theme.primary)
+                .fg(ctx.theme.primary)
                 .add_modifier(Modifier::BOLD)
         };
 
@@ -762,8 +761,8 @@ impl Component for Calendar {
             .border_style(border_style)
             .title(Span::styled(format!(" {title_text} "), header_style));
 
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
+        let inner = block.inner(ctx.area);
+        ctx.frame.render_widget(block, ctx.area);
 
         if inner.height == 0 || inner.width == 0 {
             return;
@@ -783,9 +782,9 @@ impl Component for Calendar {
         let total_days = days_in_month(state.year, state.month);
 
         let selected_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else {
-            theme.selected_highlight_style(ctx.focused)
+            ctx.theme.selected_highlight_style(ctx.focused)
         };
 
         // Build week rows
@@ -834,9 +833,9 @@ impl Component for Calendar {
 
         // Navigation hint footer
         let footer_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else {
-            theme.placeholder_style()
+            ctx.theme.placeholder_style()
         };
         lines.push(Line::from(vec![Span::styled(
             " \u{25c0} PgUp          PgDn \u{25b6}",
@@ -844,7 +843,7 @@ impl Component for Calendar {
         )]));
 
         let paragraph = Paragraph::new(lines).style(normal_style);
-        frame.render_widget(paragraph, inner);
+        ctx.frame.render_widget(paragraph, inner);
     }
 }
 

--- a/src/component/calendar/tests.rs
+++ b/src/component/calendar/tests.rs
@@ -518,55 +518,71 @@ fn test_handle_event_navigation_keys() {
         Calendar::handle_event(
             &state,
             &Event::key(KeyCode::Left),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(CalendarMessage::SelectPrevDay)
     );
     assert_eq!(
-        Calendar::handle_event(&state, &Event::char('h'), &ViewContext::new().focused(true)),
+        Calendar::handle_event(
+            &state,
+            &Event::char('h'),
+            &EventContext::new().focused(true)
+        ),
         Some(CalendarMessage::SelectPrevDay)
     );
     assert_eq!(
         Calendar::handle_event(
             &state,
             &Event::key(KeyCode::Right),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(CalendarMessage::SelectNextDay)
     );
     assert_eq!(
-        Calendar::handle_event(&state, &Event::char('l'), &ViewContext::new().focused(true)),
+        Calendar::handle_event(
+            &state,
+            &Event::char('l'),
+            &EventContext::new().focused(true)
+        ),
         Some(CalendarMessage::SelectNextDay)
     );
     assert_eq!(
         Calendar::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(CalendarMessage::SelectPrevWeek)
     );
     assert_eq!(
-        Calendar::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true)),
+        Calendar::handle_event(
+            &state,
+            &Event::char('k'),
+            &EventContext::new().focused(true)
+        ),
         Some(CalendarMessage::SelectPrevWeek)
     );
     assert_eq!(
         Calendar::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(CalendarMessage::SelectNextWeek)
     );
     assert_eq!(
-        Calendar::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true)),
+        Calendar::handle_event(
+            &state,
+            &Event::char('j'),
+            &EventContext::new().focused(true)
+        ),
         Some(CalendarMessage::SelectNextWeek)
     );
     assert_eq!(
         Calendar::handle_event(
             &state,
             &Event::key(KeyCode::PageUp),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(CalendarMessage::PrevMonth)
     );
@@ -574,7 +590,7 @@ fn test_handle_event_navigation_keys() {
         Calendar::handle_event(
             &state,
             &Event::key(KeyCode::PageDown),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(CalendarMessage::NextMonth)
     );
@@ -588,12 +604,16 @@ fn test_handle_event_confirm_keys() {
         Calendar::handle_event(
             &state,
             &Event::key(KeyCode::Enter),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(CalendarMessage::ConfirmSelection)
     );
     assert_eq!(
-        Calendar::handle_event(&state, &Event::char(' '), &ViewContext::new().focused(true)),
+        Calendar::handle_event(
+            &state,
+            &Event::char(' '),
+            &EventContext::new().focused(true)
+        ),
         Some(CalendarMessage::ConfirmSelection)
     );
 }
@@ -602,18 +622,22 @@ fn test_handle_event_confirm_keys() {
 fn test_handle_event_unfocused_ignores_events() {
     let state = CalendarState::new(2026, 3).with_selected_day(15);
     assert_eq!(
-        Calendar::handle_event(&state, &Event::key(KeyCode::Left), &ViewContext::default()),
+        Calendar::handle_event(&state, &Event::key(KeyCode::Left), &EventContext::default()),
         None
     );
     assert_eq!(
-        Calendar::handle_event(&state, &Event::key(KeyCode::Enter), &ViewContext::default()),
+        Calendar::handle_event(
+            &state,
+            &Event::key(KeyCode::Enter),
+            &EventContext::default()
+        ),
         None
     );
     assert_eq!(
         Calendar::handle_event(
             &state,
             &Event::key(KeyCode::PageUp),
-            &ViewContext::default()
+            &EventContext::default()
         ),
         None
     );
@@ -626,7 +650,7 @@ fn test_handle_event_disabled_ignores_events() {
         Calendar::handle_event(
             &state,
             &Event::key(KeyCode::Left),
-            &ViewContext::new().focused(true).disabled(true)
+            &EventContext::new().focused(true).disabled(true)
         ),
         None
     );
@@ -634,7 +658,7 @@ fn test_handle_event_disabled_ignores_events() {
         Calendar::handle_event(
             &state,
             &Event::key(KeyCode::Enter),
-            &ViewContext::new().focused(true).disabled(true)
+            &EventContext::new().focused(true).disabled(true)
         ),
         None
     );
@@ -644,7 +668,11 @@ fn test_handle_event_disabled_ignores_events() {
 fn test_handle_event_unrecognized_key_returns_none() {
     let state = CalendarState::new(2026, 3);
     assert_eq!(
-        Calendar::handle_event(&state, &Event::char('x'), &ViewContext::new().focused(true)),
+        Calendar::handle_event(
+            &state,
+            &Event::char('x'),
+            &EventContext::new().focused(true)
+        ),
         None
     );
 }
@@ -657,7 +685,7 @@ fn test_dispatch_event_navigation() {
     let output = Calendar::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(state.selected_day(), Some(16));
     assert_eq!(output, None);
@@ -665,7 +693,7 @@ fn test_dispatch_event_navigation() {
     let output = Calendar::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(state.selected_day(), Some(15));
     assert_eq!(output, None);
@@ -677,7 +705,7 @@ fn test_dispatch_event_enter_confirms() {
     let output = Calendar::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(CalendarOutput::DateSelected(2026, 3, 15)));
 }
@@ -688,7 +716,7 @@ fn test_dispatch_event_page_navigation() {
     let output = Calendar::dispatch_event(
         &mut state,
         &Event::key(KeyCode::PageUp),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(state.month(), 2);
     assert_eq!(output, Some(CalendarOutput::MonthChanged(2026, 2)));
@@ -696,7 +724,7 @@ fn test_dispatch_event_page_navigation() {
     let output = Calendar::dispatch_event(
         &mut state,
         &Event::key(KeyCode::PageDown),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(state.month(), 3);
     assert_eq!(output, Some(CalendarOutput::MonthChanged(2026, 3)));
@@ -708,7 +736,7 @@ fn test_dispatch_event_unfocused_returns_none() {
     let output = Calendar::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Right),
-        &ViewContext::default(),
+        &EventContext::default(),
     );
     assert_eq!(output, None);
     assert_eq!(state.selected_day(), Some(15));

--- a/src/component/calendar/view_tests.rs
+++ b/src/component/calendar/view_tests.rs
@@ -8,7 +8,7 @@ fn test_view_march_2026() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(34, 12);
     terminal
         .draw(|frame| {
-            Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Calendar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -20,7 +20,7 @@ fn test_view_with_selected_day() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(34, 12);
     terminal
         .draw(|frame| {
-            Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Calendar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -35,7 +35,7 @@ fn test_view_with_events() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(34, 12);
     terminal
         .draw(|frame| {
-            Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Calendar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -47,7 +47,7 @@ fn test_view_with_title() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 12);
     terminal
         .draw(|frame| {
-            Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Calendar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -61,10 +61,7 @@ fn test_view_focused() {
         .draw(|frame| {
             Calendar::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -79,10 +76,7 @@ fn test_view_disabled() {
         .draw(|frame| {
             Calendar::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -95,7 +89,7 @@ fn test_view_february_leap_year() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(34, 12);
     terminal
         .draw(|frame| {
-            Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Calendar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -107,7 +101,7 @@ fn test_view_february_non_leap_year() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(34, 12);
     terminal
         .draw(|frame| {
-            Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Calendar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -121,10 +115,7 @@ fn test_view_zero_area() {
         .draw(|frame| {
             Calendar::view(
                 &state,
-                frame,
-                Rect::new(0, 0, 0, 0),
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, Rect::new(0, 0, 0, 0), &theme),
             );
         })
         .unwrap();
@@ -137,7 +128,7 @@ fn test_view_narrow_area() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(10, 5);
     terminal
         .draw(|frame| {
-            Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Calendar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -154,7 +145,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Calendar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -177,10 +168,9 @@ fn test_annotation_reflects_state() {
             .draw(|frame| {
                 Calendar::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true).disabled(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme)
+                        .focused(true)
+                        .disabled(true),
                 );
             })
             .unwrap();

--- a/src/component/canvas/mod.rs
+++ b/src/component/canvas/mod.rs
@@ -36,8 +36,7 @@ use ratatui::widgets::canvas::{
 };
 use ratatui::widgets::{Block, Borders};
 
-use super::{Component, ViewContext};
-use crate::theme::Theme;
+use super::{Component, RenderContext};
 
 /// A drawable shape on the canvas.
 ///
@@ -564,14 +563,14 @@ impl Component for Canvas {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        if area.height < 2 || area.width < 2 {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        if ctx.area.height < 2 || ctx.area.width < 2 {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::canvas("canvas")
                     .with_focus(ctx.focused)
                     .with_disabled(ctx.disabled),
@@ -581,17 +580,17 @@ impl Component for Canvas {
         let needs_border = state.title.is_some() || ctx.focused;
 
         let border_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let content_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else {
-            theme.normal_style()
+            ctx.theme.normal_style()
         };
 
         let canvas_area = if needs_border {
@@ -603,11 +602,11 @@ impl Component for Canvas {
                 block = block.title(title.as_str());
             }
 
-            let inner = block.inner(area);
-            frame.render_widget(block, area);
+            let inner = block.inner(ctx.area);
+            ctx.frame.render_widget(block, ctx.area);
             inner
         } else {
-            area
+            ctx.area
         };
 
         if canvas_area.height == 0 || canvas_area.width == 0 {
@@ -619,7 +618,7 @@ impl Component for Canvas {
         let y_bounds = state.y_bounds;
         let shapes = state.shapes.clone();
         let is_disabled = ctx.disabled;
-        let disabled_style = theme.disabled_style();
+        let disabled_style = ctx.theme.disabled_style();
 
         let canvas = RatatuiCanvas::default()
             .x_bounds(x_bounds)
@@ -708,7 +707,7 @@ impl Component for Canvas {
                 }
             });
 
-        frame.render_widget(canvas, canvas_area);
+        ctx.frame.render_widget(canvas, canvas_area);
     }
 }
 

--- a/src/component/canvas/tests.rs
+++ b/src/component/canvas/tests.rs
@@ -479,7 +479,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Canvas::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Canvas::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -490,7 +490,7 @@ fn test_render_with_title() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            Canvas::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Canvas::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -524,7 +524,7 @@ fn test_render_with_shapes() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Canvas::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Canvas::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -539,10 +539,7 @@ fn test_render_focused() {
         .draw(|frame| {
             Canvas::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -565,10 +562,7 @@ fn test_render_disabled() {
         .draw(|frame| {
             Canvas::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -582,7 +576,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(5, 2);
     terminal
         .draw(|frame| {
-            Canvas::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Canvas::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -593,7 +587,7 @@ fn test_render_tiny_area_no_panic() {
     let (mut terminal, theme) = test_utils::setup_render(1, 1);
     terminal
         .draw(|frame| {
-            Canvas::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Canvas::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -609,7 +603,7 @@ fn test_render_with_points() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            Canvas::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Canvas::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -629,7 +623,7 @@ fn test_render_with_label() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            Canvas::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Canvas::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -648,7 +642,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Canvas::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Canvas::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/chart/annotation_tests.rs
+++ b/src/component/chart/annotation_tests.rs
@@ -153,7 +153,7 @@ fn render_chart_with_annotations(state: &ChartState) {
     let (mut terminal, theme) = test_utils::setup_render(80, 24);
     terminal
         .draw(|frame| {
-            Chart::view(state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -264,7 +264,7 @@ fn test_render_annotation_small_chart_no_panic() {
     let (mut terminal, theme) = test_utils::setup_render(10, 5);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }

--- a/src/component/chart/area_fill_tests.rs
+++ b/src/component/chart/area_fill_tests.rs
@@ -22,10 +22,7 @@ fn test_area_chart_renders_differently_from_line_chart() {
         .draw(|frame| {
             Chart::view(
                 &line_state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, frame.area(), &theme),
             );
         })
         .unwrap();
@@ -38,10 +35,7 @@ fn test_area_chart_renders_differently_from_line_chart() {
         .draw(|frame| {
             Chart::view(
                 &area_state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, frame.area(), &theme),
             );
         })
         .unwrap();
@@ -76,10 +70,7 @@ fn test_area_fill_does_not_overwrite_braille_dots() {
         .draw(|frame| {
             Chart::view(
                 &line_state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, frame.area(), &theme),
             );
         })
         .unwrap();
@@ -92,10 +83,7 @@ fn test_area_fill_does_not_overwrite_braille_dots() {
         .draw(|frame| {
             Chart::view(
                 &area_state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, frame.area(), &theme),
             );
         })
         .unwrap();
@@ -130,7 +118,7 @@ fn test_scatter_chart_has_no_area_fill() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     let output = terminal.backend().to_string();
@@ -147,7 +135,7 @@ fn test_area_chart_with_two_data_points() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     let output = terminal.backend().to_string();
@@ -168,7 +156,7 @@ fn test_area_chart_fill_with_y_range() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     let output = terminal.backend().to_string();
@@ -184,7 +172,7 @@ fn test_area_chart_multi_series_fill() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     let output = terminal.backend().to_string();
@@ -204,7 +192,7 @@ fn test_line_chart_has_no_area_fill() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     let output = terminal.backend().to_string();

--- a/src/component/chart/enhancement_tests.rs
+++ b/src/component/chart/enhancement_tests.rs
@@ -211,7 +211,7 @@ fn test_render_area_chart() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -228,7 +228,7 @@ fn test_render_area_chart_with_labels() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -239,7 +239,7 @@ fn test_render_area_chart_multi_series() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -257,7 +257,7 @@ fn test_render_scatter_chart() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -268,7 +268,7 @@ fn test_render_scatter_chart_multi_series() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -288,7 +288,7 @@ fn test_render_area_chart_with_thresholds() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -304,7 +304,7 @@ fn test_render_scatter_with_thresholds() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -320,7 +320,7 @@ fn test_render_area_chart_with_y_range() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -335,7 +335,7 @@ fn test_render_empty_area_chart() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -346,7 +346,7 @@ fn test_render_empty_scatter_chart() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -385,10 +385,7 @@ fn test_area_chart_disabled() {
         .draw(|frame| {
             Chart::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -402,10 +399,7 @@ fn test_scatter_chart_disabled() {
         .draw(|frame| {
             Chart::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -523,7 +517,7 @@ fn test_render_chart_with_vertical_lines() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -539,7 +533,7 @@ fn test_render_chart_with_vertical_and_horizontal_lines() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -621,7 +615,7 @@ fn test_cursor_home_end() {
 #[test]
 fn test_cursor_key_bindings() {
     let state = ChartState::line(sample_series());
-    let ctx = ViewContext::new().focused(true);
+    let ctx = EventContext::new().focused(true);
 
     assert_eq!(
         Chart::handle_event(&state, &Event::key(KeyCode::Left), &ctx),
@@ -656,7 +650,7 @@ fn test_cursor_key_bindings() {
 #[test]
 fn test_cursor_unfocused_ignored() {
     let state = ChartState::line(sample_series());
-    let ctx = ViewContext::default();
+    let ctx = EventContext::default();
 
     assert_eq!(
         Chart::handle_event(&state, &Event::key(KeyCode::Left), &ctx),
@@ -690,10 +684,7 @@ fn test_render_chart_with_crosshair() {
         .draw(|frame| {
             Chart::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -719,7 +710,7 @@ fn test_toggle_grid_message() {
 #[test]
 fn test_toggle_grid_key_binding() {
     let state = ChartState::line(sample_series());
-    let ctx = ViewContext::new().focused(true);
+    let ctx = EventContext::new().focused(true);
     assert_eq!(
         Chart::handle_event(&state, &Event::char('g'), &ctx),
         Some(ChartMessage::ToggleGrid)
@@ -733,7 +724,7 @@ fn test_render_line_chart_with_grid() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }

--- a/src/component/chart/error_band_tests.rs
+++ b/src/component/chart/error_band_tests.rs
@@ -47,7 +47,7 @@ fn test_render_with_bounds_shows_shading() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     let output = terminal.backend().to_string();
@@ -64,7 +64,7 @@ fn test_render_without_bounds_no_shading() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     let output = terminal.backend().to_string();
@@ -82,7 +82,7 @@ fn test_render_with_only_upper_bound() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     let output = terminal.backend().to_string();
@@ -102,10 +102,7 @@ fn test_render_bounds_disabled() {
         .draw(|frame| {
             Chart::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();

--- a/src/component/chart/grid/mod.rs
+++ b/src/component/chart/grid/mod.rs
@@ -18,8 +18,7 @@
 use ratatui::prelude::*;
 
 use super::{Chart, ChartState};
-use crate::component::{Component, ViewContext};
-use crate::theme::Theme;
+use crate::component::{Component, RenderContext};
 
 /// A grid layout for rendering multiple charts simultaneously.
 ///
@@ -216,7 +215,7 @@ impl ChartGrid {
     ///
     /// Splits the area into equal rows and columns, then delegates each
     /// occupied cell to [`Chart::view`].
-    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    pub fn render(&self, ctx: &mut RenderContext<'_, '_>) {
         let row_constraints: Vec<Constraint> = (0..self.rows)
             .map(|_| Constraint::Ratio(1, self.rows as u32))
             .collect();
@@ -224,7 +223,7 @@ impl ChartGrid {
         let row_areas = Layout::default()
             .direction(Direction::Vertical)
             .constraints(row_constraints)
-            .split(area);
+            .split(ctx.area);
 
         let col_constraints: Vec<Constraint> = (0..self.cols)
             .map(|_| Constraint::Ratio(1, self.cols as u32))
@@ -239,7 +238,7 @@ impl ChartGrid {
             for (col_idx, col_area) in col_areas.iter().enumerate() {
                 let cell_idx = row_idx * self.cols + col_idx;
                 if let Some(chart) = &self.charts[cell_idx] {
-                    Chart::view(chart, frame, *col_area, theme, ctx);
+                    Chart::view(chart, &mut ctx.with_area(*col_area));
                 }
             }
         }

--- a/src/component/chart/grid/tests.rs
+++ b/src/component/chart/grid/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::component::ViewContext;
+use crate::component::RenderContext;
 use crate::component::chart::DataSeries;
 use crate::component::test_utils;
 
@@ -163,7 +163,7 @@ fn test_render_2x2_grid_does_not_panic() {
     let (mut terminal, theme) = test_utils::setup_render(80, 24);
     terminal
         .draw(|frame| {
-            grid.render(frame, frame.area(), &theme, &ViewContext::default());
+            grid.render(&mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -175,7 +175,7 @@ fn test_render_with_empty_cells_does_not_panic() {
     let (mut terminal, theme) = test_utils::setup_render(80, 24);
     terminal
         .draw(|frame| {
-            grid.render(frame, frame.area(), &theme, &ViewContext::default());
+            grid.render(&mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -187,7 +187,7 @@ fn test_render_all_empty_does_not_panic() {
     let (mut terminal, theme) = test_utils::setup_render(80, 24);
     terminal
         .draw(|frame| {
-            grid.render(frame, frame.area(), &theme, &ViewContext::default());
+            grid.render(&mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -199,7 +199,7 @@ fn test_render_1x1_single_chart() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            grid.render(frame, frame.area(), &theme, &ViewContext::default());
+            grid.render(&mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -216,7 +216,7 @@ fn test_render_small_area_does_not_panic() {
     let (mut terminal, theme) = test_utils::setup_render(10, 6);
     terminal
         .draw(|frame| {
-            grid.render(frame, frame.area(), &theme, &ViewContext::default());
+            grid.render(&mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -228,10 +228,9 @@ fn test_render_with_focused_context() {
         .set(0, 1, sample_chart("R"));
 
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
-    let ctx = ViewContext::new().focused(true);
     terminal
         .draw(|frame| {
-            grid.render(frame, frame.area(), &theme, &ctx);
+            grid.render(&mut RenderContext::new(frame, frame.area(), &theme).focused(true));
         })
         .unwrap();
 }
@@ -248,7 +247,7 @@ fn test_render_mixed_chart_kinds() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            grid.render(frame, frame.area(), &theme, &ViewContext::default());
+            grid.render(&mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 

--- a/src/component/chart/mod.rs
+++ b/src/component/chart/mod.rs
@@ -26,9 +26,8 @@ use std::marker::PhantomData;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 mod annotations;
 pub(crate) mod downsample;
@@ -734,7 +733,7 @@ impl Component for Chart {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -855,14 +854,14 @@ impl Component for Chart {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        if area.height < 3 || area.width < 3 {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        if ctx.area.height < 3 || ctx.area.width < 3 {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::container("chart")
                     .with_focus(ctx.focused)
                     .with_disabled(ctx.disabled),
@@ -870,11 +869,11 @@ impl Component for Chart {
         });
 
         let border_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let mut block = Block::default()
@@ -885,8 +884,8 @@ impl Component for Chart {
             block = block.title(title.as_str());
         }
 
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
+        let inner = block.inner(ctx.area);
+        ctx.frame.render_widget(block, ctx.area);
 
         if inner.height == 0 || inner.width == 0 || state.series.is_empty() {
             return;
@@ -919,7 +918,7 @@ impl Component for Chart {
 
             // Render legend
             if legend_height > 0 {
-                render::render_legend(state, frame, chunks[2]);
+                render::render_legend(state, ctx.frame, chunks[2]);
             }
 
             // Render x-axis label
@@ -928,7 +927,7 @@ impl Component for Chart {
                     let p = Paragraph::new(label.as_str())
                         .alignment(Alignment::Center)
                         .style(Style::default().fg(Color::DarkGray));
-                    frame.render_widget(p, chunks[3]);
+                    ctx.frame.render_widget(p, chunks[3]);
                 }
             }
 
@@ -941,9 +940,9 @@ impl Component for Chart {
             ChartKind::Line | ChartKind::Area | ChartKind::Scatter => {
                 render::render_shared_axis_chart(
                     state,
-                    frame,
+                    ctx.frame,
                     chart_area,
-                    theme,
+                    ctx.theme,
                     ctx.focused,
                     ctx.disabled,
                 );
@@ -951,24 +950,24 @@ impl Component for Chart {
                 // Render crosshair value readout overlay
                 if state.show_crosshair {
                     if let Some(pos) = state.cursor_position {
-                        render::render_crosshair_readout(state, frame, chart_area, pos);
+                        render::render_crosshair_readout(state, ctx.frame, chart_area, pos);
                     }
                 }
             }
             ChartKind::BarVertical => render::render_bar_chart(
                 state,
-                frame,
+                ctx.frame,
                 chart_area,
-                theme,
+                ctx.theme,
                 false,
                 ctx.focused,
                 ctx.disabled,
             ),
             ChartKind::BarHorizontal => render::render_bar_chart(
                 state,
-                frame,
+                ctx.frame,
                 chart_area,
-                theme,
+                ctx.theme,
                 true,
                 ctx.focused,
                 ctx.disabled,

--- a/src/component/chart/render_tests.rs
+++ b/src/component/chart/render_tests.rs
@@ -22,7 +22,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -33,7 +33,7 @@ fn test_render_line_chart() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -47,7 +47,7 @@ fn test_render_line_chart_with_labels() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -61,7 +61,7 @@ fn test_render_bar_vertical() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -72,7 +72,7 @@ fn test_render_bar_horizontal() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -85,10 +85,7 @@ fn test_render_disabled() {
         .draw(|frame| {
             Chart::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -100,7 +97,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(60, 2);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -111,7 +108,7 @@ fn test_render_single_series_no_legend() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -156,7 +153,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -250,7 +247,7 @@ fn test_render_bar_chart_with_categories() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     // Verify no panic and rendering succeeds
@@ -263,7 +260,7 @@ fn test_render_bar_chart_falls_back_to_numeric_without_categories() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     // Verify no panic and rendering succeeds with numeric fallback
@@ -281,7 +278,7 @@ fn test_categories_fewer_than_data_points() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -295,7 +292,7 @@ fn test_categories_more_than_data_points() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -308,7 +305,7 @@ fn test_render_horizontal_bar_chart_with_categories() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -420,7 +417,7 @@ fn test_render_scatter_with_xy_data() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -437,7 +434,7 @@ fn test_render_line_with_xy_data() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -456,7 +453,7 @@ fn test_render_mixed_series_implicit_and_explicit_x() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -472,7 +469,7 @@ fn test_render_area_with_xy_data() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -488,7 +485,7 @@ fn test_xy_with_negative_x_values() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -576,7 +573,7 @@ fn test_render_single_mode() {
     ]);
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
-        .draw(|f| Chart::view(&state, f, f.area(), &theme, &ViewContext::default()))
+        .draw(|f| Chart::view(&state, &mut RenderContext::new(f, f.area(), &theme)))
         .unwrap();
 }
 
@@ -590,7 +587,7 @@ fn test_render_grouped_vertical() {
     .with_categories(vec!["A", "B"]);
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
-        .draw(|f| Chart::view(&state, f, f.area(), &theme, &ViewContext::default()))
+        .draw(|f| Chart::view(&state, &mut RenderContext::new(f, f.area(), &theme)))
         .unwrap();
 }
 
@@ -603,7 +600,7 @@ fn test_render_grouped_horizontal() {
     .with_bar_mode(BarMode::Grouped);
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
-        .draw(|f| Chart::view(&state, f, f.area(), &theme, &ViewContext::default()))
+        .draw(|f| Chart::view(&state, &mut RenderContext::new(f, f.area(), &theme)))
         .unwrap();
 }
 
@@ -617,7 +614,7 @@ fn test_render_stacked_vertical() {
     .with_categories(vec!["Q1", "Q2"]);
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
-        .draw(|f| Chart::view(&state, f, f.area(), &theme, &ViewContext::default()))
+        .draw(|f| Chart::view(&state, &mut RenderContext::new(f, f.area(), &theme)))
         .unwrap();
 }
 
@@ -630,7 +627,7 @@ fn test_render_stacked_horizontal() {
     .with_bar_mode(BarMode::Stacked);
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
-        .draw(|f| Chart::view(&state, f, f.area(), &theme, &ViewContext::default()))
+        .draw(|f| Chart::view(&state, &mut RenderContext::new(f, f.area(), &theme)))
         .unwrap();
 }
 
@@ -643,7 +640,7 @@ fn test_stacked_sums_values() {
     .with_bar_mode(BarMode::Stacked);
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
-        .draw(|f| Chart::view(&state, f, f.area(), &theme, &ViewContext::default()))
+        .draw(|f| Chart::view(&state, &mut RenderContext::new(f, f.area(), &theme)))
         .unwrap();
 }
 
@@ -652,7 +649,7 @@ fn test_bar_width_auto_scales() {
     let state = ChartState::bar_vertical(vec![DataSeries::new("A", vec![10.0, 20.0])]);
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
-        .draw(|f| Chart::view(&state, f, f.area(), &theme, &ViewContext::default()))
+        .draw(|f| Chart::view(&state, &mut RenderContext::new(f, f.area(), &theme)))
         .unwrap();
 }
 
@@ -668,10 +665,7 @@ fn test_render_grouped_disabled() {
         .draw(|f| {
             Chart::view(
                 &state,
-                f,
-                f.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(f, f.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -689,10 +683,7 @@ fn test_render_stacked_disabled() {
         .draw(|f| {
             Chart::view(
                 &state,
-                f,
-                f.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(f, f.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -707,6 +698,6 @@ fn test_render_stacked_zero_values() {
     .with_bar_mode(BarMode::Stacked);
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
-        .draw(|f| Chart::view(&state, f, f.area(), &theme, &ViewContext::default()))
+        .draw(|f| Chart::view(&state, &mut RenderContext::new(f, f.area(), &theme)))
         .unwrap();
 }

--- a/src/component/chart/snapshot_tests.rs
+++ b/src/component/chart/snapshot_tests.rs
@@ -18,7 +18,7 @@ fn test_snapshot_default_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -33,7 +33,7 @@ fn test_snapshot_populated_line_chart() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -47,10 +47,7 @@ fn test_snapshot_focused_line_chart() {
         .draw(|frame| {
             Chart::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -67,7 +64,7 @@ fn test_snapshot_bar_vertical() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -81,7 +78,7 @@ fn test_snapshot_bar_horizontal() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -96,7 +93,7 @@ fn test_snapshot_single_series() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -116,7 +113,7 @@ fn test_snapshot_area_chart() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -132,7 +129,7 @@ fn test_snapshot_scatter_chart() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -150,7 +147,7 @@ fn test_snapshot_area_chart_with_thresholds() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -167,7 +164,7 @@ fn test_snapshot_area_chart_with_y_range() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -179,7 +176,7 @@ fn test_snapshot_multi_series_area() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -191,7 +188,7 @@ fn test_snapshot_multi_series_scatter() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/chart/tests.rs
+++ b/src/component/chart/tests.rs
@@ -324,7 +324,7 @@ fn test_disabled_ignores_events() {
     let msg = Chart::handle_event(
         &state,
         &Event::key(KeyCode::Tab),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -336,7 +336,7 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = ChartState::line(sample_series());
-    let msg = Chart::handle_event(&state, &Event::key(KeyCode::Tab), &ViewContext::default());
+    let msg = Chart::handle_event(&state, &Event::key(KeyCode::Tab), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -351,7 +351,7 @@ fn test_tab_maps_to_next() {
         Chart::handle_event(
             &state,
             &Event::key(KeyCode::Tab),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ChartMessage::NextSeries)
     );
@@ -364,7 +364,7 @@ fn test_backtab_maps_to_prev() {
         Chart::handle_event(
             &state,
             &Event::key(KeyCode::BackTab),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ChartMessage::PrevSeries)
     );
@@ -384,7 +384,7 @@ fn test_render_line_chart_with_thresholds() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -399,7 +399,7 @@ fn test_render_line_chart_multi_series_overlay() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }

--- a/src/component/chart/x_labels_tests.rs
+++ b/src/component/chart/x_labels_tests.rs
@@ -176,7 +176,7 @@ fn test_render_line_chart_with_x_labels() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -197,7 +197,7 @@ fn test_render_area_chart_with_x_labels() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -217,7 +217,7 @@ fn test_render_scatter_chart_with_x_labels() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -239,7 +239,7 @@ fn test_render_without_x_labels_uses_numeric_ticks() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -262,7 +262,7 @@ fn test_render_x_labels_many_labels_are_reduced() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -284,7 +284,7 @@ fn test_render_x_labels_long_labels_do_not_panic() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -301,7 +301,7 @@ fn test_render_x_labels_empty_vec() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -325,7 +325,7 @@ fn test_snapshot_line_chart_with_x_labels() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/checkbox/mod.rs
+++ b/src/component/checkbox/mod.rs
@@ -26,12 +26,10 @@
 //! assert!(!state.is_checked());
 //! ```
 
-use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 /// Messages that can be sent to a Checkbox.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -246,7 +244,7 @@ impl Component for Checkbox {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -261,16 +259,16 @@ impl Component for Checkbox {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         let check_mark = if state.checked { "x" } else { " " };
         let text = format!("[{}] {}", check_mark, state.label);
 
         let style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_style()
+            ctx.theme.focused_style()
         } else {
-            theme.normal_style()
+            ctx.theme.normal_style()
         };
 
         let paragraph = Paragraph::new(text).style(style);
@@ -281,7 +279,7 @@ impl Component for Checkbox {
         let annotated = crate::annotation::Annotate::new(paragraph, annotation)
             .focused(ctx.focused)
             .disabled(ctx.disabled);
-        frame.render_widget(annotated, area);
+        ctx.frame.render_widget(annotated, ctx.area);
     }
 }
 

--- a/src/component/checkbox/tests.rs
+++ b/src/component/checkbox/tests.rs
@@ -56,7 +56,7 @@ fn test_view_unchecked() {
 
     terminal
         .draw(|frame| {
-            Checkbox::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Checkbox::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -70,7 +70,7 @@ fn test_view_checked() {
 
     terminal
         .draw(|frame| {
-            Checkbox::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Checkbox::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -86,10 +86,7 @@ fn test_view_focused() {
         .draw(|frame| {
             Checkbox::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -106,10 +103,7 @@ fn test_view_disabled() {
         .draw(|frame| {
             Checkbox::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -140,7 +134,7 @@ fn test_handle_event_enter_when_focused() {
     let msg = Checkbox::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CheckboxMessage::Toggle));
 }
@@ -148,14 +142,22 @@ fn test_handle_event_enter_when_focused() {
 #[test]
 fn test_handle_event_space_when_focused() {
     let state = CheckboxState::new("Test");
-    let msg = Checkbox::handle_event(&state, &Event::char(' '), &ViewContext::new().focused(true));
+    let msg = Checkbox::handle_event(
+        &state,
+        &Event::char(' '),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(CheckboxMessage::Toggle));
 }
 
 #[test]
 fn test_handle_event_ignored_when_unfocused() {
     let state = CheckboxState::new("Test");
-    let msg = Checkbox::handle_event(&state, &Event::key(KeyCode::Enter), &ViewContext::default());
+    let msg = Checkbox::handle_event(
+        &state,
+        &Event::key(KeyCode::Enter),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 }
 
@@ -165,7 +167,7 @@ fn test_handle_event_ignored_when_disabled() {
     let msg = Checkbox::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -176,7 +178,7 @@ fn test_dispatch_event() {
     let output = Checkbox::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(CheckboxOutput::Toggled(true)));
 }
@@ -198,7 +200,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Checkbox::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Checkbox::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -218,7 +220,7 @@ fn test_annotation_checked() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Checkbox::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Checkbox::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/code_block/mod.rs
+++ b/src/component/code_block/mod.rs
@@ -38,13 +38,10 @@ mod render;
 
 use std::collections::HashSet;
 
-use ratatui::prelude::*;
-
 pub use self::highlight::Language;
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
-use crate::theme::Theme;
 
 /// Messages that can be sent to a CodeBlock.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -549,7 +546,7 @@ impl Component for CodeBlock {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -632,8 +629,15 @@ impl Component for CodeBlock {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        render::render(state, frame, area, theme, ctx.focused, ctx.disabled);
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        render::render(
+            state,
+            ctx.frame,
+            ctx.area,
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
     }
 }
 

--- a/src/component/code_block/tests.rs
+++ b/src/component/code_block/tests.rs
@@ -335,7 +335,7 @@ fn test_disabled_ignores_events() {
     let msg = CodeBlock::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -343,7 +343,7 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = CodeBlockState::new();
-    let msg = CodeBlock::handle_event(&state, &Event::key(KeyCode::Up), &ViewContext::default());
+    let msg = CodeBlock::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -358,7 +358,7 @@ fn test_handle_event_up() {
         CodeBlock::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(CodeBlockMessage::ScrollUp)
     );
@@ -371,7 +371,7 @@ fn test_handle_event_down() {
         CodeBlock::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(CodeBlockMessage::ScrollDown)
     );
@@ -381,11 +381,19 @@ fn test_handle_event_down() {
 fn test_handle_event_k_j() {
     let state = focused_state();
     assert_eq!(
-        CodeBlock::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true)),
+        CodeBlock::handle_event(
+            &state,
+            &Event::char('k'),
+            &EventContext::new().focused(true)
+        ),
         Some(CodeBlockMessage::ScrollUp)
     );
     assert_eq!(
-        CodeBlock::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true)),
+        CodeBlock::handle_event(
+            &state,
+            &Event::char('j'),
+            &EventContext::new().focused(true)
+        ),
         Some(CodeBlockMessage::ScrollDown)
     );
 }
@@ -397,7 +405,7 @@ fn test_handle_event_page_up_down() {
         CodeBlock::handle_event(
             &state,
             &Event::key(KeyCode::PageUp),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(CodeBlockMessage::PageUp(10))
     );
@@ -405,7 +413,7 @@ fn test_handle_event_page_up_down() {
         CodeBlock::handle_event(
             &state,
             &Event::key(KeyCode::PageDown),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(CodeBlockMessage::PageDown(10))
     );
@@ -415,11 +423,19 @@ fn test_handle_event_page_up_down() {
 fn test_handle_event_ctrl_u_d() {
     let state = focused_state();
     assert_eq!(
-        CodeBlock::handle_event(&state, &Event::ctrl('u'), &ViewContext::new().focused(true)),
+        CodeBlock::handle_event(
+            &state,
+            &Event::ctrl('u'),
+            &EventContext::new().focused(true)
+        ),
         Some(CodeBlockMessage::PageUp(10))
     );
     assert_eq!(
-        CodeBlock::handle_event(&state, &Event::ctrl('d'), &ViewContext::new().focused(true)),
+        CodeBlock::handle_event(
+            &state,
+            &Event::ctrl('d'),
+            &EventContext::new().focused(true)
+        ),
         Some(CodeBlockMessage::PageDown(10))
     );
 }
@@ -431,7 +447,7 @@ fn test_handle_event_home_end() {
         CodeBlock::handle_event(
             &state,
             &Event::key(KeyCode::Home),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(CodeBlockMessage::Home)
     );
@@ -439,7 +455,7 @@ fn test_handle_event_home_end() {
         CodeBlock::handle_event(
             &state,
             &Event::key(KeyCode::End),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(CodeBlockMessage::End)
     );
@@ -450,14 +466,18 @@ fn test_handle_event_home_end() {
 fn test_handle_event_g_and_G() {
     let state = focused_state();
     assert_eq!(
-        CodeBlock::handle_event(&state, &Event::char('g'), &ViewContext::new().focused(true)),
+        CodeBlock::handle_event(
+            &state,
+            &Event::char('g'),
+            &EventContext::new().focused(true)
+        ),
         Some(CodeBlockMessage::Home)
     );
     assert_eq!(
         CodeBlock::handle_event(
             &state,
             &Event::key_with(KeyCode::Char('G'), KeyModifiers::SHIFT),
-            &ViewContext::new().focused(true),
+            &EventContext::new().focused(true),
         ),
         Some(CodeBlockMessage::End)
     );
@@ -467,7 +487,11 @@ fn test_handle_event_g_and_G() {
 fn test_handle_event_l_scroll_right() {
     let state = focused_state();
     assert_eq!(
-        CodeBlock::handle_event(&state, &Event::char('l'), &ViewContext::new().focused(true)),
+        CodeBlock::handle_event(
+            &state,
+            &Event::char('l'),
+            &EventContext::new().focused(true)
+        ),
         Some(CodeBlockMessage::ScrollRight)
     );
 }
@@ -476,7 +500,11 @@ fn test_handle_event_l_scroll_right() {
 fn test_handle_event_n_toggle_line_numbers() {
     let state = focused_state();
     assert_eq!(
-        CodeBlock::handle_event(&state, &Event::char('n'), &ViewContext::new().focused(true)),
+        CodeBlock::handle_event(
+            &state,
+            &Event::char('n'),
+            &EventContext::new().focused(true)
+        ),
         Some(CodeBlockMessage::ToggleLineNumbers)
     );
 }
@@ -485,7 +513,11 @@ fn test_handle_event_n_toggle_line_numbers() {
 fn test_handle_event_unrecognized() {
     let state = focused_state();
     assert_eq!(
-        CodeBlock::handle_event(&state, &Event::char('x'), &ViewContext::new().focused(true)),
+        CodeBlock::handle_event(
+            &state,
+            &Event::char('x'),
+            &EventContext::new().focused(true)
+        ),
         None
     );
 }
@@ -536,7 +568,7 @@ fn test_view_empty() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CodeBlock::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -551,7 +583,7 @@ fn test_view_with_rust_code() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CodeBlock::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -566,7 +598,7 @@ fn test_view_with_line_numbers() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CodeBlock::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -582,10 +614,7 @@ fn test_view_focused() {
         .draw(|frame| {
             CodeBlock::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -602,10 +631,7 @@ fn test_view_disabled() {
         .draw(|frame| {
             CodeBlock::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -623,7 +649,7 @@ fn test_view_scrolled() {
     let (mut terminal, theme) = test_utils::setup_render(50, 8);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CodeBlock::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -638,7 +664,7 @@ fn test_view_with_highlight_lines() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CodeBlock::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -654,7 +680,7 @@ fn test_view_python_code() {
     let (mut terminal, theme) = test_utils::setup_render(60, 8);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CodeBlock::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -672,7 +698,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                CodeBlock::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -693,10 +719,7 @@ fn test_annotation_focused() {
             .draw(|frame| {
                 CodeBlock::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
                 );
             })
             .unwrap();
@@ -716,7 +739,7 @@ fn test_zero_size_render() {
     let (mut terminal, theme) = test_utils::setup_render(3, 3);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CodeBlock::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     // Should not panic
@@ -728,7 +751,7 @@ fn test_single_line_render() {
     let (mut terminal, theme) = test_utils::setup_render(30, 5);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CodeBlock::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -741,7 +764,7 @@ fn test_scroll_beyond_content() {
     let (mut terminal, theme) = test_utils::setup_render(30, 5);
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CodeBlock::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     // Should not panic; scroll is clamped during render
@@ -821,7 +844,7 @@ fn test_horizontal_scroll_key_bindings() {
     let msg = CodeBlock::handle_event(
         &state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CodeBlockMessage::ScrollLeft));
 
@@ -829,20 +852,32 @@ fn test_horizontal_scroll_key_bindings() {
     let msg = CodeBlock::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CodeBlockMessage::ScrollRight));
 
     // h key
-    let msg = CodeBlock::handle_event(&state, &Event::char('h'), &ViewContext::new().focused(true));
+    let msg = CodeBlock::handle_event(
+        &state,
+        &Event::char('h'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(CodeBlockMessage::ScrollLeft));
 
     // l key (now horizontal scroll, not toggle line numbers)
-    let msg = CodeBlock::handle_event(&state, &Event::char('l'), &ViewContext::new().focused(true));
+    let msg = CodeBlock::handle_event(
+        &state,
+        &Event::char('l'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(CodeBlockMessage::ScrollRight));
 
     // n key (toggle line numbers)
-    let msg = CodeBlock::handle_event(&state, &Event::char('n'), &ViewContext::new().focused(true));
+    let msg = CodeBlock::handle_event(
+        &state,
+        &Event::char('n'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(CodeBlockMessage::ToggleLineNumbers));
 }
 
@@ -859,10 +894,7 @@ fn test_horizontal_scroll_renders_shifted_content() {
         .draw(|frame| {
             CodeBlock::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();

--- a/src/component/collapsible/mod.rs
+++ b/src/component/collapsible/mod.rs
@@ -36,9 +36,8 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use super::{Component, Toggleable, ViewContext};
+use super::{Component, EventContext, RenderContext, Toggleable};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 /// Messages that can be sent to a Collapsible.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -419,7 +418,7 @@ impl Component for Collapsible {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -436,14 +435,14 @@ impl Component for Collapsible {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        if area.height == 0 || area.width == 0 {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        if ctx.area.height == 0 || ctx.area.width == 0 {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::new(crate::annotation::WidgetType::Custom(
                     "Collapsible".to_string(),
                 ))
@@ -462,35 +461,36 @@ impl Component for Collapsible {
         let header_text = format!("{} {}", indicator, state.header);
 
         let header_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_style()
+            ctx.theme.focused_style()
         } else {
-            theme.normal_style()
+            ctx.theme.normal_style()
         };
 
         let header_line = Line::from(Span::styled(header_text, header_style));
-        let header_area = Rect::new(area.x, area.y, area.width, 1);
-        frame.render_widget(Paragraph::new(header_line), header_area);
+        let header_area = Rect::new(ctx.area.x, ctx.area.y, ctx.area.width, 1);
+        ctx.frame
+            .render_widget(Paragraph::new(header_line), header_area);
 
-        // Content area (below header) -- only render border when expanded
-        if state.expanded && area.height > 1 {
-            let available = area.height.saturating_sub(1);
+        // Content ctx.area (below header) -- only render border when expanded
+        if state.expanded && ctx.area.height > 1 {
+            let available = ctx.area.height.saturating_sub(1);
             let content_h = state.content_height.min(available);
 
             if content_h > 0 {
-                let content_area = Rect::new(area.x, area.y + 1, area.width, content_h);
+                let content_area = Rect::new(ctx.area.x, ctx.area.y + 1, ctx.area.width, content_h);
                 let border_style = if ctx.disabled {
-                    theme.disabled_style()
+                    ctx.theme.disabled_style()
                 } else if ctx.focused {
-                    theme.focused_border_style()
+                    ctx.theme.focused_border_style()
                 } else {
-                    theme.border_style()
+                    ctx.theme.border_style()
                 };
                 let content_block = Block::default()
                     .borders(Borders::LEFT | Borders::BOTTOM)
                     .border_style(border_style);
-                frame.render_widget(content_block, content_area);
+                ctx.frame.render_widget(content_block, content_area);
             }
         }
     }

--- a/src/component/collapsible/tests.rs
+++ b/src/component/collapsible/tests.rs
@@ -249,8 +249,11 @@ fn test_update_set_content_height() {
 #[test]
 fn test_handle_event_space_toggles() {
     let state = CollapsibleState::new("Details");
-    let msg =
-        Collapsible::handle_event(&state, &Event::char(' '), &ViewContext::new().focused(true));
+    let msg = Collapsible::handle_event(
+        &state,
+        &Event::char(' '),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(CollapsibleMessage::Toggle));
 }
 
@@ -260,7 +263,7 @@ fn test_handle_event_enter_toggles() {
     let msg = Collapsible::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CollapsibleMessage::Toggle));
 }
@@ -271,7 +274,7 @@ fn test_handle_event_right_expands() {
     let msg = Collapsible::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CollapsibleMessage::Expand));
 }
@@ -282,7 +285,7 @@ fn test_handle_event_left_collapses() {
     let msg = Collapsible::handle_event(
         &state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CollapsibleMessage::Collapse));
 }
@@ -291,19 +294,25 @@ fn test_handle_event_left_collapses() {
 fn test_handle_event_unfocused_ignores_events() {
     let state = CollapsibleState::new("Details");
 
-    let msg = Collapsible::handle_event(&state, &Event::char(' '), &ViewContext::default());
+    let msg = Collapsible::handle_event(&state, &Event::char(' '), &EventContext::default());
+    assert_eq!(msg, None);
+
+    let msg = Collapsible::handle_event(
+        &state,
+        &Event::key(KeyCode::Enter),
+        &EventContext::default(),
+    );
+    assert_eq!(msg, None);
+
+    let msg = Collapsible::handle_event(
+        &state,
+        &Event::key(KeyCode::Right),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 
     let msg =
-        Collapsible::handle_event(&state, &Event::key(KeyCode::Enter), &ViewContext::default());
-    assert_eq!(msg, None);
-
-    let msg =
-        Collapsible::handle_event(&state, &Event::key(KeyCode::Right), &ViewContext::default());
-    assert_eq!(msg, None);
-
-    let msg =
-        Collapsible::handle_event(&state, &Event::key(KeyCode::Left), &ViewContext::default());
+        Collapsible::handle_event(&state, &Event::key(KeyCode::Left), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -314,28 +323,28 @@ fn test_handle_event_disabled_ignores_events() {
     let msg = Collapsible::handle_event(
         &state,
         &Event::char(' '),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Collapsible::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Collapsible::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Collapsible::handle_event(
         &state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -343,8 +352,11 @@ fn test_handle_event_disabled_ignores_events() {
 #[test]
 fn test_handle_event_unrecognized_key_returns_none() {
     let state = CollapsibleState::new("Details");
-    let msg =
-        Collapsible::handle_event(&state, &Event::char('x'), &ViewContext::new().focused(true));
+    let msg = Collapsible::handle_event(
+        &state,
+        &Event::char('x'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, None);
 }
 
@@ -356,7 +368,7 @@ fn test_dispatch_event_space_toggles() {
     let output = Collapsible::dispatch_event(
         &mut state,
         &Event::char(' '),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(CollapsibleOutput::Toggled(false)));
     assert!(!state.expanded());
@@ -368,7 +380,7 @@ fn test_dispatch_event_enter_toggles() {
     let output = Collapsible::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(CollapsibleOutput::Toggled(true)));
     assert!(state.expanded());
@@ -380,7 +392,7 @@ fn test_dispatch_event_right_expands() {
     let output = Collapsible::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(CollapsibleOutput::Expanded));
     assert!(state.expanded());
@@ -392,7 +404,7 @@ fn test_dispatch_event_left_collapses() {
     let output = Collapsible::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(CollapsibleOutput::Collapsed));
     assert!(!state.expanded());
@@ -402,7 +414,7 @@ fn test_dispatch_event_left_collapses() {
 fn test_dispatch_event_unfocused_returns_none() {
     let mut state = CollapsibleState::new("Details");
     let output =
-        Collapsible::dispatch_event(&mut state, &Event::char(' '), &ViewContext::default());
+        Collapsible::dispatch_event(&mut state, &Event::char(' '), &EventContext::default());
     assert_eq!(output, None);
     assert!(state.expanded()); // Unchanged
 }
@@ -486,7 +498,7 @@ fn test_view_expanded() {
 
     terminal
         .draw(|frame| {
-            Collapsible::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Collapsible::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -500,7 +512,7 @@ fn test_view_collapsed() {
 
     terminal
         .draw(|frame| {
-            Collapsible::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Collapsible::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -514,7 +526,7 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            Collapsible::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Collapsible::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -530,10 +542,7 @@ fn test_view_disabled() {
         .draw(|frame| {
             Collapsible::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -548,7 +557,7 @@ fn test_view_focused_collapsed() {
 
     terminal
         .draw(|frame| {
-            Collapsible::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Collapsible::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -563,7 +572,7 @@ fn test_view_zero_area() {
     terminal
         .draw(|frame| {
             let zero_area = Rect::new(0, 0, 0, 0);
-            Collapsible::view(&state, frame, zero_area, &theme, &ViewContext::default());
+            Collapsible::view(&state, &mut RenderContext::new(frame, zero_area, &theme));
         })
         .unwrap();
     // Should not panic
@@ -577,7 +586,7 @@ fn test_view_height_one() {
     terminal
         .draw(|frame| {
             let area = Rect::new(0, 0, 40, 1);
-            Collapsible::view(&state, frame, area, &theme, &ViewContext::default());
+            Collapsible::view(&state, &mut RenderContext::new(frame, area, &theme));
         })
         .unwrap();
 
@@ -595,7 +604,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Collapsible::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Collapsible::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -619,10 +628,9 @@ fn test_annotation_reflects_state() {
             .draw(|frame| {
                 Collapsible::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true).disabled(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme)
+                        .focused(true)
+                        .disabled(true),
                 );
             })
             .unwrap();

--- a/src/component/command_palette/event_tests.rs
+++ b/src/component/command_palette/event_tests.rs
@@ -18,8 +18,11 @@ fn active_state() -> CommandPaletteState {
 #[test]
 fn test_char_maps_to_type_char() {
     let state = active_state();
-    let msg =
-        CommandPalette::handle_event(&state, &Event::char('a'), &ViewContext::new().focused(true));
+    let msg = CommandPalette::handle_event(
+        &state,
+        &Event::char('a'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(CommandPaletteMessage::TypeChar('a')));
 }
 
@@ -29,7 +32,7 @@ fn test_uppercase_char_maps_to_type_char() {
     let msg = CommandPalette::handle_event(
         &state,
         &Event::key_with(KeyCode::Char('A'), crate::input::KeyModifiers::SHIFT),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CommandPaletteMessage::TypeChar('A')));
 }
@@ -40,7 +43,7 @@ fn test_backspace_maps_to_backspace() {
     let msg = CommandPalette::handle_event(
         &state,
         &Event::key(KeyCode::Backspace),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CommandPaletteMessage::Backspace));
 }
@@ -51,7 +54,7 @@ fn test_enter_maps_to_confirm() {
     let msg = CommandPalette::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CommandPaletteMessage::Confirm));
 }
@@ -62,7 +65,7 @@ fn test_escape_maps_to_dismiss() {
     let msg = CommandPalette::handle_event(
         &state,
         &Event::key(KeyCode::Esc),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CommandPaletteMessage::Dismiss));
 }
@@ -73,7 +76,7 @@ fn test_up_maps_to_select_prev() {
     let msg = CommandPalette::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CommandPaletteMessage::SelectPrev));
 }
@@ -84,7 +87,7 @@ fn test_down_maps_to_select_next() {
     let msg = CommandPalette::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CommandPaletteMessage::SelectNext));
 }
@@ -92,24 +95,33 @@ fn test_down_maps_to_select_next() {
 #[test]
 fn test_ctrl_p_maps_to_select_prev() {
     let state = active_state();
-    let msg =
-        CommandPalette::handle_event(&state, &Event::ctrl('p'), &ViewContext::new().focused(true));
+    let msg = CommandPalette::handle_event(
+        &state,
+        &Event::ctrl('p'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(CommandPaletteMessage::SelectPrev));
 }
 
 #[test]
 fn test_ctrl_n_maps_to_select_next() {
     let state = active_state();
-    let msg =
-        CommandPalette::handle_event(&state, &Event::ctrl('n'), &ViewContext::new().focused(true));
+    let msg = CommandPalette::handle_event(
+        &state,
+        &Event::ctrl('n'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(CommandPaletteMessage::SelectNext));
 }
 
 #[test]
 fn test_ctrl_u_maps_to_clear_query() {
     let state = active_state();
-    let msg =
-        CommandPalette::handle_event(&state, &Event::ctrl('u'), &ViewContext::new().focused(true));
+    let msg = CommandPalette::handle_event(
+        &state,
+        &Event::ctrl('u'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(CommandPaletteMessage::ClearQuery));
 }
 
@@ -120,15 +132,19 @@ fn test_unfocused_ignores_all_events() {
     // focused is false
 
     assert_eq!(
-        CommandPalette::handle_event(&state, &Event::char('a'), &ViewContext::default()),
+        CommandPalette::handle_event(&state, &Event::char('a'), &EventContext::default()),
         None
     );
     assert_eq!(
-        CommandPalette::handle_event(&state, &Event::key(KeyCode::Enter), &ViewContext::default()),
+        CommandPalette::handle_event(
+            &state,
+            &Event::key(KeyCode::Enter),
+            &EventContext::default()
+        ),
         None
     );
     assert_eq!(
-        CommandPalette::handle_event(&state, &Event::key(KeyCode::Esc), &ViewContext::default()),
+        CommandPalette::handle_event(&state, &Event::key(KeyCode::Esc), &EventContext::default()),
         None
     );
 }
@@ -141,7 +157,7 @@ fn test_disabled_ignores_all_events() {
         CommandPalette::handle_event(
             &state,
             &Event::char('a'),
-            &ViewContext::new().focused(true).disabled(true)
+            &EventContext::new().focused(true).disabled(true)
         ),
         None
     );
@@ -149,7 +165,7 @@ fn test_disabled_ignores_all_events() {
         CommandPalette::handle_event(
             &state,
             &Event::key(KeyCode::Enter),
-            &ViewContext::new().focused(true).disabled(true)
+            &EventContext::new().focused(true).disabled(true)
         ),
         None
     );
@@ -161,14 +177,18 @@ fn test_hidden_ignores_all_events() {
     // visible is false
 
     assert_eq!(
-        CommandPalette::handle_event(&state, &Event::char('a'), &ViewContext::new().focused(true)),
+        CommandPalette::handle_event(
+            &state,
+            &Event::char('a'),
+            &EventContext::new().focused(true)
+        ),
         None
     );
     assert_eq!(
         CommandPalette::handle_event(
             &state,
             &Event::key(KeyCode::Enter),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         None
     );
@@ -180,7 +200,7 @@ fn test_unrecognized_key_returns_none() {
     let msg = CommandPalette::handle_event(
         &state,
         &Event::key(KeyCode::F(1)),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
 }

--- a/src/component/command_palette/mod.rs
+++ b/src/component/command_palette/mod.rs
@@ -38,12 +38,9 @@ mod render;
 
 pub use item::{PaletteItem, fuzzy_score};
 
-use ratatui::prelude::*;
-
-use super::{Component, Toggleable, ViewContext};
+use super::{Component, EventContext, RenderContext, Toggleable};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
-use crate::theme::Theme;
 
 /// Messages that can be sent to a CommandPalette.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -622,7 +619,7 @@ impl Component for CommandPalette {
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled || !state.visible {
             return None;
@@ -743,8 +740,15 @@ impl Component for CommandPalette {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        render::render_command_palette(state, frame, area, theme, ctx.focused, ctx.disabled);
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        render::render_command_palette(
+            state,
+            ctx.frame,
+            ctx.area,
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
     }
 }
 

--- a/src/component/command_palette/snapshot_tests.rs
+++ b/src/component/command_palette/snapshot_tests.rs
@@ -23,7 +23,7 @@ fn test_snapshot_visible_default() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CommandPalette::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -36,7 +36,7 @@ fn test_snapshot_with_query() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CommandPalette::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -50,7 +50,7 @@ fn test_snapshot_with_selection() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CommandPalette::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -66,7 +66,7 @@ fn test_snapshot_no_matches() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CommandPalette::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -78,7 +78,7 @@ fn test_snapshot_hidden() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CommandPalette::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -95,10 +95,7 @@ fn test_snapshot_custom_title_and_placeholder() {
         .draw(|frame| {
             CommandPalette::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -114,10 +111,7 @@ fn test_snapshot_empty_items() {
         .draw(|frame| {
             CommandPalette::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -141,10 +135,7 @@ fn test_snapshot_with_descriptions() {
         .draw(|frame| {
             CommandPalette::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();

--- a/src/component/command_palette/tests.rs
+++ b/src/component/command_palette/tests.rs
@@ -509,7 +509,7 @@ fn test_disabled_ignores_events() {
     let msg = CommandPalette::handle_event(
         &state,
         &Event::char('a'),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -523,7 +523,7 @@ fn test_unfocused_ignores_events() {
     let mut state = CommandPaletteState::new(sample_items());
     state.set_visible(true);
     // focused is false by default
-    let msg = CommandPalette::handle_event(&state, &Event::char('a'), &ViewContext::default());
+    let msg = CommandPalette::handle_event(&state, &Event::char('a'), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -535,8 +535,11 @@ fn test_unfocused_ignores_events() {
 fn test_hidden_ignores_events() {
     let state = CommandPaletteState::new(sample_items());
     // visible is false by default
-    let msg =
-        CommandPalette::handle_event(&state, &Event::char('a'), &ViewContext::new().focused(true));
+    let msg = CommandPalette::handle_event(
+        &state,
+        &Event::char('a'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, None);
 }
 
@@ -632,7 +635,7 @@ fn test_render_hidden_is_noop() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CommandPalette::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     // Should render nothing (blank)
@@ -644,7 +647,7 @@ fn test_render_visible() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CommandPalette::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -656,7 +659,7 @@ fn test_render_with_query() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CommandPalette::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -668,7 +671,7 @@ fn test_render_with_selection() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CommandPalette::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -683,7 +686,7 @@ fn test_render_no_matches() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CommandPalette::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -697,10 +700,7 @@ fn test_render_empty_items() {
         .draw(|frame| {
             CommandPalette::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -778,7 +778,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                CommandPalette::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                CommandPalette::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/confirm_dialog/mod.rs
+++ b/src/component/confirm_dialog/mod.rs
@@ -31,7 +31,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
-use super::{Component, Toggleable, ViewContext};
+use super::{Component, EventContext, RenderContext, Toggleable};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -422,7 +422,7 @@ impl ConfirmDialogState {
     /// assert_eq!(state.handle_event(&event), Some(ConfirmDialogMessage::Close));
     /// ```
     pub fn handle_event(&self, event: &Event) -> Option<ConfirmDialogMessage> {
-        ConfirmDialog::handle_event(self, event, &ViewContext::default())
+        ConfirmDialog::handle_event(self, event, &EventContext::default())
     }
 
     /// Dispatches an event, updating state and returning any output.
@@ -441,7 +441,7 @@ impl ConfirmDialogState {
     /// assert!(!state.is_visible());
     /// ```
     pub fn dispatch_event(&mut self, event: &Event) -> Option<ConfirmDialogOutput> {
-        ConfirmDialog::dispatch_event(self, event, &ViewContext::default())
+        ConfirmDialog::dispatch_event(self, event, &EventContext::default())
     }
 
     /// Updates the dialog state with a message, returning any output.
@@ -568,7 +568,7 @@ impl Component for ConfirmDialog {
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        _ctx: &ViewContext,
+        _ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !state.visible {
             return None;
@@ -592,14 +592,14 @@ impl Component for ConfirmDialog {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         if !state.visible {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::new(crate::annotation::WidgetType::ConfirmDialog)
                     .with_id("confirm_dialog")
                     .with_label(state.title.as_str())
@@ -609,25 +609,25 @@ impl Component for ConfirmDialog {
         });
 
         // Calculate dialog size
-        let dialog_width = (area.width * 60 / 100).clamp(30, 80);
+        let dialog_width = (ctx.area.width * 60 / 100).clamp(30, 80);
         let message_lines = state.message.lines().count().max(1) as u16;
-        let dialog_height = (5 + message_lines).min(area.height);
+        let dialog_height = (5 + message_lines).min(ctx.area.height);
 
-        let dialog_area = crate::util::centered_rect(dialog_width, dialog_height, area);
+        let dialog_area = crate::util::centered_rect(dialog_width, dialog_height, ctx.area);
 
-        // Clear the dialog area (overlay effect)
-        frame.render_widget(Clear, dialog_area);
+        // Clear the dialog ctx.area (overlay effect)
+        ctx.frame.render_widget(Clear, dialog_area);
 
         // Render dialog box
         let block = Block::default()
             .title(format!(" {} ", state.title))
             .borders(Borders::ALL)
-            .border_style(theme.border_style());
+            .border_style(ctx.theme.border_style());
 
         let inner = block.inner(dialog_area);
-        frame.render_widget(block, dialog_area);
+        ctx.frame.render_widget(block, dialog_area);
 
-        // Layout: message area + button row
+        // Layout: message ctx.area + button row
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -638,10 +638,17 @@ impl Component for ConfirmDialog {
 
         // Render message
         let message = Paragraph::new(state.message.as_str()).wrap(Wrap { trim: true });
-        frame.render_widget(message, chunks[0]);
+        ctx.frame.render_widget(message, chunks[0]);
 
         // Render buttons
-        render_confirm_buttons(state, frame, chunks[1], theme, ctx.focused, ctx.disabled);
+        render_confirm_buttons(
+            state,
+            ctx.frame,
+            chunks[1],
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
     }
 }
 

--- a/src/component/confirm_dialog/tests.rs
+++ b/src/component/confirm_dialog/tests.rs
@@ -159,8 +159,11 @@ fn test_press_cancel_in_ok_cancel() {
 fn test_y_shortcut_yes_no() {
     let state = ConfirmDialogState::yes_no("T", "M").with_visible(true);
 
-    let msg =
-        ConfirmDialog::handle_event(&state, &Event::char('y'), &ViewContext::new().focused(true));
+    let msg = ConfirmDialog::handle_event(
+        &state,
+        &Event::char('y'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(
         msg,
         Some(ConfirmDialogMessage::SelectResult(ConfirmDialogResult::Yes))
@@ -171,8 +174,11 @@ fn test_y_shortcut_yes_no() {
 fn test_n_shortcut_yes_no() {
     let state = ConfirmDialogState::yes_no("T", "M").with_visible(true);
 
-    let msg =
-        ConfirmDialog::handle_event(&state, &Event::char('n'), &ViewContext::new().focused(true));
+    let msg = ConfirmDialog::handle_event(
+        &state,
+        &Event::char('n'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(
         msg,
         Some(ConfirmDialogMessage::SelectResult(ConfirmDialogResult::No))
@@ -183,8 +189,11 @@ fn test_n_shortcut_yes_no() {
 fn test_y_shortcut_uppercase() {
     let state = ConfirmDialogState::yes_no("T", "M").with_visible(true);
 
-    let msg =
-        ConfirmDialog::handle_event(&state, &Event::char('Y'), &ViewContext::new().focused(true));
+    let msg = ConfirmDialog::handle_event(
+        &state,
+        &Event::char('Y'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(
         msg,
         Some(ConfirmDialogMessage::SelectResult(ConfirmDialogResult::Yes))
@@ -195,8 +204,11 @@ fn test_y_shortcut_uppercase() {
 fn test_y_shortcut_not_in_ok_config() {
     let state = ConfirmDialogState::ok("T", "M").with_visible(true);
 
-    let msg =
-        ConfirmDialog::handle_event(&state, &Event::char('y'), &ViewContext::new().focused(true));
+    let msg = ConfirmDialog::handle_event(
+        &state,
+        &Event::char('y'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, None);
 }
 
@@ -207,7 +219,7 @@ fn test_tab_key() {
     let msg = ConfirmDialog::handle_event(
         &state,
         &Event::key(KeyCode::Tab),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(ConfirmDialogMessage::FocusNext));
 }
@@ -219,7 +231,7 @@ fn test_backtab_key() {
     let msg = ConfirmDialog::handle_event(
         &state,
         &Event::key(KeyCode::BackTab),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(ConfirmDialogMessage::FocusPrev));
 }
@@ -231,7 +243,7 @@ fn test_enter_key() {
     let msg = ConfirmDialog::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(ConfirmDialogMessage::Press));
 }
@@ -243,7 +255,7 @@ fn test_esc_key() {
     let msg = ConfirmDialog::handle_event(
         &state,
         &Event::key(KeyCode::Esc),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(ConfirmDialogMessage::Close));
 }
@@ -287,8 +299,11 @@ fn test_open_resets_focus() {
 #[test]
 fn test_not_visible_ignores_events() {
     let state = ConfirmDialogState::ok("T", "M");
-    let msg =
-        ConfirmDialog::handle_event(&state, &Event::key(KeyCode::Enter), &ViewContext::default());
+    let msg = ConfirmDialog::handle_event(
+        &state,
+        &Event::key(KeyCode::Enter),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 }
 
@@ -354,7 +369,7 @@ fn test_view_not_visible() {
 
     terminal
         .draw(|frame| {
-            ConfirmDialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConfirmDialog::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -373,10 +388,7 @@ fn test_view_ok_dialog() {
         .draw(|frame| {
             ConfirmDialog::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -394,10 +406,7 @@ fn test_view_yes_no_dialog() {
         .draw(|frame| {
             ConfirmDialog::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -419,10 +428,7 @@ fn test_annotation_emitted() {
             .draw(|frame| {
                 ConfirmDialog::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
                 );
             })
             .unwrap();

--- a/src/component/context.rs
+++ b/src/component/context.rs
@@ -1,0 +1,298 @@
+//! Render-time and event-time context types for components.
+//!
+//! This module provides [`RenderContext`] and [`EventContext`], which carry
+//! per-render state (frame, area, theme, focus, disabled) into component
+//! `view` and `handle_event` methods respectively.
+
+use ratatui::prelude::{Frame, Rect};
+
+use crate::theme::Theme;
+
+/// Context passed to [`Component::handle_event`](crate::component::Component::handle_event).
+///
+/// Carries focus and disabled state from the parent so the component
+/// can decide whether and how to handle events. Use [`RenderContext`]
+/// for `view()`.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::component::EventContext;
+///
+/// let ctx = EventContext::default();
+/// assert!(!ctx.focused);
+///
+/// let ctx = EventContext::new().focused(true).disabled(false);
+/// assert!(ctx.focused);
+/// ```
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct EventContext {
+    /// Whether this component currently has keyboard focus.
+    pub focused: bool,
+    /// Whether this component is currently disabled.
+    pub disabled: bool,
+}
+
+impl EventContext {
+    /// Creates a new default EventContext (unfocused, enabled).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the focused state (builder pattern).
+    #[must_use]
+    pub fn focused(mut self, focused: bool) -> Self {
+        self.focused = focused;
+        self
+    }
+
+    /// Sets the disabled state (builder pattern).
+    #[must_use]
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+}
+
+/// Context passed to [`Component::view`](crate::component::Component::view).
+///
+/// Bundles the frame, area, theme, and focus/disabled state into a
+/// single value so component view signatures stay short and adding
+/// new render-time fields is non-breaking.
+///
+/// # Lifetimes
+///
+/// `RenderContext` carries two lifetime parameters:
+/// - `'frame` is the lifetime of the borrow on the [`Frame`] reference.
+///   This is the lifetime that shortens during reborrows via [`with_area`](Self::with_area).
+/// - `'buf` is the lifetime of the frame's internal buffer (the underlying terminal cells).
+///   This stays stable across reborrows.
+///
+/// Most callers can write `RenderContext<'_, '_>` and let lifetime elision
+/// handle both. For example, [`Component::view`](crate::component::Component::view)
+/// takes `ctx: &mut RenderContext<'_, '_>`.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use envision::component::{Component, RenderContext};
+/// use envision::theme::Theme;
+/// use envision::backend::CaptureBackend;
+/// use ratatui::Terminal;
+///
+/// let backend = CaptureBackend::new(80, 24);
+/// let mut terminal = Terminal::new(backend).unwrap();
+/// let theme = Theme::default();
+/// terminal.draw(|frame| {
+///     let area = frame.area();
+///     let mut ctx = RenderContext::new(frame, area, &theme).focused(true);
+///     // Pass `&mut ctx` to a component's `view` method.
+/// }).unwrap();
+/// ```
+pub struct RenderContext<'frame, 'buf> {
+    /// The ratatui frame to render into.
+    pub frame: &'frame mut Frame<'buf>,
+    /// The area within the frame to render to.
+    pub area: Rect,
+    /// The theme to use for styling.
+    pub theme: &'frame Theme,
+    /// Whether the component currently has keyboard focus.
+    pub focused: bool,
+    /// Whether the component is currently disabled.
+    pub disabled: bool,
+}
+
+impl<'frame, 'buf> RenderContext<'frame, 'buf> {
+    /// Constructs a new RenderContext with `focused` and `disabled` both `false`.
+    pub fn new(frame: &'frame mut Frame<'buf>, area: Rect, theme: &'frame Theme) -> Self {
+        Self {
+            frame,
+            area,
+            theme,
+            focused: false,
+            disabled: false,
+        }
+    }
+
+    /// Sets the focused state (builder pattern).
+    #[must_use]
+    pub fn focused(mut self, focused: bool) -> Self {
+        self.focused = focused;
+        self
+    }
+
+    /// Sets the disabled state (builder pattern).
+    #[must_use]
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    /// Returns a context with the same frame, theme, and focus state but
+    /// a different area.
+    ///
+    /// The returned context borrows the frame for a shorter lifetime, so
+    /// the parent context becomes valid again after the child context
+    /// goes out of scope.
+    pub fn with_area(&mut self, area: Rect) -> RenderContext<'_, 'buf> {
+        RenderContext {
+            frame: self.frame,
+            area,
+            theme: self.theme,
+            focused: self.focused,
+            disabled: self.disabled,
+        }
+    }
+
+    /// Convenience: render a widget into this context's area.
+    ///
+    /// Equivalent to `self.frame.render_widget(widget, self.area)`.
+    pub fn render_widget<W: ratatui::widgets::Widget>(&mut self, widget: W) {
+        self.frame.render_widget(widget, self.area);
+    }
+
+    /// Returns the [`EventContext`] slice of this RenderContext.
+    pub fn event_context(&self) -> EventContext {
+        EventContext {
+            focused: self.focused,
+            disabled: self.disabled,
+        }
+    }
+}
+
+impl From<&RenderContext<'_, '_>> for EventContext {
+    fn from(ctx: &RenderContext<'_, '_>) -> Self {
+        EventContext {
+            focused: ctx.focused,
+            disabled: ctx.disabled,
+        }
+    }
+}
+
+#[cfg(test)]
+mod render_context_tests {
+    use super::*;
+    use crate::component::test_utils::setup_render;
+
+    #[test]
+    fn test_event_context_default() {
+        let ctx = EventContext::default();
+        assert!(!ctx.focused);
+        assert!(!ctx.disabled);
+    }
+
+    #[test]
+    fn test_event_context_builder() {
+        let ctx = EventContext::new().focused(true);
+        assert!(ctx.focused);
+        assert!(!ctx.disabled);
+
+        let ctx = EventContext::new().focused(true).disabled(true);
+        assert!(ctx.focused);
+        assert!(ctx.disabled);
+    }
+
+    #[test]
+    fn test_render_context_construction() {
+        let (mut terminal, theme) = setup_render(60, 5);
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                let ctx = RenderContext::new(frame, area, &theme);
+                assert!(!ctx.focused);
+                assert!(!ctx.disabled);
+                assert_eq!(ctx.area, area);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn test_render_context_builder() {
+        let (mut terminal, theme) = setup_render(60, 5);
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                let ctx = RenderContext::new(frame, area, &theme)
+                    .focused(true)
+                    .disabled(true);
+                assert!(ctx.focused);
+                assert!(ctx.disabled);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn test_render_context_with_area() {
+        use ratatui::widgets::Paragraph;
+        let (mut terminal, theme) = setup_render(60, 10);
+        terminal
+            .draw(|frame| {
+                let parent_area = frame.area();
+                let mut ctx = RenderContext::new(frame, parent_area, &theme).focused(true);
+                let parent_theme_ptr = ctx.theme as *const Theme;
+                let child_area = ratatui::layout::Rect::new(5, 2, 20, 3);
+                {
+                    let mut child_ctx = ctx.with_area(child_area);
+                    assert_eq!(child_ctx.area, child_area);
+                    assert!(child_ctx.focused);
+                    // Verify child shares parent's theme reference (pointer equality)
+                    assert_eq!(child_ctx.theme as *const Theme, parent_theme_ptr);
+                    child_ctx.render_widget(Paragraph::new("child"));
+                }
+                // Critical: render through the parent ctx after child scope.
+                // This line would NOT compile if the reborrow were broken.
+                ctx.render_widget(Paragraph::new("parent"));
+                assert_eq!(ctx.area, parent_area);
+                assert!(ctx.focused);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn test_render_context_render_widget() {
+        use ratatui::widgets::Paragraph;
+        let (mut terminal, theme) = setup_render(60, 5);
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                let mut ctx = RenderContext::new(frame, area, &theme);
+                ctx.render_widget(Paragraph::new("hello"));
+            })
+            .unwrap();
+
+        let display = terminal.backend().to_string();
+        assert!(display.contains("hello"));
+    }
+
+    #[test]
+    fn test_event_context_from_render_context() {
+        let (mut terminal, theme) = setup_render(60, 5);
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                let ctx = RenderContext::new(frame, area, &theme)
+                    .focused(true)
+                    .disabled(false);
+                let event_ctx: EventContext = (&ctx).into();
+                assert!(event_ctx.focused);
+                assert!(!event_ctx.disabled);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn test_render_context_event_context_method() {
+        let (mut terminal, theme) = setup_render(60, 5);
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                let ctx = RenderContext::new(frame, area, &theme)
+                    .focused(true)
+                    .disabled(true);
+                let event_ctx = ctx.event_context();
+                assert!(event_ctx.focused);
+                assert!(event_ctx.disabled);
+            })
+            .unwrap();
+    }
+}

--- a/src/component/conversation_view/mod.rs
+++ b/src/component/conversation_view/mod.rs
@@ -46,10 +46,9 @@ use std::marker::PhantomData;
 
 use ratatui::prelude::*;
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
-use crate::theme::Theme;
 
 impl MessageSource for ConversationViewState {
     fn source_messages(&self) -> &[ConversationMessage] {
@@ -808,7 +807,7 @@ impl Component for ConversationView {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -893,21 +892,28 @@ impl Component for ConversationView {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        if area.height < 3 || area.width < 5 {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        if ctx.area.height < 3 || ctx.area.width < 5 {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.open(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::container("conversation_view")
                     .with_focus(ctx.focused)
                     .with_disabled(ctx.disabled),
             );
         });
 
-        render::render(state, frame, area, theme, ctx.focused, ctx.disabled);
+        render::render(
+            state,
+            ctx.frame,
+            ctx.area,
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
 
         crate::annotation::with_registry(|reg| {
             reg.close();
@@ -931,8 +937,11 @@ impl ConversationView {
     ///
     /// ```rust
     /// use envision::component::{
-    ///     ConversationView, ConversationViewState, ConversationMessage,
-    ///     ConversationRole, MessageSource, ViewContext,
+    ///     ConversationMessage,
+    ///     ConversationRole,
+    ///     ConversationView,
+    ///     ConversationViewState,
+    ///     MessageSource,
     /// };
     ///
     /// // Application owns the canonical message list
@@ -944,31 +953,32 @@ impl ConversationView {
     ///
     /// // State tracks only view configuration (scroll, collapsed blocks, etc.)
     /// let state = ConversationViewState::new();
-    /// // Call ConversationView::view_from(&messages, &state, frame, area, &theme, &ctx)
+    /// // Call ConversationView::view_from(&messages, &state, &mut ctx)
     /// // to render from the external source without mirroring.
     /// ```
     pub fn view_from(
         source: &dyn MessageSource,
         state: &ConversationViewState,
-        frame: &mut Frame,
-        area: Rect,
-        theme: &Theme,
-        ctx: &ViewContext,
+        ctx: &mut RenderContext<'_, '_>,
     ) {
-        if area.height < 3 || area.width < 5 {
+        if ctx.area.height < 3 || ctx.area.width < 5 {
             return;
         }
 
+        let focused = ctx.focused;
+        let disabled = ctx.disabled;
         crate::annotation::with_registry(|reg| {
             reg.open(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::container("conversation_view")
-                    .with_focus(ctx.focused)
-                    .with_disabled(ctx.disabled),
+                    .with_focus(focused)
+                    .with_disabled(disabled),
             );
         });
 
-        render::render_from(source, state, frame, area, theme, ctx.focused, ctx.disabled);
+        render::render_from(
+            source, state, ctx.frame, ctx.area, ctx.theme, focused, disabled,
+        );
 
         crate::annotation::with_registry(|reg| {
             reg.close();

--- a/src/component/conversation_view/render_tests.rs
+++ b/src/component/conversation_view/render_tests.rs
@@ -23,7 +23,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -34,7 +34,7 @@ fn test_render_with_messages() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -45,7 +45,7 @@ fn test_render_focused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -58,10 +58,7 @@ fn test_render_disabled() {
         .draw(|frame| {
             ConversationView::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -73,7 +70,7 @@ fn test_render_with_title() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -90,7 +87,7 @@ fn test_render_with_timestamps() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -103,7 +100,7 @@ fn test_render_without_role_labels() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -121,7 +118,7 @@ fn test_render_code_block() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -139,7 +136,7 @@ fn test_render_tool_use_block() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -157,7 +154,7 @@ fn test_render_thinking_block() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -172,7 +169,7 @@ fn test_render_error_block() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -186,7 +183,7 @@ fn test_render_streaming_message() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -205,7 +202,7 @@ fn test_render_collapsed_thinking() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -221,7 +218,7 @@ fn test_render_collapsed_tool_use() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -232,7 +229,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(60, 4);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -243,7 +240,7 @@ fn test_render_tiny_area_no_panic() {
     let (mut terminal, theme) = test_utils::setup_render(4, 2);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -264,7 +261,7 @@ fn test_render_mixed_blocks() {
     let (mut terminal, theme) = test_utils::setup_render(60, 30);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -283,7 +280,7 @@ fn test_render_empty_code_block() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -298,7 +295,7 @@ fn test_render_empty_tool_input() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -313,7 +310,7 @@ fn test_render_empty_text_block() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -332,10 +329,7 @@ fn test_annotation_emitted() {
             .draw(|frame| {
                 ConversationView::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::default(),
+                    &mut RenderContext::new(frame, frame.area(), &theme),
                 );
             })
             .unwrap();
@@ -360,10 +354,7 @@ fn test_view_from_renders_external_messages() {
             ConversationView::view_from(
                 &messages,
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, frame.area(), &theme),
             );
         })
         .unwrap();
@@ -387,10 +378,7 @@ fn test_view_from_matches_view_with_same_messages() {
         .draw(|frame| {
             ConversationView::view(
                 &state_owned,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, frame.area(), &theme),
             );
         })
         .unwrap();
@@ -403,10 +391,7 @@ fn test_view_from_matches_view_with_same_messages() {
             ConversationView::view_from(
                 &external_messages,
                 &state_config,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, frame.area(), &theme),
             );
         })
         .unwrap();
@@ -425,10 +410,7 @@ fn test_view_from_empty_source() {
             ConversationView::view_from(
                 &messages,
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, frame.area(), &theme),
             );
         })
         .unwrap();
@@ -446,10 +428,7 @@ fn test_view_from_respects_state_config() {
             ConversationView::view_from(
                 &messages,
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, frame.area(), &theme),
             );
         })
         .unwrap();
@@ -469,10 +448,7 @@ fn test_view_from_with_vec_reference() {
             ConversationView::view_from(
                 &messages,
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, frame.area(), &theme),
             );
         })
         .unwrap();
@@ -488,10 +464,7 @@ fn test_view_from_tiny_area_no_panic() {
             ConversationView::view_from(
                 &messages,
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, frame.area(), &theme),
             );
         })
         .unwrap();
@@ -509,10 +482,7 @@ fn test_view_from_annotation_emitted() {
                 ConversationView::view_from(
                     &messages,
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::default(),
+                    &mut RenderContext::new(frame, frame.area(), &theme),
                 );
             })
             .unwrap();
@@ -536,10 +506,7 @@ fn test_view_from_with_code_blocks() {
             ConversationView::view_from(
                 &messages,
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, frame.area(), &theme),
             );
         })
         .unwrap();
@@ -563,10 +530,7 @@ fn test_view_from_collapsed_blocks_use_state_config() {
             ConversationView::view_from(
                 &messages,
                 &state_expanded,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, frame.area(), &theme),
             );
         })
         .unwrap();
@@ -581,10 +545,7 @@ fn test_view_from_collapsed_blocks_use_state_config() {
             ConversationView::view_from(
                 &messages,
                 &state_collapsed,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, frame.area(), &theme),
             );
         })
         .unwrap();

--- a/src/component/conversation_view/snapshot_tests.rs
+++ b/src/component/conversation_view/snapshot_tests.rs
@@ -15,7 +15,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -30,7 +30,7 @@ fn test_snapshot_with_messages() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -50,7 +50,7 @@ fn test_snapshot_with_code_block() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -66,10 +66,7 @@ fn test_snapshot_disabled() {
         .draw(|frame| {
             ConversationView::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -83,7 +80,7 @@ fn test_snapshot_with_title() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -99,7 +96,7 @@ fn test_snapshot_multiple_roles() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/conversation_view/tests/events.rs
+++ b/src/component/conversation_view/tests/events.rs
@@ -8,7 +8,7 @@ use super::*;
 fn test_unfocused_ignores_events() {
     let state = ConversationViewState::new();
     assert_eq!(
-        ConversationView::handle_event(&state, &Event::char('k'), &ViewContext::default()),
+        ConversationView::handle_event(&state, &Event::char('k'), &EventContext::default()),
         None
     );
 }
@@ -20,7 +20,7 @@ fn test_disabled_ignores_events() {
         ConversationView::handle_event(
             &state,
             &Event::char('k'),
-            &ViewContext::new().focused(true).disabled(true)
+            &EventContext::new().focused(true).disabled(true)
         ),
         None
     );
@@ -33,7 +33,7 @@ fn test_scroll_up_event() {
         ConversationView::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ConversationViewMessage::ScrollUp)
     );
@@ -41,7 +41,7 @@ fn test_scroll_up_event() {
         ConversationView::handle_event(
             &state,
             &Event::char('k'),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ConversationViewMessage::ScrollUp)
     );
@@ -54,7 +54,7 @@ fn test_scroll_down_event() {
         ConversationView::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ConversationViewMessage::ScrollDown)
     );
@@ -62,7 +62,7 @@ fn test_scroll_down_event() {
         ConversationView::handle_event(
             &state,
             &Event::char('j'),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ConversationViewMessage::ScrollDown)
     );
@@ -75,7 +75,7 @@ fn test_scroll_to_top_event() {
         ConversationView::handle_event(
             &state,
             &Event::key(KeyCode::Home),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ConversationViewMessage::ScrollToTop)
     );
@@ -83,7 +83,7 @@ fn test_scroll_to_top_event() {
         ConversationView::handle_event(
             &state,
             &Event::char('g'),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ConversationViewMessage::ScrollToTop)
     );
@@ -96,7 +96,7 @@ fn test_scroll_to_bottom_event() {
         ConversationView::handle_event(
             &state,
             &Event::key(KeyCode::End),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ConversationViewMessage::ScrollToBottom)
     );
@@ -104,7 +104,7 @@ fn test_scroll_to_bottom_event() {
         ConversationView::handle_event(
             &state,
             &Event::char('G'),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ConversationViewMessage::ScrollToBottom)
     );
@@ -117,7 +117,7 @@ fn test_page_up_event() {
         ConversationView::handle_event(
             &state,
             &Event::key(KeyCode::PageUp),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ConversationViewMessage::PageUp)
     );
@@ -130,7 +130,7 @@ fn test_page_down_event() {
         ConversationView::handle_event(
             &state,
             &Event::key(KeyCode::PageDown),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ConversationViewMessage::PageDown)
     );
@@ -143,7 +143,7 @@ fn test_unrecognized_key_ignored() {
         ConversationView::handle_event(
             &state,
             &Event::char('x'),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         None
     );

--- a/src/component/data_grid/mod.rs
+++ b/src/component/data_grid/mod.rs
@@ -43,10 +43,11 @@ use std::marker::PhantomData;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Row, Table as RatatuiTable};
 
-use super::{Column, Component, InputFieldMessage, InputFieldState, TableRow, ViewContext};
+use super::{
+    Column, Component, EventContext, InputFieldMessage, InputFieldState, RenderContext, TableRow,
+};
 use crate::input::{Event, KeyCode};
 use crate::scroll::ScrollState;
-use crate::theme::Theme;
 
 /// Messages that can be sent to a DataGrid.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -623,7 +624,7 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -819,14 +820,14 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         if state.columns.is_empty() {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::table("data_grid")
                     .with_focus(ctx.focused)
                     .with_disabled(ctx.disabled),
@@ -860,7 +861,7 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
             .collect();
 
         let header_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else {
             Style::default().add_modifier(Modifier::BOLD)
         };
@@ -894,17 +895,17 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
             .collect();
 
         let border_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let highlight_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else {
-            theme.selected_highlight_style(ctx.focused)
+            ctx.theme.selected_highlight_style(ctx.focused)
         };
 
         let table = RatatuiTable::new(rows, widths)
@@ -919,17 +920,23 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
 
         let mut table_state = ratatui::widgets::TableState::default();
         table_state.select(state.selected_row);
-        frame.render_stateful_widget(table, area, &mut table_state);
+        ctx.frame
+            .render_stateful_widget(table, ctx.area, &mut table_state);
 
         // Render scrollbar by mirroring the offset from ratatui's TableState
-        let inner = area.inner(Margin::new(1, 1));
+        let inner = ctx.area.inner(Margin::new(1, 1));
         // Viewport for data rows: inner height minus header row (1) and bottom margin (1)
         let data_viewport = (inner.height as usize).saturating_sub(2);
         if data_viewport > 0 && state.rows.len() > data_viewport {
             let mut bar_scroll = ScrollState::new(state.rows.len());
             bar_scroll.set_viewport_height(data_viewport);
             bar_scroll.set_offset(table_state.offset());
-            crate::scroll::render_scrollbar_inside_border(&bar_scroll, frame, area, theme);
+            crate::scroll::render_scrollbar_inside_border(
+                &bar_scroll,
+                ctx.frame,
+                ctx.area,
+                ctx.theme,
+            );
         }
 
         // Show cursor when editing
@@ -937,7 +944,7 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
             if let Some(row_idx) = state.selected_row {
                 // Calculate cursor position for the edit cell
                 // This is approximate — exact positioning depends on column widths
-                let content_area = area.inner(Margin::new(1, 1));
+                let content_area = ctx.area.inner(Margin::new(1, 1));
                 let col_areas = Layout::default()
                     .direction(Direction::Horizontal)
                     .constraints(state.columns.iter().map(|c| c.width()).collect::<Vec<_>>())
@@ -947,8 +954,9 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
                     // +2 for header row and margin
                     let cursor_y = content_area.y + 2 + (row_idx as u16);
                     let cursor_x = col_area.x + state.editor.cursor_display_position() as u16;
-                    if cursor_y < area.bottom() && cursor_x < col_area.right() {
-                        frame.set_cursor_position(Position::new(cursor_x, cursor_y));
+                    if cursor_y < ctx.area.bottom() && cursor_x < col_area.right() {
+                        ctx.frame
+                            .set_cursor_position(Position::new(cursor_x, cursor_y));
                     }
                 }
             }

--- a/src/component/data_grid/snapshot_tests.rs
+++ b/src/component/data_grid/snapshot_tests.rs
@@ -47,7 +47,7 @@ fn test_snapshot_default_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DataGrid::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -59,7 +59,7 @@ fn test_snapshot_populated() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DataGrid::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -73,10 +73,7 @@ fn test_snapshot_focused() {
         .draw(|frame| {
             DataGrid::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -92,10 +89,7 @@ fn test_snapshot_focused_second_column() {
         .draw(|frame| {
             DataGrid::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -111,10 +105,7 @@ fn test_snapshot_editing() {
         .draw(|frame| {
             DataGrid::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();

--- a/src/component/data_grid/tests.rs
+++ b/src/component/data_grid/tests.rs
@@ -308,7 +308,7 @@ fn test_disabled_ignores_events() {
     let msg = DataGrid::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -320,7 +320,7 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = DataGridState::new(sample_rows(), sample_columns());
-    let msg = DataGrid::handle_event(&state, &Event::key(KeyCode::Down), &ViewContext::default());
+    let msg = DataGrid::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -335,12 +335,16 @@ fn test_up_key_maps() {
         DataGrid::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DataGridMessage::Up)
     );
     assert_eq!(
-        DataGrid::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true)),
+        DataGrid::handle_event(
+            &state,
+            &Event::char('k'),
+            &EventContext::new().focused(true)
+        ),
         Some(DataGridMessage::Up)
     );
 }
@@ -352,12 +356,16 @@ fn test_down_key_maps() {
         DataGrid::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DataGridMessage::Down)
     );
     assert_eq!(
-        DataGrid::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true)),
+        DataGrid::handle_event(
+            &state,
+            &Event::char('j'),
+            &EventContext::new().focused(true)
+        ),
         Some(DataGridMessage::Down)
     );
 }
@@ -369,7 +377,7 @@ fn test_left_right_key_maps() {
         DataGrid::handle_event(
             &state,
             &Event::key(KeyCode::Left),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DataGridMessage::Left)
     );
@@ -377,16 +385,24 @@ fn test_left_right_key_maps() {
         DataGrid::handle_event(
             &state,
             &Event::key(KeyCode::Right),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DataGridMessage::Right)
     );
     assert_eq!(
-        DataGrid::handle_event(&state, &Event::char('h'), &ViewContext::new().focused(true)),
+        DataGrid::handle_event(
+            &state,
+            &Event::char('h'),
+            &EventContext::new().focused(true)
+        ),
         Some(DataGridMessage::Left)
     );
     assert_eq!(
-        DataGrid::handle_event(&state, &Event::char('l'), &ViewContext::new().focused(true)),
+        DataGrid::handle_event(
+            &state,
+            &Event::char('l'),
+            &EventContext::new().focused(true)
+        ),
         Some(DataGridMessage::Right)
     );
 }
@@ -398,7 +414,7 @@ fn test_home_end_key_maps() {
         DataGrid::handle_event(
             &state,
             &Event::key(KeyCode::Home),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DataGridMessage::First)
     );
@@ -406,7 +422,7 @@ fn test_home_end_key_maps() {
         DataGrid::handle_event(
             &state,
             &Event::key(KeyCode::End),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DataGridMessage::Last)
     );
@@ -419,7 +435,7 @@ fn test_enter_key_maps() {
         DataGrid::handle_event(
             &state,
             &Event::key(KeyCode::Enter),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DataGridMessage::Enter)
     );
@@ -436,7 +452,11 @@ fn test_editing_char_maps_to_input() {
     assert!(state.is_editing());
 
     assert_eq!(
-        DataGrid::handle_event(&state, &Event::char('x'), &ViewContext::new().focused(true)),
+        DataGrid::handle_event(
+            &state,
+            &Event::char('x'),
+            &EventContext::new().focused(true)
+        ),
         Some(DataGridMessage::Input('x'))
     );
 }
@@ -450,7 +470,7 @@ fn test_editing_enter_maps() {
         DataGrid::handle_event(
             &state,
             &Event::key(KeyCode::Enter),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DataGridMessage::Enter)
     );
@@ -465,7 +485,7 @@ fn test_editing_esc_maps_to_cancel() {
         DataGrid::handle_event(
             &state,
             &Event::key(KeyCode::Esc),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DataGridMessage::Cancel)
     );
@@ -480,7 +500,7 @@ fn test_editing_backspace_maps() {
         DataGrid::handle_event(
             &state,
             &Event::key(KeyCode::Backspace),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DataGridMessage::Backspace)
     );
@@ -545,7 +565,7 @@ fn test_render_unfocused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DataGrid::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -556,7 +576,7 @@ fn test_render_focused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DataGrid::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -568,7 +588,7 @@ fn test_render_editing() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DataGrid::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -581,10 +601,7 @@ fn test_render_disabled() {
         .draw(|frame| {
             DataGrid::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -596,7 +613,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DataGrid::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -648,7 +665,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                DataGrid::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                DataGrid::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/dependency_graph/mod.rs
+++ b/src/component/dependency_graph/mod.rs
@@ -27,11 +27,8 @@
 //! assert_eq!(state.selected(), Some(0));
 //! ```
 
-use ratatui::prelude::*;
-
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 pub mod layout;
 mod render;
@@ -794,7 +791,7 @@ impl Component for DependencyGraph {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -817,8 +814,15 @@ impl Component for DependencyGraph {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        render::render_dependency_graph(state, frame, area, theme, ctx.focused, ctx.disabled);
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        render::render_dependency_graph(
+            state,
+            ctx.frame,
+            ctx.area,
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
     }
 }
 

--- a/src/component/dependency_graph/snapshot_tests.rs
+++ b/src/component/dependency_graph/snapshot_tests.rs
@@ -7,7 +7,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 10);
     terminal
         .draw(|frame| {
-            DependencyGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DependencyGraph::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -21,7 +21,7 @@ fn test_snapshot_single_node() {
     let (mut terminal, theme) = test_utils::setup_render(60, 10);
     terminal
         .draw(|frame| {
-            DependencyGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DependencyGraph::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -39,7 +39,7 @@ fn test_snapshot_simple_graph() {
     let (mut terminal, theme) = test_utils::setup_render(80, 16);
     terminal
         .draw(|frame| {
-            DependencyGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DependencyGraph::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -58,10 +58,7 @@ fn test_snapshot_with_selection() {
         .draw(|frame| {
             DependencyGraph::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -82,7 +79,7 @@ fn test_snapshot_with_statuses() {
     let (mut terminal, theme) = test_utils::setup_render(80, 16);
     terminal
         .draw(|frame| {
-            DependencyGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DependencyGraph::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -100,10 +97,7 @@ fn test_snapshot_disabled() {
         .draw(|frame| {
             DependencyGraph::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -121,7 +115,7 @@ fn test_snapshot_top_to_bottom() {
     let (mut terminal, theme) = test_utils::setup_render(60, 16);
     terminal
         .draw(|frame| {
-            DependencyGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DependencyGraph::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/dependency_graph/tests.rs
+++ b/src/component/dependency_graph/tests.rs
@@ -365,7 +365,7 @@ fn test_selected_node_some() {
 fn test_handle_event_not_focused() {
     let state = DependencyGraphState::new().with_node(GraphNode::new("a", "A"));
     let msg =
-        DependencyGraph::handle_event(&state, &Event::key(KeyCode::Down), &ViewContext::default());
+        DependencyGraph::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -373,7 +373,7 @@ fn test_handle_event_not_focused() {
 fn test_handle_event_disabled() {
     let state = DependencyGraphState::new().with_node(GraphNode::new("a", "A"));
     let msg =
-        DependencyGraph::handle_event(&state, &Event::key(KeyCode::Down), &ViewContext::default());
+        DependencyGraph::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -384,7 +384,7 @@ fn test_handle_event_down() {
         DependencyGraph::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DependencyGraphMessage::SelectNext)
     );
@@ -394,7 +394,11 @@ fn test_handle_event_down() {
 fn test_handle_event_j() {
     let state = DependencyGraphState::new().with_node(GraphNode::new("a", "A"));
     assert_eq!(
-        DependencyGraph::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true)),
+        DependencyGraph::handle_event(
+            &state,
+            &Event::char('j'),
+            &EventContext::new().focused(true)
+        ),
         Some(DependencyGraphMessage::SelectNext)
     );
 }
@@ -406,7 +410,7 @@ fn test_handle_event_tab() {
         DependencyGraph::handle_event(
             &state,
             &Event::key(KeyCode::Tab),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DependencyGraphMessage::SelectNext)
     );
@@ -419,7 +423,7 @@ fn test_handle_event_up() {
         DependencyGraph::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DependencyGraphMessage::SelectPrev)
     );
@@ -429,7 +433,11 @@ fn test_handle_event_up() {
 fn test_handle_event_k() {
     let state = DependencyGraphState::new().with_node(GraphNode::new("a", "A"));
     assert_eq!(
-        DependencyGraph::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true)),
+        DependencyGraph::handle_event(
+            &state,
+            &Event::char('k'),
+            &EventContext::new().focused(true)
+        ),
         Some(DependencyGraphMessage::SelectPrev)
     );
 }
@@ -441,7 +449,7 @@ fn test_handle_event_backtab() {
         DependencyGraph::handle_event(
             &state,
             &Event::key(KeyCode::BackTab),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DependencyGraphMessage::SelectPrev)
     );
@@ -454,7 +462,7 @@ fn test_handle_event_enter() {
         DependencyGraph::handle_event(
             &state,
             &Event::key(KeyCode::Enter),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DependencyGraphMessage::SelectConnected)
     );
@@ -464,7 +472,11 @@ fn test_handle_event_enter() {
 fn test_handle_event_l() {
     let state = DependencyGraphState::new().with_node(GraphNode::new("a", "A"));
     assert_eq!(
-        DependencyGraph::handle_event(&state, &Event::char('l'), &ViewContext::new().focused(true)),
+        DependencyGraph::handle_event(
+            &state,
+            &Event::char('l'),
+            &EventContext::new().focused(true)
+        ),
         Some(DependencyGraphMessage::SelectConnected)
     );
 }
@@ -476,7 +488,7 @@ fn test_handle_event_right() {
         DependencyGraph::handle_event(
             &state,
             &Event::key(KeyCode::Right),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DependencyGraphMessage::SelectConnected)
     );
@@ -486,7 +498,11 @@ fn test_handle_event_right() {
 fn test_handle_event_unknown_key() {
     let state = DependencyGraphState::new().with_node(GraphNode::new("a", "A"));
     assert_eq!(
-        DependencyGraph::handle_event(&state, &Event::char('x'), &ViewContext::new().focused(true)),
+        DependencyGraph::handle_event(
+            &state,
+            &Event::char('x'),
+            &EventContext::new().focused(true)
+        ),
         None
     );
 }
@@ -674,7 +690,7 @@ fn test_dispatch_event() {
     let output = DependencyGraph::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(
         output,

--- a/src/component/dialog/mod.rs
+++ b/src/component/dialog/mod.rs
@@ -27,7 +27,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
-use super::{Component, Toggleable, ViewContext};
+use super::{Component, EventContext, RenderContext, Toggleable};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -519,7 +519,7 @@ impl DialogState {
     /// assert_eq!(state.handle_event(&event), Some(DialogMessage::Press));
     /// ```
     pub fn handle_event(&self, event: &Event) -> Option<DialogMessage> {
-        Dialog::handle_event(self, event, &ViewContext::default())
+        Dialog::handle_event(self, event, &EventContext::default())
     }
 
     /// Dispatches an event, updating state and returning any output.
@@ -537,7 +537,7 @@ impl DialogState {
     /// assert_eq!(output, Some(DialogOutput::ButtonPressed("ok".into())));
     /// ```
     pub fn dispatch_event(&mut self, event: &Event) -> Option<DialogOutput> {
-        Dialog::dispatch_event(self, event, &ViewContext::default())
+        Dialog::dispatch_event(self, event, &EventContext::default())
     }
 
     /// Updates the dialog state with a message, returning any output.
@@ -657,7 +657,7 @@ impl Component for Dialog {
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        _ctx: &ViewContext,
+        _ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !state.visible {
             return None;
@@ -675,14 +675,14 @@ impl Component for Dialog {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         if !state.visible {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::dialog(state.title.as_str())
                     .with_id("dialog")
                     .with_focus(ctx.focused)
@@ -691,26 +691,26 @@ impl Component for Dialog {
         });
 
         // Calculate dialog size
-        let dialog_width = (area.width * 60 / 100).clamp(30, 80);
+        let dialog_width = (ctx.area.width * 60 / 100).clamp(30, 80);
         let message_lines = state.message.lines().count().max(1) as u16;
-        let dialog_height = (5 + message_lines).min(area.height);
+        let dialog_height = (5 + message_lines).min(ctx.area.height);
 
         // Center the dialog
-        let dialog_area = centered_rect(dialog_width, dialog_height, area);
+        let dialog_area = centered_rect(dialog_width, dialog_height, ctx.area);
 
-        // Clear the dialog area (overlay effect)
-        frame.render_widget(Clear, dialog_area);
+        // Clear the dialog ctx.area (overlay effect)
+        ctx.frame.render_widget(Clear, dialog_area);
 
         // Render dialog box
         let block = Block::default()
             .title(format!(" {} ", state.title))
             .borders(Borders::ALL)
-            .border_style(theme.border_style());
+            .border_style(ctx.theme.border_style());
 
         let inner = block.inner(dialog_area);
-        frame.render_widget(block, dialog_area);
+        ctx.frame.render_widget(block, dialog_area);
 
-        // Layout: message area + button row
+        // Layout: message ctx.area + button row
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -721,10 +721,17 @@ impl Component for Dialog {
 
         // Render message
         let message = Paragraph::new(state.message.as_str()).wrap(Wrap { trim: true });
-        frame.render_widget(message, chunks[0]);
+        ctx.frame.render_widget(message, chunks[0]);
 
         // Render buttons horizontally centered
-        render_buttons(state, frame, chunks[1], theme, ctx.focused, ctx.disabled);
+        render_buttons(
+            state,
+            ctx.frame,
+            chunks[1],
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
     }
 }
 

--- a/src/component/dialog/tests.rs
+++ b/src/component/dialog/tests.rs
@@ -306,7 +306,7 @@ fn test_view_when_hidden() {
 
     terminal
         .draw(|frame| {
-            Dialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Dialog::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -325,7 +325,7 @@ fn test_view_renders() {
 
     terminal
         .draw(|frame| {
-            Dialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Dialog::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -340,7 +340,7 @@ fn test_view_title() {
 
     terminal
         .draw(|frame| {
-            Dialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Dialog::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -355,7 +355,7 @@ fn test_view_message() {
 
     terminal
         .draw(|frame| {
-            Dialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Dialog::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -370,7 +370,7 @@ fn test_view_buttons() {
 
     terminal
         .draw(|frame| {
-            Dialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Dialog::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -385,7 +385,7 @@ fn test_view_focused_button() {
 
     terminal
         .draw(|frame| {
-            Dialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Dialog::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -400,7 +400,7 @@ fn test_view_primary_button() {
 
     terminal
         .draw(|frame| {
-            Dialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Dialog::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -415,7 +415,7 @@ fn test_view_multiline_message() {
 
     terminal
         .draw(|frame| {
-            Dialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Dialog::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -510,7 +510,7 @@ fn test_handle_event_tab() {
     let mut state = DialogState::confirm("T", "M");
     Dialog::show(&mut state);
 
-    let msg = Dialog::handle_event(&state, &Event::key(KeyCode::Tab), &ViewContext::default());
+    let msg = Dialog::handle_event(&state, &Event::key(KeyCode::Tab), &EventContext::default());
     assert_eq!(msg, Some(DialogMessage::FocusNext));
 }
 
@@ -522,7 +522,7 @@ fn test_handle_event_backtab() {
     let msg = Dialog::handle_event(
         &state,
         &Event::key(KeyCode::BackTab),
-        &ViewContext::default(),
+        &EventContext::default(),
     );
     assert_eq!(msg, Some(DialogMessage::FocusPrev));
 }
@@ -532,7 +532,11 @@ fn test_handle_event_enter() {
     let mut state = DialogState::confirm("T", "M");
     Dialog::show(&mut state);
 
-    let msg = Dialog::handle_event(&state, &Event::key(KeyCode::Enter), &ViewContext::default());
+    let msg = Dialog::handle_event(
+        &state,
+        &Event::key(KeyCode::Enter),
+        &EventContext::default(),
+    );
     assert_eq!(msg, Some(DialogMessage::Press));
 }
 
@@ -541,7 +545,7 @@ fn test_handle_event_escape() {
     let mut state = DialogState::confirm("T", "M");
     Dialog::show(&mut state);
 
-    let msg = Dialog::handle_event(&state, &Event::key(KeyCode::Esc), &ViewContext::default());
+    let msg = Dialog::handle_event(&state, &Event::key(KeyCode::Esc), &EventContext::default());
     assert_eq!(msg, Some(DialogMessage::Close));
 }
 
@@ -551,7 +555,11 @@ fn test_handle_event_ignored_when_not_visible() {
     // Not visible by default
     assert!(!Dialog::is_visible(&state));
 
-    let msg = Dialog::handle_event(&state, &Event::key(KeyCode::Enter), &ViewContext::default());
+    let msg = Dialog::handle_event(
+        &state,
+        &Event::key(KeyCode::Enter),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 }
 
@@ -568,7 +576,7 @@ fn test_dispatch_event() {
     let output = Dialog::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::default(),
+        &EventContext::default(),
     );
     assert_eq!(output, Some(DialogOutput::ButtonPressed("ok".into())));
     assert!(!Dialog::is_visible(&state));
@@ -693,7 +701,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Dialog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Dialog::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/diff_viewer/mod.rs
+++ b/src/component/diff_viewer/mod.rs
@@ -37,12 +37,9 @@
 pub mod parser;
 mod render;
 
-use ratatui::prelude::*;
-
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
-use crate::theme::Theme;
 
 /// Display mode for the diff.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -752,7 +749,7 @@ impl Component for DiffViewer {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -905,8 +902,15 @@ impl Component for DiffViewer {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        render::render(state, frame, area, theme, ctx.focused, ctx.disabled);
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        render::render(
+            state,
+            ctx.frame,
+            ctx.area,
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
     }
 }
 

--- a/src/component/diff_viewer/tests.rs
+++ b/src/component/diff_viewer/tests.rs
@@ -407,7 +407,7 @@ fn test_disabled_ignores_events() {
     let msg = DiffViewer::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -415,7 +415,7 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = DiffViewerState::new();
-    let msg = DiffViewer::handle_event(&state, &Event::key(KeyCode::Up), &ViewContext::default());
+    let msg = DiffViewer::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -430,7 +430,7 @@ fn test_handle_event_up() {
         DiffViewer::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DiffViewerMessage::ScrollUp)
     );
@@ -443,7 +443,7 @@ fn test_handle_event_down() {
         DiffViewer::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DiffViewerMessage::ScrollDown)
     );
@@ -453,11 +453,19 @@ fn test_handle_event_down() {
 fn test_handle_event_k_j() {
     let state = focused_state();
     assert_eq!(
-        DiffViewer::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true)),
+        DiffViewer::handle_event(
+            &state,
+            &Event::char('k'),
+            &EventContext::new().focused(true)
+        ),
         Some(DiffViewerMessage::ScrollUp)
     );
     assert_eq!(
-        DiffViewer::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true)),
+        DiffViewer::handle_event(
+            &state,
+            &Event::char('j'),
+            &EventContext::new().focused(true)
+        ),
         Some(DiffViewerMessage::ScrollDown)
     );
 }
@@ -466,7 +474,11 @@ fn test_handle_event_k_j() {
 fn test_handle_event_n_for_next_hunk() {
     let state = focused_state();
     assert_eq!(
-        DiffViewer::handle_event(&state, &Event::char('n'), &ViewContext::new().focused(true)),
+        DiffViewer::handle_event(
+            &state,
+            &Event::char('n'),
+            &EventContext::new().focused(true)
+        ),
         Some(DiffViewerMessage::NextHunk)
     );
 }
@@ -478,7 +490,7 @@ fn test_handle_event_shift_n_for_prev_hunk() {
         DiffViewer::handle_event(
             &state,
             &Event::key_with(KeyCode::Char('N'), KeyModifiers::SHIFT),
-            &ViewContext::new().focused(true),
+            &EventContext::new().focused(true),
         ),
         Some(DiffViewerMessage::PrevHunk)
     );
@@ -488,7 +500,11 @@ fn test_handle_event_shift_n_for_prev_hunk() {
 fn test_handle_event_p_for_prev_hunk() {
     let state = focused_state();
     assert_eq!(
-        DiffViewer::handle_event(&state, &Event::char('p'), &ViewContext::new().focused(true)),
+        DiffViewer::handle_event(
+            &state,
+            &Event::char('p'),
+            &EventContext::new().focused(true)
+        ),
         Some(DiffViewerMessage::PrevHunk)
     );
 }
@@ -500,7 +516,7 @@ fn test_handle_event_page_up_down() {
         DiffViewer::handle_event(
             &state,
             &Event::key(KeyCode::PageUp),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DiffViewerMessage::PageUp(10))
     );
@@ -508,7 +524,7 @@ fn test_handle_event_page_up_down() {
         DiffViewer::handle_event(
             &state,
             &Event::key(KeyCode::PageDown),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DiffViewerMessage::PageDown(10))
     );
@@ -518,11 +534,19 @@ fn test_handle_event_page_up_down() {
 fn test_handle_event_ctrl_u_d() {
     let state = focused_state();
     assert_eq!(
-        DiffViewer::handle_event(&state, &Event::ctrl('u'), &ViewContext::new().focused(true)),
+        DiffViewer::handle_event(
+            &state,
+            &Event::ctrl('u'),
+            &EventContext::new().focused(true)
+        ),
         Some(DiffViewerMessage::PageUp(10))
     );
     assert_eq!(
-        DiffViewer::handle_event(&state, &Event::ctrl('d'), &ViewContext::new().focused(true)),
+        DiffViewer::handle_event(
+            &state,
+            &Event::ctrl('d'),
+            &EventContext::new().focused(true)
+        ),
         Some(DiffViewerMessage::PageDown(10))
     );
 }
@@ -534,7 +558,7 @@ fn test_handle_event_home_end() {
         DiffViewer::handle_event(
             &state,
             &Event::key(KeyCode::Home),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DiffViewerMessage::Home)
     );
@@ -542,7 +566,7 @@ fn test_handle_event_home_end() {
         DiffViewer::handle_event(
             &state,
             &Event::key(KeyCode::End),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(DiffViewerMessage::End)
     );
@@ -553,14 +577,18 @@ fn test_handle_event_home_end() {
 fn test_handle_event_g_and_G() {
     let state = focused_state();
     assert_eq!(
-        DiffViewer::handle_event(&state, &Event::char('g'), &ViewContext::new().focused(true)),
+        DiffViewer::handle_event(
+            &state,
+            &Event::char('g'),
+            &EventContext::new().focused(true)
+        ),
         Some(DiffViewerMessage::Home)
     );
     assert_eq!(
         DiffViewer::handle_event(
             &state,
             &Event::key_with(KeyCode::Char('G'), KeyModifiers::SHIFT),
-            &ViewContext::new().focused(true),
+            &EventContext::new().focused(true),
         ),
         Some(DiffViewerMessage::End)
     );
@@ -570,7 +598,11 @@ fn test_handle_event_g_and_G() {
 fn test_handle_event_m_toggle_mode() {
     let state = focused_state();
     assert_eq!(
-        DiffViewer::handle_event(&state, &Event::char('m'), &ViewContext::new().focused(true)),
+        DiffViewer::handle_event(
+            &state,
+            &Event::char('m'),
+            &EventContext::new().focused(true)
+        ),
         Some(DiffViewerMessage::ToggleMode)
     );
 }
@@ -579,7 +611,11 @@ fn test_handle_event_m_toggle_mode() {
 fn test_handle_event_unrecognized() {
     let state = focused_state();
     assert_eq!(
-        DiffViewer::handle_event(&state, &Event::char('x'), &ViewContext::new().focused(true)),
+        DiffViewer::handle_event(
+            &state,
+            &Event::char('x'),
+            &EventContext::new().focused(true)
+        ),
         None
     );
 }
@@ -696,7 +732,7 @@ fn test_view_unified_empty() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            DiffViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DiffViewer::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -708,7 +744,7 @@ fn test_view_unified_with_diff() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            DiffViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DiffViewer::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -722,10 +758,7 @@ fn test_view_unified_focused() {
         .draw(|frame| {
             DiffViewer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -740,10 +773,7 @@ fn test_view_unified_disabled() {
         .draw(|frame| {
             DiffViewer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -759,7 +789,7 @@ fn test_view_side_by_side() {
     let (mut terminal, theme) = test_utils::setup_render(80, 12);
     terminal
         .draw(|frame| {
-            DiffViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DiffViewer::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -771,7 +801,7 @@ fn test_view_with_line_numbers() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            DiffViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DiffViewer::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -783,7 +813,7 @@ fn test_view_without_line_numbers() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            DiffViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            DiffViewer::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -802,7 +832,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                DiffViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                DiffViewer::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/divider/mod.rs
+++ b/src/component/divider/mod.rs
@@ -25,9 +25,8 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::Event;
-use crate::theme::Theme;
 
 /// Orientation of the divider.
 ///
@@ -330,7 +329,7 @@ impl DividerState {
     /// assert!(state.handle_event(&Event::key(KeyCode::Enter)).is_none());
     /// ```
     pub fn handle_event(&self, event: &Event) -> Option<DividerMessage> {
-        Divider::handle_event(self, event, &ViewContext::default())
+        Divider::handle_event(self, event, &EventContext::default())
     }
 
     /// Dispatches an event by mapping it to a message and updating state.
@@ -349,7 +348,7 @@ impl DividerState {
     /// assert!(state.dispatch_event(&Event::key(KeyCode::Enter)).is_none());
     /// ```
     pub fn dispatch_event(&mut self, event: &Event) -> Option<()> {
-        Divider::dispatch_event(self, event, &ViewContext::default())
+        Divider::dispatch_event(self, event, &EventContext::default())
     }
 }
 
@@ -391,34 +390,34 @@ impl Component for Divider {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::divider("divider")
                     .with_label(state.label.as_deref().unwrap_or(""))
                     .with_disabled(ctx.disabled),
             );
         });
 
-        if area.width == 0 || area.height == 0 {
+        if ctx.area.width == 0 || ctx.area.height == 0 {
             return;
         }
 
         let style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if let Some(color) = state.color {
             Style::default().fg(color)
         } else {
-            theme.normal_style()
+            ctx.theme.normal_style()
         };
 
         match state.orientation {
             DividerOrientation::Horizontal => {
-                render_horizontal(state, frame, area, style);
+                render_horizontal(state, ctx.frame, ctx.area, style);
             }
             DividerOrientation::Vertical => {
-                render_vertical(state, frame, area, style);
+                render_vertical(state, ctx.frame, ctx.area, style);
             }
         }
     }

--- a/src/component/divider/tests.rs
+++ b/src/component/divider/tests.rs
@@ -175,7 +175,7 @@ fn test_view_horizontal_no_label() {
 
     terminal
         .draw(|frame| {
-            Divider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Divider::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -189,7 +189,7 @@ fn test_view_horizontal_with_label() {
 
     terminal
         .draw(|frame| {
-            Divider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Divider::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -203,7 +203,7 @@ fn test_view_vertical() {
 
     terminal
         .draw(|frame| {
-            Divider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Divider::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -217,7 +217,7 @@ fn test_view_vertical_with_label() {
 
     terminal
         .draw(|frame| {
-            Divider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Divider::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -233,10 +233,7 @@ fn test_view_disabled() {
         .draw(|frame| {
             Divider::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -252,7 +249,7 @@ fn test_view_zero_width() {
     terminal
         .draw(|frame| {
             let area = Rect::new(0, 0, 0, 3);
-            Divider::view(&state, frame, area, &theme, &ViewContext::default());
+            Divider::view(&state, &mut RenderContext::new(frame, area, &theme));
         })
         .unwrap();
 
@@ -267,7 +264,7 @@ fn test_view_zero_height() {
     terminal
         .draw(|frame| {
             let area = Rect::new(0, 0, 40, 0);
-            Divider::view(&state, frame, area, &theme, &ViewContext::default());
+            Divider::view(&state, &mut RenderContext::new(frame, area, &theme));
         })
         .unwrap();
 
@@ -281,7 +278,7 @@ fn test_view_narrow_with_long_label() {
 
     terminal
         .draw(|frame| {
-            Divider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Divider::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -300,7 +297,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Divider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Divider::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -321,7 +318,7 @@ fn test_annotation_emitted_no_label() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Divider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Divider::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -344,10 +341,7 @@ fn test_annotation_disabled() {
             .draw(|frame| {
                 Divider::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().disabled(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
                 );
             })
             .unwrap();

--- a/src/component/dropdown/mod.rs
+++ b/src/component/dropdown/mod.rs
@@ -32,9 +32,8 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
-use crate::theme::Theme;
 
 /// Messages that can be sent to a Dropdown.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -649,7 +648,7 @@ impl Component for Dropdown {
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -678,7 +677,7 @@ impl Component for Dropdown {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         crate::annotation::with_registry(|reg| {
             let mut ann = crate::annotation::Annotation::dropdown("dropdown")
                 .with_focus(ctx.focused)
@@ -687,24 +686,24 @@ impl Component for Dropdown {
             if let Some(val) = state.selected_value() {
                 ann = ann.with_value(val.to_string());
             }
-            reg.register(area, ann);
+            reg.register(ctx.area, ann);
         });
 
         let style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_style()
+            ctx.theme.focused_style()
         } else {
-            theme.normal_style()
+            ctx.theme.normal_style()
         };
 
         let border_style = if ctx.focused && !ctx.disabled {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
-        // Determine what to show in the input area
+        // Determine what to show in the input ctx.area
         let display_text = if state.is_open {
             // When open, show filter text with cursor indicator
             let arrow = "▲";
@@ -724,7 +723,7 @@ impl Component for Dropdown {
             && !ctx.disabled
             && !ctx.focused
         {
-            theme.placeholder_style()
+            ctx.theme.placeholder_style()
         } else {
             style
         };
@@ -736,37 +735,37 @@ impl Component for Dropdown {
         );
 
         if !state.is_open {
-            frame.render_widget(paragraph, area);
+            ctx.frame.render_widget(paragraph, ctx.area);
         } else {
-            // Render input area at top
+            // Render input ctx.area at top
             let closed_height = 3; // 1 line + 2 borders
             let closed_area = Rect {
-                x: area.x,
-                y: area.y,
-                width: area.width,
-                height: closed_height.min(area.height),
+                x: ctx.area.x,
+                y: ctx.area.y,
+                width: ctx.area.width,
+                height: closed_height.min(ctx.area.height),
             };
-            frame.render_widget(paragraph, closed_area);
+            ctx.frame.render_widget(paragraph, closed_area);
 
             // Render dropdown list below
-            if area.height > closed_height {
+            if ctx.area.height > closed_height {
                 let list_area = Rect {
-                    x: area.x,
-                    y: area.y + closed_height,
-                    width: area.width,
-                    height: area.height.saturating_sub(closed_height),
+                    x: ctx.area.x,
+                    y: ctx.area.y + closed_height,
+                    width: ctx.area.width,
+                    height: ctx.area.height.saturating_sub(closed_height),
                 };
 
                 if state.filtered_indices.is_empty() {
                     // Show "no matches" message
                     let no_match = Paragraph::new("  No matches")
-                        .style(theme.placeholder_style())
+                        .style(ctx.theme.placeholder_style())
                         .block(
                             Block::default()
                                 .borders(Borders::ALL)
                                 .border_style(border_style),
                         );
-                    frame.render_widget(no_match, list_area);
+                    ctx.frame.render_widget(no_match, list_area);
                 } else {
                     let items: Vec<ListItem> = state
                         .filtered_indices
@@ -781,9 +780,9 @@ impl Component for Dropdown {
                             };
                             let text = format!("{}{}", prefix, opt);
                             let item_style = if i == state.highlighted_index {
-                                theme.selected_style(ctx.focused)
+                                ctx.theme.selected_style(ctx.focused)
                             } else {
-                                theme.normal_style()
+                                ctx.theme.normal_style()
                             };
                             ListItem::new(text).style(item_style)
                         })
@@ -795,7 +794,7 @@ impl Component for Dropdown {
                             .border_style(border_style),
                     );
 
-                    frame.render_widget(list, list_area);
+                    ctx.frame.render_widget(list, list_area);
                 }
             }
         }

--- a/src/component/dropdown/tests.rs
+++ b/src/component/dropdown/tests.rs
@@ -429,7 +429,7 @@ fn test_view_closed_empty() {
 
     terminal
         .draw(|frame| {
-            Dropdown::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Dropdown::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -444,7 +444,7 @@ fn test_view_closed_with_selection() {
 
     terminal
         .draw(|frame| {
-            Dropdown::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Dropdown::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -460,7 +460,7 @@ fn test_view_open_no_filter() {
 
     terminal
         .draw(|frame| {
-            Dropdown::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Dropdown::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -477,7 +477,7 @@ fn test_view_open_with_filter() {
 
     terminal
         .draw(|frame| {
-            Dropdown::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Dropdown::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -494,7 +494,7 @@ fn test_view_highlight() {
 
     terminal
         .draw(|frame| {
-            Dropdown::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Dropdown::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -511,7 +511,7 @@ fn test_view_no_matches() {
 
     terminal
         .draw(|frame| {
-            Dropdown::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Dropdown::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -526,7 +526,7 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            Dropdown::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Dropdown::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -628,7 +628,7 @@ fn test_handle_event_toggle_when_closed() {
     let msg = Dropdown::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(DropdownMessage::Toggle));
 }
@@ -641,7 +641,7 @@ fn test_handle_event_confirm_when_open() {
     let msg = Dropdown::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(DropdownMessage::Confirm));
 }
@@ -654,7 +654,7 @@ fn test_handle_event_close_when_open() {
     let msg = Dropdown::handle_event(
         &state,
         &Event::key(KeyCode::Esc),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(DropdownMessage::Close));
 }
@@ -667,7 +667,7 @@ fn test_handle_event_up_when_open() {
     let msg = Dropdown::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(DropdownMessage::Up));
 }
@@ -680,7 +680,7 @@ fn test_handle_event_down_when_open() {
     let msg = Dropdown::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(DropdownMessage::Down));
 }
@@ -690,7 +690,11 @@ fn test_handle_event_char_when_open() {
     let mut state = DropdownState::new(vec!["A", "B", "C"]);
     Dropdown::update(&mut state, DropdownMessage::Open);
 
-    let msg = Dropdown::handle_event(&state, &Event::char('a'), &ViewContext::new().focused(true));
+    let msg = Dropdown::handle_event(
+        &state,
+        &Event::char('a'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(DropdownMessage::Insert('a')));
 }
 
@@ -702,7 +706,7 @@ fn test_handle_event_backspace_when_open() {
     let msg = Dropdown::handle_event(
         &state,
         &Event::key(KeyCode::Backspace),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(DropdownMessage::Backspace));
 }
@@ -710,7 +714,11 @@ fn test_handle_event_backspace_when_open() {
 #[test]
 fn test_handle_event_ignored_when_unfocused() {
     let state = DropdownState::new(vec!["A", "B", "C"]);
-    let msg = Dropdown::handle_event(&state, &Event::key(KeyCode::Enter), &ViewContext::default());
+    let msg = Dropdown::handle_event(
+        &state,
+        &Event::key(KeyCode::Enter),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 }
 
@@ -720,7 +728,7 @@ fn test_handle_event_ignored_when_disabled() {
     let msg = Dropdown::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -739,7 +747,7 @@ fn test_dispatch_event() {
     let output = Dropdown::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(DropdownOutput::Selected("B".to_string())));
     assert!(!state.is_open());
@@ -798,7 +806,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Dropdown::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Dropdown::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/event_stream/event_tests.rs
+++ b/src/component/event_stream/event_tests.rs
@@ -67,12 +67,16 @@ fn test_list_mode_up_key() {
         EventStream::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::ScrollUp)
     );
     assert_eq!(
-        EventStream::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true)),
+        EventStream::handle_event(
+            &state,
+            &Event::char('k'),
+            &EventContext::new().focused(true)
+        ),
         Some(EventStreamMessage::ScrollUp)
     );
 }
@@ -84,12 +88,16 @@ fn test_list_mode_down_key() {
         EventStream::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::ScrollDown)
     );
     assert_eq!(
-        EventStream::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true)),
+        EventStream::handle_event(
+            &state,
+            &Event::char('j'),
+            &EventContext::new().focused(true)
+        ),
         Some(EventStreamMessage::ScrollDown)
     );
 }
@@ -101,12 +109,16 @@ fn test_list_mode_home_g() {
         EventStream::handle_event(
             &state,
             &Event::key(KeyCode::Home),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::ScrollToTop)
     );
     assert_eq!(
-        EventStream::handle_event(&state, &Event::char('g'), &ViewContext::new().focused(true)),
+        EventStream::handle_event(
+            &state,
+            &Event::char('g'),
+            &EventContext::new().focused(true)
+        ),
         Some(EventStreamMessage::ScrollToTop)
     );
 }
@@ -118,12 +130,16 @@ fn test_list_mode_end_shift_g() {
         EventStream::handle_event(
             &state,
             &Event::key(KeyCode::End),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::ScrollToBottom)
     );
     assert_eq!(
-        EventStream::handle_event(&state, &Event::char('G'), &ViewContext::new().focused(true)),
+        EventStream::handle_event(
+            &state,
+            &Event::char('G'),
+            &EventContext::new().focused(true)
+        ),
         Some(EventStreamMessage::ScrollToBottom)
     );
 }
@@ -132,7 +148,11 @@ fn test_list_mode_end_shift_g() {
 fn test_list_mode_slash() {
     let state = focused_state();
     assert_eq!(
-        EventStream::handle_event(&state, &Event::char('/'), &ViewContext::new().focused(true)),
+        EventStream::handle_event(
+            &state,
+            &Event::char('/'),
+            &EventContext::new().focused(true)
+        ),
         Some(EventStreamMessage::FocusSearch)
     );
 }
@@ -141,23 +161,43 @@ fn test_list_mode_slash() {
 fn test_list_mode_number_keys() {
     let state = focused_state();
     assert_eq!(
-        EventStream::handle_event(&state, &Event::char('1'), &ViewContext::new().focused(true)),
+        EventStream::handle_event(
+            &state,
+            &Event::char('1'),
+            &EventContext::new().focused(true)
+        ),
         Some(EventStreamMessage::QuickLevelFilter(1))
     );
     assert_eq!(
-        EventStream::handle_event(&state, &Event::char('2'), &ViewContext::new().focused(true)),
+        EventStream::handle_event(
+            &state,
+            &Event::char('2'),
+            &EventContext::new().focused(true)
+        ),
         Some(EventStreamMessage::QuickLevelFilter(2))
     );
     assert_eq!(
-        EventStream::handle_event(&state, &Event::char('3'), &ViewContext::new().focused(true)),
+        EventStream::handle_event(
+            &state,
+            &Event::char('3'),
+            &EventContext::new().focused(true)
+        ),
         Some(EventStreamMessage::QuickLevelFilter(3))
     );
     assert_eq!(
-        EventStream::handle_event(&state, &Event::char('4'), &ViewContext::new().focused(true)),
+        EventStream::handle_event(
+            &state,
+            &Event::char('4'),
+            &EventContext::new().focused(true)
+        ),
         Some(EventStreamMessage::QuickLevelFilter(4))
     );
     assert_eq!(
-        EventStream::handle_event(&state, &Event::char('5'), &ViewContext::new().focused(true)),
+        EventStream::handle_event(
+            &state,
+            &Event::char('5'),
+            &EventContext::new().focused(true)
+        ),
         Some(EventStreamMessage::QuickLevelFilter(5))
     );
 }
@@ -166,7 +206,11 @@ fn test_list_mode_number_keys() {
 fn test_list_mode_f_toggle_auto() {
     let state = focused_state();
     assert_eq!(
-        EventStream::handle_event(&state, &Event::char('f'), &ViewContext::new().focused(true)),
+        EventStream::handle_event(
+            &state,
+            &Event::char('f'),
+            &EventContext::new().focused(true)
+        ),
         Some(EventStreamMessage::ToggleAutoScroll)
     );
 }
@@ -180,7 +224,11 @@ fn test_search_mode_char_input() {
     let mut state = focused_state();
     EventStream::update(&mut state, EventStreamMessage::FocusSearch);
     assert_eq!(
-        EventStream::handle_event(&state, &Event::char('a'), &ViewContext::new().focused(true)),
+        EventStream::handle_event(
+            &state,
+            &Event::char('a'),
+            &EventContext::new().focused(true)
+        ),
         Some(EventStreamMessage::SearchInput('a'))
     );
 }
@@ -193,7 +241,7 @@ fn test_search_mode_esc() {
         EventStream::handle_event(
             &state,
             &Event::key(KeyCode::Esc),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::ClearSearch)
     );
@@ -207,7 +255,7 @@ fn test_search_mode_enter() {
         EventStream::handle_event(
             &state,
             &Event::key(KeyCode::Enter),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::FocusList)
     );
@@ -221,7 +269,7 @@ fn test_search_mode_backspace() {
         EventStream::handle_event(
             &state,
             &Event::key(KeyCode::Backspace),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::SearchBackspace)
     );
@@ -235,7 +283,7 @@ fn test_search_mode_delete() {
         EventStream::handle_event(
             &state,
             &Event::key(KeyCode::Delete),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::SearchDelete)
     );
@@ -249,7 +297,7 @@ fn test_search_mode_left_right() {
         EventStream::handle_event(
             &state,
             &Event::key(KeyCode::Left),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::SearchLeft)
     );
@@ -257,7 +305,7 @@ fn test_search_mode_left_right() {
         EventStream::handle_event(
             &state,
             &Event::key(KeyCode::Right),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::SearchRight)
     );
@@ -271,7 +319,7 @@ fn test_search_mode_home_end() {
         EventStream::handle_event(
             &state,
             &Event::key(KeyCode::Home),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::SearchHome)
     );
@@ -279,7 +327,7 @@ fn test_search_mode_home_end() {
         EventStream::handle_event(
             &state,
             &Event::key(KeyCode::End),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::SearchEnd)
     );
@@ -297,10 +345,7 @@ fn test_render_empty() {
         .draw(|frame| {
             EventStream::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -314,10 +359,7 @@ fn test_render_with_events() {
         .draw(|frame| {
             EventStream::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -331,10 +373,7 @@ fn test_render_focused() {
         .draw(|frame| {
             EventStream::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -348,10 +387,7 @@ fn test_render_with_sources() {
         .draw(|frame| {
             EventStream::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -365,10 +401,7 @@ fn test_render_disabled() {
         .draw(|frame| {
             EventStream::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -384,10 +417,7 @@ fn test_render_with_title() {
         .draw(|frame| {
             EventStream::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -402,10 +432,7 @@ fn test_render_filtered() {
         .draw(|frame| {
             EventStream::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -419,10 +446,7 @@ fn test_render_small_area() {
         .draw(|frame| {
             EventStream::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -439,10 +463,7 @@ fn test_render_search_focused() {
         .draw(|frame| {
             EventStream::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -460,10 +481,7 @@ fn test_annotation_emitted() {
             .draw(|frame| {
                 EventStream::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
                 );
             })
             .unwrap();

--- a/src/component/event_stream/mod.rs
+++ b/src/component/event_stream/mod.rs
@@ -8,7 +8,7 @@
 //! State is stored in [`EventStreamState`], updated via [`EventStreamMessage`],
 //! and produces [`EventStreamOutput`].
 //!
-//! Focus and disabled state are managed via [`ViewContext`].
+//! Focus and disabled state are managed via [`EventContext`].
 //!
 //! # Example
 //!
@@ -36,11 +36,8 @@ mod types;
 
 use std::marker::PhantomData;
 
-use ratatui::prelude::*;
-
-use super::{Component, InputFieldMessage, ViewContext};
+use super::{Component, EventContext, InputFieldMessage, RenderContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
-use crate::theme::Theme;
 
 pub use state::EventStreamState;
 pub use types::{EventLevel, StreamEvent};
@@ -168,7 +165,7 @@ impl Component for EventStream {
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -378,8 +375,15 @@ impl Component for EventStream {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        render::render_event_stream(state, frame, area, theme, ctx.focused, ctx.disabled);
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        render::render_event_stream(
+            state,
+            ctx.frame,
+            ctx.area,
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
     }
 }
 

--- a/src/component/event_stream/snapshot_tests.rs
+++ b/src/component/event_stream/snapshot_tests.rs
@@ -49,7 +49,7 @@ fn test_snapshot_default_empty() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            EventStream::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -61,7 +61,7 @@ fn test_snapshot_populated() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            EventStream::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -75,10 +75,7 @@ fn test_snapshot_focused() {
         .draw(|frame| {
             EventStream::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -94,7 +91,7 @@ fn test_snapshot_with_title() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            EventStream::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -108,10 +105,7 @@ fn test_snapshot_disabled() {
         .draw(|frame| {
             EventStream::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -125,7 +119,7 @@ fn test_snapshot_filtered() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            EventStream::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            EventStream::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -143,10 +137,7 @@ fn test_snapshot_search_active() {
         .draw(|frame| {
             EventStream::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();

--- a/src/component/event_stream/tests.rs
+++ b/src/component/event_stream/tests.rs
@@ -1,3 +1,5 @@
+use ratatui::style::Color;
+
 use super::*;
 
 fn sample_state() -> EventStreamState {
@@ -734,7 +736,7 @@ fn test_disabled_ignores_events() {
     let msg = EventStream::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -743,7 +745,7 @@ fn test_disabled_ignores_events() {
 fn test_unfocused_ignores_events() {
     let state = sample_state();
     let msg =
-        EventStream::handle_event(&state, &Event::key(KeyCode::Down), &ViewContext::default());
+        EventStream::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
     assert_eq!(msg, None);
 }
 

--- a/src/component/file_browser/helper_tests.rs
+++ b/src/component/file_browser/helper_tests.rs
@@ -140,14 +140,18 @@ fn test_pathbar_focus_only_handles_tab() {
     FileBrowser::update(&mut state, FileBrowserMessage::CycleFocus);
     // In PathBar focus, regular keys shouldn't map
     assert!(
-        FileBrowser::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true))
-            .is_none()
+        FileBrowser::handle_event(
+            &state,
+            &Event::char('j'),
+            &EventContext::new().focused(true)
+        )
+        .is_none()
     );
     assert!(
         FileBrowser::handle_event(
             &state,
             &Event::key(KeyCode::Enter),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         )
         .is_none()
     );
@@ -155,7 +159,7 @@ fn test_pathbar_focus_only_handles_tab() {
     let msg = FileBrowser::handle_event(
         &state,
         &Event::key(KeyCode::Tab),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::CycleFocus));
 }
@@ -170,8 +174,11 @@ fn test_filter_focus_handles_chars() {
     // Cycle to Filter
     FileBrowser::update(&mut state, FileBrowserMessage::CycleFocus);
     // In Filter focus, chars should map to FilterChar
-    let msg =
-        FileBrowser::handle_event(&state, &Event::char('z'), &ViewContext::new().focused(true));
+    let msg = FileBrowser::handle_event(
+        &state,
+        &Event::char('z'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(FileBrowserMessage::FilterChar('z')));
 }
 
@@ -182,7 +189,7 @@ fn test_filter_focus_backspace() {
     let msg = FileBrowser::handle_event(
         &state,
         &Event::key(KeyCode::Backspace),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::FilterBackspace));
 }
@@ -194,7 +201,7 @@ fn test_filter_focus_esc() {
     let msg = FileBrowser::handle_event(
         &state,
         &Event::key(KeyCode::Esc),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::FilterClear));
 }

--- a/src/component/file_browser/mod.rs
+++ b/src/component/file_browser/mod.rs
@@ -7,7 +7,7 @@
 //! and produces [`FileBrowserOutput`]. Entries are represented as
 //! [`FileEntry`].
 //!
-//! Focus and disabled state are managed via [`ViewContext`].
+//! Focus and disabled state are managed via [`EventContext`].
 //!
 //! # Example
 //!
@@ -34,13 +34,11 @@ pub use types::*;
 
 use std::sync::Arc;
 
-use ratatui::prelude::*;
 use ratatui::widgets::ListState;
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
-use crate::theme::Theme;
-use types::FileBrowserFocus;
+use types::{FileBrowserFocus, compute_segments};
 
 /// Trait for providing directory listings.
 ///
@@ -57,68 +55,6 @@ pub trait DirectoryProvider: Send + 'static {
     fn separator(&self) -> &str {
         "/"
     }
-}
-
-/// Messages that can be sent to a FileBrowser.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum FileBrowserMessage {
-    /// Move selection up.
-    Up,
-    /// Move selection down.
-    Down,
-    /// Jump to first entry.
-    First,
-    /// Jump to last entry.
-    Last,
-    /// Page up.
-    PageUp(usize),
-    /// Page down.
-    PageDown(usize),
-    /// Enter selected directory or select file.
-    Enter,
-    /// Navigate to parent directory.
-    Back,
-    /// Toggle selection of current entry.
-    ToggleSelect,
-    /// Toggle visibility of hidden files.
-    ToggleHidden,
-    /// Cycle internal focus (PathBar -> FileList -> Filter).
-    CycleFocus,
-    /// Add a character to the filter.
-    FilterChar(char),
-    /// Remove last filter character.
-    FilterBackspace,
-    /// Clear the filter.
-    FilterClear,
-    /// Set the sort field.
-    SetSort(FileSortField),
-    /// Toggle sort direction.
-    ToggleSortDirection,
-    /// Navigate to a path segment in the breadcrumb.
-    NavigateToSegment(usize),
-    /// Refresh the file listing.
-    Refresh,
-}
-
-/// Output messages from a FileBrowser.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum FileBrowserOutput {
-    /// A file was selected (Enter on a file).
-    FileSelected(FileEntry),
-    /// A directory was entered.
-    DirectoryEntered(String),
-    /// Navigated back to parent.
-    NavigatedBack(String),
-    /// The selected index changed.
-    SelectionChanged(usize),
-    /// A path was toggled in multi-select mode.
-    SelectionToggled(String),
-    /// The filter text changed.
-    FilterChanged(String),
-    /// The sort field or direction changed.
-    SortChanged(FileSortField, FileSortDirection),
-    /// Hidden file visibility toggled.
-    HiddenToggled(bool),
 }
 
 /// State for a FileBrowser component.
@@ -658,32 +594,6 @@ impl FileBrowserState {
     }
 }
 
-fn compute_segments(path: &str) -> Vec<String> {
-    let mut segments = Vec::new();
-    if path.starts_with('/') {
-        segments.push("/".to_string());
-    }
-    for part in path.split('/').filter(|s| !s.is_empty()) {
-        segments.push(part.to_string());
-    }
-    if segments.is_empty() {
-        segments.push("/".to_string());
-    }
-    segments
-}
-
-pub(crate) fn format_size(size: u64) -> String {
-    if size < 1024 {
-        format!("{}B", size)
-    } else if size < 1024 * 1024 {
-        format!("{:.1}K", size as f64 / 1024.0)
-    } else if size < 1024 * 1024 * 1024 {
-        format!("{:.1}M", size as f64 / (1024.0 * 1024.0))
-    } else {
-        format!("{:.1}G", size as f64 / (1024.0 * 1024.0 * 1024.0))
-    }
-}
-
 /// A compound file browsing component.
 ///
 /// Displays a navigable directory listing with filtering, sorting, and
@@ -734,7 +644,7 @@ impl Component for FileBrowser {
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -983,8 +893,15 @@ impl Component for FileBrowser {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        view::render(state, frame, area, theme, ctx.focused, ctx.disabled);
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        view::render(
+            state,
+            ctx.frame,
+            ctx.area,
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
     }
 }
 

--- a/src/component/file_browser/snapshot_tests.rs
+++ b/src/component/file_browser/snapshot_tests.rs
@@ -26,7 +26,7 @@ fn test_render_basic() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            FileBrowser::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            FileBrowser::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -38,7 +38,7 @@ fn test_render_unfocused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            FileBrowser::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            FileBrowser::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -51,7 +51,7 @@ fn test_render_with_filter() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            FileBrowser::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            FileBrowser::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -65,10 +65,9 @@ fn test_render_disabled() {
         .draw(|frame| {
             FileBrowser::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true).disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme)
+                    .focused(true)
+                    .disabled(true),
             );
         })
         .unwrap();
@@ -83,7 +82,7 @@ fn test_render_with_selection_markers() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            FileBrowser::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            FileBrowser::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -97,10 +96,7 @@ fn test_render_empty() {
         .draw(|frame| {
             FileBrowser::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -118,7 +114,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                FileBrowser::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                FileBrowser::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/file_browser/tests.rs
+++ b/src/component/file_browser/tests.rs
@@ -604,11 +604,11 @@ fn test_cycle_focus() {
 fn test_unfocused_ignores_events() {
     let state = FileBrowserState::new("/", sample_entries());
     assert!(
-        FileBrowser::handle_event(&state, &Event::key(KeyCode::Down), &ViewContext::default())
+        FileBrowser::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default())
             .is_none()
     );
     assert!(
-        FileBrowser::handle_event(&state, &Event::char('j'), &ViewContext::default()).is_none()
+        FileBrowser::handle_event(&state, &Event::char('j'), &EventContext::default()).is_none()
     );
 }
 
@@ -619,7 +619,7 @@ fn test_disabled_ignores_events() {
         FileBrowser::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true).disabled(true)
+            &EventContext::new().focused(true).disabled(true)
         )
         .is_none()
     );
@@ -635,7 +635,7 @@ fn test_key_up() {
     let msg = FileBrowser::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::Up));
 }
@@ -643,8 +643,11 @@ fn test_key_up() {
 #[test]
 fn test_key_k_maps_to_up() {
     let state = focused_state();
-    let msg =
-        FileBrowser::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true));
+    let msg = FileBrowser::handle_event(
+        &state,
+        &Event::char('k'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(FileBrowserMessage::Up));
 }
 
@@ -654,7 +657,7 @@ fn test_key_down() {
     let msg = FileBrowser::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::Down));
 }
@@ -662,8 +665,11 @@ fn test_key_down() {
 #[test]
 fn test_key_j_maps_to_down() {
     let state = focused_state();
-    let msg =
-        FileBrowser::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true));
+    let msg = FileBrowser::handle_event(
+        &state,
+        &Event::char('j'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(FileBrowserMessage::Down));
 }
 
@@ -673,7 +679,7 @@ fn test_key_home_maps_to_first() {
     let msg = FileBrowser::handle_event(
         &state,
         &Event::key(KeyCode::Home),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::First));
 }
@@ -684,7 +690,7 @@ fn test_key_end_maps_to_last() {
     let msg = FileBrowser::handle_event(
         &state,
         &Event::key(KeyCode::End),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::Last));
 }
@@ -695,7 +701,7 @@ fn test_key_enter_maps_to_enter() {
     let msg = FileBrowser::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::Enter));
 }
@@ -706,7 +712,7 @@ fn test_key_backspace_maps_to_back_when_filter_empty() {
     let msg = FileBrowser::handle_event(
         &state,
         &Event::key(KeyCode::Backspace),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::Back));
 }
@@ -718,7 +724,7 @@ fn test_key_backspace_maps_to_filter_backspace_when_filter_active() {
     let msg = FileBrowser::handle_event(
         &state,
         &Event::key(KeyCode::Backspace),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::FilterBackspace));
 }
@@ -726,16 +732,22 @@ fn test_key_backspace_maps_to_filter_backspace_when_filter_active() {
 #[test]
 fn test_key_space_maps_to_toggle_select() {
     let state = focused_state();
-    let msg =
-        FileBrowser::handle_event(&state, &Event::char(' '), &ViewContext::new().focused(true));
+    let msg = FileBrowser::handle_event(
+        &state,
+        &Event::char(' '),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(FileBrowserMessage::ToggleSelect));
 }
 
 #[test]
 fn test_key_ctrl_h_maps_to_toggle_hidden() {
     let state = focused_state();
-    let msg =
-        FileBrowser::handle_event(&state, &Event::ctrl('h'), &ViewContext::new().focused(true));
+    let msg = FileBrowser::handle_event(
+        &state,
+        &Event::ctrl('h'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(FileBrowserMessage::ToggleHidden));
 }
 
@@ -745,7 +757,7 @@ fn test_key_tab_maps_to_cycle_focus() {
     let msg = FileBrowser::handle_event(
         &state,
         &Event::key(KeyCode::Tab),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::CycleFocus));
 }
@@ -756,7 +768,7 @@ fn test_key_esc_maps_to_filter_clear() {
     let msg = FileBrowser::handle_event(
         &state,
         &Event::key(KeyCode::Esc),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::FilterClear));
 }
@@ -764,16 +776,22 @@ fn test_key_esc_maps_to_filter_clear() {
 #[test]
 fn test_alphanumeric_char_maps_to_filter_char() {
     let state = focused_state();
-    let msg =
-        FileBrowser::handle_event(&state, &Event::char('a'), &ViewContext::new().focused(true));
+    let msg = FileBrowser::handle_event(
+        &state,
+        &Event::char('a'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(FileBrowserMessage::FilterChar('a')));
 }
 
 #[test]
 fn test_dot_maps_to_filter_char() {
     let state = focused_state();
-    let msg =
-        FileBrowser::handle_event(&state, &Event::char('.'), &ViewContext::new().focused(true));
+    let msg = FileBrowser::handle_event(
+        &state,
+        &Event::char('.'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(FileBrowserMessage::FilterChar('.')));
 }
 

--- a/src/component/file_browser/types.rs
+++ b/src/component/file_browser/types.rs
@@ -1,5 +1,95 @@
 //! Types for the file browser component.
 
+/// Messages that can be sent to a FileBrowser.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FileBrowserMessage {
+    /// Move selection up.
+    Up,
+    /// Move selection down.
+    Down,
+    /// Jump to first entry.
+    First,
+    /// Jump to last entry.
+    Last,
+    /// Page up.
+    PageUp(usize),
+    /// Page down.
+    PageDown(usize),
+    /// Enter selected directory or select file.
+    Enter,
+    /// Navigate to parent directory.
+    Back,
+    /// Toggle selection of current entry.
+    ToggleSelect,
+    /// Toggle visibility of hidden files.
+    ToggleHidden,
+    /// Cycle internal focus (PathBar -> FileList -> Filter).
+    CycleFocus,
+    /// Add a character to the filter.
+    FilterChar(char),
+    /// Remove last filter character.
+    FilterBackspace,
+    /// Clear the filter.
+    FilterClear,
+    /// Set the sort field.
+    SetSort(FileSortField),
+    /// Toggle sort direction.
+    ToggleSortDirection,
+    /// Navigate to a path segment in the breadcrumb.
+    NavigateToSegment(usize),
+    /// Refresh the file listing.
+    Refresh,
+}
+
+/// Output messages from a FileBrowser.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FileBrowserOutput {
+    /// A file was selected (Enter on a file).
+    FileSelected(FileEntry),
+    /// A directory was entered.
+    DirectoryEntered(String),
+    /// Navigated back to parent.
+    NavigatedBack(String),
+    /// The selected index changed.
+    SelectionChanged(usize),
+    /// A path was toggled in multi-select mode.
+    SelectionToggled(String),
+    /// The filter text changed.
+    FilterChanged(String),
+    /// The sort field or direction changed.
+    SortChanged(FileSortField, FileSortDirection),
+    /// Hidden file visibility toggled.
+    HiddenToggled(bool),
+}
+
+/// Computes path segments from a path string.
+pub(super) fn compute_segments(path: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    if path.starts_with('/') {
+        segments.push("/".to_string());
+    }
+    for part in path.split('/').filter(|s| !s.is_empty()) {
+        segments.push(part.to_string());
+    }
+    if segments.is_empty() {
+        segments.push("/".to_string());
+    }
+    segments
+}
+
+/// Formats a file size in human-readable form.
+pub(crate) fn format_size(size: u64) -> String {
+    if size < 1024 {
+        format!("{}B", size)
+    } else if size < 1024 * 1024 {
+        format!("{:.1}K", size as f64 / 1024.0)
+    } else if size < 1024 * 1024 * 1024 {
+        format!("{:.1}M", size as f64 / (1024.0 * 1024.0))
+    } else {
+        format!("{:.1}G", size as f64 / (1024.0 * 1024.0 * 1024.0))
+    }
+}
+
 /// A single file or directory entry.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(

--- a/src/component/flame_graph/mod.rs
+++ b/src/component/flame_graph/mod.rs
@@ -30,11 +30,8 @@
 //! assert_eq!(state.selected_depth(), 1);
 //! ```
 
-use ratatui::prelude::*;
-
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 mod node;
 mod render;
@@ -861,7 +858,7 @@ impl Component for FlameGraph {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -883,8 +880,15 @@ impl Component for FlameGraph {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        render::render_flame_graph(state, frame, area, theme, ctx.focused, ctx.disabled);
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        render::render_flame_graph(
+            state,
+            ctx.frame,
+            ctx.area,
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
     }
 }
 

--- a/src/component/flame_graph/snapshot_tests.rs
+++ b/src/component/flame_graph/snapshot_tests.rs
@@ -8,7 +8,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 10);
     terminal
         .draw(|frame| {
-            FlameGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            FlameGraph::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -20,7 +20,7 @@ fn test_snapshot_single_frame() {
     let (mut terminal, theme) = test_utils::setup_render(60, 8);
     terminal
         .draw(|frame| {
-            FlameGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            FlameGraph::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -41,7 +41,7 @@ fn test_snapshot_simple_tree() {
     let (mut terminal, theme) = test_utils::setup_render(60, 10);
     terminal
         .draw(|frame| {
-            FlameGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            FlameGraph::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -62,10 +62,7 @@ fn test_snapshot_focused_with_selection() {
         .draw(|frame| {
             FlameGraph::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -92,10 +89,7 @@ fn test_snapshot_zoomed() {
         .draw(|frame| {
             FlameGraph::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -111,10 +105,7 @@ fn test_snapshot_disabled() {
         .draw(|frame| {
             FlameGraph::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -137,7 +128,7 @@ fn test_snapshot_with_search() {
     let (mut terminal, theme) = test_utils::setup_render(60, 10);
     terminal
         .draw(|frame| {
-            FlameGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            FlameGraph::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -164,7 +155,7 @@ fn test_snapshot_deep_nesting() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            FlameGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            FlameGraph::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/flame_graph/tests.rs
+++ b/src/component/flame_graph/tests.rs
@@ -484,7 +484,8 @@ fn test_max_depth_empty() {
 #[test]
 fn test_handle_event_not_focused() {
     let state = FlameGraphState::with_root(FlameNode::new("main()", 500));
-    let msg = FlameGraph::handle_event(&state, &Event::key(KeyCode::Down), &ViewContext::default());
+    let msg =
+        FlameGraph::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -494,7 +495,7 @@ fn test_handle_event_disabled() {
     let msg = FlameGraph::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -507,12 +508,16 @@ fn test_handle_event_down() {
         FlameGraph::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(FlameGraphMessage::SelectDown)
     );
     assert_eq!(
-        FlameGraph::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true)),
+        FlameGraph::handle_event(
+            &state,
+            &Event::char('j'),
+            &EventContext::new().focused(true)
+        ),
         Some(FlameGraphMessage::SelectDown)
     );
 }
@@ -525,12 +530,16 @@ fn test_handle_event_up() {
         FlameGraph::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(FlameGraphMessage::SelectUp)
     );
     assert_eq!(
-        FlameGraph::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true)),
+        FlameGraph::handle_event(
+            &state,
+            &Event::char('k'),
+            &EventContext::new().focused(true)
+        ),
         Some(FlameGraphMessage::SelectUp)
     );
 }
@@ -543,12 +552,16 @@ fn test_handle_event_left() {
         FlameGraph::handle_event(
             &state,
             &Event::key(KeyCode::Left),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(FlameGraphMessage::SelectLeft)
     );
     assert_eq!(
-        FlameGraph::handle_event(&state, &Event::char('h'), &ViewContext::new().focused(true)),
+        FlameGraph::handle_event(
+            &state,
+            &Event::char('h'),
+            &EventContext::new().focused(true)
+        ),
         Some(FlameGraphMessage::SelectLeft)
     );
 }
@@ -561,12 +574,16 @@ fn test_handle_event_right() {
         FlameGraph::handle_event(
             &state,
             &Event::key(KeyCode::Right),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(FlameGraphMessage::SelectRight)
     );
     assert_eq!(
-        FlameGraph::handle_event(&state, &Event::char('l'), &ViewContext::new().focused(true)),
+        FlameGraph::handle_event(
+            &state,
+            &Event::char('l'),
+            &EventContext::new().focused(true)
+        ),
         Some(FlameGraphMessage::SelectRight)
     );
 }
@@ -579,7 +596,7 @@ fn test_handle_event_enter_zoom_in() {
         FlameGraph::handle_event(
             &state,
             &Event::key(KeyCode::Enter),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(FlameGraphMessage::ZoomIn)
     );
@@ -593,7 +610,7 @@ fn test_handle_event_escape_zoom_out() {
         FlameGraph::handle_event(
             &state,
             &Event::key(KeyCode::Esc),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(FlameGraphMessage::ZoomOut)
     );
@@ -601,7 +618,7 @@ fn test_handle_event_escape_zoom_out() {
         FlameGraph::handle_event(
             &state,
             &Event::key(KeyCode::Backspace),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(FlameGraphMessage::ZoomOut)
     );
@@ -615,7 +632,7 @@ fn test_handle_event_home_reset_zoom() {
         FlameGraph::handle_event(
             &state,
             &Event::key(KeyCode::Home),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(FlameGraphMessage::ResetZoom)
     );
@@ -626,7 +643,11 @@ fn test_handle_event_slash_search() {
     let state = FlameGraphState::with_root(FlameNode::new("main()", 500));
 
     assert_eq!(
-        FlameGraph::handle_event(&state, &Event::char('/'), &ViewContext::new().focused(true)),
+        FlameGraph::handle_event(
+            &state,
+            &Event::char('/'),
+            &EventContext::new().focused(true)
+        ),
         Some(FlameGraphMessage::SetSearch(String::new()))
     );
 }
@@ -636,7 +657,11 @@ fn test_handle_event_unknown_key() {
     let state = FlameGraphState::with_root(FlameNode::new("main()", 500));
 
     assert_eq!(
-        FlameGraph::handle_event(&state, &Event::char('x'), &ViewContext::new().focused(true)),
+        FlameGraph::handle_event(
+            &state,
+            &Event::char('x'),
+            &EventContext::new().focused(true)
+        ),
         None
     );
 }

--- a/src/component/form/mod.rs
+++ b/src/component/form/mod.rs
@@ -7,7 +7,7 @@
 //! [`FormMessage`], and produces [`FormOutput`]. Fields are defined with
 //! [`FormField`] and [`FormFieldKind`].
 //!
-//! Focus and disabled state are managed via [`ViewContext`].
+//! Focus and disabled state are managed via [`EventContext`].
 //!
 //! # Example
 //!
@@ -43,8 +43,8 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use super::{
-    Checkbox, CheckboxMessage, CheckboxState, Component, InputField, InputFieldMessage,
-    InputFieldState, Select, SelectMessage, SelectState, ViewContext,
+    Checkbox, CheckboxMessage, CheckboxState, Component, EventContext, InputField,
+    InputFieldMessage, InputFieldState, RenderContext, Select, SelectMessage, SelectState,
 };
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
@@ -452,7 +452,7 @@ impl Component for Form {
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled || state.fields.is_empty() {
             return None;
@@ -640,14 +640,14 @@ impl Component for Form {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         if state.fields.is_empty() {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.open(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::new(crate::annotation::WidgetType::Form)
                     .with_id("form")
                     .with_focus(ctx.focused)
@@ -669,7 +669,7 @@ impl Component for Form {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints(constraints)
-            .split(area);
+            .split(ctx.area);
 
         for (i, ((field, field_state), chunk)) in state
             .fields
@@ -683,27 +683,34 @@ impl Component for Form {
             match field_state {
                 FieldState::Text(s) => {
                     render_text_field(
-                        frame,
+                        ctx.frame,
                         *chunk,
                         field,
                         s,
                         is_field_focused,
                         ctx.disabled,
-                        theme,
+                        ctx.theme,
                     );
                 }
                 FieldState::Checkbox(s) => {
-                    render_checkbox(frame, *chunk, s, is_field_focused, ctx.disabled, theme);
+                    render_checkbox(
+                        ctx.frame,
+                        *chunk,
+                        s,
+                        is_field_focused,
+                        ctx.disabled,
+                        ctx.theme,
+                    );
                 }
                 FieldState::Select(s) => {
                     render_select_field(
-                        frame,
+                        ctx.frame,
                         *chunk,
                         field,
                         s,
                         is_field_focused,
                         ctx.disabled,
-                        theme,
+                        ctx.theme,
                     );
                 }
             }

--- a/src/component/form/snapshot_tests.rs
+++ b/src/component/form/snapshot_tests.rs
@@ -19,7 +19,7 @@ fn test_snapshot_default_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Form::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -41,10 +41,7 @@ fn test_snapshot_populated() {
         .draw(|frame| {
             Form::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -60,10 +57,7 @@ fn test_snapshot_focused_text_field() {
         .draw(|frame| {
             Form::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -80,10 +74,7 @@ fn test_snapshot_focused_checkbox() {
         .draw(|frame| {
             Form::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -101,10 +92,7 @@ fn test_snapshot_focused_select() {
         .draw(|frame| {
             Form::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -117,7 +105,7 @@ fn test_snapshot_unfocused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Form::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -132,7 +120,7 @@ fn test_snapshot_with_placeholder() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Form::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Form::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/form/tests.rs
+++ b/src/component/form/tests.rs
@@ -355,7 +355,7 @@ fn test_disabled_ignores_events() {
     let msg = Form::handle_event(
         &state,
         &Event::char('a'),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -367,7 +367,7 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = sample_form();
-    let msg = Form::handle_event(&state, &Event::char('a'), &ViewContext::default());
+    let msg = Form::handle_event(&state, &Event::char('a'), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -381,7 +381,7 @@ fn test_tab_maps_to_focus_next() {
     let msg = Form::handle_event(
         &state,
         &Event::key(KeyCode::Tab),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FormMessage::FocusNext));
 }
@@ -392,7 +392,7 @@ fn test_backtab_maps_to_focus_prev() {
     let msg = Form::handle_event(
         &state,
         &Event::key(KeyCode::BackTab),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FormMessage::FocusPrev));
 }
@@ -403,13 +403,13 @@ fn test_ctrl_enter_maps_to_submit() {
     let _msg = Form::handle_event(
         &state,
         &Event::ctrl('\n'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     // Ctrl+Enter on terminal may send ctrl('\n'). Test via explicit key_with.
     let msg = Form::handle_event(
         &state,
         &Event::key_with(KeyCode::Enter, crate::input::KeyModifiers::CONTROL),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FormMessage::Submit));
 }
@@ -417,7 +417,11 @@ fn test_ctrl_enter_maps_to_submit() {
 #[test]
 fn test_char_in_text_field_maps_to_input() {
     let state = focused_form();
-    let msg = Form::handle_event(&state, &Event::char('x'), &ViewContext::new().focused(true));
+    let msg = Form::handle_event(
+        &state,
+        &Event::char('x'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(FormMessage::Input('x')));
 }
 
@@ -427,7 +431,7 @@ fn test_backspace_in_text_field_maps() {
     let msg = Form::handle_event(
         &state,
         &Event::key(KeyCode::Backspace),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FormMessage::Backspace));
 }
@@ -436,7 +440,11 @@ fn test_backspace_in_text_field_maps() {
 fn test_space_in_checkbox_maps_to_toggle() {
     let mut state = focused_form();
     Form::update(&mut state, FormMessage::FocusNext); // Move to checkbox
-    let msg = Form::handle_event(&state, &Event::char(' '), &ViewContext::new().focused(true));
+    let msg = Form::handle_event(
+        &state,
+        &Event::char(' '),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(FormMessage::Toggle));
 }
 
@@ -447,7 +455,7 @@ fn test_enter_in_checkbox_maps_to_toggle() {
     let msg = Form::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FormMessage::Toggle));
 }
@@ -460,7 +468,7 @@ fn test_enter_in_closed_select_maps_to_toggle() {
     let msg = Form::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FormMessage::Toggle));
 }
@@ -475,21 +483,21 @@ fn test_arrow_keys_in_open_select() {
     let msg = Form::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FormMessage::SelectDown));
 
     let msg = Form::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FormMessage::SelectUp));
 
     let msg = Form::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FormMessage::SelectConfirm));
 }
@@ -504,7 +512,7 @@ fn test_esc_in_open_select_maps_to_toggle() {
     let msg = Form::handle_event(
         &state,
         &Event::key(KeyCode::Esc),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FormMessage::Toggle));
 }
@@ -555,10 +563,7 @@ fn test_render_unfocused() {
         .draw(|frame| {
             Form::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -572,10 +577,7 @@ fn test_render_focused() {
         .draw(|frame| {
             Form::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -592,10 +594,7 @@ fn test_render_with_values() {
         .draw(|frame| {
             Form::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -609,10 +608,7 @@ fn test_render_disabled() {
         .draw(|frame| {
             Form::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -626,10 +622,7 @@ fn test_render_empty_form() {
         .draw(|frame| {
             Form::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -676,7 +669,11 @@ fn test_empty_form_ignores_all_messages() {
 fn test_empty_form_ignores_events() {
     let state = FormState::new(vec![]);
 
-    let msg = Form::handle_event(&state, &Event::char('a'), &ViewContext::new().focused(true));
+    let msg = Form::handle_event(
+        &state,
+        &Event::char('a'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, None);
 }
 
@@ -692,10 +689,7 @@ fn test_annotation_emitted() {
             .draw(|frame| {
                 Form::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
                 );
             })
             .unwrap();

--- a/src/component/gauge/mod.rs
+++ b/src/component/gauge/mod.rs
@@ -40,7 +40,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Gauge as RatatuiGauge, LineGauge};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::theme::Theme;
 
 /// The visual variant of the gauge.
@@ -473,14 +473,14 @@ impl GaugeState {
     ///
     /// Since Gauge is display-only, this always returns `None`.
     pub fn handle_event(&self, event: &crate::input::Event) -> Option<GaugeMessage> {
-        Gauge::handle_event(self, event, &ViewContext::default())
+        Gauge::handle_event(self, event, &EventContext::default())
     }
 
     /// Dispatches an event, updating state and returning any output.
     ///
     /// Since Gauge is display-only, this always returns `None`.
     pub fn dispatch_event(&mut self, event: &crate::input::Event) -> Option<GaugeOutput> {
-        Gauge::dispatch_event(self, event, &ViewContext::default())
+        Gauge::dispatch_event(self, event, &EventContext::default())
     }
 }
 
@@ -561,15 +561,29 @@ impl Component for Gauge {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         let label_text = state.label_text();
 
         match state.variant {
             GaugeVariant::Full => {
-                render_full_gauge(state, frame, area, theme, &label_text, ctx.disabled);
+                render_full_gauge(
+                    state,
+                    ctx.frame,
+                    ctx.area,
+                    ctx.theme,
+                    &label_text,
+                    ctx.disabled,
+                );
             }
             GaugeVariant::Line => {
-                render_line_gauge(state, frame, area, theme, &label_text, ctx.disabled);
+                render_line_gauge(
+                    state,
+                    ctx.frame,
+                    ctx.area,
+                    ctx.theme,
+                    &label_text,
+                    ctx.disabled,
+                );
             }
         }
     }

--- a/src/component/gauge/tests.rs
+++ b/src/component/gauge/tests.rs
@@ -464,7 +464,7 @@ fn test_view_full_gauge() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Gauge::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -478,7 +478,7 @@ fn test_view_full_gauge_with_title() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Gauge::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -494,7 +494,7 @@ fn test_view_full_gauge_with_units() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Gauge::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -508,7 +508,7 @@ fn test_view_line_gauge() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Gauge::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -524,7 +524,7 @@ fn test_view_line_gauge_with_title() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Gauge::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -540,10 +540,7 @@ fn test_view_disabled() {
         .draw(|frame| {
             Gauge::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -558,7 +555,7 @@ fn test_view_green_zone() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Gauge::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -572,7 +569,7 @@ fn test_view_yellow_zone() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Gauge::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -586,7 +583,7 @@ fn test_view_red_zone() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Gauge::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -600,7 +597,7 @@ fn test_view_zero_percent() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Gauge::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -614,7 +611,7 @@ fn test_view_full_percent() {
 
     terminal
         .draw(|frame| {
-            Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Gauge::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -633,7 +630,7 @@ fn test_annotation_emitted_full() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Gauge::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -651,7 +648,7 @@ fn test_annotation_emitted_line() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Gauge::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/heatmap/mod.rs
+++ b/src/component/heatmap/mod.rs
@@ -24,12 +24,10 @@
 
 use std::marker::PhantomData;
 
-use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 mod color;
 pub mod distribution;
@@ -619,7 +617,7 @@ impl Component for Heatmap {
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -702,14 +700,14 @@ impl Component for Heatmap {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        if area.height < 3 || area.width < 3 {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        if ctx.area.height < 3 || ctx.area.width < 3 {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::container("heatmap")
                     .with_focus(ctx.focused)
                     .with_disabled(ctx.disabled),
@@ -717,11 +715,11 @@ impl Component for Heatmap {
         });
 
         let border_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let mut block = Block::default()
@@ -732,14 +730,21 @@ impl Component for Heatmap {
             block = block.title(title.as_str());
         }
 
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
+        let inner = block.inner(ctx.area);
+        ctx.frame.render_widget(block, ctx.area);
 
         if inner.height == 0 || inner.width == 0 || state.data.is_empty() {
             return;
         }
 
-        render::render_heatmap(state, frame, inner, theme, ctx.focused, ctx.disabled);
+        render::render_heatmap(
+            state,
+            ctx.frame,
+            inner,
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
     }
 }
 

--- a/src/component/heatmap/snapshot_tests.rs
+++ b/src/component/heatmap/snapshot_tests.rs
@@ -7,7 +7,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Heatmap::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -19,7 +19,7 @@ fn test_snapshot_small_grid() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Heatmap::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -34,7 +34,7 @@ fn test_snapshot_with_labels() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Heatmap::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -48,7 +48,7 @@ fn test_snapshot_with_values() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Heatmap::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -64,10 +64,7 @@ fn test_snapshot_focused() {
         .draw(|frame| {
             Heatmap::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -85,10 +82,7 @@ fn test_snapshot_focused_with_selection() {
         .draw(|frame| {
             Heatmap::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -104,10 +98,7 @@ fn test_snapshot_disabled() {
         .draw(|frame| {
             Heatmap::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -122,7 +113,7 @@ fn test_snapshot_blue_to_red_scale() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Heatmap::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -134,7 +125,7 @@ fn test_snapshot_1x1_grid() {
     let (mut terminal, theme) = test_utils::setup_render(20, 6);
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Heatmap::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/heatmap/tests.rs
+++ b/src/component/heatmap/tests.rs
@@ -2,6 +2,7 @@ use super::render::{contrasting_fg, format_value, truncate_str};
 use super::*;
 use crate::component::test_utils;
 use crate::input::Event;
+use ratatui::style::Color;
 
 // =============================================================================
 // Construction
@@ -290,7 +291,7 @@ fn test_arrow_up_maps_to_select_up() {
     let msg = Heatmap::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(HeatmapMessage::SelectUp));
 }
@@ -301,7 +302,7 @@ fn test_arrow_down_maps_to_select_down() {
     let msg = Heatmap::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(HeatmapMessage::SelectDown));
 }
@@ -312,7 +313,7 @@ fn test_arrow_left_maps_to_select_left() {
     let msg = Heatmap::handle_event(
         &state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(HeatmapMessage::SelectLeft));
 }
@@ -323,7 +324,7 @@ fn test_arrow_right_maps_to_select_right() {
     let msg = Heatmap::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(HeatmapMessage::SelectRight));
 }
@@ -332,19 +333,35 @@ fn test_arrow_right_maps_to_select_right() {
 fn test_hjkl_keys() {
     let state = focused_3x3();
     assert_eq!(
-        Heatmap::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true)),
+        Heatmap::handle_event(
+            &state,
+            &Event::char('k'),
+            &EventContext::new().focused(true)
+        ),
         Some(HeatmapMessage::SelectUp)
     );
     assert_eq!(
-        Heatmap::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true)),
+        Heatmap::handle_event(
+            &state,
+            &Event::char('j'),
+            &EventContext::new().focused(true)
+        ),
         Some(HeatmapMessage::SelectDown)
     );
     assert_eq!(
-        Heatmap::handle_event(&state, &Event::char('h'), &ViewContext::new().focused(true)),
+        Heatmap::handle_event(
+            &state,
+            &Event::char('h'),
+            &EventContext::new().focused(true)
+        ),
         Some(HeatmapMessage::SelectLeft)
     );
     assert_eq!(
-        Heatmap::handle_event(&state, &Event::char('l'), &ViewContext::new().focused(true)),
+        Heatmap::handle_event(
+            &state,
+            &Event::char('l'),
+            &EventContext::new().focused(true)
+        ),
         Some(HeatmapMessage::SelectRight)
     );
 }
@@ -355,7 +372,7 @@ fn test_enter_emits_cell_selected() {
     let output = Heatmap::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(
         output,
@@ -377,7 +394,7 @@ fn test_disabled_ignores_events() {
     let msg = Heatmap::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -385,7 +402,7 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = HeatmapState::with_data(vec![vec![1.0]]);
-    let msg = Heatmap::handle_event(&state, &Event::key(KeyCode::Down), &ViewContext::default());
+    let msg = Heatmap::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -540,10 +557,7 @@ fn test_render_empty() {
         .draw(|frame| {
             Heatmap::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -557,10 +571,7 @@ fn test_render_small_grid() {
         .draw(|frame| {
             Heatmap::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -577,10 +588,7 @@ fn test_render_with_labels() {
         .draw(|frame| {
             Heatmap::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -596,10 +604,7 @@ fn test_render_with_values() {
         .draw(|frame| {
             Heatmap::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -613,10 +618,7 @@ fn test_render_disabled() {
         .draw(|frame| {
             Heatmap::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -634,10 +636,7 @@ fn test_render_focused_with_selection() {
         .draw(|frame| {
             Heatmap::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -651,10 +650,7 @@ fn test_render_small_area() {
         .draw(|frame| {
             Heatmap::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -731,10 +727,7 @@ fn test_annotation_emitted() {
             .draw(|frame| {
                 Heatmap::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
                 );
             })
             .unwrap();

--- a/src/component/help_panel/mod.rs
+++ b/src/component/help_panel/mod.rs
@@ -37,7 +37,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
-use super::{Component, Toggleable, ViewContext};
+use super::{Component, EventContext, RenderContext, Toggleable};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
@@ -625,7 +625,7 @@ impl Component for HelpPanel {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -682,10 +682,10 @@ impl Component for HelpPanel {
         None // Display-only, no output
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::help_panel("help_panel")
                     .with_focus(ctx.focused)
                     .with_disabled(ctx.disabled),
@@ -693,11 +693,11 @@ impl Component for HelpPanel {
         });
 
         let border_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let mut block = Block::default()
@@ -708,15 +708,15 @@ impl Component for HelpPanel {
             block = block.title(format!(" {} ", title));
         }
 
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
+        let inner = block.inner(ctx.area);
+        ctx.frame.render_widget(block, ctx.area);
 
         if inner.height == 0 || inner.width == 0 {
             return;
         }
 
         // Build all lines and compute scroll dimensions
-        let all_lines = state.build_lines(theme);
+        let all_lines = state.build_lines(ctx.theme);
         let total_lines = all_lines.len();
         let visible_height = inner.height as usize;
         let max_scroll = total_lines.saturating_sub(visible_height);
@@ -736,7 +736,8 @@ impl Component for HelpPanel {
                 break;
             }
             let line_area = Rect::new(inner.x + 1, y, inner.width.saturating_sub(2), 1);
-            frame.render_widget(ratatui::widgets::Paragraph::new(line), line_area);
+            ctx.frame
+                .render_widget(ratatui::widgets::Paragraph::new(line), line_area);
         }
 
         // Render scrollbar when content exceeds viewport
@@ -744,7 +745,12 @@ impl Component for HelpPanel {
             let mut bar_scroll = ScrollState::new(total_lines);
             bar_scroll.set_viewport_height(visible_height);
             bar_scroll.set_offset(effective_scroll);
-            crate::scroll::render_scrollbar_inside_border(&bar_scroll, frame, area, theme);
+            crate::scroll::render_scrollbar_inside_border(
+                &bar_scroll,
+                ctx.frame,
+                ctx.area,
+                ctx.theme,
+            );
         }
     }
 }

--- a/src/component/help_panel/tests.rs
+++ b/src/component/help_panel/tests.rs
@@ -313,7 +313,7 @@ fn test_handle_event_up() {
         HelpPanel::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(HelpPanelMessage::ScrollUp)
     );
@@ -326,7 +326,7 @@ fn test_handle_event_down() {
         HelpPanel::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(HelpPanelMessage::ScrollDown)
     );
@@ -336,11 +336,19 @@ fn test_handle_event_down() {
 fn test_handle_event_k_j() {
     let state = focused_state();
     assert_eq!(
-        HelpPanel::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true)),
+        HelpPanel::handle_event(
+            &state,
+            &Event::char('k'),
+            &EventContext::new().focused(true)
+        ),
         Some(HelpPanelMessage::ScrollUp)
     );
     assert_eq!(
-        HelpPanel::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true)),
+        HelpPanel::handle_event(
+            &state,
+            &Event::char('j'),
+            &EventContext::new().focused(true)
+        ),
         Some(HelpPanelMessage::ScrollDown)
     );
 }
@@ -352,7 +360,7 @@ fn test_handle_event_page_up_down() {
         HelpPanel::handle_event(
             &state,
             &Event::key(KeyCode::PageUp),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(HelpPanelMessage::PageUp(10))
     );
@@ -360,7 +368,7 @@ fn test_handle_event_page_up_down() {
         HelpPanel::handle_event(
             &state,
             &Event::key(KeyCode::PageDown),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(HelpPanelMessage::PageDown(10))
     );
@@ -370,11 +378,19 @@ fn test_handle_event_page_up_down() {
 fn test_handle_event_ctrl_u_d() {
     let state = focused_state();
     assert_eq!(
-        HelpPanel::handle_event(&state, &Event::ctrl('u'), &ViewContext::new().focused(true)),
+        HelpPanel::handle_event(
+            &state,
+            &Event::ctrl('u'),
+            &EventContext::new().focused(true)
+        ),
         Some(HelpPanelMessage::PageUp(10))
     );
     assert_eq!(
-        HelpPanel::handle_event(&state, &Event::ctrl('d'), &ViewContext::new().focused(true)),
+        HelpPanel::handle_event(
+            &state,
+            &Event::ctrl('d'),
+            &EventContext::new().focused(true)
+        ),
         Some(HelpPanelMessage::PageDown(10))
     );
 }
@@ -386,7 +402,7 @@ fn test_handle_event_home_end() {
         HelpPanel::handle_event(
             &state,
             &Event::key(KeyCode::Home),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(HelpPanelMessage::Home)
     );
@@ -394,7 +410,7 @@ fn test_handle_event_home_end() {
         HelpPanel::handle_event(
             &state,
             &Event::key(KeyCode::End),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(HelpPanelMessage::End)
     );
@@ -405,14 +421,18 @@ fn test_handle_event_home_end() {
 fn test_handle_event_g_and_G() {
     let state = focused_state();
     assert_eq!(
-        HelpPanel::handle_event(&state, &Event::char('g'), &ViewContext::new().focused(true)),
+        HelpPanel::handle_event(
+            &state,
+            &Event::char('g'),
+            &EventContext::new().focused(true)
+        ),
         Some(HelpPanelMessage::Home)
     );
     assert_eq!(
         HelpPanel::handle_event(
             &state,
             &Event::key_with(KeyCode::Char('G'), KeyModifiers::SHIFT),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(HelpPanelMessage::End)
     );
@@ -422,7 +442,11 @@ fn test_handle_event_g_and_G() {
 fn test_handle_event_unrecognized() {
     let state = focused_state();
     assert_eq!(
-        HelpPanel::handle_event(&state, &Event::char('x'), &ViewContext::new().focused(true)),
+        HelpPanel::handle_event(
+            &state,
+            &Event::char('x'),
+            &EventContext::new().focused(true)
+        ),
         None
     );
 }
@@ -438,7 +462,7 @@ fn test_disabled_ignores_events() {
         HelpPanel::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true).disabled(true)
+            &EventContext::new().focused(true).disabled(true)
         ),
         None
     );
@@ -448,7 +472,7 @@ fn test_disabled_ignores_events() {
 fn test_unfocused_ignores_events() {
     let state = HelpPanelState::new();
     assert_eq!(
-        HelpPanel::handle_event(&state, &Event::key(KeyCode::Up), &ViewContext::default()),
+        HelpPanel::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default()),
         None
     );
 }
@@ -521,10 +545,7 @@ fn test_view_empty() {
         .draw(|frame| {
             HelpPanel::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -539,10 +560,7 @@ fn test_view_with_groups() {
         .draw(|frame| {
             HelpPanel::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -557,10 +575,7 @@ fn test_view_focused() {
         .draw(|frame| {
             HelpPanel::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -575,10 +590,9 @@ fn test_view_disabled() {
         .draw(|frame| {
             HelpPanel::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true).disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme)
+                    .focused(true)
+                    .disabled(true),
             );
         })
         .unwrap();
@@ -597,10 +611,7 @@ fn test_view_scrolled() {
         .draw(|frame| {
             HelpPanel::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -619,7 +630,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                HelpPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                HelpPanel::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -640,10 +651,7 @@ fn test_annotation_focused() {
             .draw(|frame| {
                 HelpPanel::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
                 );
             })
             .unwrap();

--- a/src/component/histogram/mod.rs
+++ b/src/component/histogram/mod.rs
@@ -31,9 +31,8 @@ use std::marker::PhantomData;
 use ratatui::prelude::*;
 use ratatui::widgets::{Bar, BarChart, BarGroup, Block, Borders};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::Event;
-use crate::theme::Theme;
 
 /// Strategy for computing the number of histogram bins.
 ///
@@ -680,12 +679,12 @@ impl HistogramState {
 
     /// Maps an input event to a histogram message.
     pub fn handle_event(&self, event: &Event) -> Option<HistogramMessage> {
-        Histogram::handle_event(self, event, &ViewContext::default())
+        Histogram::handle_event(self, event, &EventContext::default())
     }
 
     /// Dispatches an event, updating state and returning any output.
     pub fn dispatch_event(&mut self, event: &Event) -> Option<()> {
-        Histogram::dispatch_event(self, event, &ViewContext::default())
+        Histogram::dispatch_event(self, event, &EventContext::default())
     }
 
     /// Updates the state with a message, returning any output.
@@ -749,7 +748,7 @@ impl Component for Histogram {
     fn handle_event(
         _state: &Self::State,
         _event: &Event,
-        _ctx: &ViewContext,
+        _ctx: &EventContext,
     ) -> Option<Self::Message> {
         // Display-only component; no event handling.
         None
@@ -783,14 +782,14 @@ impl Component for Histogram {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        if area.height < 3 || area.width < 3 {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        if ctx.area.height < 3 || ctx.area.width < 3 {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::container("histogram")
                     .with_focus(ctx.focused)
                     .with_disabled(ctx.disabled),
@@ -798,11 +797,11 @@ impl Component for Histogram {
         });
 
         let border_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let mut block = Block::default()
@@ -813,8 +812,8 @@ impl Component for Histogram {
             block = block.title(title.as_str());
         }
 
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
+        let inner = block.inner(ctx.area);
+        ctx.frame.render_widget(block, ctx.area);
 
         if inner.height == 0 || inner.width == 0 {
             return;
@@ -856,7 +855,7 @@ impl Component for Histogram {
                 let p = ratatui::widgets::Paragraph::new(label.as_str())
                     .alignment(Alignment::Left)
                     .style(Style::default().fg(Color::DarkGray));
-                frame.render_widget(p, y_area);
+                ctx.frame.render_widget(p, y_area);
             }
         }
 
@@ -866,7 +865,7 @@ impl Component for Histogram {
                 let p = ratatui::widgets::Paragraph::new(label.as_str())
                     .alignment(Alignment::Center)
                     .style(Style::default().fg(Color::DarkGray));
-                frame.render_widget(p, x_area);
+                ctx.frame.render_widget(p, x_area);
             }
         }
 
@@ -876,7 +875,7 @@ impl Component for Histogram {
 
         let bar_color = state.color.unwrap_or(Color::Cyan);
         let bar_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else {
             Style::default().fg(bar_color)
         };
@@ -917,7 +916,7 @@ impl Component for Histogram {
             .bar_style(bar_style)
             .max(max_count as u64);
 
-        frame.render_widget(chart, chart_area);
+        ctx.frame.render_widget(chart, chart_area);
     }
 }
 

--- a/src/component/histogram/tests.rs
+++ b/src/component/histogram/tests.rs
@@ -745,7 +745,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Histogram::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -759,7 +759,7 @@ fn test_render_with_data() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Histogram::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -774,7 +774,7 @@ fn test_render_with_labels() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Histogram::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -787,7 +787,7 @@ fn test_render_with_show_counts() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Histogram::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -800,10 +800,7 @@ fn test_render_disabled() {
         .draw(|frame| {
             Histogram::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -818,10 +815,7 @@ fn test_render_focused() {
         .draw(|frame| {
             Histogram::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -833,7 +827,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(60, 2);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Histogram::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -846,7 +840,7 @@ fn test_render_with_color() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Histogram::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -860,7 +854,7 @@ fn test_render_with_adaptive_binning() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Histogram::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -875,7 +869,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Histogram::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -890,7 +884,7 @@ fn test_snapshot_with_data() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Histogram::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -904,7 +898,7 @@ fn test_snapshot_with_title() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Histogram::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -920,10 +914,7 @@ fn test_snapshot_disabled() {
         .draw(|frame| {
             Histogram::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -942,7 +933,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Histogram::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Histogram::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/input_field/mod.rs
+++ b/src/component/input_field/mod.rs
@@ -29,9 +29,8 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 use unicode_width::UnicodeWidthStr;
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
-use crate::theme::Theme;
 use crate::undo::{EditKind, UndoStack};
 
 mod editing;
@@ -777,7 +776,7 @@ impl Component for InputField {
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -840,10 +839,10 @@ impl Component for InputField {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::input("input_field")
                     .with_value(state.value.as_str())
                     .with_focus(ctx.focused)
@@ -852,9 +851,9 @@ impl Component for InputField {
         });
 
         let border_style = if ctx.focused {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let block = Block::default()
@@ -864,13 +863,13 @@ impl Component for InputField {
         let is_placeholder = state.value.is_empty() && !state.placeholder.is_empty();
 
         let base_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_style()
+            ctx.theme.focused_style()
         } else if is_placeholder {
-            theme.placeholder_style()
+            ctx.theme.placeholder_style()
         } else {
-            theme.normal_style()
+            ctx.theme.normal_style()
         };
 
         let text = if is_placeholder {
@@ -881,7 +880,7 @@ impl Component for InputField {
 
         // Build line with selection highlighting
         let line = if let Some((sel_start, sel_end)) = state.selection_range() {
-            let selection_style = theme.selection_style();
+            let selection_style = ctx.theme.selection_style();
             let before = &state.value[..sel_start];
             let selected = &state.value[sel_start..sel_end];
             let after = &state.value[sel_end..];
@@ -895,15 +894,15 @@ impl Component for InputField {
         };
 
         let paragraph = Paragraph::new(line).block(block);
-        frame.render_widget(paragraph, area);
+        ctx.frame.render_widget(paragraph, ctx.area);
 
         // Show cursor when focused
-        if ctx.focused && area.width > 2 && area.height > 2 {
-            let cursor_x = area.x + 1 + state.cursor_display_position() as u16;
-            let cursor_y = area.y + 1;
+        if ctx.focused && ctx.area.width > 2 && ctx.area.height > 2 {
+            let cursor_x = ctx.area.x + 1 + state.cursor_display_position() as u16;
+            let cursor_y = ctx.area.y + 1;
 
-            if cursor_x < area.x + area.width - 1 {
-                frame.set_cursor_position((cursor_x, cursor_y));
+            if cursor_x < ctx.area.x + ctx.area.width - 1 {
+                ctx.frame.set_cursor_position((cursor_x, cursor_y));
             }
         }
     }

--- a/src/component/input_field/selection_tests.rs
+++ b/src/component/input_field/selection_tests.rs
@@ -365,7 +365,7 @@ fn test_shift_left_event() {
     let msg = InputField::handle_event(
         &state,
         &Event::key_with(KeyCode::Left, KeyModifiers::SHIFT),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::SelectLeft));
 }
@@ -376,7 +376,7 @@ fn test_shift_right_event() {
     let msg = InputField::handle_event(
         &state,
         &Event::key_with(KeyCode::Right, KeyModifiers::SHIFT),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::SelectRight));
 }
@@ -387,7 +387,7 @@ fn test_shift_home_event() {
     let msg = InputField::handle_event(
         &state,
         &Event::key_with(KeyCode::Home, KeyModifiers::SHIFT),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::SelectHome));
 }
@@ -398,7 +398,7 @@ fn test_shift_end_event() {
     let msg = InputField::handle_event(
         &state,
         &Event::key_with(KeyCode::End, KeyModifiers::SHIFT),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::SelectEnd));
 }
@@ -409,7 +409,7 @@ fn test_ctrl_shift_left_event() {
     let msg = InputField::handle_event(
         &state,
         &Event::key_with(KeyCode::Left, KeyModifiers::CONTROL | KeyModifiers::SHIFT),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::SelectWordLeft));
 }
@@ -420,7 +420,7 @@ fn test_ctrl_shift_right_event() {
     let msg = InputField::handle_event(
         &state,
         &Event::key_with(KeyCode::Right, KeyModifiers::CONTROL | KeyModifiers::SHIFT),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::SelectWordRight));
 }
@@ -428,16 +428,22 @@ fn test_ctrl_shift_right_event() {
 #[test]
 fn test_ctrl_c_event() {
     let state = focused_state("hello");
-    let msg =
-        InputField::handle_event(&state, &Event::ctrl('c'), &ViewContext::new().focused(true));
+    let msg = InputField::handle_event(
+        &state,
+        &Event::ctrl('c'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(InputFieldMessage::Copy));
 }
 
 #[test]
 fn test_ctrl_x_event() {
     let state = focused_state("hello");
-    let msg =
-        InputField::handle_event(&state, &Event::ctrl('x'), &ViewContext::new().focused(true));
+    let msg = InputField::handle_event(
+        &state,
+        &Event::ctrl('x'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(InputFieldMessage::Cut));
 }
 
@@ -449,8 +455,11 @@ fn test_ctrl_x_event() {
 fn test_ctrl_v_event_with_clipboard() {
     let mut state = focused_state("hello");
     state.clipboard = "world".into();
-    let msg =
-        InputField::handle_event(&state, &Event::ctrl('v'), &ViewContext::new().focused(true));
+    let msg = InputField::handle_event(
+        &state,
+        &Event::ctrl('v'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(InputFieldMessage::Paste("world".into())));
 }
 
@@ -461,8 +470,11 @@ fn test_ctrl_v_event_with_clipboard() {
 #[test]
 fn test_ctrl_v_event_empty_clipboard() {
     let state = focused_state("hello");
-    let msg =
-        InputField::handle_event(&state, &Event::ctrl('v'), &ViewContext::new().focused(true));
+    let msg = InputField::handle_event(
+        &state,
+        &Event::ctrl('v'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, None);
 }
 
@@ -473,8 +485,11 @@ fn test_ctrl_v_event_empty_clipboard() {
 fn test_ctrl_v_event_with_internal_clipboard() {
     let mut state = focused_state("hello");
     state.clipboard = "world".into();
-    let msg =
-        InputField::handle_event(&state, &Event::ctrl('v'), &ViewContext::new().focused(true));
+    let msg = InputField::handle_event(
+        &state,
+        &Event::ctrl('v'),
+        &EventContext::new().focused(true),
+    );
     // System clipboard may override internal, but should still produce a Paste
     assert!(matches!(msg, Some(InputFieldMessage::Paste(_))));
 }
@@ -482,8 +497,11 @@ fn test_ctrl_v_event_with_internal_clipboard() {
 #[test]
 fn test_ctrl_a_event() {
     let state = focused_state("hello");
-    let msg =
-        InputField::handle_event(&state, &Event::ctrl('a'), &ViewContext::new().focused(true));
+    let msg = InputField::handle_event(
+        &state,
+        &Event::ctrl('a'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(InputFieldMessage::SelectAll));
 }
 
@@ -493,7 +511,7 @@ fn test_paste_event() {
     let msg = InputField::handle_event(
         &state,
         &Event::Paste("pasted text".into()),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::Paste("pasted text".into())));
 }

--- a/src/component/input_field/tests.rs
+++ b/src/component/input_field/tests.rs
@@ -261,10 +261,7 @@ fn test_view() {
         .draw(|frame| {
             InputField::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -281,10 +278,7 @@ fn test_view_unfocused() {
         .draw(|frame| {
             InputField::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -301,10 +295,7 @@ fn test_view_disabled() {
         .draw(|frame| {
             InputField::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -322,10 +313,7 @@ fn test_view_placeholder() {
         .draw(|frame| {
             InputField::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -408,8 +396,11 @@ fn test_word_nav_with_emoji() {
 fn test_handle_event_char_insert() {
     let state = InputField::init();
 
-    let msg =
-        InputField::handle_event(&state, &Event::char('a'), &ViewContext::new().focused(true));
+    let msg = InputField::handle_event(
+        &state,
+        &Event::char('a'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(InputFieldMessage::Insert('a')));
 }
 
@@ -420,7 +411,7 @@ fn test_handle_event_backspace() {
     let msg = InputField::handle_event(
         &state,
         &Event::key(KeyCode::Backspace),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::Backspace));
 }
@@ -432,7 +423,7 @@ fn test_handle_event_delete() {
     let msg = InputField::handle_event(
         &state,
         &Event::key(KeyCode::Delete),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::Delete));
 }
@@ -444,7 +435,7 @@ fn test_handle_event_left() {
     let msg = InputField::handle_event(
         &state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::Left));
 }
@@ -456,7 +447,7 @@ fn test_handle_event_right() {
     let msg = InputField::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::Right));
 }
@@ -468,7 +459,7 @@ fn test_handle_event_home() {
     let msg = InputField::handle_event(
         &state,
         &Event::key(KeyCode::Home),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::Home));
 }
@@ -480,7 +471,7 @@ fn test_handle_event_end() {
     let msg = InputField::handle_event(
         &state,
         &Event::key(KeyCode::End),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::End));
 }
@@ -492,7 +483,7 @@ fn test_handle_event_enter() {
     let msg = InputField::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::Submit));
 }
@@ -504,7 +495,7 @@ fn test_handle_event_ctrl_left() {
     let msg = InputField::handle_event(
         &state,
         &Event::key_with(KeyCode::Left, KeyModifiers::CONTROL),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::WordLeft));
 }
@@ -516,7 +507,7 @@ fn test_handle_event_ctrl_right() {
     let msg = InputField::handle_event(
         &state,
         &Event::key_with(KeyCode::Right, KeyModifiers::CONTROL),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::WordRight));
 }
@@ -524,7 +515,7 @@ fn test_handle_event_ctrl_right() {
 #[test]
 fn test_handle_event_ignored_when_unfocused() {
     let state = InputField::init();
-    let msg = InputField::handle_event(&state, &Event::char('a'), &ViewContext::default());
+    let msg = InputField::handle_event(&state, &Event::char('a'), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -535,7 +526,7 @@ fn test_dispatch_event_char() {
     let output = InputField::dispatch_event(
         &mut state,
         &Event::char('a'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(InputFieldOutput::Changed("a".to_string())));
 }
@@ -549,28 +540,28 @@ fn test_handle_event_ignored_when_disabled() {
     let msg = InputField::handle_event(
         &state,
         &Event::char('a'),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = InputField::handle_event(
         &state,
         &Event::key(KeyCode::Backspace),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = InputField::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = InputField::handle_event(
         &state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -582,7 +573,7 @@ fn test_dispatch_event_ignored_when_disabled() {
     let output = InputField::dispatch_event(
         &mut state,
         &Event::char('a'),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(output, None);
     assert!(state.is_empty());
@@ -657,10 +648,7 @@ fn test_annotation_emitted() {
             .draw(|frame| {
                 InputField::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
                 );
             })
             .unwrap();

--- a/src/component/input_field/undo_tests.rs
+++ b/src/component/input_field/undo_tests.rs
@@ -232,16 +232,22 @@ fn test_new_edit_clears_redo() {
 #[test]
 fn test_ctrl_z_maps_to_undo() {
     let state = focused_state("hello");
-    let msg =
-        InputField::handle_event(&state, &Event::ctrl('z'), &ViewContext::new().focused(true));
+    let msg = InputField::handle_event(
+        &state,
+        &Event::ctrl('z'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(InputFieldMessage::Undo));
 }
 
 #[test]
 fn test_ctrl_y_maps_to_redo() {
     let state = focused_state("hello");
-    let msg =
-        InputField::handle_event(&state, &Event::ctrl('y'), &ViewContext::new().focused(true));
+    let msg = InputField::handle_event(
+        &state,
+        &Event::ctrl('y'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(InputFieldMessage::Redo));
 }
 

--- a/src/component/key_hints/mod.rs
+++ b/src/component/key_hints/mod.rs
@@ -27,8 +27,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, ViewContext};
-use crate::theme::Theme;
+use super::{Component, RenderContext};
 
 /// Layout style for key hints display.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -770,8 +769,8 @@ impl Component for KeyHints {
         None // Display-only, no output
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
-        if state.hints.is_empty() || area.width == 0 || area.height == 0 {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        if state.hints.is_empty() || ctx.area.width == 0 || ctx.area.height == 0 {
             return;
         }
 
@@ -782,9 +781,9 @@ impl Component for KeyHints {
 
         let mut spans = Vec::new();
 
-        // Use theme for key style (focused/success color for keys)
+        // Use ctx.theme for key style (focused/success color for keys)
         let key_style = if state.key_style == Style::default().fg(Color::Green) {
-            theme.success_style()
+            ctx.theme.success_style()
         } else {
             state.key_style
         };
@@ -811,7 +810,7 @@ impl Component for KeyHints {
             crate::annotation::Annotation::new(crate::annotation::WidgetType::KeyHints)
                 .with_id("key_hints");
         let annotated = crate::annotation::Annotate::new(paragraph, annotation);
-        frame.render_widget(annotated, area);
+        ctx.frame.render_widget(annotated, ctx.area);
     }
 }
 

--- a/src/component/key_hints/tests.rs
+++ b/src/component/key_hints/tests.rs
@@ -287,7 +287,7 @@ fn test_view_empty() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(80, 1);
 
     terminal
-        .draw(|frame| KeyHints::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| KeyHints::view(&state, &mut RenderContext::new(frame, frame.area(), &theme)))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -299,7 +299,7 @@ fn test_view_single_hint() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(80, 1);
 
     terminal
-        .draw(|frame| KeyHints::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| KeyHints::view(&state, &mut RenderContext::new(frame, frame.area(), &theme)))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -315,7 +315,7 @@ fn test_view_multiple_hints() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(80, 1);
 
     terminal
-        .draw(|frame| KeyHints::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| KeyHints::view(&state, &mut RenderContext::new(frame, frame.area(), &theme)))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -331,7 +331,7 @@ fn test_view_disabled_hints_hidden() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(80, 1);
 
     terminal
-        .draw(|frame| KeyHints::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| KeyHints::view(&state, &mut RenderContext::new(frame, frame.area(), &theme)))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -347,7 +347,7 @@ fn test_view_inline_layout() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(80, 1);
 
     terminal
-        .draw(|frame| KeyHints::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| KeyHints::view(&state, &mut RenderContext::new(frame, frame.area(), &theme)))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -435,7 +435,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                KeyHints::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                KeyHints::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/line_input/handle_event_tests.rs
+++ b/src/component/line_input/handle_event_tests.rs
@@ -8,7 +8,7 @@ fn test_handle_event_unfocused() {
     let state = LineInputState::new();
     let event = Event::char('a');
     assert_eq!(
-        LineInput::handle_event(&state, &event, &ViewContext::default()),
+        LineInput::handle_event(&state, &event, &EventContext::default()),
         None
     );
 }
@@ -21,7 +21,7 @@ fn test_handle_event_disabled() {
         LineInput::handle_event(
             &state,
             &event,
-            &ViewContext::new().focused(true).disabled(true)
+            &EventContext::new().focused(true).disabled(true)
         ),
         None
     );
@@ -32,7 +32,7 @@ fn test_handle_event_char() {
     let state = LineInputState::new();
     let event = Event::char('a');
     assert_eq!(
-        LineInput::handle_event(&state, &event, &ViewContext::new().focused(true)),
+        LineInput::handle_event(&state, &event, &EventContext::new().focused(true)),
         Some(LineInputMessage::Insert('a'))
     );
 }
@@ -42,7 +42,7 @@ fn test_handle_event_enter() {
     let state = LineInputState::new();
     let event = Event::key(KeyCode::Enter);
     assert_eq!(
-        LineInput::handle_event(&state, &event, &ViewContext::new().focused(true)),
+        LineInput::handle_event(&state, &event, &EventContext::new().focused(true)),
         Some(LineInputMessage::Submit)
     );
 }
@@ -52,7 +52,7 @@ fn test_handle_event_backspace() {
     let state = LineInputState::new();
     let event = Event::key(KeyCode::Backspace);
     assert_eq!(
-        LineInput::handle_event(&state, &event, &ViewContext::new().focused(true)),
+        LineInput::handle_event(&state, &event, &EventContext::new().focused(true)),
         Some(LineInputMessage::Backspace)
     );
 }
@@ -62,7 +62,7 @@ fn test_handle_event_delete() {
     let state = LineInputState::new();
     let event = Event::key(KeyCode::Delete);
     assert_eq!(
-        LineInput::handle_event(&state, &event, &ViewContext::new().focused(true)),
+        LineInput::handle_event(&state, &event, &EventContext::new().focused(true)),
         Some(LineInputMessage::Delete)
     );
 }
@@ -70,7 +70,7 @@ fn test_handle_event_delete() {
 #[test]
 fn test_handle_event_arrows() {
     let state = LineInputState::new();
-    let ctx = ViewContext::new().focused(true);
+    let ctx = EventContext::new().focused(true);
     assert_eq!(
         LineInput::handle_event(&state, &Event::key(KeyCode::Left), &ctx),
         Some(LineInputMessage::Left)
@@ -92,7 +92,7 @@ fn test_handle_event_arrows() {
 #[test]
 fn test_handle_event_ctrl_keys() {
     let state = LineInputState::new();
-    let ctx = ViewContext::new().focused(true);
+    let ctx = EventContext::new().focused(true);
     assert_eq!(
         LineInput::handle_event(&state, &Event::ctrl('z'), &ctx),
         Some(LineInputMessage::Undo)
@@ -122,7 +122,7 @@ fn test_handle_event_ctrl_keys() {
 #[test]
 fn test_handle_event_shift_arrows() {
     let state = LineInputState::new();
-    let ctx = ViewContext::new().focused(true);
+    let ctx = EventContext::new().focused(true);
     assert_eq!(
         LineInput::handle_event(
             &state,
@@ -160,7 +160,7 @@ fn test_handle_event_shift_arrows() {
 #[test]
 fn test_handle_event_ctrl_arrows() {
     let state = LineInputState::new();
-    let ctx = ViewContext::new().focused(true);
+    let ctx = EventContext::new().focused(true);
     assert_eq!(
         LineInput::handle_event(
             &state,
@@ -182,7 +182,7 @@ fn test_handle_event_ctrl_arrows() {
 #[test]
 fn test_handle_event_ctrl_shift_arrows() {
     let state = LineInputState::new();
-    let ctx = ViewContext::new().focused(true);
+    let ctx = EventContext::new().focused(true);
     let mods = KeyModifiers::CONTROL | KeyModifiers::SHIFT;
     assert_eq!(
         LineInput::handle_event(&state, &Event::key_with(KeyCode::Left, mods), &ctx),
@@ -197,7 +197,7 @@ fn test_handle_event_ctrl_shift_arrows() {
 #[test]
 fn test_handle_event_ctrl_backspace() {
     let state = LineInputState::new();
-    let ctx = ViewContext::new().focused(true);
+    let ctx = EventContext::new().focused(true);
     assert_eq!(
         LineInput::handle_event(
             &state,
@@ -211,7 +211,7 @@ fn test_handle_event_ctrl_backspace() {
 #[test]
 fn test_handle_event_ctrl_delete() {
     let state = LineInputState::new();
-    let ctx = ViewContext::new().focused(true);
+    let ctx = EventContext::new().focused(true);
     assert_eq!(
         LineInput::handle_event(
             &state,
@@ -228,7 +228,7 @@ fn test_handle_event_ctrl_delete() {
 fn test_up_on_first_row_is_history_prev() {
     let mut state = LineInputState::with_value("hello");
     state.set_display_width(80);
-    let ctx = ViewContext::new().focused(true);
+    let ctx = EventContext::new().focused(true);
     // Single row -> cursor on row 0 -> Up = HistoryPrev
     assert_eq!(
         LineInput::handle_event(&state, &Event::key(KeyCode::Up), &ctx),
@@ -240,7 +240,7 @@ fn test_up_on_first_row_is_history_prev() {
 fn test_up_on_second_row_is_visual_up() {
     let mut state = LineInputState::with_value("hello world!");
     state.set_display_width(5);
-    let ctx = ViewContext::new().focused(true);
+    let ctx = EventContext::new().focused(true);
     // "hello" | " worl" | "d!" -> cursor at end (row 2)
     assert_eq!(
         LineInput::handle_event(&state, &Event::key(KeyCode::Up), &ctx),
@@ -252,7 +252,7 @@ fn test_up_on_second_row_is_visual_up() {
 fn test_down_on_last_row_is_history_next() {
     let mut state = LineInputState::with_value("hello");
     state.set_display_width(80);
-    let ctx = ViewContext::new().focused(true);
+    let ctx = EventContext::new().focused(true);
     // Single row -> cursor on last row -> Down = HistoryNext
     assert_eq!(
         LineInput::handle_event(&state, &Event::key(KeyCode::Down), &ctx),
@@ -265,7 +265,7 @@ fn test_down_on_first_row_is_visual_down() {
     let mut state = LineInputState::with_value("hello world!");
     state.set_display_width(5);
     state.cursor = 0;
-    let ctx = ViewContext::new().focused(true);
+    let ctx = EventContext::new().focused(true);
     // cursor at row 0, multiple rows -> Down = VisualDown
     assert_eq!(
         LineInput::handle_event(&state, &Event::key(KeyCode::Down), &ctx),
@@ -278,7 +278,7 @@ fn test_down_on_first_row_is_visual_down() {
 #[test]
 fn test_handle_event_paste() {
     let state = LineInputState::new();
-    let ctx = ViewContext::new().focused(true);
+    let ctx = EventContext::new().focused(true);
     let event = Event::Paste("pasted text".to_string());
     assert_eq!(
         LineInput::handle_event(&state, &event, &ctx),

--- a/src/component/line_input/mod.rs
+++ b/src/component/line_input/mod.rs
@@ -36,11 +36,8 @@ mod property_tests;
 #[cfg(test)]
 mod tests;
 
-use ratatui::prelude::*;
-
-use crate::component::{Component, ViewContext};
+use crate::component::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
-use crate::theme::Theme;
 use crate::undo::UndoStack;
 
 use chunking::{chunk_buffer, cursor_to_visual};
@@ -661,7 +658,7 @@ impl Component for LineInput {
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -763,7 +760,7 @@ impl Component for LineInput {
         update::update(state, msg)
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        view_helpers::render(state, frame, area, theme, ctx);
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        view_helpers::render(state, ctx);
     }
 }

--- a/src/component/line_input/tests.rs
+++ b/src/component/line_input/tests.rs
@@ -604,10 +604,7 @@ fn test_snapshot_focused() {
         .draw(|frame| {
             LineInput::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -620,7 +617,7 @@ fn test_snapshot_unfocused() {
     let state = LineInputState::with_value("hello");
     terminal
         .draw(|frame| {
-            LineInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LineInput::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -634,10 +631,7 @@ fn test_snapshot_disabled() {
         .draw(|frame| {
             LineInput::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -650,7 +644,7 @@ fn test_snapshot_placeholder() {
     let state = LineInputState::new().with_placeholder("Type here...");
     terminal
         .draw(|frame| {
-            LineInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LineInput::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -665,10 +659,7 @@ fn test_snapshot_wrapped() {
         .draw(|frame| {
             LineInput::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -684,10 +675,7 @@ fn test_snapshot_wide_chars() {
         .draw(|frame| {
             LineInput::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -705,10 +693,7 @@ fn test_snapshot_selection() {
         .draw(|frame| {
             LineInput::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -845,7 +830,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                LineInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                LineInput::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/line_input/view_helpers.rs
+++ b/src/component/line_input/view_helpers.rs
@@ -5,20 +5,13 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 
 use super::LineInputState;
 use super::chunking::{chunk_buffer, cursor_to_visual};
-use crate::component::ViewContext;
-use crate::theme::Theme;
+use crate::component::RenderContext;
 
 /// Renders the LineInput component.
-pub(super) fn render(
-    state: &LineInputState,
-    frame: &mut Frame,
-    area: ratatui::layout::Rect,
-    theme: &Theme,
-    ctx: &ViewContext,
-) {
+pub(super) fn render(state: &LineInputState, ctx: &mut RenderContext<'_, '_>) {
     crate::annotation::with_registry(|reg| {
         reg.register(
-            area,
+            ctx.area,
             crate::annotation::Annotation::line_input("line_input")
                 .with_value(state.value())
                 .with_focus(ctx.focused)
@@ -27,18 +20,18 @@ pub(super) fn render(
     });
 
     let border_style = if ctx.focused {
-        theme.focused_border_style()
+        ctx.theme.focused_border_style()
     } else {
-        theme.border_style()
+        ctx.theme.border_style()
     };
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(border_style);
 
-    // Inner area (inside borders)
-    let inner = block.inner(area);
+    // Inner ctx.area (inside borders)
+    let inner = block.inner(ctx.area);
     if inner.width == 0 || inner.height == 0 {
-        frame.render_widget(block, area);
+        ctx.frame.render_widget(block, ctx.area);
         return;
     }
 
@@ -46,13 +39,13 @@ pub(super) fn render(
     let is_placeholder = state.buffer.is_empty();
 
     let base_style = if ctx.disabled {
-        theme.disabled_style()
+        ctx.theme.disabled_style()
     } else if ctx.focused {
-        theme.focused_style()
+        ctx.theme.focused_style()
     } else if is_placeholder {
-        theme.placeholder_style()
+        ctx.theme.placeholder_style()
     } else {
-        theme.normal_style()
+        ctx.theme.normal_style()
     };
 
     let display_text = if is_placeholder {
@@ -85,7 +78,10 @@ pub(super) fn render(
                 if !before.is_empty() {
                     spans.push(Span::styled(before.to_string(), base_style));
                 }
-                spans.push(Span::styled(selected.to_string(), theme.selection_style()));
+                spans.push(Span::styled(
+                    selected.to_string(),
+                    ctx.theme.selection_style(),
+                ));
                 if !after.is_empty() {
                     spans.push(Span::styled(after.to_string(), base_style));
                 }
@@ -99,7 +95,7 @@ pub(super) fn render(
     }
 
     let paragraph = Paragraph::new(Text::from(lines)).block(block);
-    frame.render_widget(paragraph, area);
+    ctx.frame.render_widget(paragraph, ctx.area);
 
     // Set cursor position when focused
     if ctx.focused && !ctx.disabled && inner.width > 0 && inner.height > 0 {
@@ -109,7 +105,7 @@ pub(super) fn render(
         let cursor_y = inner.y + cursor_row as u16;
 
         if cursor_x < inner.x + inner.width && cursor_y < inner.y + inner.height {
-            frame.set_cursor_position((cursor_x, cursor_y));
+            ctx.frame.set_cursor_position((cursor_x, cursor_y));
         }
     }
 }

--- a/src/component/loading_list/items.rs
+++ b/src/component/loading_list/items.rs
@@ -1,0 +1,244 @@
+//! Item types for the LoadingList component.
+//!
+//! Extracted from the main loading_list module to keep file sizes manageable.
+
+use ratatui::prelude::*;
+
+use crate::theme::Theme;
+
+/// Loading state of an individual item.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub enum ItemState {
+    /// Item is ready (normal state).
+    #[default]
+    Ready,
+    /// Item is currently loading.
+    Loading,
+    /// Item has an error.
+    Error(String),
+}
+
+impl ItemState {
+    /// Returns true if the item is loading.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ItemState;
+    ///
+    /// assert!(!ItemState::Ready.is_loading());
+    /// assert!(ItemState::Loading.is_loading());
+    /// ```
+    pub fn is_loading(&self) -> bool {
+        matches!(self, Self::Loading)
+    }
+
+    /// Returns true if the item has an error.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ItemState;
+    ///
+    /// assert!(!ItemState::Ready.is_error());
+    /// assert!(ItemState::Error("failed".into()).is_error());
+    /// ```
+    pub fn is_error(&self) -> bool {
+        matches!(self, Self::Error(_))
+    }
+
+    /// Returns true if the item is ready.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ItemState;
+    ///
+    /// assert!(ItemState::Ready.is_ready());
+    /// assert!(!ItemState::Loading.is_ready());
+    /// ```
+    pub fn is_ready(&self) -> bool {
+        matches!(self, Self::Ready)
+    }
+
+    /// Returns the error message if in error state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ItemState;
+    ///
+    /// let state = ItemState::Error("connection lost".into());
+    /// assert_eq!(state.error_message(), Some("connection lost"));
+    ///
+    /// assert_eq!(ItemState::Ready.error_message(), None);
+    /// ```
+    pub fn error_message(&self) -> Option<&str> {
+        if let Self::Error(msg) = self {
+            Some(msg)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the symbol for this state.
+    pub fn symbol(&self, spinner_frame: usize) -> &'static str {
+        match self {
+            Self::Ready => " ",
+            Self::Loading => {
+                // Braille dots animation matching SpinnerStyle::Dots
+                const LOADING_FRAMES: [&str; 10] =
+                    ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+                LOADING_FRAMES[spinner_frame % LOADING_FRAMES.len()]
+            }
+            Self::Error(_) => "✗",
+        }
+    }
+
+    /// Returns the style for this state using the theme.
+    pub fn style(&self, theme: &Theme) -> Style {
+        match self {
+            Self::Ready => theme.normal_style(),
+            Self::Loading => theme.warning_style(),
+            Self::Error(_) => theme.error_style(),
+        }
+    }
+}
+
+/// A single item in the loading list.
+#[derive(Clone, Debug)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct LoadingListItem<T: Clone> {
+    /// The underlying data.
+    pub(super) data: T,
+    /// Display label.
+    pub(super) label: String,
+    /// Current loading state.
+    pub(super) state: ItemState,
+}
+
+impl<T: Clone + PartialEq> PartialEq for LoadingListItem<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data && self.label == other.label && self.state == other.state
+    }
+}
+
+impl<T: Clone> LoadingListItem<T> {
+    /// Creates a new item.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListItem;
+    ///
+    /// let item = LoadingListItem::new("data", "Label");
+    /// assert_eq!(item.label(), "Label");
+    /// assert!(item.is_ready());
+    /// ```
+    pub fn new(data: T, label: impl Into<String>) -> Self {
+        Self {
+            data,
+            label: label.into(),
+            state: ItemState::Ready,
+        }
+    }
+
+    /// Returns the underlying data.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListItem;
+    ///
+    /// let item = LoadingListItem::new(42, "Answer");
+    /// assert_eq!(*item.data(), 42);
+    /// ```
+    pub fn data(&self) -> &T {
+        &self.data
+    }
+
+    /// Returns a mutable reference to the data.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListItem;
+    ///
+    /// let mut item = LoadingListItem::new(42u32, "Answer");
+    /// *item.data_mut() = 99;
+    /// assert_eq!(*item.data(), 99);
+    /// ```
+    pub fn data_mut(&mut self) -> &mut T {
+        &mut self.data
+    }
+
+    /// Returns the label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListItem;
+    ///
+    /// let item = LoadingListItem::new("x", "Display Name");
+    /// assert_eq!(item.label(), "Display Name");
+    /// ```
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// Sets the label.
+    pub fn set_label(&mut self, label: impl Into<String>) {
+        self.label = label.into();
+    }
+
+    /// Returns the current state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ItemState, LoadingListItem};
+    ///
+    /// let item = LoadingListItem::new("x", "Item");
+    /// assert_eq!(item.state(), &ItemState::Ready);
+    /// ```
+    pub fn state(&self) -> &ItemState {
+        &self.state
+    }
+
+    /// Sets the state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ItemState, LoadingListItem};
+    ///
+    /// let mut item = LoadingListItem::new("x", "Item");
+    /// item.set_state(ItemState::Loading);
+    /// assert!(item.is_loading());
+    /// ```
+    pub fn set_state(&mut self, state: ItemState) {
+        self.state = state;
+    }
+
+    /// Returns true if the item is loading.
+    pub fn is_loading(&self) -> bool {
+        self.state.is_loading()
+    }
+
+    /// Returns true if the item has an error.
+    pub fn is_error(&self) -> bool {
+        self.state.is_error()
+    }
+
+    /// Returns true if the item is ready.
+    pub fn is_ready(&self) -> bool {
+        self.state.is_ready()
+    }
+}

--- a/src/component/loading_list/mod.rs
+++ b/src/component/loading_list/mod.rs
@@ -35,251 +35,14 @@
 //! // Or: LoadingList::update(&mut state, LoadingListMessage::SetError { index: 0, message: "Failed".to_string() });
 //! ```
 
-use ratatui::prelude::*;
-
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
 use crate::scroll::ScrollState;
-use crate::theme::Theme;
 
+mod items;
 mod render;
 
-/// Loading state of an individual item.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serialization",
-    derive(serde::Serialize, serde::Deserialize)
-)]
-pub enum ItemState {
-    /// Item is ready (normal state).
-    #[default]
-    Ready,
-    /// Item is currently loading.
-    Loading,
-    /// Item has an error.
-    Error(String),
-}
-
-impl ItemState {
-    /// Returns true if the item is loading.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::ItemState;
-    ///
-    /// assert!(!ItemState::Ready.is_loading());
-    /// assert!(ItemState::Loading.is_loading());
-    /// ```
-    pub fn is_loading(&self) -> bool {
-        matches!(self, Self::Loading)
-    }
-
-    /// Returns true if the item has an error.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::ItemState;
-    ///
-    /// assert!(!ItemState::Ready.is_error());
-    /// assert!(ItemState::Error("failed".into()).is_error());
-    /// ```
-    pub fn is_error(&self) -> bool {
-        matches!(self, Self::Error(_))
-    }
-
-    /// Returns true if the item is ready.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::ItemState;
-    ///
-    /// assert!(ItemState::Ready.is_ready());
-    /// assert!(!ItemState::Loading.is_ready());
-    /// ```
-    pub fn is_ready(&self) -> bool {
-        matches!(self, Self::Ready)
-    }
-
-    /// Returns the error message if in error state.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::ItemState;
-    ///
-    /// let state = ItemState::Error("connection lost".into());
-    /// assert_eq!(state.error_message(), Some("connection lost"));
-    ///
-    /// assert_eq!(ItemState::Ready.error_message(), None);
-    /// ```
-    pub fn error_message(&self) -> Option<&str> {
-        if let Self::Error(msg) = self {
-            Some(msg)
-        } else {
-            None
-        }
-    }
-
-    /// Returns the symbol for this state.
-    pub fn symbol(&self, spinner_frame: usize) -> &'static str {
-        match self {
-            Self::Ready => " ",
-            Self::Loading => {
-                // Braille dots animation matching SpinnerStyle::Dots
-                const LOADING_FRAMES: [&str; 10] =
-                    ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-                LOADING_FRAMES[spinner_frame % LOADING_FRAMES.len()]
-            }
-            Self::Error(_) => "✗",
-        }
-    }
-
-    /// Returns the style for this state using the theme.
-    pub fn style(&self, theme: &Theme) -> Style {
-        match self {
-            Self::Ready => theme.normal_style(),
-            Self::Loading => theme.warning_style(),
-            Self::Error(_) => theme.error_style(),
-        }
-    }
-}
-
-/// A single item in the loading list.
-#[derive(Clone, Debug)]
-#[cfg_attr(
-    feature = "serialization",
-    derive(serde::Serialize, serde::Deserialize)
-)]
-pub struct LoadingListItem<T: Clone> {
-    /// The underlying data.
-    data: T,
-    /// Display label.
-    label: String,
-    /// Current loading state.
-    state: ItemState,
-}
-
-impl<T: Clone + PartialEq> PartialEq for LoadingListItem<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.data == other.data && self.label == other.label && self.state == other.state
-    }
-}
-
-impl<T: Clone> LoadingListItem<T> {
-    /// Creates a new item.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::LoadingListItem;
-    ///
-    /// let item = LoadingListItem::new("data", "Label");
-    /// assert_eq!(item.label(), "Label");
-    /// assert!(item.is_ready());
-    /// ```
-    pub fn new(data: T, label: impl Into<String>) -> Self {
-        Self {
-            data,
-            label: label.into(),
-            state: ItemState::Ready,
-        }
-    }
-
-    /// Returns the underlying data.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::LoadingListItem;
-    ///
-    /// let item = LoadingListItem::new(42, "Answer");
-    /// assert_eq!(*item.data(), 42);
-    /// ```
-    pub fn data(&self) -> &T {
-        &self.data
-    }
-
-    /// Returns a mutable reference to the data.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::LoadingListItem;
-    ///
-    /// let mut item = LoadingListItem::new(42u32, "Answer");
-    /// *item.data_mut() = 99;
-    /// assert_eq!(*item.data(), 99);
-    /// ```
-    pub fn data_mut(&mut self) -> &mut T {
-        &mut self.data
-    }
-
-    /// Returns the label.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::LoadingListItem;
-    ///
-    /// let item = LoadingListItem::new("x", "Display Name");
-    /// assert_eq!(item.label(), "Display Name");
-    /// ```
-    pub fn label(&self) -> &str {
-        &self.label
-    }
-
-    /// Sets the label.
-    pub fn set_label(&mut self, label: impl Into<String>) {
-        self.label = label.into();
-    }
-
-    /// Returns the current state.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::{ItemState, LoadingListItem};
-    ///
-    /// let item = LoadingListItem::new("x", "Item");
-    /// assert_eq!(item.state(), &ItemState::Ready);
-    /// ```
-    pub fn state(&self) -> &ItemState {
-        &self.state
-    }
-
-    /// Sets the state.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::{ItemState, LoadingListItem};
-    ///
-    /// let mut item = LoadingListItem::new("x", "Item");
-    /// item.set_state(ItemState::Loading);
-    /// assert!(item.is_loading());
-    /// ```
-    pub fn set_state(&mut self, state: ItemState) {
-        self.state = state;
-    }
-
-    /// Returns true if the item is loading.
-    pub fn is_loading(&self) -> bool {
-        self.state.is_loading()
-    }
-
-    /// Returns true if the item has an error.
-    pub fn is_error(&self) -> bool {
-        self.state.is_error()
-    }
-
-    /// Returns true if the item is ready.
-    pub fn is_ready(&self) -> bool {
-        self.state.is_ready()
-    }
-}
+pub use items::{ItemState, LoadingListItem};
 
 /// Messages for the LoadingList component.
 #[derive(Clone, Debug, PartialEq)]
@@ -970,7 +733,7 @@ impl<T: Clone> Component for LoadingList<T> {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -987,8 +750,15 @@ impl<T: Clone> Component for LoadingList<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        render::render_loading_list(state, frame, area, theme, ctx.focused, ctx.disabled);
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        render::render_loading_list(
+            state,
+            ctx.frame,
+            ctx.area,
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
     }
 }
 

--- a/src/component/loading_list/render.rs
+++ b/src/component/loading_list/render.rs
@@ -6,6 +6,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem};
 
 use super::*;
+use crate::theme::Theme;
 
 /// Renders the loading list into the given frame area.
 pub(super) fn render_loading_list<T: Clone>(

--- a/src/component/loading_list/snapshot_tests.rs
+++ b/src/component/loading_list/snapshot_tests.rs
@@ -34,7 +34,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LoadingList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -47,7 +47,7 @@ fn test_snapshot_with_items() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LoadingList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -60,7 +60,7 @@ fn test_snapshot_with_selected() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LoadingList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -74,7 +74,7 @@ fn test_snapshot_with_loading_item() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LoadingList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -88,7 +88,7 @@ fn test_snapshot_with_error_item() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LoadingList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -104,7 +104,7 @@ fn test_snapshot_mixed_states() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LoadingList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -119,10 +119,7 @@ fn test_snapshot_disabled() {
         .draw(|frame| {
             LoadingList::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();

--- a/src/component/loading_list/tests/component.rs
+++ b/src/component/loading_list/tests/component.rs
@@ -797,7 +797,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                LoadingList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/loading_list/tests/events.rs
+++ b/src/component/loading_list/tests/events.rs
@@ -12,7 +12,7 @@ fn test_handle_event_up() {
     let msg = LoadingList::<TestItem>::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(LoadingListMessage::Up));
 }
@@ -25,7 +25,7 @@ fn test_handle_event_down() {
     let msg = LoadingList::<TestItem>::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(LoadingListMessage::Down));
 }
@@ -38,7 +38,7 @@ fn test_handle_event_select() {
     let msg = LoadingList::<TestItem>::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(LoadingListMessage::Select));
 }
@@ -52,7 +52,7 @@ fn test_handle_event_vim_keys() {
     let msg = LoadingList::<TestItem>::handle_event(
         &state,
         &Event::char('k'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(LoadingListMessage::Up));
 
@@ -60,7 +60,7 @@ fn test_handle_event_vim_keys() {
     let msg = LoadingList::<TestItem>::handle_event(
         &state,
         &Event::char('j'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(LoadingListMessage::Down));
 }
@@ -73,7 +73,7 @@ fn test_handle_event_ignored_when_unfocused() {
     let msg = LoadingList::<TestItem>::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::default(),
+        &EventContext::default(),
     );
     assert_eq!(msg, None);
 }
@@ -91,7 +91,7 @@ fn test_dispatch_event() {
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert!(matches!(
         output,
@@ -129,7 +129,7 @@ fn test_disabled_prevents_handle_event() {
     let msg = LoadingList::<TestItem>::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -166,28 +166,28 @@ fn test_handle_event_unrecognized_key() {
     let msg = LoadingList::<TestItem>::handle_event(
         &state,
         &Event::char('a'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
 
     let msg = LoadingList::<TestItem>::handle_event(
         &state,
         &Event::char('x'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
 
     let msg = LoadingList::<TestItem>::handle_event(
         &state,
         &Event::key(KeyCode::Tab),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
 
     let msg = LoadingList::<TestItem>::handle_event(
         &state,
         &Event::key(KeyCode::Esc),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
 }
@@ -206,7 +206,7 @@ fn test_handle_event_all_keys_ignored_when_unfocused() {
         LoadingList::<TestItem>::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::default()
+            &EventContext::default()
         ),
         None
     );
@@ -214,7 +214,7 @@ fn test_handle_event_all_keys_ignored_when_unfocused() {
         LoadingList::<TestItem>::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::default()
+            &EventContext::default()
         ),
         None
     );
@@ -222,16 +222,16 @@ fn test_handle_event_all_keys_ignored_when_unfocused() {
         LoadingList::<TestItem>::handle_event(
             &state,
             &Event::key(KeyCode::Enter),
-            &ViewContext::default()
+            &EventContext::default()
         ),
         None
     );
     assert_eq!(
-        LoadingList::<TestItem>::handle_event(&state, &Event::char('k'), &ViewContext::default()),
+        LoadingList::<TestItem>::handle_event(&state, &Event::char('k'), &EventContext::default()),
         None
     );
     assert_eq!(
-        LoadingList::<TestItem>::handle_event(&state, &Event::char('j'), &ViewContext::default()),
+        LoadingList::<TestItem>::handle_event(&state, &Event::char('j'), &EventContext::default()),
         None
     );
 }
@@ -295,21 +295,21 @@ fn test_dispatch_event_chained_navigation() {
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(LoadingListOutput::SelectionChanged(0)));
 
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(LoadingListOutput::SelectionChanged(1)));
 
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(LoadingListOutput::SelectionChanged(2)));
 
@@ -317,7 +317,7 @@ fn test_dispatch_event_chained_navigation() {
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(LoadingListOutput::SelectionChanged(0)));
 }
@@ -332,14 +332,14 @@ fn test_dispatch_event_up_navigation() {
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(LoadingListOutput::SelectionChanged(1)));
 
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(LoadingListOutput::SelectionChanged(0)));
 
@@ -347,7 +347,7 @@ fn test_dispatch_event_up_navigation() {
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(LoadingListOutput::SelectionChanged(2)));
 }
@@ -362,7 +362,7 @@ fn test_dispatch_event_enter_selects() {
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert!(matches!(
         output,
@@ -379,7 +379,7 @@ fn test_dispatch_event_vim_keys() {
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
         &Event::char('j'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(LoadingListOutput::SelectionChanged(0)));
 
@@ -387,7 +387,7 @@ fn test_dispatch_event_vim_keys() {
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
         &Event::char('k'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(LoadingListOutput::SelectionChanged(2)));
 }

--- a/src/component/loading_list/tests/item.rs
+++ b/src/component/loading_list/tests/item.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::theme::Theme;
 
 // ========================================
 // ItemState Tests

--- a/src/component/loading_list/tests/view.rs
+++ b/src/component/loading_list/tests/view.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::theme::Theme;
 use ratatui::prelude::Rect;
 
 // ========================================
@@ -12,7 +13,7 @@ fn test_view_empty() {
 
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            LoadingList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
 
@@ -29,7 +30,7 @@ fn test_view_with_items() {
 
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            LoadingList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
 
@@ -45,7 +46,7 @@ fn test_view_with_title() {
 
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            LoadingList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
 
@@ -62,7 +63,7 @@ fn test_view_with_error() {
 
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            LoadingList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
 
@@ -80,10 +81,7 @@ fn test_view_zero_size_area() {
         .draw(|frame| {
             LoadingList::view(
                 &state,
-                frame,
-                Rect::new(0, 0, 0, 10),
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, Rect::new(0, 0, 0, 10), &theme),
             );
         })
         .unwrap();
@@ -93,10 +91,7 @@ fn test_view_zero_size_area() {
         .draw(|frame| {
             LoadingList::view(
                 &state,
-                frame,
-                Rect::new(0, 0, 60, 0),
-                &Theme::default(),
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, Rect::new(0, 0, 60, 0), &Theme::default()),
             );
         })
         .unwrap();
@@ -112,7 +107,7 @@ fn test_view_without_indicators() {
 
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            LoadingList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
 
@@ -129,7 +124,7 @@ fn test_view_without_indicators_with_error() {
 
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            LoadingList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
 
@@ -152,10 +147,7 @@ fn test_view_focused() {
         .draw(|frame| {
             LoadingList::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             )
         })
         .unwrap();
@@ -173,7 +165,7 @@ fn test_view_with_loading_item() {
 
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            LoadingList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
 
@@ -192,7 +184,7 @@ fn test_view_with_mixed_states() {
 
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            LoadingList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
 
@@ -211,7 +203,7 @@ fn test_view_single_item() {
 
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            LoadingList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
 
@@ -230,10 +222,7 @@ fn test_view_disabled() {
         .draw(|frame| {
             LoadingList::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             )
         })
         .unwrap();
@@ -251,7 +240,7 @@ fn test_view_with_title_and_selection() {
 
     terminal
         .draw(|frame| {
-            LoadingList::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            LoadingList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
 

--- a/src/component/log_correlation/mod.rs
+++ b/src/component/log_correlation/mod.rs
@@ -39,10 +39,9 @@ use std::marker::PhantomData;
 
 use ratatui::prelude::*;
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
-use crate::theme::Theme;
 
 /// Severity level for a correlation log entry.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
@@ -729,7 +728,7 @@ impl Component for LogCorrelation {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -854,8 +853,15 @@ impl Component for LogCorrelation {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        render::render(state, frame, area, theme, ctx.focused, ctx.disabled);
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        render::render(
+            state,
+            ctx.frame,
+            ctx.area,
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
     }
 }
 

--- a/src/component/log_correlation/snapshot_tests.rs
+++ b/src/component/log_correlation/snapshot_tests.rs
@@ -67,7 +67,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LogCorrelation::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -79,7 +79,7 @@ fn test_snapshot_two_streams() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LogCorrelation::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -93,10 +93,7 @@ fn test_snapshot_focused() {
         .draw(|frame| {
             LogCorrelation::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -118,7 +115,7 @@ fn test_snapshot_with_title() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LogCorrelation::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -132,10 +129,7 @@ fn test_snapshot_disabled() {
         .draw(|frame| {
             LogCorrelation::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -149,7 +143,7 @@ fn test_snapshot_with_filter() {
     let (mut terminal, theme) = test_utils::setup_render(80, 20);
     terminal
         .draw(|frame| {
-            LogCorrelation::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LogCorrelation::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/log_correlation/tests/edge_cases.rs
+++ b/src/component/log_correlation/tests/edge_cases.rs
@@ -71,10 +71,7 @@ fn test_annotation_emitted() {
             .draw(|frame| {
                 LogCorrelation::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
                 );
             })
             .unwrap();

--- a/src/component/log_correlation/tests/events.rs
+++ b/src/component/log_correlation/tests/events.rs
@@ -216,7 +216,7 @@ fn test_disabled_ignores_events() {
     let msg = LogCorrelation::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -236,7 +236,7 @@ fn test_disabled_ignores_update() {
 fn test_unfocused_ignores_events() {
     let state = two_stream_state();
     let msg =
-        LogCorrelation::handle_event(&state, &Event::key(KeyCode::Down), &ViewContext::default());
+        LogCorrelation::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -251,12 +251,16 @@ fn test_up_key() {
         LogCorrelation::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(LogCorrelationMessage::ScrollUp)
     );
     assert_eq!(
-        LogCorrelation::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true)),
+        LogCorrelation::handle_event(
+            &state,
+            &Event::char('k'),
+            &EventContext::new().focused(true)
+        ),
         Some(LogCorrelationMessage::ScrollUp)
     );
 }
@@ -268,12 +272,16 @@ fn test_down_key() {
         LogCorrelation::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(LogCorrelationMessage::ScrollDown)
     );
     assert_eq!(
-        LogCorrelation::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true)),
+        LogCorrelation::handle_event(
+            &state,
+            &Event::char('j'),
+            &EventContext::new().focused(true)
+        ),
         Some(LogCorrelationMessage::ScrollDown)
     );
 }
@@ -285,7 +293,7 @@ fn test_home_end_keys() {
         LogCorrelation::handle_event(
             &state,
             &Event::key(KeyCode::Home),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(LogCorrelationMessage::ScrollToTop)
     );
@@ -293,7 +301,7 @@ fn test_home_end_keys() {
         LogCorrelation::handle_event(
             &state,
             &Event::key(KeyCode::End),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(LogCorrelationMessage::ScrollToBottom)
     );
@@ -306,7 +314,7 @@ fn test_tab_key() {
         LogCorrelation::handle_event(
             &state,
             &Event::key(KeyCode::Tab),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(LogCorrelationMessage::FocusNextStream)
     );
@@ -319,7 +327,7 @@ fn test_backtab_key() {
         LogCorrelation::handle_event(
             &state,
             &Event::key(KeyCode::BackTab),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(LogCorrelationMessage::FocusPrevStream)
     );
@@ -329,7 +337,11 @@ fn test_backtab_key() {
 fn test_s_key() {
     let state = focused_state();
     assert_eq!(
-        LogCorrelation::handle_event(&state, &Event::char('s'), &ViewContext::new().focused(true)),
+        LogCorrelation::handle_event(
+            &state,
+            &Event::char('s'),
+            &EventContext::new().focused(true)
+        ),
         Some(LogCorrelationMessage::ToggleSyncScroll)
     );
 }
@@ -344,7 +356,7 @@ fn test_instance_handle_event() {
     let msg = LogCorrelation::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(LogCorrelationMessage::ScrollDown));
 }
@@ -362,7 +374,7 @@ fn test_instance_dispatch_event() {
     LogCorrelation::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(state.scroll_offset(), 1);
 }

--- a/src/component/log_correlation/tests/view.rs
+++ b/src/component/log_correlation/tests/view.rs
@@ -12,10 +12,7 @@ fn test_render_empty() {
         .draw(|frame| {
             LogCorrelation::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -29,10 +26,7 @@ fn test_render_two_streams() {
         .draw(|frame| {
             LogCorrelation::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -46,10 +40,7 @@ fn test_render_focused() {
         .draw(|frame| {
             LogCorrelation::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -63,10 +54,7 @@ fn test_render_disabled() {
         .draw(|frame| {
             LogCorrelation::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -93,10 +81,7 @@ fn test_render_with_title() {
         .draw(|frame| {
             LogCorrelation::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -111,10 +96,7 @@ fn test_render_with_filter() {
         .draw(|frame| {
             LogCorrelation::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -128,10 +110,7 @@ fn test_render_small_area() {
         .draw(|frame| {
             LogCorrelation::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -145,10 +124,7 @@ fn test_render_narrow_area() {
         .draw(|frame| {
             LogCorrelation::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();

--- a/src/component/log_viewer/enhancement_tests.rs
+++ b/src/component/log_viewer/enhancement_tests.rs
@@ -57,7 +57,11 @@ fn test_toggle_follow() {
 fn test_follow_key_binding() {
     let state = focused_state();
     assert_eq!(
-        LogViewer::handle_event(&state, &Event::char('f'), &ViewContext::new().focused(true)),
+        LogViewer::handle_event(
+            &state,
+            &Event::char('f'),
+            &EventContext::new().focused(true)
+        ),
         Some(LogViewerMessage::ToggleFollow)
     );
 }
@@ -186,7 +190,11 @@ fn test_toggle_regex_key_binding() {
     let mut state = focused_state();
     LogViewer::update(&mut state, LogViewerMessage::FocusSearch);
     assert_eq!(
-        LogViewer::handle_event(&state, &Event::ctrl('r'), &ViewContext::new().focused(true)),
+        LogViewer::handle_event(
+            &state,
+            &Event::ctrl('r'),
+            &EventContext::new().focused(true)
+        ),
         Some(LogViewerMessage::ToggleRegex)
     );
 }
@@ -389,7 +397,7 @@ fn test_search_history_up_key_binding() {
         LogViewer::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::SearchHistoryUp)
     );
@@ -403,7 +411,7 @@ fn test_search_history_down_key_binding() {
         LogViewer::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::SearchHistoryDown)
     );
@@ -597,10 +605,7 @@ fn test_render_with_follow() {
         .draw(|frame| {
             LogViewer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -615,10 +620,7 @@ fn test_render_without_follow() {
         .draw(|frame| {
             LogViewer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -633,10 +635,7 @@ fn test_render_with_regex() {
         .draw(|frame| {
             LogViewer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();

--- a/src/component/log_viewer/mod.rs
+++ b/src/component/log_viewer/mod.rs
@@ -43,10 +43,10 @@ use std::marker::PhantomData;
 use ratatui::prelude::*;
 
 use super::{
-    Component, InputFieldMessage, InputFieldState, StatusLogEntry, StatusLogLevel, ViewContext,
+    Component, EventContext, InputFieldMessage, InputFieldState, RenderContext, StatusLogEntry,
+    StatusLogLevel,
 };
 use crate::input::{Event, KeyCode, KeyModifiers};
-use crate::theme::Theme;
 
 pub use state::LogViewerState;
 
@@ -191,7 +191,7 @@ impl Component for LogViewer {
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -444,21 +444,21 @@ impl Component for LogViewer {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        if area.height < 3 {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        if ctx.area.height < 3 {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::container("log_viewer")
                     .with_focus(ctx.focused)
                     .with_disabled(ctx.disabled),
             );
         });
 
-        // Layout: search bar (1 line) + filter bar (1 line) + log area
+        // Layout: search bar (1 line) + filter bar (1 line) + log ctx.area
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -466,20 +466,20 @@ impl Component for LogViewer {
                 Constraint::Length(1),
                 Constraint::Min(1),
             ])
-            .split(area);
+            .split(ctx.area);
 
         let search_area = chunks[0];
         let filter_area = chunks[1];
         let log_area = chunks[2];
 
         // Render search bar
-        view::render_search_bar(state, frame, search_area, theme, ctx);
+        view::render_search_bar(state, &mut ctx.with_area(search_area));
 
         // Render filter bar
-        view::render_filter_bar(state, frame, filter_area, theme, ctx);
+        view::render_filter_bar(state, &mut ctx.with_area(filter_area));
 
         // Render log entries
-        view::render_log(state, frame, log_area, theme, ctx);
+        view::render_log(state, &mut ctx.with_area(log_area));
     }
 }
 

--- a/src/component/log_viewer/snapshot_tests.rs
+++ b/src/component/log_viewer/snapshot_tests.rs
@@ -20,7 +20,7 @@ fn test_snapshot_default_empty() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LogViewer::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -32,7 +32,7 @@ fn test_snapshot_populated() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LogViewer::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -46,10 +46,7 @@ fn test_snapshot_focused() {
         .draw(|frame| {
             LogViewer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -65,7 +62,7 @@ fn test_snapshot_with_title() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LogViewer::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -80,7 +77,7 @@ fn test_snapshot_with_timestamps() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            LogViewer::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            LogViewer::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -98,10 +95,7 @@ fn test_snapshot_search_active() {
         .draw(|frame| {
             LogViewer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();

--- a/src/component/log_viewer/tests/edge_cases.rs
+++ b/src/component/log_viewer/tests/edge_cases.rs
@@ -106,10 +106,7 @@ fn test_annotation_emitted() {
             .draw(|frame| {
                 LogViewer::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
                 );
             })
             .unwrap();

--- a/src/component/log_viewer/tests/events.rs
+++ b/src/component/log_viewer/tests/events.rs
@@ -11,12 +11,16 @@ fn test_log_mode_up_key() {
         LogViewer::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::ScrollUp)
     );
     assert_eq!(
-        LogViewer::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true)),
+        LogViewer::handle_event(
+            &state,
+            &Event::char('k'),
+            &EventContext::new().focused(true)
+        ),
         Some(LogViewerMessage::ScrollUp)
     );
 }
@@ -28,12 +32,16 @@ fn test_log_mode_down_key() {
         LogViewer::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::ScrollDown)
     );
     assert_eq!(
-        LogViewer::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true)),
+        LogViewer::handle_event(
+            &state,
+            &Event::char('j'),
+            &EventContext::new().focused(true)
+        ),
         Some(LogViewerMessage::ScrollDown)
     );
 }
@@ -45,7 +53,7 @@ fn test_log_mode_home_end() {
         LogViewer::handle_event(
             &state,
             &Event::key(KeyCode::Home),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::ScrollToTop)
     );
@@ -53,7 +61,7 @@ fn test_log_mode_home_end() {
         LogViewer::handle_event(
             &state,
             &Event::key(KeyCode::End),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::ScrollToBottom)
     );
@@ -63,7 +71,11 @@ fn test_log_mode_home_end() {
 fn test_log_mode_slash() {
     let state = focused_state();
     assert_eq!(
-        LogViewer::handle_event(&state, &Event::char('/'), &ViewContext::new().focused(true)),
+        LogViewer::handle_event(
+            &state,
+            &Event::char('/'),
+            &EventContext::new().focused(true)
+        ),
         Some(LogViewerMessage::FocusSearch)
     );
 }
@@ -72,19 +84,35 @@ fn test_log_mode_slash() {
 fn test_log_mode_number_keys() {
     let state = focused_state();
     assert_eq!(
-        LogViewer::handle_event(&state, &Event::char('1'), &ViewContext::new().focused(true)),
+        LogViewer::handle_event(
+            &state,
+            &Event::char('1'),
+            &EventContext::new().focused(true)
+        ),
         Some(LogViewerMessage::ToggleInfo)
     );
     assert_eq!(
-        LogViewer::handle_event(&state, &Event::char('2'), &ViewContext::new().focused(true)),
+        LogViewer::handle_event(
+            &state,
+            &Event::char('2'),
+            &EventContext::new().focused(true)
+        ),
         Some(LogViewerMessage::ToggleSuccess)
     );
     assert_eq!(
-        LogViewer::handle_event(&state, &Event::char('3'), &ViewContext::new().focused(true)),
+        LogViewer::handle_event(
+            &state,
+            &Event::char('3'),
+            &EventContext::new().focused(true)
+        ),
         Some(LogViewerMessage::ToggleWarning)
     );
     assert_eq!(
-        LogViewer::handle_event(&state, &Event::char('4'), &ViewContext::new().focused(true)),
+        LogViewer::handle_event(
+            &state,
+            &Event::char('4'),
+            &EventContext::new().focused(true)
+        ),
         Some(LogViewerMessage::ToggleError)
     );
 }
@@ -98,7 +126,11 @@ fn test_search_mode_char_input() {
     let mut state = focused_state();
     LogViewer::update(&mut state, LogViewerMessage::FocusSearch);
     assert_eq!(
-        LogViewer::handle_event(&state, &Event::char('a'), &ViewContext::new().focused(true)),
+        LogViewer::handle_event(
+            &state,
+            &Event::char('a'),
+            &EventContext::new().focused(true)
+        ),
         Some(LogViewerMessage::SearchInput('a'))
     );
 }
@@ -111,7 +143,7 @@ fn test_search_mode_esc() {
         LogViewer::handle_event(
             &state,
             &Event::key(KeyCode::Esc),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::ClearSearch)
     );
@@ -125,7 +157,7 @@ fn test_search_mode_enter() {
         LogViewer::handle_event(
             &state,
             &Event::key(KeyCode::Enter),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::ConfirmSearch)
     );
@@ -139,7 +171,7 @@ fn test_search_mode_backspace() {
         LogViewer::handle_event(
             &state,
             &Event::key(KeyCode::Backspace),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::SearchBackspace)
     );
@@ -153,7 +185,7 @@ fn test_search_mode_delete() {
         LogViewer::handle_event(
             &state,
             &Event::key(KeyCode::Delete),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::SearchDelete)
     );
@@ -167,7 +199,7 @@ fn test_search_mode_left_right() {
         LogViewer::handle_event(
             &state,
             &Event::key(KeyCode::Left),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::SearchLeft)
     );
@@ -175,7 +207,7 @@ fn test_search_mode_left_right() {
         LogViewer::handle_event(
             &state,
             &Event::key(KeyCode::Right),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::SearchRight)
     );
@@ -189,7 +221,7 @@ fn test_search_mode_home_end() {
         LogViewer::handle_event(
             &state,
             &Event::key(KeyCode::Home),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::SearchHome)
     );
@@ -197,7 +229,7 @@ fn test_search_mode_home_end() {
         LogViewer::handle_event(
             &state,
             &Event::key(KeyCode::End),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::SearchEnd)
     );
@@ -213,7 +245,7 @@ fn test_instance_handle_event() {
     let msg = LogViewer::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(LogViewerMessage::ScrollDown));
 }
@@ -231,7 +263,7 @@ fn test_instance_dispatch_event() {
     LogViewer::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(state.scroll_offset(), 1);
 }

--- a/src/component/log_viewer/tests/update.rs
+++ b/src/component/log_viewer/tests/update.rs
@@ -156,7 +156,7 @@ fn test_disabled_ignores_events() {
     let msg = LogViewer::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -168,6 +168,6 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = sample_state();
-    let msg = LogViewer::handle_event(&state, &Event::key(KeyCode::Down), &ViewContext::default());
+    let msg = LogViewer::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
     assert_eq!(msg, None);
 }

--- a/src/component/log_viewer/tests/view.rs
+++ b/src/component/log_viewer/tests/view.rs
@@ -8,10 +8,7 @@ fn test_render_empty() {
         .draw(|frame| {
             LogViewer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -25,10 +22,7 @@ fn test_render_with_entries() {
         .draw(|frame| {
             LogViewer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -42,10 +36,7 @@ fn test_render_focused() {
         .draw(|frame| {
             LogViewer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -62,10 +53,7 @@ fn test_render_search_focused() {
         .draw(|frame| {
             LogViewer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -79,10 +67,7 @@ fn test_render_disabled() {
         .draw(|frame| {
             LogViewer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -98,10 +83,7 @@ fn test_render_with_title() {
         .draw(|frame| {
             LogViewer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -117,10 +99,7 @@ fn test_render_with_timestamps() {
         .draw(|frame| {
             LogViewer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -134,10 +113,7 @@ fn test_render_small_area() {
         .draw(|frame| {
             LogViewer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();

--- a/src/component/log_viewer/view.rs
+++ b/src/component/log_viewer/view.rs
@@ -2,23 +2,16 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
 
 use super::{LogViewerState, StatusLogLevel};
-use crate::component::ViewContext;
-use crate::theme::Theme;
+use crate::component::RenderContext;
 
 /// Renders the search bar area.
-pub(super) fn render_search_bar(
-    state: &LogViewerState,
-    frame: &mut Frame,
-    area: Rect,
-    theme: &Theme,
-    ctx: &ViewContext,
-) {
+pub(super) fn render_search_bar(state: &LogViewerState, ctx: &mut RenderContext<'_, '_>) {
     let search_style = if ctx.disabled {
-        theme.disabled_style()
+        ctx.theme.disabled_style()
     } else if state.is_search_focused() {
-        theme.focused_style()
+        ctx.theme.focused_style()
     } else {
-        theme.normal_style()
+        ctx.theme.normal_style()
     };
 
     // Build the search prefix with regex indicator
@@ -35,30 +28,25 @@ pub(super) fn render_search_bar(
     };
 
     let paragraph = Paragraph::new(display).style(search_style);
-    frame.render_widget(paragraph, area);
+    ctx.frame.render_widget(paragraph, ctx.area);
 
     // Show cursor when search is focused
     if ctx.focused && state.is_search_focused() && !ctx.disabled {
         let prefix_len = prefix.len() as u16;
-        let cursor_x = area.x + prefix_len + state.search_cursor_position() as u16;
-        if cursor_x < area.right() {
-            frame.set_cursor_position(Position::new(cursor_x, area.y));
+        let cursor_x = ctx.area.x + prefix_len + state.search_cursor_position() as u16;
+        if cursor_x < ctx.area.right() {
+            ctx.frame
+                .set_cursor_position(Position::new(cursor_x, ctx.area.y));
         }
     }
 }
 
 /// Renders the filter bar showing which severity levels are active.
-pub(super) fn render_filter_bar(
-    state: &LogViewerState,
-    frame: &mut Frame,
-    area: Rect,
-    theme: &Theme,
-    ctx: &ViewContext,
-) {
+pub(super) fn render_filter_bar(state: &LogViewerState, ctx: &mut RenderContext<'_, '_>) {
     let filter_style = if ctx.disabled {
-        theme.disabled_style()
+        ctx.theme.disabled_style()
     } else {
-        theme.normal_style()
+        ctx.theme.normal_style()
     };
 
     let info_marker = if state.show_info() { "●" } else { "○" };
@@ -115,25 +103,19 @@ pub(super) fn render_filter_bar(
 
     let line = Line::from(spans);
     let paragraph = Paragraph::new(line);
-    frame.render_widget(paragraph, area);
+    ctx.frame.render_widget(paragraph, ctx.area);
 }
 
 /// Renders the log entries area.
-pub(super) fn render_log(
-    state: &LogViewerState,
-    frame: &mut Frame,
-    area: Rect,
-    theme: &Theme,
-    ctx: &ViewContext,
-) {
+pub(super) fn render_log(state: &LogViewerState, ctx: &mut RenderContext<'_, '_>) {
     let visible = state.visible_entries();
 
     let border_style = if ctx.disabled {
-        theme.disabled_style()
+        ctx.theme.disabled_style()
     } else if ctx.focused && !state.is_search_focused() {
-        theme.focused_border_style()
+        ctx.theme.focused_border_style()
     } else {
-        theme.border_style()
+        ctx.theme.border_style()
     };
 
     let mut block = Block::default()
@@ -150,8 +132,8 @@ pub(super) fn render_log(
         }
     }
 
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+    let inner = block.inner(ctx.area);
+    ctx.frame.render_widget(block, ctx.area);
 
     if inner.height == 0 || inner.width == 0 {
         return;
@@ -164,7 +146,7 @@ pub(super) fn render_log(
         .take(inner.height as usize)
         .map(|entry| {
             let style = if disabled {
-                theme.disabled_style()
+                ctx.theme.disabled_style()
             } else {
                 Style::default().fg(entry.level().color())
             };
@@ -218,7 +200,7 @@ pub(super) fn render_log(
         .collect();
 
     let list = List::new(items);
-    frame.render_widget(list, inner);
+    ctx.frame.render_widget(list, inner);
 
     // Render scrollbar if content exceeds viewport
     if visible.len() > inner.height as usize {
@@ -229,6 +211,6 @@ pub(super) fn render_log(
                 .scroll_offset()
                 .min(visible.len().saturating_sub(inner.height as usize)),
         );
-        crate::scroll::render_scrollbar_inside_border(&bar_scroll, frame, area, theme);
+        crate::scroll::render_scrollbar_inside_border(&bar_scroll, ctx.frame, ctx.area, ctx.theme);
     }
 }

--- a/src/component/markdown_renderer/mod.rs
+++ b/src/component/markdown_renderer/mod.rs
@@ -35,10 +35,9 @@ pub mod render;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
-use crate::theme::Theme;
 
 /// Messages that can be sent to a [`MarkdownRenderer`].
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -320,7 +319,7 @@ impl Component for MarkdownRenderer {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -381,10 +380,10 @@ impl Component for MarkdownRenderer {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::new(crate::annotation::WidgetType::Custom(
                     "MarkdownRenderer".to_string(),
                 ))
@@ -395,11 +394,11 @@ impl Component for MarkdownRenderer {
         });
 
         let border_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let mut block = Block::default()
@@ -411,8 +410,8 @@ impl Component for MarkdownRenderer {
             block = block.title(format!("{}{}", title, suffix));
         }
 
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
+        let inner = block.inner(ctx.area);
+        ctx.frame.render_widget(block, ctx.area);
 
         if inner.height == 0 || inner.width == 0 {
             return;
@@ -421,9 +420,9 @@ impl Component for MarkdownRenderer {
         if state.show_source {
             // Raw source view
             let text_style = if ctx.disabled {
-                theme.disabled_style()
+                ctx.theme.disabled_style()
             } else {
-                theme.normal_style()
+                ctx.theme.normal_style()
             };
 
             let total_lines = crate::util::wrapped_line_count(&state.source, inner.width as usize);
@@ -436,17 +435,22 @@ impl Component for MarkdownRenderer {
                 .wrap(Wrap { trim: false })
                 .scroll((effective_scroll as u16, 0));
 
-            frame.render_widget(paragraph, inner);
+            ctx.frame.render_widget(paragraph, inner);
 
             if total_lines > visible {
                 let mut bar_scroll = ScrollState::new(total_lines);
                 bar_scroll.set_viewport_height(visible);
                 bar_scroll.set_offset(effective_scroll);
-                crate::scroll::render_scrollbar_inside_border(&bar_scroll, frame, area, theme);
+                crate::scroll::render_scrollbar_inside_border(
+                    &bar_scroll,
+                    ctx.frame,
+                    ctx.area,
+                    ctx.theme,
+                );
             }
         } else {
             // Rendered markdown view
-            let rendered_lines = render::render_markdown(&state.source, inner.width, theme);
+            let rendered_lines = render::render_markdown(&state.source, inner.width, ctx.theme);
             let total_lines = rendered_lines.len();
             let visible = inner.height as usize;
             let max_scroll = total_lines.saturating_sub(visible);
@@ -457,13 +461,18 @@ impl Component for MarkdownRenderer {
                 .wrap(Wrap { trim: false })
                 .scroll((effective_scroll as u16, 0));
 
-            frame.render_widget(paragraph, inner);
+            ctx.frame.render_widget(paragraph, inner);
 
             if total_lines > visible {
                 let mut bar_scroll = ScrollState::new(total_lines);
                 bar_scroll.set_viewport_height(visible);
                 bar_scroll.set_offset(effective_scroll);
-                crate::scroll::render_scrollbar_inside_border(&bar_scroll, frame, area, theme);
+                crate::scroll::render_scrollbar_inside_border(
+                    &bar_scroll,
+                    ctx.frame,
+                    ctx.area,
+                    ctx.theme,
+                );
             }
         }
     }

--- a/src/component/markdown_renderer/tests.rs
+++ b/src/component/markdown_renderer/tests.rs
@@ -192,7 +192,7 @@ fn test_disabled_ignores_events() {
     let msg = MarkdownRenderer::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -201,7 +201,7 @@ fn test_disabled_ignores_events() {
 fn test_unfocused_ignores_events() {
     let state = MarkdownRendererState::new();
     let msg =
-        MarkdownRenderer::handle_event(&state, &Event::key(KeyCode::Up), &ViewContext::default());
+        MarkdownRenderer::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -216,7 +216,7 @@ fn test_handle_event_up() {
         MarkdownRenderer::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MarkdownRendererMessage::ScrollUp)
     );
@@ -229,7 +229,7 @@ fn test_handle_event_down() {
         MarkdownRenderer::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MarkdownRendererMessage::ScrollDown)
     );
@@ -242,7 +242,7 @@ fn test_handle_event_k_j() {
         MarkdownRenderer::handle_event(
             &state,
             &Event::char('k'),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MarkdownRendererMessage::ScrollUp)
     );
@@ -250,7 +250,7 @@ fn test_handle_event_k_j() {
         MarkdownRenderer::handle_event(
             &state,
             &Event::char('j'),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MarkdownRendererMessage::ScrollDown)
     );
@@ -263,7 +263,7 @@ fn test_handle_event_page_up_down() {
         MarkdownRenderer::handle_event(
             &state,
             &Event::key(KeyCode::PageUp),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MarkdownRendererMessage::PageUp(10))
     );
@@ -271,7 +271,7 @@ fn test_handle_event_page_up_down() {
         MarkdownRenderer::handle_event(
             &state,
             &Event::key(KeyCode::PageDown),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MarkdownRendererMessage::PageDown(10))
     );
@@ -284,7 +284,7 @@ fn test_handle_event_ctrl_u_d() {
         MarkdownRenderer::handle_event(
             &state,
             &Event::ctrl('u'),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MarkdownRendererMessage::PageUp(10))
     );
@@ -292,7 +292,7 @@ fn test_handle_event_ctrl_u_d() {
         MarkdownRenderer::handle_event(
             &state,
             &Event::ctrl('d'),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MarkdownRendererMessage::PageDown(10))
     );
@@ -305,7 +305,7 @@ fn test_handle_event_home_end() {
         MarkdownRenderer::handle_event(
             &state,
             &Event::key(KeyCode::Home),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MarkdownRendererMessage::Home)
     );
@@ -313,7 +313,7 @@ fn test_handle_event_home_end() {
         MarkdownRenderer::handle_event(
             &state,
             &Event::key(KeyCode::End),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MarkdownRendererMessage::End)
     );
@@ -327,7 +327,7 @@ fn test_handle_event_g_and_G() {
         MarkdownRenderer::handle_event(
             &state,
             &Event::char('g'),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MarkdownRendererMessage::Home)
     );
@@ -335,7 +335,7 @@ fn test_handle_event_g_and_G() {
         MarkdownRenderer::handle_event(
             &state,
             &Event::key_with(KeyCode::Char('G'), KeyModifiers::SHIFT),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MarkdownRendererMessage::End)
     );
@@ -348,7 +348,7 @@ fn test_handle_event_s_toggle() {
         MarkdownRenderer::handle_event(
             &state,
             &Event::char('s'),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MarkdownRendererMessage::ToggleSource)
     );
@@ -361,7 +361,7 @@ fn test_handle_event_unrecognized() {
         MarkdownRenderer::handle_event(
             &state,
             &Event::char('x'),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         None
     );
@@ -384,10 +384,7 @@ fn test_view_empty() {
         .draw(|frame| {
             MarkdownRenderer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -402,10 +399,7 @@ fn test_view_with_heading() {
         .draw(|frame| {
             MarkdownRenderer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -421,10 +415,7 @@ fn test_view_with_paragraph() {
         .draw(|frame| {
             MarkdownRenderer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -440,10 +431,7 @@ fn test_view_with_code_block() {
         .draw(|frame| {
             MarkdownRenderer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -458,10 +446,7 @@ fn test_view_with_list() {
         .draw(|frame| {
             MarkdownRenderer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -476,10 +461,7 @@ fn test_view_focused() {
         .draw(|frame| {
             MarkdownRenderer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -495,10 +477,7 @@ fn test_view_with_title() {
         .draw(|frame| {
             MarkdownRenderer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -516,10 +495,7 @@ fn test_view_source_mode() {
         .draw(|frame| {
             MarkdownRenderer::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -540,10 +516,7 @@ fn test_annotation_emitted() {
             .draw(|frame| {
                 MarkdownRenderer::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::default(),
+                    &mut RenderContext::new(frame, frame.area(), &theme),
                 );
             })
             .unwrap();

--- a/src/component/menu/mod.rs
+++ b/src/component/menu/mod.rs
@@ -23,12 +23,10 @@
 //! assert_eq!(output, Some(MenuOutput::Selected(0)));
 //! ```
 
-use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 /// A menu item.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -511,7 +509,7 @@ impl Component for Menu {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -528,7 +526,7 @@ impl Component for Menu {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         let mut menu_text = String::new();
 
         for (idx, item) in state.items.iter().enumerate() {
@@ -547,11 +545,11 @@ impl Component for Menu {
 
         // Determine style based on state
         let style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_style()
+            ctx.theme.focused_style()
         } else {
-            theme.normal_style()
+            ctx.theme.normal_style()
         };
 
         let paragraph = Paragraph::new(menu_text).style(style);
@@ -561,7 +559,7 @@ impl Component for Menu {
             .with_focus(ctx.focused)
             .with_disabled(ctx.disabled);
         let annotated = crate::annotation::Annotate::new(paragraph, annotation);
-        frame.render_widget(annotated, area);
+        ctx.frame.render_widget(annotated, ctx.area);
     }
 }
 

--- a/src/component/menu/tests.rs
+++ b/src/component/menu/tests.rs
@@ -317,7 +317,7 @@ fn test_view() {
 
     terminal
         .draw(|frame| {
-            Menu::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Menu::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -334,10 +334,7 @@ fn test_view_focused() {
         .draw(|frame| {
             Menu::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -360,10 +357,7 @@ fn test_view_selected() {
         .draw(|frame| {
             Menu::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -381,10 +375,7 @@ fn test_view_empty() {
         .draw(|frame| {
             Menu::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -442,7 +433,7 @@ fn test_handle_event_left_when_focused() {
     let msg = Menu::handle_event(
         &state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(MenuMessage::Left));
 }
@@ -454,7 +445,7 @@ fn test_handle_event_right_when_focused() {
     let msg = Menu::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(MenuMessage::Right));
 }
@@ -466,7 +457,7 @@ fn test_handle_event_select_when_focused() {
     let msg = Menu::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(MenuMessage::Select));
 }
@@ -476,13 +467,21 @@ fn test_handle_event_ignored_when_unfocused() {
     let state = MenuState::new(vec![MenuItem::new("File"), MenuItem::new("Edit")]);
     // Not focused by default
 
-    let msg = Menu::handle_event(&state, &Event::key(KeyCode::Right), &ViewContext::default());
+    let msg = Menu::handle_event(
+        &state,
+        &Event::key(KeyCode::Right),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 
-    let msg = Menu::handle_event(&state, &Event::key(KeyCode::Enter), &ViewContext::default());
+    let msg = Menu::handle_event(
+        &state,
+        &Event::key(KeyCode::Enter),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 
-    let msg = Menu::handle_event(&state, &Event::key(KeyCode::Left), &ViewContext::default());
+    let msg = Menu::handle_event(&state, &Event::key(KeyCode::Left), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -496,7 +495,7 @@ fn test_dispatch_event() {
     let output = Menu::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(MenuOutput::SelectionChanged(1)));
     assert_eq!(state.selected_index(), Some(1));
@@ -505,7 +504,7 @@ fn test_dispatch_event() {
     let output = Menu::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(MenuOutput::Selected(1)));
 }
@@ -520,7 +519,7 @@ fn test_instance_methods() {
     let output = Menu::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(MenuOutput::SelectionChanged(1)));
     assert_eq!(state.selected_index(), Some(1));
@@ -534,7 +533,7 @@ fn test_instance_methods() {
     let msg = Menu::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(MenuMessage::Select));
 }
@@ -572,21 +571,21 @@ fn test_handle_event_ignored_when_disabled() {
     let msg = Menu::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Menu::handle_event(
         &state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Menu::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -598,7 +597,7 @@ fn test_dispatch_event_ignored_when_disabled() {
     let output = Menu::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(output, None);
     assert_eq!(state.selected_index(), Some(0));
@@ -616,10 +615,7 @@ fn test_annotation_emitted() {
             .draw(|frame| {
                 Menu::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
                 );
             })
             .unwrap();

--- a/src/component/metrics_dashboard/mod.rs
+++ b/src/component/metrics_dashboard/mod.rs
@@ -35,7 +35,7 @@ use std::marker::PhantomData;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Sparkline};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -524,7 +524,7 @@ impl Component for MetricsDashboard {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -617,14 +617,14 @@ impl Component for MetricsDashboard {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        if state.widgets.is_empty() || area.height < 3 || area.width < 3 {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        if state.widgets.is_empty() || ctx.area.height < 3 || ctx.area.width < 3 {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::container("metrics_dashboard")
                     .with_focus(ctx.focused)
                     .with_disabled(ctx.disabled),
@@ -642,7 +642,7 @@ impl Component for MetricsDashboard {
         let row_areas = Layout::default()
             .direction(Direction::Vertical)
             .constraints(row_constraints)
-            .split(area);
+            .split(ctx.area);
 
         // Compute column widths
         let col_constraints: Vec<Constraint> = (0..cols)
@@ -659,7 +659,7 @@ impl Component for MetricsDashboard {
                 let widget_idx = row_idx * cols + col_idx;
                 if let Some(widget) = state.widgets.get(widget_idx) {
                     let is_selected = state.selected == Some(widget_idx);
-                    render_widget(widget, is_selected, frame, *col_area, theme, ctx);
+                    render_widget(widget, is_selected, &mut ctx.with_area(*col_area));
                 }
             }
         }
@@ -667,20 +667,13 @@ impl Component for MetricsDashboard {
 }
 
 /// Renders a single metric widget.
-fn render_widget(
-    widget: &MetricWidget,
-    is_selected: bool,
-    frame: &mut Frame,
-    area: Rect,
-    theme: &Theme,
-    ctx: &ViewContext,
-) {
+fn render_widget(widget: &MetricWidget, is_selected: bool, ctx: &mut RenderContext<'_, '_>) {
     let border_style = if ctx.disabled {
-        theme.disabled_style()
+        ctx.theme.disabled_style()
     } else if is_selected && ctx.focused {
-        theme.focused_border_style()
+        ctx.theme.focused_border_style()
     } else {
-        theme.border_style()
+        ctx.theme.border_style()
     };
 
     let block = Block::default()
@@ -688,17 +681,17 @@ fn render_widget(
         .borders(Borders::ALL)
         .border_style(border_style);
 
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+    let inner = block.inner(ctx.area);
+    ctx.frame.render_widget(block, ctx.area);
 
     if inner.height == 0 || inner.width == 0 {
         return;
     }
 
     let value_style = if ctx.disabled {
-        theme.disabled_style()
+        ctx.theme.disabled_style()
     } else {
-        value_color(widget, theme)
+        value_color(widget, ctx.theme)
     };
 
     // Show sparkline if there's history and enough space
@@ -711,20 +704,20 @@ fn render_widget(
         // Value line
         let value_text = widget.display_value();
         let paragraph = Paragraph::new(value_text).style(value_style);
-        frame.render_widget(paragraph, chunks[0]);
+        ctx.frame.render_widget(paragraph, chunks[0]);
 
         // Sparkline
         let sparkline = Sparkline::default()
             .data(&widget.history)
             .style(value_style);
-        frame.render_widget(sparkline, chunks[1]);
+        ctx.frame.render_widget(sparkline, chunks[1]);
     } else {
         // Just value
         let value_text = widget.display_value();
         let paragraph = Paragraph::new(value_text)
             .style(value_style)
             .alignment(Alignment::Center);
-        frame.render_widget(paragraph, inner);
+        ctx.frame.render_widget(paragraph, inner);
     }
 }
 

--- a/src/component/metrics_dashboard/snapshot_tests.rs
+++ b/src/component/metrics_dashboard/snapshot_tests.rs
@@ -22,7 +22,7 @@ fn test_snapshot_default_empty() {
     let (mut terminal, theme) = test_utils::setup_render(80, 25);
     terminal
         .draw(|frame| {
-            MetricsDashboard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            MetricsDashboard::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -34,7 +34,7 @@ fn test_snapshot_populated() {
     let (mut terminal, theme) = test_utils::setup_render(80, 25);
     terminal
         .draw(|frame| {
-            MetricsDashboard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            MetricsDashboard::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -48,10 +48,7 @@ fn test_snapshot_focused() {
         .draw(|frame| {
             MetricsDashboard::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -67,10 +64,7 @@ fn test_snapshot_focused_second_widget() {
         .draw(|frame| {
             MetricsDashboard::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -91,7 +85,7 @@ fn test_snapshot_two_columns() {
     let (mut terminal, theme) = test_utils::setup_render(80, 25);
     terminal
         .draw(|frame| {
-            MetricsDashboard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            MetricsDashboard::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -112,7 +106,7 @@ fn test_snapshot_with_sparkline_history() {
     let (mut terminal, theme) = test_utils::setup_render(80, 25);
     terminal
         .draw(|frame| {
-            MetricsDashboard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            MetricsDashboard::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/metrics_dashboard/tests.rs
+++ b/src/component/metrics_dashboard/tests.rs
@@ -350,7 +350,7 @@ fn test_disabled_ignores_events() {
     let msg = MetricsDashboard::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -365,7 +365,7 @@ fn test_unfocused_ignores_events() {
     let msg = MetricsDashboard::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::default(),
+        &EventContext::default(),
     );
     assert_eq!(msg, None);
 }
@@ -381,7 +381,7 @@ fn test_key_maps() {
         MetricsDashboard::handle_event(
             &state,
             &Event::key(KeyCode::Left),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MetricsDashboardMessage::Left)
     );
@@ -389,7 +389,7 @@ fn test_key_maps() {
         MetricsDashboard::handle_event(
             &state,
             &Event::key(KeyCode::Right),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MetricsDashboardMessage::Right)
     );
@@ -397,7 +397,7 @@ fn test_key_maps() {
         MetricsDashboard::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MetricsDashboardMessage::Up)
     );
@@ -405,7 +405,7 @@ fn test_key_maps() {
         MetricsDashboard::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MetricsDashboardMessage::Down)
     );
@@ -413,7 +413,7 @@ fn test_key_maps() {
         MetricsDashboard::handle_event(
             &state,
             &Event::key(KeyCode::Home),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MetricsDashboardMessage::First)
     );
@@ -421,7 +421,7 @@ fn test_key_maps() {
         MetricsDashboard::handle_event(
             &state,
             &Event::key(KeyCode::End),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MetricsDashboardMessage::Last)
     );
@@ -429,7 +429,7 @@ fn test_key_maps() {
         MetricsDashboard::handle_event(
             &state,
             &Event::key(KeyCode::Enter),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MetricsDashboardMessage::Select)
     );
@@ -442,7 +442,7 @@ fn test_vim_key_maps() {
         MetricsDashboard::handle_event(
             &state,
             &Event::char('h'),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MetricsDashboardMessage::Left)
     );
@@ -450,7 +450,7 @@ fn test_vim_key_maps() {
         MetricsDashboard::handle_event(
             &state,
             &Event::char('l'),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MetricsDashboardMessage::Right)
     );
@@ -458,7 +458,7 @@ fn test_vim_key_maps() {
         MetricsDashboard::handle_event(
             &state,
             &Event::char('k'),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MetricsDashboardMessage::Up)
     );
@@ -466,7 +466,7 @@ fn test_vim_key_maps() {
         MetricsDashboard::handle_event(
             &state,
             &Event::char('j'),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(MetricsDashboardMessage::Down)
     );
@@ -528,7 +528,7 @@ fn test_instance_handle_event() {
     let msg = MetricsDashboard::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(MetricsDashboardMessage::Right));
 }
@@ -546,7 +546,7 @@ fn test_instance_dispatch_event() {
     let output = MetricsDashboard::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(MetricsDashboardOutput::SelectionChanged(1)));
 }
@@ -563,10 +563,7 @@ fn test_render_empty() {
         .draw(|frame| {
             MetricsDashboard::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -580,10 +577,7 @@ fn test_render_with_widgets() {
         .draw(|frame| {
             MetricsDashboard::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -597,10 +591,7 @@ fn test_render_disabled() {
         .draw(|frame| {
             MetricsDashboard::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -618,10 +609,7 @@ fn test_render_with_history() {
         .draw(|frame| {
             MetricsDashboard::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -635,10 +623,7 @@ fn test_render_small_area() {
         .draw(|frame| {
             MetricsDashboard::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -708,10 +693,7 @@ fn test_annotation_emitted() {
             .draw(|frame| {
                 MetricsDashboard::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
                 );
             })
             .unwrap();

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -253,6 +253,7 @@ mod tooltip;
 pub mod markdown_renderer;
 
 // Always available
+mod context;
 mod focus_manager;
 
 // Input components
@@ -491,8 +492,13 @@ pub use tooltip::{Tooltip, TooltipMessage, TooltipOutput, TooltipPosition, Toolt
 pub use markdown_renderer::{MarkdownRenderer, MarkdownRendererMessage, MarkdownRendererState};
 
 // Always available
+pub use context::{EventContext, RenderContext};
 pub use focus_manager::FocusManager;
 
+/// **Deprecated:** `ViewContext` will be renamed to [`EventContext`] in 0.14.0
+/// (when [`Component::view`] switches to taking [`RenderContext`]). For new code,
+/// prefer `EventContext`.
+///
 /// Render-time context passed to [`Component::view`].
 ///
 /// `ViewContext` carries information that the parent determines at render
@@ -535,12 +541,14 @@ impl ViewContext {
     }
 
     /// Sets the focused state (builder pattern).
+    #[must_use]
     pub fn focused(mut self, focused: bool) -> Self {
         self.focused = focused;
         self
     }
 
     /// Sets the disabled state (builder pattern).
+    #[must_use]
     pub fn disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
         self

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -11,7 +11,8 @@
 //!
 //! - [`Component`]: The base trait for all components
 //! - [`Toggleable`]: Components that can be shown or hidden
-//! - [`ViewContext`]: Focus and disabled state passed to `handle_event` and `view`
+//! - [`RenderContext`]: Render-time context (frame, area, theme, focus) passed to `view`
+//! - [`EventContext`]: Focus and disabled state passed to `handle_event`
 //!
 //! # Built-in Components
 //!
@@ -34,9 +35,7 @@
 //! # Example
 //!
 //! ```rust
-//! use envision::component::{Component, ViewContext};
-//! use envision::theme::Theme;
-//! use ratatui::prelude::*;
+//! use envision::component::{Component, RenderContext};
 //!
 //! struct Counter;
 //!
@@ -73,25 +72,21 @@
 //!         Some(CounterOutput::ValueChanged(state.value))
 //!     }
 //!
-//!     fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+//!     fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
 //!         let style = if ctx.focused {
-//!             theme.focused_style()
+//!             ctx.theme.focused_style()
 //!         } else {
-//!             theme.normal_style()
+//!             ctx.theme.normal_style()
 //!         };
 //!         let text = format!("Count: {}", state.value);
-//!         frame.render_widget(
+//!         ctx.render_widget(
 //!             ratatui::widgets::Paragraph::new(text).style(style),
-//!             area,
 //!         );
 //!     }
 //! }
 //! ```
 
-use ratatui::prelude::*;
-
 use crate::input::Event;
-use crate::theme::Theme;
 
 // Input components
 #[cfg(feature = "input-components")]
@@ -495,66 +490,6 @@ pub use markdown_renderer::{MarkdownRenderer, MarkdownRendererMessage, MarkdownR
 pub use context::{EventContext, RenderContext};
 pub use focus_manager::FocusManager;
 
-/// **Deprecated:** `ViewContext` will be renamed to [`EventContext`] in 0.14.0
-/// (when [`Component::view`] switches to taking [`RenderContext`]). For new code,
-/// prefer `EventContext`.
-///
-/// Render-time context passed to [`Component::view`].
-///
-/// `ViewContext` carries information that the parent determines at render
-/// time, such as whether a component is focused or disabled. This separates
-/// render-time concerns from persistent component state, allowing parents
-/// to control visual appearance without mutating component state.
-///
-/// # Usage
-///
-/// `ctx` values are authoritative for both rendering and event handling.
-/// Components read `ctx.focused` / `ctx.disabled` for visual appearance
-/// (border style, text color, cursor) and to guard `handle_event`.
-///
-/// # Example
-///
-/// ```rust
-/// use envision::component::ViewContext;
-///
-/// // Default: unfocused, enabled
-/// let ctx = ViewContext::default();
-///
-/// // Focused component
-/// let ctx = ViewContext::new().focused(true);
-///
-/// // Disabled and focused
-/// let ctx = ViewContext::new().focused(true).disabled(true);
-/// ```
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct ViewContext {
-    /// Whether this component currently has keyboard focus.
-    pub focused: bool,
-    /// Whether this component is currently disabled.
-    pub disabled: bool,
-}
-
-impl ViewContext {
-    /// Creates a new default ViewContext (unfocused, enabled).
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Sets the focused state (builder pattern).
-    #[must_use]
-    pub fn focused(mut self, focused: bool) -> Self {
-        self.focused = focused;
-        self
-    }
-
-    /// Sets the disabled state (builder pattern).
-    #[must_use]
-    pub fn disabled(mut self, disabled: bool) -> Self {
-        self.disabled = disabled;
-        self
-    }
-}
-
 /// A composable UI component with its own state and message handling.
 ///
 /// Components are the building blocks of complex TUI applications. Each
@@ -610,13 +545,10 @@ pub trait Component: Sized {
     /// Render the component to the given area.
     ///
     /// Unlike [`App::view`](crate::app::App::view) which renders to the full
-    /// frame, components render to a specific `Rect` area provided by their
-    /// parent.
-    ///
-    /// The `theme` parameter provides the color scheme to use for rendering.
-    /// Use [`Theme::default()`] for the standard color scheme, or
-    /// [`Theme::nord()`] for the Nord color palette.
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext);
+    /// frame, components render to a specific area carried by the
+    /// [`RenderContext`]. The context bundles the frame, render area, theme,
+    /// and focus/disabled state.
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>);
 
     /// Renders the component with optional tracing instrumentation.
     ///
@@ -624,43 +556,38 @@ pub trait Component: Sized {
     /// around the [`view`](Component::view) call with the component type name
     /// and render area dimensions. When the feature is disabled, this is
     /// identical to calling `view` directly.
-    fn traced_view(
-        state: &Self::State,
-        frame: &mut Frame,
-        area: Rect,
-        theme: &Theme,
-        ctx: &ViewContext,
-    ) {
+    fn traced_view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         #[cfg(feature = "tracing")]
         let _span = tracing::trace_span!(
             "component_view",
             component = std::any::type_name::<Self>(),
-            area.x = area.x,
-            area.y = area.y,
-            area.width = area.width,
-            area.height = area.height,
+            area.x = ctx.area.x,
+            area.y = ctx.area.y,
+            area.width = ctx.area.width,
+            area.height = ctx.area.height,
         )
         .entered();
-        Self::view(state, frame, area, theme, ctx);
+        Self::view(state, ctx);
     }
 
     /// Maps an input event to a component message.
     ///
     /// This is the read-only half of event handling. It inspects the
-    /// component's state, the incoming event, and the [`ViewContext`]
+    /// component's state, the incoming event, and the [`EventContext`]
     /// (which carries focused/disabled state from the parent), and
     /// returns an appropriate message if the event is relevant.
     ///
     /// Components should check `ctx.focused` and `ctx.disabled` to
-    /// decide whether to process the event. The same `ctx` should be
-    /// passed to both `handle_event` and [`view`](Component::view) so
-    /// that visual state and event routing are always consistent.
+    /// decide whether to process the event. The same focus/disabled
+    /// state should be passed to both `handle_event` and
+    /// [`view`](Component::view) (via the [`RenderContext`]) so that
+    /// visual state and event routing are always consistent.
     ///
     /// The default implementation returns `None` (ignores all events).
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         let _ = (state, event, ctx);
         None
@@ -677,7 +604,7 @@ pub trait Component: Sized {
     fn dispatch_event(
         state: &mut Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Output> {
         #[cfg(feature = "tracing")]
         let _span = tracing::debug_span!(
@@ -712,9 +639,7 @@ pub trait Component: Sized {
 /// # Example
 ///
 /// ```rust
-/// use envision::component::{Component, Toggleable, ViewContext};
-/// use envision::theme::Theme;
-/// use ratatui::prelude::*;
+/// use envision::component::{Component, RenderContext, Toggleable};
 ///
 /// struct HelpPanel;
 ///
@@ -735,7 +660,7 @@ pub trait Component: Sized {
 /// #     type Output = HelpPanelOutput;
 /// #     fn init() -> Self::State { HelpPanelState { visible: false, content: String::new() } }
 /// #     fn update(_: &mut Self::State, _: Self::Message) -> Option<Self::Output> { None }
-/// #     fn view(_: &Self::State, _: &mut Frame, _: Rect, _: &Theme, _: &ViewContext) {}
+/// #     fn view(_: &Self::State, _: &mut RenderContext<'_, '_>) {}
 /// # }
 /// #
 /// impl Toggleable for HelpPanel {

--- a/src/component/multi_progress/mod.rs
+++ b/src/component/multi_progress/mod.rs
@@ -32,12 +32,10 @@ mod types;
 
 pub use types::*;
 
-use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 /// State for the MultiProgress component.
 #[derive(Clone, Debug, PartialEq)]
@@ -702,7 +700,7 @@ impl Component for MultiProgress {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -719,14 +717,14 @@ impl Component for MultiProgress {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        if area.width == 0 || area.height == 0 {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        if ctx.area.width == 0 || ctx.area.height == 0 {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::new(crate::annotation::WidgetType::MultiProgress)
                     .with_id("multi_progress")
                     .with_meta("item_count", state.items.len().to_string()),
@@ -739,8 +737,8 @@ impl Component for MultiProgress {
             Block::default().borders(Borders::ALL)
         };
 
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
+        let inner = block.inner(ctx.area);
+        ctx.frame.render_widget(block, ctx.area);
 
         if state.items.is_empty() || inner.height == 0 {
             return;
@@ -758,9 +756,9 @@ impl Component for MultiProgress {
             .map(|item| {
                 let symbol = item.status.symbol();
                 let style = if ctx.disabled {
-                    theme.disabled_style()
+                    ctx.theme.disabled_style()
                 } else {
-                    item.status.style(theme)
+                    item.status.style(ctx.theme)
                 };
 
                 // Build the content string
@@ -791,7 +789,7 @@ impl Component for MultiProgress {
             .collect();
 
         let list = List::new(items);
-        frame.render_widget(list, inner);
+        ctx.frame.render_widget(list, inner);
     }
 }
 

--- a/src/component/multi_progress/snapshot_tests.rs
+++ b/src/component/multi_progress/snapshot_tests.rs
@@ -11,7 +11,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            MultiProgress::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -26,7 +26,7 @@ fn test_snapshot_with_items() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            MultiProgress::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -54,7 +54,7 @@ fn test_snapshot_active_progress() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            MultiProgress::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -84,7 +84,7 @@ fn test_snapshot_completed_and_failed() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            MultiProgress::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -98,7 +98,7 @@ fn test_snapshot_without_percentages() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            MultiProgress::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -113,10 +113,7 @@ fn test_snapshot_disabled() {
         .draw(|frame| {
             MultiProgress::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();

--- a/src/component/multi_progress/tests/component.rs
+++ b/src/component/multi_progress/tests/component.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::theme::Theme;
+use ratatui::layout::Rect;
 
 // ========================================
 // Component Tests
@@ -241,7 +243,7 @@ fn test_view_empty() {
 
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            MultiProgress::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
 
@@ -266,7 +268,7 @@ fn test_view_with_items() {
 
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            MultiProgress::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
 
@@ -280,7 +282,7 @@ fn test_view_with_title() {
 
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            MultiProgress::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
 
@@ -304,7 +306,7 @@ fn test_view_failed_item() {
 
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            MultiProgress::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
 
@@ -325,7 +327,7 @@ fn test_view_completed_item() {
 
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            MultiProgress::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
 
@@ -347,10 +349,7 @@ fn test_view_zero_size_area() {
         .draw(|frame| {
             MultiProgress::view(
                 &state,
-                frame,
-                Rect::new(0, 0, 0, 10),
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, Rect::new(0, 0, 0, 10), &theme),
             );
         })
         .unwrap();
@@ -360,10 +359,7 @@ fn test_view_zero_size_area() {
         .draw(|frame| {
             MultiProgress::view(
                 &state,
-                frame,
-                Rect::new(0, 0, 60, 0),
-                &Theme::default(),
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, Rect::new(0, 0, 60, 0), &Theme::default()),
             );
         })
         .unwrap();
@@ -378,7 +374,7 @@ fn test_view_without_percentages() {
 
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            MultiProgress::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
 
@@ -402,7 +398,7 @@ fn test_view_failed_without_message() {
 
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            MultiProgress::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
 
@@ -586,7 +582,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                MultiProgress::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/multi_progress/tests/events.rs
+++ b/src/component/multi_progress/tests/events.rs
@@ -12,13 +12,16 @@ fn test_handle_event_scroll_up() {
     let msg = MultiProgress::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(MultiProgressMessage::ScrollUp));
 
     // Vim 'k' -> ScrollUp
-    let msg =
-        MultiProgress::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true));
+    let msg = MultiProgress::handle_event(
+        &state,
+        &Event::char('k'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(MultiProgressMessage::ScrollUp));
 }
 
@@ -30,13 +33,16 @@ fn test_handle_event_scroll_down() {
     let msg = MultiProgress::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(MultiProgressMessage::ScrollDown));
 
     // Vim 'j' -> ScrollDown
-    let msg =
-        MultiProgress::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true));
+    let msg = MultiProgress::handle_event(
+        &state,
+        &Event::char('j'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(MultiProgressMessage::ScrollDown));
 }
 
@@ -44,7 +50,7 @@ fn test_handle_event_scroll_down() {
 fn test_handle_event_ignored_when_unfocused() {
     let state = MultiProgressState::new();
     let msg =
-        MultiProgress::handle_event(&state, &Event::key(KeyCode::Up), &ViewContext::default());
+        MultiProgress::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -64,7 +70,7 @@ fn test_dispatch_event() {
     MultiProgress::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(state.selected(), Some(6));
 }
@@ -85,7 +91,7 @@ fn test_instance_methods() {
     let msg = MultiProgress::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(MultiProgressMessage::ScrollUp));
 
@@ -97,7 +103,7 @@ fn test_instance_methods() {
     MultiProgress::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(state.selected(), Some(3));
 }
@@ -113,28 +119,28 @@ fn test_handle_event_ignored_when_disabled() {
     let msg = MultiProgress::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = MultiProgress::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = MultiProgress::handle_event(
         &state,
         &Event::char('k'),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = MultiProgress::handle_event(
         &state,
         &Event::char('j'),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -150,7 +156,7 @@ fn test_dispatch_event_ignored_when_disabled() {
     MultiProgress::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(state.selected(), Some(5)); // Should not change
 }
@@ -166,28 +172,28 @@ fn test_handle_event_unrecognized_key() {
     let msg = MultiProgress::handle_event(
         &state,
         &Event::key(KeyCode::Tab),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
 
     let msg = MultiProgress::handle_event(
         &state,
         &Event::key(KeyCode::Esc),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
 
     let msg = MultiProgress::handle_event(
         &state,
         &Event::key(KeyCode::Home),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
 
     let msg = MultiProgress::handle_event(
         &state,
         &Event::key(KeyCode::End),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
 }
@@ -196,16 +202,25 @@ fn test_handle_event_unrecognized_key() {
 fn test_handle_event_unrecognized_char() {
     let state = MultiProgressState::new();
 
-    let msg =
-        MultiProgress::handle_event(&state, &Event::char('a'), &ViewContext::new().focused(true));
+    let msg = MultiProgress::handle_event(
+        &state,
+        &Event::char('a'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, None);
 
-    let msg =
-        MultiProgress::handle_event(&state, &Event::char('z'), &ViewContext::new().focused(true));
+    let msg = MultiProgress::handle_event(
+        &state,
+        &Event::char('z'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, None);
 
-    let msg =
-        MultiProgress::handle_event(&state, &Event::char('q'), &ViewContext::new().focused(true));
+    let msg = MultiProgress::handle_event(
+        &state,
+        &Event::char('q'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, None);
 }
 
@@ -216,7 +231,7 @@ fn test_handle_event_instance_unrecognized() {
     let msg = MultiProgress::handle_event(
         &state,
         &Event::key(KeyCode::Tab),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
 }
@@ -232,7 +247,7 @@ fn test_dispatch_event_unrecognized_returns_none() {
     let output = MultiProgress::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Tab),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert!(output.is_none());
 }
@@ -245,7 +260,7 @@ fn test_dispatch_event_unfocused_returns_none() {
     let output = MultiProgress::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Up),
-        &ViewContext::default(),
+        &EventContext::default(),
     );
     assert!(output.is_none());
 }
@@ -265,7 +280,7 @@ fn test_dispatch_event_scroll_up() {
     MultiProgress::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(state.selected(), Some(4));
 }
@@ -281,7 +296,7 @@ fn test_dispatch_event_scroll_up_vim_k() {
     MultiProgress::dispatch_event(
         &mut state,
         &Event::char('k'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(state.selected(), Some(4));
 }
@@ -297,7 +312,7 @@ fn test_dispatch_event_scroll_down_vim_j() {
     MultiProgress::dispatch_event(
         &mut state,
         &Event::char('j'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(state.selected(), Some(4));
 }
@@ -313,7 +328,7 @@ fn test_instance_dispatch_event_scroll_up() {
     MultiProgress::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(state.selected(), Some(4));
 }
@@ -355,7 +370,7 @@ fn test_handle_event_enter_produces_select() {
     let msg = MultiProgress::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(MultiProgressMessage::Select));
 }
@@ -412,7 +427,7 @@ fn test_dispatch_event_enter_selects_item() {
     let output = MultiProgress::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(MultiProgressOutput::Selected(1)));
 }
@@ -424,7 +439,7 @@ fn test_instance_handle_event_enter() {
     let msg = MultiProgress::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(MultiProgressMessage::Select));
 }
@@ -437,7 +452,7 @@ fn test_instance_dispatch_event_enter() {
     let output = MultiProgress::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(MultiProgressOutput::Selected(0)));
 }

--- a/src/component/multi_progress/tests/item.rs
+++ b/src/component/multi_progress/tests/item.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::theme::Theme;
 
 // ========================================
 // ProgressItemStatus Tests

--- a/src/component/multi_progress/tests/workflow.rs
+++ b/src/component/multi_progress/tests/workflow.rs
@@ -401,7 +401,7 @@ fn test_view_multiple_items_mixed_states() {
 
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            MultiProgress::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
 
@@ -427,10 +427,7 @@ fn test_view_disabled_state() {
         .draw(|frame| {
             MultiProgress::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             )
         })
         .unwrap();
@@ -455,7 +452,7 @@ fn test_view_single_item_full_progress() {
 
     terminal
         .draw(|frame| {
-            MultiProgress::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            MultiProgress::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
 

--- a/src/component/number_input/mod.rs
+++ b/src/component/number_input/mod.rs
@@ -33,9 +33,8 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 /// Messages that can be sent to a NumberInput.
 #[derive(Clone, Debug, PartialEq)]
@@ -532,7 +531,7 @@ impl Component for NumberInput {
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -564,15 +563,15 @@ impl Component for NumberInput {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        if area.width == 0 || area.height == 0 {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        if ctx.area.width == 0 || ctx.area.height == 0 {
             return;
         }
 
         let border_style = if ctx.focused {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let block = Block::default()
@@ -580,11 +579,11 @@ impl Component for NumberInput {
             .border_style(border_style);
 
         let content_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_style()
+            ctx.theme.focused_style()
         } else {
-            theme.normal_style()
+            ctx.theme.normal_style()
         };
 
         // Build the display text
@@ -632,7 +631,7 @@ impl Component for NumberInput {
         let annotated = crate::annotation::Annotate::new(paragraph, annotation)
             .focused(ctx.focused)
             .disabled(ctx.disabled);
-        frame.render_widget(annotated, area);
+        ctx.frame.render_widget(annotated, ctx.area);
     }
 }
 

--- a/src/component/number_input/tests.rs
+++ b/src/component/number_input/tests.rs
@@ -480,7 +480,7 @@ fn test_handle_event_up_increments() {
     let msg = NumberInput::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(NumberInputMessage::Increment));
 }
@@ -491,7 +491,7 @@ fn test_handle_event_down_decrements() {
     let msg = NumberInput::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(NumberInputMessage::Decrement));
 }
@@ -499,16 +499,22 @@ fn test_handle_event_down_decrements() {
 #[test]
 fn test_handle_event_k_increments() {
     let state = NumberInputState::new(0.0);
-    let msg =
-        NumberInput::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true));
+    let msg = NumberInput::handle_event(
+        &state,
+        &Event::char('k'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(NumberInputMessage::Increment));
 }
 
 #[test]
 fn test_handle_event_j_decrements() {
     let state = NumberInputState::new(0.0);
-    let msg =
-        NumberInput::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true));
+    let msg = NumberInput::handle_event(
+        &state,
+        &Event::char('j'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(NumberInputMessage::Decrement));
 }
 
@@ -518,7 +524,7 @@ fn test_handle_event_enter_starts_edit() {
     let msg = NumberInput::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(NumberInputMessage::StartEdit));
 }
@@ -526,8 +532,11 @@ fn test_handle_event_enter_starts_edit() {
 #[test]
 fn test_handle_event_unrelated_key() {
     let state = NumberInputState::new(0.0);
-    let msg =
-        NumberInput::handle_event(&state, &Event::char('q'), &ViewContext::new().focused(true));
+    let msg = NumberInput::handle_event(
+        &state,
+        &Event::char('q'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, None);
 }
 
@@ -540,8 +549,11 @@ fn test_handle_event_edit_mode_char() {
     let mut state = NumberInputState::new(0.0);
     state.editing = true;
     state.edit_buffer.clear();
-    let msg =
-        NumberInput::handle_event(&state, &Event::char('5'), &ViewContext::new().focused(true));
+    let msg = NumberInput::handle_event(
+        &state,
+        &Event::char('5'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(NumberInputMessage::EditChar('5')));
 }
 
@@ -550,8 +562,11 @@ fn test_handle_event_edit_mode_decimal() {
     let mut state = NumberInputState::new(0.0);
     state.editing = true;
     state.edit_buffer = "3".to_string();
-    let msg =
-        NumberInput::handle_event(&state, &Event::char('.'), &ViewContext::new().focused(true));
+    let msg = NumberInput::handle_event(
+        &state,
+        &Event::char('.'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(NumberInputMessage::EditChar('.')));
 }
 
@@ -560,8 +575,11 @@ fn test_handle_event_edit_mode_minus() {
     let mut state = NumberInputState::new(0.0);
     state.editing = true;
     state.edit_buffer.clear();
-    let msg =
-        NumberInput::handle_event(&state, &Event::char('-'), &ViewContext::new().focused(true));
+    let msg = NumberInput::handle_event(
+        &state,
+        &Event::char('-'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(NumberInputMessage::EditChar('-')));
 }
 
@@ -572,7 +590,7 @@ fn test_handle_event_edit_mode_enter_confirms() {
     let msg = NumberInput::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(NumberInputMessage::ConfirmEdit));
 }
@@ -584,7 +602,7 @@ fn test_handle_event_edit_mode_escape_cancels() {
     let msg = NumberInput::handle_event(
         &state,
         &Event::key(KeyCode::Esc),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(NumberInputMessage::CancelEdit));
 }
@@ -596,7 +614,7 @@ fn test_handle_event_edit_mode_backspace() {
     let msg = NumberInput::handle_event(
         &state,
         &Event::key(KeyCode::Backspace),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(NumberInputMessage::EditBackspace));
 }
@@ -606,8 +624,11 @@ fn test_handle_event_edit_mode_rejects_letter() {
     let mut state = NumberInputState::new(0.0);
     state.editing = true;
     state.edit_buffer.clear();
-    let msg =
-        NumberInput::handle_event(&state, &Event::char('a'), &ViewContext::new().focused(true));
+    let msg = NumberInput::handle_event(
+        &state,
+        &Event::char('a'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, None);
 }
 
@@ -616,8 +637,11 @@ fn test_handle_event_edit_mode_rejects_duplicate_decimal() {
     let mut state = NumberInputState::new(0.0);
     state.editing = true;
     state.edit_buffer = "3.1".to_string();
-    let msg =
-        NumberInput::handle_event(&state, &Event::char('.'), &ViewContext::new().focused(true));
+    let msg = NumberInput::handle_event(
+        &state,
+        &Event::char('.'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, None);
 }
 
@@ -626,8 +650,11 @@ fn test_handle_event_edit_mode_rejects_non_leading_minus() {
     let mut state = NumberInputState::new(0.0);
     state.editing = true;
     state.edit_buffer = "5".to_string();
-    let msg =
-        NumberInput::handle_event(&state, &Event::char('-'), &ViewContext::new().focused(true));
+    let msg = NumberInput::handle_event(
+        &state,
+        &Event::char('-'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, None);
 }
 
@@ -638,7 +665,7 @@ fn test_handle_event_edit_mode_rejects_non_leading_minus() {
 #[test]
 fn test_handle_event_unfocused() {
     let state = NumberInputState::new(0.0);
-    let msg = NumberInput::handle_event(&state, &Event::key(KeyCode::Up), &ViewContext::default());
+    let msg = NumberInput::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -648,7 +675,7 @@ fn test_handle_event_disabled() {
     let msg = NumberInput::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -660,7 +687,7 @@ fn test_handle_event_disabled_edit_mode() {
     let msg = NumberInput::handle_event(
         &state,
         &Event::char('5'),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -675,7 +702,7 @@ fn test_dispatch_event_increment() {
     let output = NumberInput::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(NumberInputOutput::ValueChanged(1.0)));
     assert_eq!(state.value(), 1.0);
@@ -687,7 +714,7 @@ fn test_dispatch_event_unfocused() {
     let output = NumberInput::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Up),
-        &ViewContext::default(),
+        &EventContext::default(),
     );
     assert_eq!(output, None);
     assert_eq!(state.value(), 0.0);
@@ -701,7 +728,7 @@ fn test_dispatch_event_enter_then_type() {
     let output = NumberInput::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(NumberInputOutput::EditStarted));
     assert!(state.is_editing());
@@ -710,7 +737,7 @@ fn test_dispatch_event_enter_then_type() {
     let output = NumberInput::dispatch_event(
         &mut state,
         &Event::char('5'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, None);
     assert_eq!(state.edit_buffer(), "05");
@@ -726,7 +753,7 @@ fn test_instance_handle_event() {
     let msg = NumberInput::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(NumberInputMessage::Increment));
 }
@@ -737,7 +764,7 @@ fn test_instance_dispatch_event() {
     let output = NumberInput::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(NumberInputOutput::ValueChanged(1.0)));
 }

--- a/src/component/number_input/view_tests.rs
+++ b/src/component/number_input/view_tests.rs
@@ -11,7 +11,7 @@ fn test_view_normal() {
 
     terminal
         .draw(|frame| {
-            NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            NumberInput::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -27,10 +27,7 @@ fn test_view_focused() {
         .draw(|frame| {
             NumberInput::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -45,7 +42,7 @@ fn test_view_with_label() {
 
     terminal
         .draw(|frame| {
-            NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            NumberInput::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -62,10 +59,7 @@ fn test_view_editing() {
         .draw(|frame| {
             NumberInput::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -83,10 +77,7 @@ fn test_view_editing_with_label() {
         .draw(|frame| {
             NumberInput::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -103,10 +94,7 @@ fn test_view_disabled() {
         .draw(|frame| {
             NumberInput::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -121,7 +109,7 @@ fn test_view_negative_value() {
 
     terminal
         .draw(|frame| {
-            NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            NumberInput::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -135,7 +123,7 @@ fn test_view_float_precision() {
 
     terminal
         .draw(|frame| {
-            NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            NumberInput::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -150,7 +138,7 @@ fn test_view_zero_area() {
     // Should not panic
     terminal
         .draw(|frame| {
-            NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            NumberInput::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -167,7 +155,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                NumberInput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                NumberInput::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -188,10 +176,7 @@ fn test_annotation_focused() {
             .draw(|frame| {
                 NumberInput::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
                 );
             })
             .unwrap();
@@ -211,10 +196,7 @@ fn test_annotation_disabled() {
             .draw(|frame| {
                 NumberInput::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().disabled(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
                 );
             })
             .unwrap();

--- a/src/component/paginator/mod.rs
+++ b/src/component/paginator/mod.rs
@@ -39,7 +39,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -483,7 +483,7 @@ impl Component for Paginator {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -555,10 +555,10 @@ impl Component for Paginator {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::paginator("paginator")
                     .with_focus(ctx.focused)
                     .with_disabled(ctx.disabled)
@@ -567,11 +567,11 @@ impl Component for Paginator {
         });
 
         let text_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_style()
+            ctx.theme.focused_style()
         } else {
-            theme.normal_style()
+            ctx.theme.normal_style()
         };
 
         let content = match &state.style {
@@ -593,20 +593,20 @@ impl Component for Paginator {
                 }
             }
             PaginatorStyle::Dots => render_dots(state),
-            PaginatorStyle::Compact => render_compact(state, theme),
+            PaginatorStyle::Compact => render_compact(state, ctx.theme),
         };
 
         // For Compact style, we need special span-based rendering for arrow dimming
         if state.style == PaginatorStyle::Compact {
-            let spans = render_compact_spans(state, theme, ctx);
+            let spans = render_compact_spans(state, ctx.theme, &ctx.event_context());
             let line = Line::from(spans);
             let paragraph = Paragraph::new(line).alignment(Alignment::Center);
-            frame.render_widget(paragraph, area);
+            ctx.frame.render_widget(paragraph, ctx.area);
         } else {
             let paragraph = Paragraph::new(content)
                 .style(text_style)
                 .alignment(Alignment::Center);
-            frame.render_widget(paragraph, area);
+            ctx.frame.render_widget(paragraph, ctx.area);
         }
     }
 }
@@ -714,7 +714,7 @@ fn render_compact(state: &PaginatorState, _theme: &Theme) -> String {
 fn render_compact_spans<'a>(
     state: &PaginatorState,
     theme: &Theme,
-    ctx: &ViewContext,
+    ctx: &EventContext,
 ) -> Vec<Span<'a>> {
     let text_style = if ctx.disabled {
         theme.disabled_style()

--- a/src/component/paginator/tests.rs
+++ b/src/component/paginator/tests.rs
@@ -322,7 +322,7 @@ fn test_handle_event_right_next() {
     let msg = Paginator::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(PaginatorMessage::NextPage));
 }
@@ -330,7 +330,11 @@ fn test_handle_event_right_next() {
 #[test]
 fn test_handle_event_l_next() {
     let state = focused_state(5);
-    let msg = Paginator::handle_event(&state, &Event::char('l'), &ViewContext::new().focused(true));
+    let msg = Paginator::handle_event(
+        &state,
+        &Event::char('l'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(PaginatorMessage::NextPage));
 }
 
@@ -340,7 +344,7 @@ fn test_handle_event_left_prev() {
     let msg = Paginator::handle_event(
         &state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(PaginatorMessage::PrevPage));
 }
@@ -348,7 +352,11 @@ fn test_handle_event_left_prev() {
 #[test]
 fn test_handle_event_h_prev() {
     let state = focused_state(5);
-    let msg = Paginator::handle_event(&state, &Event::char('h'), &ViewContext::new().focused(true));
+    let msg = Paginator::handle_event(
+        &state,
+        &Event::char('h'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(PaginatorMessage::PrevPage));
 }
 
@@ -358,7 +366,7 @@ fn test_handle_event_home() {
     let msg = Paginator::handle_event(
         &state,
         &Event::key(KeyCode::Home),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(PaginatorMessage::FirstPage));
 }
@@ -369,7 +377,7 @@ fn test_handle_event_end() {
     let msg = Paginator::handle_event(
         &state,
         &Event::key(KeyCode::End),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(PaginatorMessage::LastPage));
 }
@@ -377,14 +385,22 @@ fn test_handle_event_end() {
 #[test]
 fn test_handle_event_unrecognized() {
     let state = focused_state(5);
-    let msg = Paginator::handle_event(&state, &Event::char('x'), &ViewContext::new().focused(true));
+    let msg = Paginator::handle_event(
+        &state,
+        &Event::char('x'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, None);
 }
 
 #[test]
 fn test_handle_event_unfocused_ignores() {
     let state = PaginatorState::new(5);
-    let msg = Paginator::handle_event(&state, &Event::key(KeyCode::Right), &ViewContext::default());
+    let msg = Paginator::handle_event(
+        &state,
+        &Event::key(KeyCode::Right),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 }
 
@@ -394,7 +410,7 @@ fn test_handle_event_disabled_ignores() {
     let msg = Paginator::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -409,7 +425,7 @@ fn test_instance_handle_event() {
     let msg = Paginator::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(PaginatorMessage::NextPage));
 }
@@ -420,7 +436,7 @@ fn test_instance_dispatch_event() {
     let output = Paginator::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(PaginatorOutput::PageChanged(1)));
     assert_eq!(state.current_page(), 1);
@@ -530,7 +546,7 @@ fn test_view_page_of_total_first_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Paginator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -542,7 +558,7 @@ fn test_view_page_of_total_middle_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Paginator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -554,7 +570,7 @@ fn test_view_page_of_total_last_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Paginator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -570,7 +586,7 @@ fn test_view_range_of_total_first_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Paginator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -584,7 +600,7 @@ fn test_view_range_of_total_middle_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Paginator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -598,7 +614,7 @@ fn test_view_range_of_total_last_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Paginator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -610,7 +626,7 @@ fn test_view_range_of_total_zero_items() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Paginator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -626,7 +642,7 @@ fn test_view_dots_first_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Paginator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -640,7 +656,7 @@ fn test_view_dots_middle_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Paginator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -654,7 +670,7 @@ fn test_view_dots_last_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Paginator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -666,7 +682,7 @@ fn test_view_dots_single_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Paginator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -680,7 +696,7 @@ fn test_view_dots_many_pages() {
     let (mut terminal, theme) = test_utils::setup_render(50, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Paginator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -696,7 +712,7 @@ fn test_view_compact_first_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Paginator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -710,7 +726,7 @@ fn test_view_compact_middle_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Paginator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -724,7 +740,7 @@ fn test_view_compact_last_page() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Paginator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -740,7 +756,7 @@ fn test_view_focused() {
     let (mut terminal, theme) = test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Paginator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -754,10 +770,7 @@ fn test_view_disabled() {
         .draw(|frame| {
             Paginator::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -776,7 +789,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Paginator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -798,10 +811,7 @@ fn test_annotation_focused() {
             .draw(|frame| {
                 Paginator::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
                 );
             })
             .unwrap();

--- a/src/component/pane_layout/mod.rs
+++ b/src/component/pane_layout/mod.rs
@@ -39,9 +39,8 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
-use crate::theme::Theme;
 
 /// The direction in which panes are arranged.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -797,7 +796,7 @@ impl Component for PaneLayout {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -906,10 +905,10 @@ impl Component for PaneLayout {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::new(crate::annotation::WidgetType::PaneLayout)
                     .with_id("pane_layout")
                     .with_focus(ctx.focused)
@@ -917,16 +916,16 @@ impl Component for PaneLayout {
             );
         });
 
-        let rects = state.layout(area);
+        let rects = state.layout(ctx.area);
 
         for (i, (pane, rect)) in state.panes.iter().zip(rects.iter()).enumerate() {
             let is_focused_pane = ctx.focused && i == state.focused_pane;
             let border_style = if ctx.disabled {
-                theme.disabled_style()
+                ctx.theme.disabled_style()
             } else if is_focused_pane {
-                theme.focused_border_style()
+                ctx.theme.focused_border_style()
             } else {
-                theme.border_style()
+                ctx.theme.border_style()
             };
 
             let mut block = Block::default()
@@ -937,7 +936,7 @@ impl Component for PaneLayout {
                 block = block.title(format!(" {} ", title));
             }
 
-            frame.render_widget(block, *rect);
+            ctx.frame.render_widget(block, *rect);
         }
     }
 }

--- a/src/component/pane_layout/tests.rs
+++ b/src/component/pane_layout/tests.rs
@@ -500,7 +500,7 @@ fn test_handle_event_tab() {
     let msg = PaneLayout::handle_event(
         &state,
         &Event::key(KeyCode::Tab),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(PaneLayoutMessage::FocusNext));
 }
@@ -512,7 +512,7 @@ fn test_handle_event_backtab() {
     let msg = PaneLayout::handle_event(
         &state,
         &Event::key(KeyCode::BackTab),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(PaneLayoutMessage::FocusPrev));
 }
@@ -524,7 +524,7 @@ fn test_handle_event_ctrl_right() {
     let msg = PaneLayout::handle_event(
         &state,
         &Event::key_with(KeyCode::Right, KeyModifiers::CONTROL),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(PaneLayoutMessage::GrowFocused));
 }
@@ -536,7 +536,7 @@ fn test_handle_event_ctrl_left() {
     let msg = PaneLayout::handle_event(
         &state,
         &Event::key_with(KeyCode::Left, KeyModifiers::CONTROL),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(PaneLayoutMessage::ShrinkFocused));
 }
@@ -545,8 +545,11 @@ fn test_handle_event_ctrl_left() {
 fn test_handle_event_ctrl_0() {
     let panes = vec![PaneConfig::new("a"), PaneConfig::new("b")];
     let state = PaneLayoutState::new(PaneDirection::Horizontal, panes);
-    let msg =
-        PaneLayout::handle_event(&state, &Event::ctrl('0'), &ViewContext::new().focused(true));
+    let msg = PaneLayout::handle_event(
+        &state,
+        &Event::ctrl('0'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(PaneLayoutMessage::ResetProportions));
 }
 
@@ -554,7 +557,7 @@ fn test_handle_event_ctrl_0() {
 fn test_handle_event_unfocused_ignored() {
     let panes = vec![PaneConfig::new("a")];
     let state = PaneLayoutState::new(PaneDirection::Horizontal, panes);
-    let msg = PaneLayout::handle_event(&state, &Event::key(KeyCode::Tab), &ViewContext::default());
+    let msg = PaneLayout::handle_event(&state, &Event::key(KeyCode::Tab), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -565,7 +568,7 @@ fn test_handle_event_disabled_ignored() {
     let msg = PaneLayout::handle_event(
         &state,
         &Event::key(KeyCode::Tab),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -574,8 +577,11 @@ fn test_handle_event_disabled_ignored() {
 fn test_handle_event_unrecognized() {
     let panes = vec![PaneConfig::new("a")];
     let state = PaneLayoutState::new(PaneDirection::Horizontal, panes);
-    let msg =
-        PaneLayout::handle_event(&state, &Event::char('z'), &ViewContext::new().focused(true));
+    let msg = PaneLayout::handle_event(
+        &state,
+        &Event::char('z'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, None);
 }
 
@@ -588,7 +594,7 @@ fn test_dispatch_event() {
     let output = PaneLayout::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Tab),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert!(matches!(
         output,
@@ -625,7 +631,7 @@ fn test_view_two_panes_horizontal() {
 
     terminal
         .draw(|frame| {
-            PaneLayout::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            PaneLayout::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -644,7 +650,7 @@ fn test_view_two_panes_vertical() {
 
     terminal
         .draw(|frame| {
-            PaneLayout::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            PaneLayout::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -667,10 +673,7 @@ fn test_view_three_panes_focused() {
         .draw(|frame| {
             PaneLayout::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -686,7 +689,7 @@ fn test_view_empty_panes() {
 
     terminal
         .draw(|frame| {
-            PaneLayout::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            PaneLayout::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -707,10 +710,7 @@ fn test_annotation_emission() {
             .draw(|frame| {
                 PaneLayout::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
                 );
             })
             .unwrap();

--- a/src/component/progress_bar/mod.rs
+++ b/src/component/progress_bar/mod.rs
@@ -34,11 +34,9 @@
 
 use std::time::Duration;
 
-use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Gauge};
 
-use super::{Component, ViewContext};
-use crate::theme::Theme;
+use super::{Component, RenderContext};
 
 /// Messages that can be sent to a ProgressBar.
 #[derive(Clone, Debug, PartialEq)]
@@ -599,12 +597,12 @@ impl Component for ProgressBar {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         let label = build_label(state);
 
         let gauge = Gauge::default()
             .block(Block::default().borders(Borders::ALL))
-            .gauge_style(theme.progress_filled_style())
+            .gauge_style(ctx.theme.progress_filled_style())
             .percent(state.percentage())
             .label(label.clone());
 
@@ -614,7 +612,7 @@ impl Component for ProgressBar {
                 .with_label(label)
                 .with_value(format!("{}%", state.percentage()));
         let annotated = crate::annotation::Annotate::new(gauge, annotation);
-        frame.render_widget(annotated, area);
+        ctx.frame.render_widget(annotated, ctx.area);
     }
 }
 

--- a/src/component/progress_bar/tests.rs
+++ b/src/component/progress_bar/tests.rs
@@ -195,7 +195,7 @@ fn test_view_zero_progress() {
 
     terminal
         .draw(|frame| {
-            ProgressBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ProgressBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -209,7 +209,7 @@ fn test_view_half_progress() {
 
     terminal
         .draw(|frame| {
-            ProgressBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ProgressBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -223,7 +223,7 @@ fn test_view_full_progress() {
 
     terminal
         .draw(|frame| {
-            ProgressBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ProgressBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -238,7 +238,7 @@ fn test_view_renders() {
 
     terminal
         .draw(|frame| {
-            ProgressBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ProgressBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -252,7 +252,7 @@ fn test_view_without_label() {
 
     terminal
         .draw(|frame| {
-            ProgressBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ProgressBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -546,7 +546,7 @@ fn test_view_with_eta_and_rate() {
 
     terminal
         .draw(|frame| {
-            ProgressBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ProgressBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -564,7 +564,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                ProgressBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                ProgressBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/radio_group/mod.rs
+++ b/src/component/radio_group/mod.rs
@@ -28,12 +28,10 @@
 
 use std::marker::PhantomData;
 
-use ratatui::prelude::*;
 use ratatui::widgets::{List, ListItem};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 /// Messages that can be sent to a RadioGroup.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -331,7 +329,7 @@ impl<T: Clone + std::fmt::Display + 'static> Component for RadioGroup<T> {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -382,7 +380,7 @@ impl<T: Clone + std::fmt::Display + 'static> Component for RadioGroup<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         let items: Vec<ListItem> = state
             .options
             .iter()
@@ -393,11 +391,11 @@ impl<T: Clone + std::fmt::Display + 'static> Component for RadioGroup<T> {
                 let text = format!("{} {}", indicator, option);
 
                 let style = if ctx.disabled {
-                    theme.disabled_style()
+                    ctx.theme.disabled_style()
                 } else if is_selected && ctx.focused {
-                    theme.focused_style()
+                    ctx.theme.focused_style()
                 } else {
-                    theme.normal_style()
+                    ctx.theme.normal_style()
                 };
 
                 ListItem::new(text).style(style)
@@ -414,7 +412,7 @@ impl<T: Clone + std::fmt::Display + 'static> Component for RadioGroup<T> {
             ann = ann.with_selected(true).with_value(idx.to_string());
         }
         let annotated = crate::annotation::Annotate::new(list, ann);
-        frame.render_widget(annotated, area);
+        ctx.frame.render_widget(annotated, ctx.area);
     }
 }
 

--- a/src/component/radio_group/tests.rs
+++ b/src/component/radio_group/tests.rs
@@ -157,10 +157,7 @@ fn test_view_renders_indicators() {
         .draw(|frame| {
             RadioGroup::<&str>::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -190,7 +187,7 @@ fn test_view_unfocused() {
 
     terminal
         .draw(|frame| {
-            RadioGroup::<&str>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            RadioGroup::<&str>::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -207,10 +204,7 @@ fn test_view_focused_not_selected() {
         .draw(|frame| {
             RadioGroup::<&str>::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -278,7 +272,7 @@ fn test_handle_event_up() {
     let msg = RadioGroup::<String>::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(RadioGroupMessage::Up));
 }
@@ -289,7 +283,7 @@ fn test_handle_event_down() {
     let msg = RadioGroup::<String>::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(RadioGroupMessage::Down));
 }
@@ -300,7 +294,7 @@ fn test_handle_event_k() {
     let msg = RadioGroup::<String>::handle_event(
         &state,
         &Event::char('k'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(RadioGroupMessage::Up));
 }
@@ -311,7 +305,7 @@ fn test_handle_event_j() {
     let msg = RadioGroup::<String>::handle_event(
         &state,
         &Event::char('j'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(RadioGroupMessage::Down));
 }
@@ -322,7 +316,7 @@ fn test_handle_event_enter() {
     let msg = RadioGroup::<String>::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(RadioGroupMessage::Confirm));
 }
@@ -333,7 +327,7 @@ fn test_handle_event_ignored_when_unfocused() {
     let msg = RadioGroup::<String>::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::default(),
+        &EventContext::default(),
     );
     assert_eq!(msg, None);
 }
@@ -344,7 +338,7 @@ fn test_handle_event_ignored_when_disabled() {
     let msg = RadioGroup::<String>::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -355,7 +349,7 @@ fn test_dispatch_event_radio() {
     let output = RadioGroup::<String>::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(RadioGroupOutput::SelectionChanged(1)));
     assert_eq!(state.selected_index(), Some(1));
@@ -454,10 +448,7 @@ fn test_annotation_emitted() {
             .draw(|frame| {
                 RadioGroup::<String>::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::default(),
+                    &mut RenderContext::new(frame, frame.area(), &theme),
                 );
             })
             .unwrap();

--- a/src/component/router/mod.rs
+++ b/src/component/router/mod.rs
@@ -54,11 +54,7 @@
 //! }
 //! ```
 
-use ratatui::prelude::*;
-
-use super::Component;
-use super::ViewContext;
-use crate::theme::Theme;
+use super::{Component, RenderContext};
 
 /// Navigation mode for screen transitions.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -483,13 +479,7 @@ impl<S: Clone + PartialEq> Router<S> {
     ///
     /// Router is state-only, so this is a no-op. The parent application
     /// should render based on `state.current()`.
-    pub fn view(
-        _state: &RouterState<S>,
-        _frame: &mut Frame,
-        _area: Rect,
-        _theme: &Theme,
-        _ctx: &ViewContext,
-    ) {
+    pub fn view(_state: &RouterState<S>, _ctx: &mut RenderContext<'_, '_>) {
         // Router is state-only - no view implementation.
         // The parent application should render based on state.current()
     }
@@ -508,8 +498,8 @@ impl<S: Clone + PartialEq + Default> Component for Router<S> {
         Router::update(state, msg)
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
-        Router::view(state, frame, area, theme, &ViewContext::default())
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        Router::view(state, ctx)
     }
 }
 

--- a/src/component/router/snapshot_tests.rs
+++ b/src/component/router/snapshot_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::component::ViewContext;
+use crate::component::RenderContext;
 use crate::component::test_utils;
 
 /// Router is a state-only component with no visual output.
@@ -24,7 +24,7 @@ fn test_snapshot_initial_screen() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Router::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Router::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     // Router renders nothing -- the output should be blank
@@ -42,7 +42,7 @@ fn test_snapshot_after_navigation() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Router::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Router::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     // Router renders nothing -- the output should be blank
@@ -59,7 +59,7 @@ fn test_snapshot_after_back() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Router::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Router::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/router/tests.rs
+++ b/src/component/router/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::component::ViewContext;
+use crate::component::RenderContext;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 enum TestScreen {
@@ -304,7 +304,7 @@ fn test_view_is_noop() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(80, 24);
 
     terminal
-        .draw(|frame| Router::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| Router::view(&state, &mut RenderContext::new(frame, frame.area(), &theme)))
         .unwrap();
 
     // View should do nothing - output should be empty

--- a/src/component/scroll_view/mod.rs
+++ b/src/component/scroll_view/mod.rs
@@ -32,10 +32,9 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
-use crate::theme::Theme;
 
 /// Messages that can be sent to a ScrollView.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -446,7 +445,7 @@ impl Component for ScrollView {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -525,14 +524,14 @@ impl Component for ScrollView {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        if area.width == 0 || area.height == 0 {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        if ctx.area.width == 0 || ctx.area.height == 0 {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::new(crate::annotation::WidgetType::Custom(
                     "ScrollView".to_string(),
                 ))
@@ -543,11 +542,11 @@ impl Component for ScrollView {
         });
 
         let border_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let mut block = Block::default()
@@ -558,8 +557,8 @@ impl Component for ScrollView {
             block = block.title(title.as_str());
         }
 
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
+        let inner = block.inner(ctx.area);
+        ctx.frame.render_widget(block, ctx.area);
 
         if inner.height == 0 || inner.width == 0 {
             return;
@@ -579,7 +578,12 @@ impl Component for ScrollView {
                     .offset()
                     .min(total.saturating_sub(viewport_height)),
             );
-            crate::scroll::render_scrollbar_inside_border(&bar_scroll, frame, area, theme);
+            crate::scroll::render_scrollbar_inside_border(
+                &bar_scroll,
+                ctx.frame,
+                ctx.area,
+                ctx.theme,
+            );
         }
     }
 }

--- a/src/component/scroll_view/tests.rs
+++ b/src/component/scroll_view/tests.rs
@@ -314,7 +314,7 @@ fn test_handle_event_up() {
         ScrollView::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ScrollViewMessage::ScrollUp)
     );
@@ -327,7 +327,7 @@ fn test_handle_event_down() {
         ScrollView::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ScrollViewMessage::ScrollDown)
     );
@@ -337,11 +337,19 @@ fn test_handle_event_down() {
 fn test_handle_event_k_j() {
     let state = focused_state();
     assert_eq!(
-        ScrollView::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true)),
+        ScrollView::handle_event(
+            &state,
+            &Event::char('k'),
+            &EventContext::new().focused(true)
+        ),
         Some(ScrollViewMessage::ScrollUp)
     );
     assert_eq!(
-        ScrollView::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true)),
+        ScrollView::handle_event(
+            &state,
+            &Event::char('j'),
+            &EventContext::new().focused(true)
+        ),
         Some(ScrollViewMessage::ScrollDown)
     );
 }
@@ -353,7 +361,7 @@ fn test_handle_event_page_up_down() {
         ScrollView::handle_event(
             &state,
             &Event::key(KeyCode::PageUp),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ScrollViewMessage::PageUp)
     );
@@ -361,7 +369,7 @@ fn test_handle_event_page_up_down() {
         ScrollView::handle_event(
             &state,
             &Event::key(KeyCode::PageDown),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ScrollViewMessage::PageDown)
     );
@@ -371,11 +379,19 @@ fn test_handle_event_page_up_down() {
 fn test_handle_event_ctrl_u_d() {
     let state = focused_state();
     assert_eq!(
-        ScrollView::handle_event(&state, &Event::ctrl('u'), &ViewContext::new().focused(true)),
+        ScrollView::handle_event(
+            &state,
+            &Event::ctrl('u'),
+            &EventContext::new().focused(true)
+        ),
         Some(ScrollViewMessage::PageUp)
     );
     assert_eq!(
-        ScrollView::handle_event(&state, &Event::ctrl('d'), &ViewContext::new().focused(true)),
+        ScrollView::handle_event(
+            &state,
+            &Event::ctrl('d'),
+            &EventContext::new().focused(true)
+        ),
         Some(ScrollViewMessage::PageDown)
     );
 }
@@ -387,7 +403,7 @@ fn test_handle_event_home_end() {
         ScrollView::handle_event(
             &state,
             &Event::key(KeyCode::Home),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ScrollViewMessage::Home)
     );
@@ -395,7 +411,7 @@ fn test_handle_event_home_end() {
         ScrollView::handle_event(
             &state,
             &Event::key(KeyCode::End),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ScrollViewMessage::End)
     );
@@ -406,14 +422,18 @@ fn test_handle_event_home_end() {
 fn test_handle_event_g_and_G() {
     let state = focused_state();
     assert_eq!(
-        ScrollView::handle_event(&state, &Event::char('g'), &ViewContext::new().focused(true)),
+        ScrollView::handle_event(
+            &state,
+            &Event::char('g'),
+            &EventContext::new().focused(true)
+        ),
         Some(ScrollViewMessage::Home)
     );
     assert_eq!(
         ScrollView::handle_event(
             &state,
             &Event::key_with(KeyCode::Char('G'), KeyModifiers::SHIFT),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ScrollViewMessage::End)
     );
@@ -423,7 +443,11 @@ fn test_handle_event_g_and_G() {
 fn test_handle_event_unrecognized() {
     let state = focused_state();
     assert_eq!(
-        ScrollView::handle_event(&state, &Event::char('x'), &ViewContext::new().focused(true)),
+        ScrollView::handle_event(
+            &state,
+            &Event::char('x'),
+            &EventContext::new().focused(true)
+        ),
         None
     );
 }
@@ -432,11 +456,11 @@ fn test_handle_event_unrecognized() {
 fn test_handle_event_unfocused_ignores() {
     let state = ScrollViewState::new();
     assert_eq!(
-        ScrollView::handle_event(&state, &Event::key(KeyCode::Up), &ViewContext::default()),
+        ScrollView::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default()),
         None
     );
     assert_eq!(
-        ScrollView::handle_event(&state, &Event::key(KeyCode::Down), &ViewContext::default()),
+        ScrollView::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default()),
         None
     );
 }
@@ -448,7 +472,7 @@ fn test_handle_event_disabled_ignores() {
         ScrollView::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true).disabled(true)
+            &EventContext::new().focused(true).disabled(true)
         ),
         None
     );
@@ -459,7 +483,7 @@ fn test_dispatch_event_no_change() {
     let output = ScrollView::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, None);
     assert_eq!(state.scroll_offset(), 0);
@@ -494,7 +518,7 @@ fn test_view_empty() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ScrollView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -506,7 +530,7 @@ fn test_view_with_title() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ScrollView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -518,7 +542,7 @@ fn test_view_focused() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ScrollView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -532,7 +556,7 @@ fn test_view_with_scrollbar() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ScrollView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -546,7 +570,7 @@ fn test_view_no_scrollbar_when_disabled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ScrollView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -558,7 +582,7 @@ fn test_view_no_scrollbar_when_content_fits() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ScrollView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -571,7 +595,7 @@ fn test_view_zero_area() {
     terminal
         .draw(|frame| {
             let zero_area = Rect::new(0, 0, 0, 0);
-            ScrollView::view(&state, frame, zero_area, &theme, &ViewContext::default());
+            ScrollView::view(&state, &mut RenderContext::new(frame, zero_area, &theme));
         })
         .unwrap();
     // Should not panic
@@ -584,7 +608,7 @@ fn test_view_minimal_area() {
     terminal
         .draw(|frame| {
             let small_area = Rect::new(0, 0, 3, 3);
-            ScrollView::view(&state, frame, small_area, &theme, &ViewContext::default());
+            ScrollView::view(&state, &mut RenderContext::new(frame, small_area, &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -603,7 +627,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                ScrollView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                ScrollView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -626,10 +650,9 @@ fn test_annotation_reflects_focus_and_disabled() {
             .draw(|frame| {
                 ScrollView::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true).disabled(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme)
+                        .focused(true)
+                        .disabled(true),
                 );
             })
             .unwrap();

--- a/src/component/scrollable_text/mod.rs
+++ b/src/component/scrollable_text/mod.rs
@@ -26,13 +26,11 @@
 //! assert_eq!(state.scroll_offset(), 0);
 //! ```
 
-use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
-use crate::theme::Theme;
 
 /// Messages that can be sent to a ScrollableText.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -306,7 +304,7 @@ impl Component for ScrollableText {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -383,10 +381,10 @@ impl Component for ScrollableText {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::scrollable_text("scrollable_text")
                     .with_focus(ctx.focused)
                     .with_disabled(ctx.disabled),
@@ -394,19 +392,19 @@ impl Component for ScrollableText {
         });
 
         let border_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let text_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_style()
+            ctx.theme.focused_style()
         } else {
-            theme.normal_style()
+            ctx.theme.normal_style()
         };
 
         let mut block = Block::default()
@@ -417,8 +415,8 @@ impl Component for ScrollableText {
             block = block.title(title.as_str());
         }
 
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
+        let inner = block.inner(ctx.area);
+        ctx.frame.render_widget(block, ctx.area);
 
         if inner.height == 0 || inner.width == 0 {
             return;
@@ -435,14 +433,19 @@ impl Component for ScrollableText {
             .wrap(Wrap { trim: false })
             .scroll((effective_scroll as u16, 0));
 
-        frame.render_widget(paragraph, inner);
+        ctx.frame.render_widget(paragraph, inner);
 
         // Render scrollbar when content exceeds viewport
         if total_lines > visible_lines {
             let mut bar_scroll = ScrollState::new(total_lines);
             bar_scroll.set_viewport_height(visible_lines);
             bar_scroll.set_offset(effective_scroll);
-            crate::scroll::render_scrollbar_inside_border(&bar_scroll, frame, area, theme);
+            crate::scroll::render_scrollbar_inside_border(
+                &bar_scroll,
+                ctx.frame,
+                ctx.area,
+                ctx.theme,
+            );
         }
     }
 }

--- a/src/component/scrollable_text/tests.rs
+++ b/src/component/scrollable_text/tests.rs
@@ -196,7 +196,7 @@ fn test_disabled_ignores_events() {
     let msg = ScrollableText::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -205,7 +205,7 @@ fn test_disabled_ignores_events() {
 fn test_unfocused_ignores_events() {
     let state = ScrollableTextState::new();
     let msg =
-        ScrollableText::handle_event(&state, &Event::key(KeyCode::Up), &ViewContext::default());
+        ScrollableText::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -220,7 +220,7 @@ fn test_handle_event_up() {
         ScrollableText::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ScrollableTextMessage::ScrollUp)
     );
@@ -233,7 +233,7 @@ fn test_handle_event_down() {
         ScrollableText::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ScrollableTextMessage::ScrollDown)
     );
@@ -243,11 +243,19 @@ fn test_handle_event_down() {
 fn test_handle_event_k_j() {
     let state = focused_state();
     assert_eq!(
-        ScrollableText::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true)),
+        ScrollableText::handle_event(
+            &state,
+            &Event::char('k'),
+            &EventContext::new().focused(true)
+        ),
         Some(ScrollableTextMessage::ScrollUp)
     );
     assert_eq!(
-        ScrollableText::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true)),
+        ScrollableText::handle_event(
+            &state,
+            &Event::char('j'),
+            &EventContext::new().focused(true)
+        ),
         Some(ScrollableTextMessage::ScrollDown)
     );
 }
@@ -259,7 +267,7 @@ fn test_handle_event_page_up_down() {
         ScrollableText::handle_event(
             &state,
             &Event::key(KeyCode::PageUp),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ScrollableTextMessage::PageUp(10))
     );
@@ -267,7 +275,7 @@ fn test_handle_event_page_up_down() {
         ScrollableText::handle_event(
             &state,
             &Event::key(KeyCode::PageDown),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ScrollableTextMessage::PageDown(10))
     );
@@ -277,11 +285,19 @@ fn test_handle_event_page_up_down() {
 fn test_handle_event_ctrl_u_d() {
     let state = focused_state();
     assert_eq!(
-        ScrollableText::handle_event(&state, &Event::ctrl('u'), &ViewContext::new().focused(true)),
+        ScrollableText::handle_event(
+            &state,
+            &Event::ctrl('u'),
+            &EventContext::new().focused(true)
+        ),
         Some(ScrollableTextMessage::PageUp(10))
     );
     assert_eq!(
-        ScrollableText::handle_event(&state, &Event::ctrl('d'), &ViewContext::new().focused(true)),
+        ScrollableText::handle_event(
+            &state,
+            &Event::ctrl('d'),
+            &EventContext::new().focused(true)
+        ),
         Some(ScrollableTextMessage::PageDown(10))
     );
 }
@@ -293,7 +309,7 @@ fn test_handle_event_home_end() {
         ScrollableText::handle_event(
             &state,
             &Event::key(KeyCode::Home),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ScrollableTextMessage::Home)
     );
@@ -301,7 +317,7 @@ fn test_handle_event_home_end() {
         ScrollableText::handle_event(
             &state,
             &Event::key(KeyCode::End),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ScrollableTextMessage::End)
     );
@@ -312,14 +328,18 @@ fn test_handle_event_home_end() {
 fn test_handle_event_g_and_G() {
     let state = focused_state();
     assert_eq!(
-        ScrollableText::handle_event(&state, &Event::char('g'), &ViewContext::new().focused(true)),
+        ScrollableText::handle_event(
+            &state,
+            &Event::char('g'),
+            &EventContext::new().focused(true)
+        ),
         Some(ScrollableTextMessage::Home)
     );
     assert_eq!(
         ScrollableText::handle_event(
             &state,
             &Event::key_with(KeyCode::Char('G'), KeyModifiers::SHIFT),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(ScrollableTextMessage::End)
     );
@@ -329,7 +349,11 @@ fn test_handle_event_g_and_G() {
 fn test_handle_event_unrecognized() {
     let state = focused_state();
     assert_eq!(
-        ScrollableText::handle_event(&state, &Event::char('x'), &ViewContext::new().focused(true)),
+        ScrollableText::handle_event(
+            &state,
+            &Event::char('x'),
+            &EventContext::new().focused(true)
+        ),
         None
     );
 }
@@ -349,7 +373,7 @@ fn test_view_empty() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollableText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ScrollableText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -362,7 +386,7 @@ fn test_view_with_content() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollableText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ScrollableText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -376,7 +400,7 @@ fn test_view_scrolled() {
     let (mut terminal, theme) = test_utils::setup_render(40, 6);
     terminal
         .draw(|frame| {
-            ScrollableText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ScrollableText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -388,7 +412,7 @@ fn test_view_focused() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            ScrollableText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ScrollableText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -403,7 +427,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                ScrollableText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                ScrollableText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/searchable_list/event_tests.rs
+++ b/src/component/searchable_list/event_tests.rs
@@ -21,7 +21,7 @@ fn test_tab_maps_to_toggle_focus() {
     let msg = SearchableList::handle_event(
         &state,
         &Event::key(KeyCode::Tab),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::ToggleFocus));
 }
@@ -32,7 +32,7 @@ fn test_backtab_maps_to_toggle_focus() {
     let msg = SearchableList::handle_event(
         &state,
         &Event::key(KeyCode::BackTab),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::ToggleFocus));
 }
@@ -43,7 +43,7 @@ fn test_esc_maps_to_filter_clear() {
     let msg = SearchableList::handle_event(
         &state,
         &Event::key(KeyCode::Esc),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::FilterClear));
 }
@@ -52,8 +52,11 @@ fn test_esc_maps_to_filter_clear() {
 fn test_char_in_filter_mode_maps_to_filter_char() {
     let state = focused_state();
     assert!(state.is_filter_focused());
-    let msg =
-        SearchableList::handle_event(&state, &Event::char('a'), &ViewContext::new().focused(true));
+    let msg = SearchableList::handle_event(
+        &state,
+        &Event::char('a'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(SearchableListMessage::FilterChar('a')));
 }
 
@@ -64,7 +67,7 @@ fn test_enter_in_filter_mode_maps_to_toggle_focus() {
     let msg = SearchableList::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::ToggleFocus));
 }
@@ -75,7 +78,7 @@ fn test_backspace_in_filter_mode_maps_to_filter_backspace() {
     let msg = SearchableList::handle_event(
         &state,
         &Event::key(KeyCode::Backspace),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::FilterBackspace));
 }
@@ -83,16 +86,22 @@ fn test_backspace_in_filter_mode_maps_to_filter_backspace() {
 #[test]
 fn test_ctrl_j_in_filter_maps_to_down() {
     let state = focused_state();
-    let msg =
-        SearchableList::handle_event(&state, &Event::ctrl('j'), &ViewContext::new().focused(true));
+    let msg = SearchableList::handle_event(
+        &state,
+        &Event::ctrl('j'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(SearchableListMessage::Down));
 }
 
 #[test]
 fn test_ctrl_k_in_filter_maps_to_up() {
     let state = focused_state();
-    let msg =
-        SearchableList::handle_event(&state, &Event::ctrl('k'), &ViewContext::new().focused(true));
+    let msg = SearchableList::handle_event(
+        &state,
+        &Event::ctrl('k'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(SearchableListMessage::Up));
 }
 
@@ -105,14 +114,14 @@ fn test_arrow_keys_in_list_mode() {
     let msg = SearchableList::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::Up));
 
     let msg = SearchableList::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::Down));
 }
@@ -122,12 +131,18 @@ fn test_vim_keys_in_list_mode() {
     let mut state = focused_state();
     SearchableList::update(&mut state, SearchableListMessage::ToggleFocus);
 
-    let msg =
-        SearchableList::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true));
+    let msg = SearchableList::handle_event(
+        &state,
+        &Event::char('k'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(SearchableListMessage::Up));
 
-    let msg =
-        SearchableList::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true));
+    let msg = SearchableList::handle_event(
+        &state,
+        &Event::char('j'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(SearchableListMessage::Down));
 }
 
@@ -139,14 +154,14 @@ fn test_home_end_in_list_mode() {
     let msg = SearchableList::handle_event(
         &state,
         &Event::key(KeyCode::Home),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::First));
 
     let msg = SearchableList::handle_event(
         &state,
         &Event::key(KeyCode::End),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::Last));
 }
@@ -156,12 +171,18 @@ fn test_g_and_shift_g_in_list_mode() {
     let mut state = focused_state();
     SearchableList::update(&mut state, SearchableListMessage::ToggleFocus);
 
-    let msg =
-        SearchableList::handle_event(&state, &Event::char('g'), &ViewContext::new().focused(true));
+    let msg = SearchableList::handle_event(
+        &state,
+        &Event::char('g'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(SearchableListMessage::First));
 
-    let msg =
-        SearchableList::handle_event(&state, &Event::char('G'), &ViewContext::new().focused(true));
+    let msg = SearchableList::handle_event(
+        &state,
+        &Event::char('G'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(SearchableListMessage::Last));
 }
 
@@ -173,14 +194,14 @@ fn test_page_keys_in_list_mode() {
     let msg = SearchableList::handle_event(
         &state,
         &Event::key(KeyCode::PageUp),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::PageUp(10)));
 
     let msg = SearchableList::handle_event(
         &state,
         &Event::key(KeyCode::PageDown),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::PageDown(10)));
 }
@@ -193,7 +214,7 @@ fn test_enter_in_list_mode_maps_to_select() {
     let msg = SearchableList::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::Select));
 }
@@ -205,7 +226,10 @@ fn test_char_in_list_mode_maps_to_filter_char() {
     assert!(state.is_list_focused());
 
     // Typing in list mode should redirect to filter
-    let msg =
-        SearchableList::handle_event(&state, &Event::char('x'), &ViewContext::new().focused(true));
+    let msg = SearchableList::handle_event(
+        &state,
+        &Event::char('x'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(SearchableListMessage::FilterChar('x')));
 }

--- a/src/component/searchable_list/mod.rs
+++ b/src/component/searchable_list/mod.rs
@@ -38,13 +38,11 @@ use std::fmt::Display;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use ratatui::prelude::*;
 use ratatui::widgets::ListState;
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
-use crate::theme::Theme;
 
 /// A matcher function that takes `(query, item_text)` and returns
 /// `None` for no match or `Some(score)` for a ranked match (higher = better).
@@ -720,7 +718,7 @@ impl<T: Clone + Display + 'static> Component for SearchableList<T> {
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -901,8 +899,15 @@ impl<T: Clone + Display + 'static> Component for SearchableList<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        render::render_searchable_list(state, frame, area, theme, ctx.focused, ctx.disabled);
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        render::render_searchable_list(
+            state,
+            ctx.frame,
+            ctx.area,
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
     }
 }
 

--- a/src/component/searchable_list/snapshot_tests.rs
+++ b/src/component/searchable_list/snapshot_tests.rs
@@ -21,7 +21,7 @@ fn test_snapshot_default_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SearchableList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -33,7 +33,7 @@ fn test_snapshot_populated() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SearchableList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -47,10 +47,7 @@ fn test_snapshot_focused_filter() {
         .draw(|frame| {
             SearchableList::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -66,10 +63,7 @@ fn test_snapshot_focused_list() {
         .draw(|frame| {
             SearchableList::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -85,10 +79,7 @@ fn test_snapshot_filtered() {
         .draw(|frame| {
             SearchableList::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -107,10 +98,7 @@ fn test_snapshot_no_matches() {
         .draw(|frame| {
             SearchableList::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -123,7 +111,7 @@ fn test_snapshot_custom_placeholder() {
     let (mut terminal, theme) = test_utils::setup_render(60, 20);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SearchableList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/searchable_list/tests.rs
+++ b/src/component/searchable_list/tests.rs
@@ -479,7 +479,7 @@ fn test_disabled_ignores_events() {
     let msg = SearchableList::handle_event(
         &state,
         &Event::char('a'),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -492,7 +492,7 @@ fn test_disabled_ignores_events() {
 fn test_unfocused_ignores_events() {
     let state = SearchableListState::new(sample_items());
 
-    let msg = SearchableList::handle_event(&state, &Event::char('a'), &ViewContext::default());
+    let msg = SearchableList::handle_event(&state, &Event::char('a'), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -508,7 +508,7 @@ fn test_dispatch_event_filters_and_selects() {
     let output = SearchableList::dispatch_event(
         &mut state,
         &Event::char('b'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(
         output,
@@ -520,7 +520,7 @@ fn test_dispatch_event_filters_and_selects() {
     let output = SearchableList::dispatch_event(
         &mut state,
         &Event::char('a'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(
         output,
@@ -565,7 +565,7 @@ fn test_render_unfocused() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SearchableList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -578,10 +578,7 @@ fn test_render_focused_filter() {
         .draw(|frame| {
             SearchableList::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -596,10 +593,7 @@ fn test_render_focused_list() {
         .draw(|frame| {
             SearchableList::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -617,10 +611,7 @@ fn test_render_with_filter() {
         .draw(|frame| {
             SearchableList::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -634,10 +625,7 @@ fn test_render_disabled() {
         .draw(|frame| {
             SearchableList::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -649,7 +637,7 @@ fn test_render_empty_list() {
     let (mut terminal, theme) = test_utils::setup_render(40, 15);
     terminal
         .draw(|frame| {
-            SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SearchableList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -872,7 +860,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                SearchableList::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                SearchableList::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/select/mod.rs
+++ b/src/component/select/mod.rs
@@ -29,9 +29,8 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 /// Messages that can be sent to a Select.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -483,7 +482,7 @@ impl Component for Select {
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -508,7 +507,7 @@ impl Component for Select {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         crate::annotation::with_registry(|reg| {
             let mut ann = crate::annotation::Annotation::new(crate::annotation::WidgetType::Select)
                 .with_id("select")
@@ -518,21 +517,21 @@ impl Component for Select {
             if let Some(val) = state.selected_value() {
                 ann = ann.with_value(val.to_string());
             }
-            reg.register(area, ann);
+            reg.register(ctx.area, ann);
         });
 
         let style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_style()
+            ctx.theme.focused_style()
         } else {
-            theme.normal_style()
+            ctx.theme.normal_style()
         };
 
         let border_style = if ctx.focused && !ctx.disabled {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         // Display selected value or placeholder
@@ -551,25 +550,25 @@ impl Component for Select {
         );
 
         if !state.is_open {
-            frame.render_widget(paragraph, area);
+            ctx.frame.render_widget(paragraph, ctx.area);
         } else {
             // Render closed state in first line
             let closed_height = 3; // 1 line + 2 borders
             let closed_area = Rect {
-                x: area.x,
-                y: area.y,
-                width: area.width,
-                height: closed_height.min(area.height),
+                x: ctx.area.x,
+                y: ctx.area.y,
+                width: ctx.area.width,
+                height: closed_height.min(ctx.area.height),
             };
-            frame.render_widget(paragraph, closed_area);
+            ctx.frame.render_widget(paragraph, closed_area);
 
             // Render dropdown list below
-            if area.height > closed_height {
+            if ctx.area.height > closed_height {
                 let list_area = Rect {
-                    x: area.x,
-                    y: area.y + closed_height,
-                    width: area.width,
-                    height: area.height.saturating_sub(closed_height),
+                    x: ctx.area.x,
+                    y: ctx.area.y + closed_height,
+                    width: ctx.area.width,
+                    height: ctx.area.height.saturating_sub(closed_height),
                 };
 
                 let items: Vec<ListItem> = state
@@ -584,9 +583,9 @@ impl Component for Select {
                         };
                         let text = format!("{}{}", prefix, opt);
                         let item_style = if idx == state.highlighted_index {
-                            theme.selected_style(ctx.focused)
+                            ctx.theme.selected_style(ctx.focused)
                         } else {
-                            theme.normal_style()
+                            ctx.theme.normal_style()
                         };
                         ListItem::new(text).style(item_style)
                     })
@@ -598,7 +597,7 @@ impl Component for Select {
                         .border_style(border_style),
                 );
 
-                frame.render_widget(list, list_area);
+                ctx.frame.render_widget(list, list_area);
             }
         }
     }

--- a/src/component/select/tests.rs
+++ b/src/component/select/tests.rs
@@ -170,7 +170,7 @@ fn test_view_closed() {
 
     terminal
         .draw(|frame| {
-            Select::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Select::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -186,7 +186,7 @@ fn test_view_open() {
 
     terminal
         .draw(|frame| {
-            Select::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Select::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -201,7 +201,7 @@ fn test_view_with_selection() {
 
     terminal
         .draw(|frame| {
-            Select::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Select::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -216,7 +216,7 @@ fn test_view_focused() {
 
     terminal
         .draw(|frame| {
-            Select::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Select::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -272,12 +272,16 @@ fn test_handle_event_toggle_when_closed() {
     let msg = Select::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectMessage::Toggle));
 
     // Space when closed -> Toggle
-    let msg = Select::handle_event(&state, &Event::char(' '), &ViewContext::new().focused(true));
+    let msg = Select::handle_event(
+        &state,
+        &Event::char(' '),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(SelectMessage::Toggle));
 }
 
@@ -289,7 +293,7 @@ fn test_handle_event_confirm_when_open() {
     let msg = Select::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectMessage::Confirm));
 }
@@ -302,7 +306,7 @@ fn test_handle_event_close_when_open() {
     let msg = Select::handle_event(
         &state,
         &Event::key(KeyCode::Esc),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectMessage::Close));
 }
@@ -315,12 +319,16 @@ fn test_handle_event_up_when_open() {
     let msg = Select::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectMessage::Up));
 
     // Vim 'k' also maps to Up
-    let msg = Select::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true));
+    let msg = Select::handle_event(
+        &state,
+        &Event::char('k'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(SelectMessage::Up));
 }
 
@@ -332,19 +340,27 @@ fn test_handle_event_down_when_open() {
     let msg = Select::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectMessage::Down));
 
     // Vim 'j' also maps to Down
-    let msg = Select::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true));
+    let msg = Select::handle_event(
+        &state,
+        &Event::char('j'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(SelectMessage::Down));
 }
 
 #[test]
 fn test_handle_event_ignored_when_unfocused() {
     let state = SelectState::new(vec!["A", "B", "C"]);
-    let msg = Select::handle_event(&state, &Event::key(KeyCode::Enter), &ViewContext::default());
+    let msg = Select::handle_event(
+        &state,
+        &Event::key(KeyCode::Enter),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 }
 
@@ -354,7 +370,7 @@ fn test_handle_event_ignored_when_disabled() {
     let msg = Select::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -373,7 +389,7 @@ fn test_dispatch_event() {
     let output = Select::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(SelectOutput::Selected("B".to_string())));
     assert!(!state.is_open());
@@ -386,7 +402,7 @@ fn test_instance_methods() {
     let msg = Select::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectMessage::Toggle));
 
@@ -399,7 +415,7 @@ fn test_instance_methods() {
     let output = Select::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(SelectOutput::SelectionChanged(1)));
 }
@@ -442,7 +458,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Select::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Select::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/selectable_list/mod.rs
+++ b/src/component/selectable_list/mod.rs
@@ -26,13 +26,11 @@
 //! assert_eq!(state.selected_item(), Some(&"Item 2".into()));
 //! ```
 
-use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
 use crate::scroll::ScrollState;
-use crate::theme::Theme;
 
 /// Messages that can be sent to a SelectableList.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -515,7 +513,7 @@ impl<T: Clone + std::fmt::Display + 'static> Component for SelectableList<T> {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -618,7 +616,7 @@ impl<T: Clone + std::fmt::Display + 'static> Component for SelectableList<T> {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         crate::annotation::with_registry(|reg| {
             let mut ann = crate::annotation::Annotation::list("selectable_list")
                 .with_focus(ctx.focused)
@@ -626,7 +624,7 @@ impl<T: Clone + std::fmt::Display + 'static> Component for SelectableList<T> {
             if let Some(idx) = state.selected_index() {
                 ann = ann.with_selected(true).with_value(idx.to_string());
             }
-            reg.register(area, ann);
+            reg.register(ctx.area, ann);
         });
 
         let mut items = Vec::with_capacity(state.filtered_indices.len());
@@ -635,13 +633,13 @@ impl<T: Clone + std::fmt::Display + 'static> Component for SelectableList<T> {
         }
 
         let highlight_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else {
-            theme.selected_highlight_style(ctx.focused)
+            ctx.theme.selected_highlight_style(ctx.focused)
         };
 
         let block = Block::default().borders(Borders::ALL);
-        let inner = block.inner(area);
+        let inner = block.inner(ctx.area);
 
         let list = List::new(items)
             .block(block)
@@ -650,14 +648,20 @@ impl<T: Clone + std::fmt::Display + 'static> Component for SelectableList<T> {
 
         // We need to clone the state for rendering since StatefulWidget needs &mut
         let mut list_state = state.list_state.clone();
-        frame.render_stateful_widget(list, area, &mut list_state);
+        ctx.frame
+            .render_stateful_widget(list, ctx.area, &mut list_state);
 
         // Render scrollbar when content exceeds viewport
         if state.filtered_indices.len() > inner.height as usize {
             let mut bar_scroll = ScrollState::new(state.filtered_indices.len());
             bar_scroll.set_viewport_height(inner.height as usize);
             bar_scroll.set_offset(list_state.offset());
-            crate::scroll::render_scrollbar_inside_border(&bar_scroll, frame, area, theme);
+            crate::scroll::render_scrollbar_inside_border(
+                &bar_scroll,
+                ctx.frame,
+                ctx.area,
+                ctx.theme,
+            );
         }
     }
 }

--- a/src/component/selectable_list/tests.rs
+++ b/src/component/selectable_list/tests.rs
@@ -260,10 +260,7 @@ fn test_view() {
         .draw(|frame| {
             SelectableList::<&str>::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -280,10 +277,7 @@ fn test_view_unfocused() {
         .draw(|frame| {
             SelectableList::<&str>::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, frame.area(), &theme),
             );
         })
         .unwrap();
@@ -345,7 +339,7 @@ fn test_handle_event_up() {
     let msg = SelectableList::<String>::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectableListMessage::Up));
 }
@@ -356,7 +350,7 @@ fn test_handle_event_down() {
     let msg = SelectableList::<String>::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectableListMessage::Down));
 }
@@ -367,7 +361,7 @@ fn test_handle_event_home() {
     let msg = SelectableList::<String>::handle_event(
         &state,
         &Event::key(KeyCode::Home),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectableListMessage::First));
 }
@@ -378,7 +372,7 @@ fn test_handle_event_end() {
     let msg = SelectableList::<String>::handle_event(
         &state,
         &Event::key(KeyCode::End),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectableListMessage::Last));
 }
@@ -389,7 +383,7 @@ fn test_handle_event_enter() {
     let msg = SelectableList::<String>::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectableListMessage::Select));
 }
@@ -400,7 +394,7 @@ fn test_handle_event_page_up() {
     let msg = SelectableList::<String>::handle_event(
         &state,
         &Event::key(KeyCode::PageUp),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectableListMessage::PageUp(10)));
 }
@@ -411,7 +405,7 @@ fn test_handle_event_page_down() {
     let msg = SelectableList::<String>::handle_event(
         &state,
         &Event::key(KeyCode::PageDown),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectableListMessage::PageDown(10)));
 }
@@ -422,7 +416,7 @@ fn test_handle_event_vim_k() {
     let msg = SelectableList::<String>::handle_event(
         &state,
         &Event::char('k'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectableListMessage::Up));
 }
@@ -433,7 +427,7 @@ fn test_handle_event_vim_j() {
     let msg = SelectableList::<String>::handle_event(
         &state,
         &Event::char('j'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectableListMessage::Down));
 }
@@ -444,7 +438,7 @@ fn test_handle_event_vim_g() {
     let msg = SelectableList::<String>::handle_event(
         &state,
         &Event::char('g'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectableListMessage::First));
 }
@@ -455,7 +449,7 @@ fn test_handle_event_vim_shift_g() {
     let msg = SelectableList::<String>::handle_event(
         &state,
         &Event::char('G'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectableListMessage::Last));
 }
@@ -466,7 +460,7 @@ fn test_handle_event_ignored_when_unfocused() {
     let msg = SelectableList::<String>::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::default(),
+        &EventContext::default(),
     );
     assert_eq!(msg, None);
 }
@@ -477,7 +471,7 @@ fn test_dispatch_event_selectable_list() {
     let output = SelectableList::<String>::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(SelectableListOutput::SelectionChanged(1)));
     assert_eq!(state.selected_index(), Some(1));
@@ -738,10 +732,7 @@ fn test_filter_view() {
         .draw(|frame| {
             SelectableList::<String>::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -821,10 +812,7 @@ fn test_annotation_emitted() {
             .draw(|frame| {
                 SelectableList::<String>::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::default(),
+                    &mut RenderContext::new(frame, frame.area(), &theme),
                 );
             })
             .unwrap();

--- a/src/component/slider/mod.rs
+++ b/src/component/slider/mod.rs
@@ -33,7 +33,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -447,7 +447,7 @@ impl Component for Slider {
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -479,27 +479,21 @@ impl Component for Slider {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         match state.orientation {
-            SliderOrientation::Horizontal => view_horizontal(state, frame, area, theme, ctx),
-            SliderOrientation::Vertical => view_vertical(state, frame, area, theme, ctx),
+            SliderOrientation::Horizontal => view_horizontal(state, ctx),
+            SliderOrientation::Vertical => view_vertical(state, ctx),
         }
     }
 }
 
 /// Renders the slider in horizontal orientation.
-fn view_horizontal(
-    state: &SliderState,
-    frame: &mut Frame,
-    area: Rect,
-    theme: &Theme,
-    ctx: &ViewContext,
-) {
-    if area.height == 0 || area.width == 0 {
+fn view_horizontal(state: &SliderState, ctx: &mut RenderContext<'_, '_>) {
+    if ctx.area.height == 0 || ctx.area.width == 0 {
         return;
     }
 
-    let (label_style, filled_style, empty_style) = compute_styles(theme, ctx);
+    let (label_style, filled_style, empty_style) = compute_styles(ctx.theme, &ctx.event_context());
 
     let mut lines = Vec::new();
 
@@ -510,7 +504,7 @@ fn view_horizontal(
     }
 
     // Build track line
-    let track_width = area.width as usize;
+    let track_width = ctx.area.width as usize;
     let pct = state.percentage();
     let filled = (pct * track_width as f64).round() as usize;
     let empty = track_width.saturating_sub(filled);
@@ -542,22 +536,16 @@ fn view_horizontal(
     let annotated = crate::annotation::Annotate::new(paragraph, annotation)
         .focused(ctx.focused)
         .disabled(ctx.disabled);
-    frame.render_widget(annotated, area);
+    ctx.frame.render_widget(annotated, ctx.area);
 }
 
 /// Renders the slider in vertical orientation.
-fn view_vertical(
-    state: &SliderState,
-    frame: &mut Frame,
-    area: Rect,
-    theme: &Theme,
-    ctx: &ViewContext,
-) {
-    if area.height == 0 || area.width == 0 {
+fn view_vertical(state: &SliderState, ctx: &mut RenderContext<'_, '_>) {
+    if ctx.area.height == 0 || ctx.area.width == 0 {
         return;
     }
 
-    let (label_style, filled_style, empty_style) = compute_styles(theme, ctx);
+    let (label_style, filled_style, empty_style) = compute_styles(ctx.theme, &ctx.event_context());
 
     let mut lines = Vec::new();
 
@@ -567,7 +555,7 @@ fn view_vertical(
     } else {
         0
     };
-    let track_height = (area.height as usize).saturating_sub(label_lines);
+    let track_height = (ctx.area.height as usize).saturating_sub(label_lines);
 
     // Label at top
     if state.label.is_some() || state.show_value {
@@ -607,11 +595,11 @@ fn view_vertical(
     let annotated = crate::annotation::Annotate::new(paragraph, annotation)
         .focused(ctx.focused)
         .disabled(ctx.disabled);
-    frame.render_widget(annotated, area);
+    ctx.frame.render_widget(annotated, ctx.area);
 }
 
 /// Computes the styles for label, filled, and empty portions.
-fn compute_styles(theme: &Theme, ctx: &ViewContext) -> (Style, Style, Style) {
+fn compute_styles(theme: &Theme, ctx: &EventContext) -> (Style, Style, Style) {
     if ctx.disabled {
         let disabled = theme.disabled_style();
         (disabled, disabled, disabled)

--- a/src/component/slider/tests.rs
+++ b/src/component/slider/tests.rs
@@ -306,7 +306,7 @@ fn test_handle_event_right_horizontal() {
     let msg = Slider::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::Increment));
 }
@@ -317,7 +317,7 @@ fn test_handle_event_left_horizontal() {
     let msg = Slider::handle_event(
         &state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::Decrement));
 }
@@ -325,14 +325,22 @@ fn test_handle_event_left_horizontal() {
 #[test]
 fn test_handle_event_l_horizontal() {
     let state = SliderState::new(0.0, 100.0);
-    let msg = Slider::handle_event(&state, &Event::char('l'), &ViewContext::new().focused(true));
+    let msg = Slider::handle_event(
+        &state,
+        &Event::char('l'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(SliderMessage::Increment));
 }
 
 #[test]
 fn test_handle_event_h_horizontal() {
     let state = SliderState::new(0.0, 100.0);
-    let msg = Slider::handle_event(&state, &Event::char('h'), &ViewContext::new().focused(true));
+    let msg = Slider::handle_event(
+        &state,
+        &Event::char('h'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(SliderMessage::Decrement));
 }
 
@@ -342,7 +350,7 @@ fn test_handle_event_page_up() {
     let msg = Slider::handle_event(
         &state,
         &Event::key(KeyCode::PageUp),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::IncrementPage));
 }
@@ -353,7 +361,7 @@ fn test_handle_event_page_down() {
     let msg = Slider::handle_event(
         &state,
         &Event::key(KeyCode::PageDown),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::DecrementPage));
 }
@@ -364,7 +372,7 @@ fn test_handle_event_home() {
     let msg = Slider::handle_event(
         &state,
         &Event::key(KeyCode::Home),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::SetMin));
 }
@@ -375,7 +383,7 @@ fn test_handle_event_end() {
     let msg = Slider::handle_event(
         &state,
         &Event::key(KeyCode::End),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::SetMax));
 }
@@ -390,7 +398,7 @@ fn test_handle_event_up_vertical() {
     let msg = Slider::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::Increment));
 }
@@ -401,7 +409,7 @@ fn test_handle_event_down_vertical() {
     let msg = Slider::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::Decrement));
 }
@@ -409,14 +417,22 @@ fn test_handle_event_down_vertical() {
 #[test]
 fn test_handle_event_k_vertical() {
     let state = SliderState::new(0.0, 100.0).with_orientation(SliderOrientation::Vertical);
-    let msg = Slider::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true));
+    let msg = Slider::handle_event(
+        &state,
+        &Event::char('k'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(SliderMessage::Increment));
 }
 
 #[test]
 fn test_handle_event_j_vertical() {
     let state = SliderState::new(0.0, 100.0).with_orientation(SliderOrientation::Vertical);
-    let msg = Slider::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true));
+    let msg = Slider::handle_event(
+        &state,
+        &Event::char('j'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(SliderMessage::Decrement));
 }
 
@@ -426,7 +442,7 @@ fn test_handle_event_page_up_vertical() {
     let msg = Slider::handle_event(
         &state,
         &Event::key(KeyCode::PageUp),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::IncrementPage));
 }
@@ -437,7 +453,7 @@ fn test_handle_event_home_vertical() {
     let msg = Slider::handle_event(
         &state,
         &Event::key(KeyCode::Home),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::SetMin));
 }
@@ -448,7 +464,7 @@ fn test_handle_event_end_vertical() {
     let msg = Slider::handle_event(
         &state,
         &Event::key(KeyCode::End),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::SetMax));
 }
@@ -460,13 +476,21 @@ fn test_handle_event_end_vertical() {
 #[test]
 fn test_handle_event_unfocused() {
     let state = SliderState::new(0.0, 100.0);
-    let msg = Slider::handle_event(&state, &Event::key(KeyCode::Right), &ViewContext::default());
+    let msg = Slider::handle_event(
+        &state,
+        &Event::key(KeyCode::Right),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 }
 #[test]
 fn test_handle_event_unrelated_key() {
     let state = SliderState::new(0.0, 100.0);
-    let msg = Slider::handle_event(&state, &Event::char('q'), &ViewContext::new().focused(true));
+    let msg = Slider::handle_event(
+        &state,
+        &Event::char('q'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, None);
 }
 
@@ -480,7 +504,7 @@ fn test_dispatch_event() {
     let output = Slider::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(SliderOutput::ValueChanged(1.0)));
     assert_eq!(state.value(), 1.0);
@@ -492,7 +516,7 @@ fn test_dispatch_event_unfocused() {
     let output = Slider::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Right),
-        &ViewContext::default(),
+        &EventContext::default(),
     );
     assert_eq!(output, None);
     assert_eq!(state.value(), 0.0);
@@ -528,7 +552,7 @@ fn test_view_horizontal_empty() {
 
     terminal
         .draw(|frame| {
-            Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Slider::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -542,7 +566,7 @@ fn test_view_horizontal_half() {
 
     terminal
         .draw(|frame| {
-            Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Slider::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -556,7 +580,7 @@ fn test_view_horizontal_full() {
 
     terminal
         .draw(|frame| {
-            Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Slider::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -572,7 +596,7 @@ fn test_view_horizontal_with_label() {
 
     terminal
         .draw(|frame| {
-            Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Slider::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -588,7 +612,7 @@ fn test_view_horizontal_no_value_display() {
 
     terminal
         .draw(|frame| {
-            Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Slider::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -604,10 +628,7 @@ fn test_view_horizontal_focused() {
         .draw(|frame| {
             Slider::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -624,10 +645,7 @@ fn test_view_horizontal_disabled() {
         .draw(|frame| {
             Slider::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -644,7 +662,7 @@ fn test_view_vertical() {
 
     terminal
         .draw(|frame| {
-            Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Slider::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -661,7 +679,7 @@ fn test_view_vertical_with_label() {
 
     terminal
         .draw(|frame| {
-            Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Slider::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -676,7 +694,7 @@ fn test_view_zero_area() {
     // Should not panic
     terminal
         .draw(|frame| {
-            Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Slider::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -719,7 +737,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Slider::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Slider::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -740,10 +758,7 @@ fn test_annotation_focused() {
             .draw(|frame| {
                 Slider::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
                 );
             })
             .unwrap();
@@ -763,10 +778,7 @@ fn test_annotation_disabled() {
             .draw(|frame| {
                 Slider::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().disabled(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
                 );
             })
             .unwrap();

--- a/src/component/span_tree/mod.rs
+++ b/src/component/span_tree/mod.rs
@@ -32,12 +32,9 @@
 
 use std::collections::HashSet;
 
-use ratatui::prelude::*;
-
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
-use crate::theme::Theme;
 
 mod render;
 mod types;
@@ -758,7 +755,7 @@ impl Component for SpanTree {
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -786,8 +783,15 @@ impl Component for SpanTree {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        render::render_span_tree(state, frame, area, theme, ctx.focused, ctx.disabled);
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        render::render_span_tree(
+            state,
+            ctx.frame,
+            ctx.area,
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
     }
 }
 

--- a/src/component/span_tree/snapshot_tests.rs
+++ b/src/component/span_tree/snapshot_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::component::test_utils;
+use ratatui::style::Color;
 
 #[test]
 fn test_snapshot_empty() {
@@ -7,7 +8,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 10);
     terminal
         .draw(|frame| {
-            SpanTree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SpanTree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -30,7 +31,7 @@ fn test_snapshot_simple_tree() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            SpanTree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SpanTree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -48,10 +49,7 @@ fn test_snapshot_with_selection() {
         .draw(|frame| {
             SpanTree::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -68,7 +66,7 @@ fn test_snapshot_collapsed() {
     let (mut terminal, theme) = test_utils::setup_render(60, 10);
     terminal
         .draw(|frame| {
-            SpanTree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SpanTree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -88,10 +86,7 @@ fn test_snapshot_disabled() {
         .draw(|frame| {
             SpanTree::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -104,7 +99,7 @@ fn test_snapshot_single_span() {
     let (mut terminal, theme) = test_utils::setup_render(60, 8);
     terminal
         .draw(|frame| {
-            SpanTree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SpanTree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -124,7 +119,7 @@ fn test_snapshot_custom_label_width() {
     let (mut terminal, theme) = test_utils::setup_render(60, 10);
     terminal
         .draw(|frame| {
-            SpanTree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SpanTree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/span_tree/tests.rs
+++ b/src/component/span_tree/tests.rs
@@ -506,7 +506,7 @@ fn test_set_label_width_clamped_high() {
 #[test]
 fn test_handle_event_not_focused() {
     let state = SpanTreeState::new(vec![SpanNode::new("r", "root", 0.0, 10.0)]);
-    let msg = SpanTree::handle_event(&state, &Event::key(KeyCode::Down), &ViewContext::default());
+    let msg = SpanTree::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
     assert_eq!(msg, None);
 }
 #[test]
@@ -516,12 +516,16 @@ fn test_handle_event_down() {
         SpanTree::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(SpanTreeMessage::SelectDown)
     );
     assert_eq!(
-        SpanTree::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true)),
+        SpanTree::handle_event(
+            &state,
+            &Event::char('j'),
+            &EventContext::new().focused(true)
+        ),
         Some(SpanTreeMessage::SelectDown)
     );
 }
@@ -533,12 +537,16 @@ fn test_handle_event_up() {
         SpanTree::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(SpanTreeMessage::SelectUp)
     );
     assert_eq!(
-        SpanTree::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true)),
+        SpanTree::handle_event(
+            &state,
+            &Event::char('k'),
+            &EventContext::new().focused(true)
+        ),
         Some(SpanTreeMessage::SelectUp)
     );
 }
@@ -550,12 +558,16 @@ fn test_handle_event_expand() {
         SpanTree::handle_event(
             &state,
             &Event::key(KeyCode::Right),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(SpanTreeMessage::Expand)
     );
     assert_eq!(
-        SpanTree::handle_event(&state, &Event::char('l'), &ViewContext::new().focused(true)),
+        SpanTree::handle_event(
+            &state,
+            &Event::char('l'),
+            &EventContext::new().focused(true)
+        ),
         Some(SpanTreeMessage::Expand)
     );
 }
@@ -567,12 +579,16 @@ fn test_handle_event_collapse() {
         SpanTree::handle_event(
             &state,
             &Event::key(KeyCode::Left),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(SpanTreeMessage::Collapse)
     );
     assert_eq!(
-        SpanTree::handle_event(&state, &Event::char('h'), &ViewContext::new().focused(true)),
+        SpanTree::handle_event(
+            &state,
+            &Event::char('h'),
+            &EventContext::new().focused(true)
+        ),
         Some(SpanTreeMessage::Collapse)
     );
 }
@@ -581,14 +597,18 @@ fn test_handle_event_collapse() {
 fn test_handle_event_toggle() {
     let state = SpanTreeState::new(vec![SpanNode::new("r", "root", 0.0, 10.0)]);
     assert_eq!(
-        SpanTree::handle_event(&state, &Event::char(' '), &ViewContext::new().focused(true)),
+        SpanTree::handle_event(
+            &state,
+            &Event::char(' '),
+            &EventContext::new().focused(true)
+        ),
         Some(SpanTreeMessage::Toggle)
     );
     assert_eq!(
         SpanTree::handle_event(
             &state,
             &Event::key(KeyCode::Enter),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(SpanTreeMessage::Toggle)
     );
@@ -600,7 +620,7 @@ fn test_handle_event_shift_right() {
     let msg = SpanTree::handle_event(
         &state,
         &Event::key_with(KeyCode::Right, KeyModifiers::SHIFT),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SpanTreeMessage::SetLabelWidth(32)));
 }
@@ -611,7 +631,7 @@ fn test_handle_event_shift_left() {
     let msg = SpanTree::handle_event(
         &state,
         &Event::key_with(KeyCode::Left, KeyModifiers::SHIFT),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SpanTreeMessage::SetLabelWidth(28)));
 }
@@ -629,7 +649,7 @@ fn test_dispatch_event() {
     let output = SpanTree::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(SpanTreeOutput::Selected("c".into())));
     assert_eq!(state.selected_index(), Some(1));

--- a/src/component/sparkline/mod.rs
+++ b/src/component/sparkline/mod.rs
@@ -34,8 +34,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, RenderDirection, Sparkline as RatatuiSparkline};
 
-use super::{Component, ViewContext};
-use crate::theme::Theme;
+use super::{Component, RenderContext};
 
 /// The direction in which sparkline data is rendered.
 ///
@@ -486,7 +485,7 @@ impl Component for Sparkline {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         let display_data = match state.max_display_points {
             Some(n) if state.data.len() > n => &state.data[state.data.len() - n..],
             _ => &state.data,
@@ -506,11 +505,11 @@ impl Component for Sparkline {
         };
 
         let style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if let Some(color) = state.color {
             Style::default().fg(color)
         } else {
-            theme.normal_style()
+            ctx.theme.normal_style()
         };
 
         let direction: RenderDirection = state.direction.clone().into();
@@ -530,7 +529,7 @@ impl Component for Sparkline {
                 .with_id("sparkline")
                 .with_label(state.title.as_deref().unwrap_or(""));
         let annotated = crate::annotation::Annotate::new(sparkline, annotation);
-        frame.render_widget(annotated, area);
+        ctx.frame.render_widget(annotated, ctx.area);
     }
 }
 

--- a/src/component/sparkline/tests.rs
+++ b/src/component/sparkline/tests.rs
@@ -288,7 +288,7 @@ fn test_view_empty() {
 
     terminal
         .draw(|frame| {
-            Sparkline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Sparkline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -302,7 +302,7 @@ fn test_view_with_data() {
 
     terminal
         .draw(|frame| {
-            Sparkline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Sparkline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -317,7 +317,7 @@ fn test_view_with_title() {
 
     terminal
         .draw(|frame| {
-            Sparkline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Sparkline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -331,7 +331,7 @@ fn test_view_right_to_left() {
 
     terminal
         .draw(|frame| {
-            Sparkline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Sparkline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -346,7 +346,7 @@ fn test_view_with_max_display_points() {
 
     terminal
         .draw(|frame| {
-            Sparkline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Sparkline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -360,7 +360,7 @@ fn test_view_with_color() {
 
     terminal
         .draw(|frame| {
-            Sparkline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Sparkline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -378,7 +378,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Sparkline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Sparkline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -397,7 +397,7 @@ fn test_annotation_emitted_no_title() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Sparkline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Sparkline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/spinner/mod.rs
+++ b/src/component/spinner/mod.rs
@@ -38,11 +38,9 @@
 //! assert!(!state.is_spinning());
 //! ```
 
-use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, ViewContext};
-use crate::theme::Theme;
+use super::{Component, RenderContext};
 
 /// Built-in spinner animation styles.
 ///
@@ -467,7 +465,7 @@ impl Component for Spinner {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         let spinner_char = if state.spinning {
             state.current_frame().to_string()
         } else {
@@ -479,12 +477,12 @@ impl Component for Spinner {
             None => spinner_char,
         };
 
-        let paragraph = Paragraph::new(text).style(theme.info_style());
+        let paragraph = Paragraph::new(text).style(ctx.theme.info_style());
 
         let annotation = crate::annotation::Annotation::spinner("spinner")
             .with_label(state.label.as_deref().unwrap_or(""));
         let annotated = crate::annotation::Annotate::new(paragraph, annotation);
-        frame.render_widget(annotated, area);
+        ctx.frame.render_widget(annotated, ctx.area);
     }
 }
 

--- a/src/component/spinner/tests.rs
+++ b/src/component/spinner/tests.rs
@@ -173,7 +173,7 @@ fn test_view_spinning() {
 
     terminal
         .draw(|frame| {
-            Spinner::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Spinner::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -189,7 +189,7 @@ fn test_view_stopped() {
 
     terminal
         .draw(|frame| {
-            Spinner::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Spinner::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -204,7 +204,7 @@ fn test_view_with_label() {
 
     terminal
         .draw(|frame| {
-            Spinner::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Spinner::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -283,7 +283,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Spinner::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Spinner::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/split_panel/mod.rs
+++ b/src/component/split_panel/mod.rs
@@ -34,9 +34,8 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
-use crate::theme::Theme;
 
 /// The orientation of a split panel.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -369,7 +368,7 @@ impl Component for SplitPanel {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -464,10 +463,10 @@ impl Component for SplitPanel {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         crate::annotation::with_registry(|reg| {
             reg.open(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::new(crate::annotation::WidgetType::SplitPanel)
                     .with_id("split_panel")
                     .with_focus(ctx.focused)
@@ -475,25 +474,25 @@ impl Component for SplitPanel {
             );
         });
 
-        let (first_area, second_area) = state.layout(area);
+        let (first_area, second_area) = state.layout(ctx.area);
 
         let first_focused = ctx.focused && state.focused_pane == Pane::First;
         let second_focused = ctx.focused && state.focused_pane == Pane::Second;
 
         let first_border = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if first_focused {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let second_border = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if second_focused {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let first_block = Block::default()
@@ -506,8 +505,8 @@ impl Component for SplitPanel {
             .border_style(second_border)
             .title(" Pane 2 ");
 
-        frame.render_widget(first_block, first_area);
-        frame.render_widget(second_block, second_area);
+        ctx.frame.render_widget(first_block, first_area);
+        ctx.frame.render_widget(second_block, second_area);
 
         crate::annotation::with_registry(|reg| {
             reg.close();

--- a/src/component/split_panel/snapshot_tests.rs
+++ b/src/component/split_panel/snapshot_tests.rs
@@ -11,7 +11,7 @@ fn test_snapshot_default() {
     let (mut terminal, theme) = test_utils::setup_render(70, 20);
     terminal
         .draw(|frame| {
-            SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SplitPanel::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -25,10 +25,7 @@ fn test_snapshot_vertical_focused_first() {
         .draw(|frame| {
             SplitPanel::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -44,10 +41,7 @@ fn test_snapshot_vertical_focused_second() {
         .draw(|frame| {
             SplitPanel::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -62,10 +56,7 @@ fn test_snapshot_horizontal() {
         .draw(|frame| {
             SplitPanel::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -80,10 +71,7 @@ fn test_snapshot_custom_ratio() {
         .draw(|frame| {
             SplitPanel::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -101,10 +89,7 @@ fn test_snapshot_resized() {
         .draw(|frame| {
             SplitPanel::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();

--- a/src/component/split_panel/tests.rs
+++ b/src/component/split_panel/tests.rs
@@ -247,7 +247,7 @@ fn test_disabled_ignores_events() {
     let msg = SplitPanel::handle_event(
         &state,
         &Event::key(KeyCode::Tab),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -259,7 +259,7 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = SplitPanelState::new(SplitOrientation::Vertical);
-    let msg = SplitPanel::handle_event(&state, &Event::key(KeyCode::Tab), &ViewContext::default());
+    let msg = SplitPanel::handle_event(&state, &Event::key(KeyCode::Tab), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -273,7 +273,7 @@ fn test_tab_maps_to_focus_other() {
     let msg = SplitPanel::handle_event(
         &state,
         &Event::key(KeyCode::Tab),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SplitPanelMessage::FocusOther));
 }
@@ -284,7 +284,7 @@ fn test_backtab_maps_to_focus_other() {
     let msg = SplitPanel::handle_event(
         &state,
         &Event::key(KeyCode::BackTab),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SplitPanelMessage::FocusOther));
 }
@@ -295,7 +295,7 @@ fn test_ctrl_right_maps_to_grow_first() {
     let msg = SplitPanel::handle_event(
         &state,
         &Event::key_with(KeyCode::Right, KeyModifiers::CONTROL),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SplitPanelMessage::GrowFirst));
 }
@@ -306,7 +306,7 @@ fn test_ctrl_left_maps_to_shrink_first() {
     let msg = SplitPanel::handle_event(
         &state,
         &Event::key_with(KeyCode::Left, KeyModifiers::CONTROL),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SplitPanelMessage::ShrinkFirst));
 }
@@ -317,7 +317,7 @@ fn test_ctrl_down_maps_to_grow_first() {
     let msg = SplitPanel::handle_event(
         &state,
         &Event::key_with(KeyCode::Down, KeyModifiers::CONTROL),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SplitPanelMessage::GrowFirst));
 }
@@ -328,7 +328,7 @@ fn test_ctrl_up_maps_to_shrink_first() {
     let msg = SplitPanel::handle_event(
         &state,
         &Event::key_with(KeyCode::Up, KeyModifiers::CONTROL),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SplitPanelMessage::ShrinkFirst));
 }
@@ -336,8 +336,11 @@ fn test_ctrl_up_maps_to_shrink_first() {
 #[test]
 fn test_ctrl_0_maps_to_reset_ratio() {
     let state = vertical_state();
-    let msg =
-        SplitPanel::handle_event(&state, &Event::ctrl('0'), &ViewContext::new().focused(true));
+    let msg = SplitPanel::handle_event(
+        &state,
+        &Event::ctrl('0'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(SplitPanelMessage::ResetRatio));
 }
 
@@ -347,7 +350,7 @@ fn test_arrow_without_ctrl_ignored() {
     let msg = SplitPanel::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
 }
@@ -406,7 +409,7 @@ fn test_dispatch_event_resize() {
     let output = SplitPanel::dispatch_event(
         &mut state,
         &Event::key_with(KeyCode::Right, KeyModifiers::CONTROL),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert!(matches!(output, Some(SplitPanelOutput::RatioChanged(_))));
 }
@@ -426,7 +429,7 @@ fn test_render_vertical() {
     let (mut terminal, theme) = test_utils::setup_render(80, 24);
     terminal
         .draw(|frame| {
-            SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SplitPanel::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -437,7 +440,7 @@ fn test_render_horizontal() {
     let (mut terminal, theme) = test_utils::setup_render(80, 24);
     terminal
         .draw(|frame| {
-            SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SplitPanel::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -449,7 +452,7 @@ fn test_render_second_pane_focused() {
     let (mut terminal, theme) = test_utils::setup_render(80, 24);
     terminal
         .draw(|frame| {
-            SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SplitPanel::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -462,10 +465,7 @@ fn test_render_disabled() {
         .draw(|frame| {
             SplitPanel::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -498,7 +498,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                SplitPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                SplitPanel::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/status_bar/mod.rs
+++ b/src/component/status_bar/mod.rs
@@ -60,7 +60,7 @@ pub use item::*;
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, ViewContext};
+use super::{Component, RenderContext};
 use crate::theme::Theme;
 
 /// Section of the status bar for addressing items.
@@ -806,21 +806,21 @@ impl Component for StatusBar {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         // Render background
         let bg_style = Style::default().bg(state.background);
 
         // Calculate section widths
-        let left_spans = Self::render_section(&state.left, &state.separator, theme);
-        let center_spans = Self::render_section(&state.center, &state.separator, theme);
-        let right_spans = Self::render_section(&state.right, &state.separator, theme);
+        let left_spans = Self::render_section(&state.left, &state.separator, ctx.theme);
+        let center_spans = Self::render_section(&state.center, &state.separator, ctx.theme);
+        let right_spans = Self::render_section(&state.right, &state.separator, ctx.theme);
 
         // Calculate the width of each section
         let left_width: usize = left_spans.iter().map(|s| s.content.len()).sum();
         let center_width: usize = center_spans.iter().map(|s| s.content.len()).sum();
         let right_width: usize = right_spans.iter().map(|s| s.content.len()).sum();
 
-        let total_width = area.width as usize;
+        let total_width = ctx.area.width as usize;
 
         // Determine how much space is available for center after left and right.
         // Priority: left (full), right (full), center (gets remainder).
@@ -873,7 +873,7 @@ impl Component for StatusBar {
                 .with_id("status_bar")
                 .with_meta("item_count", item_count.to_string());
         let annotated = crate::annotation::Annotate::new(paragraph, annotation);
-        frame.render_widget(annotated, area);
+        ctx.frame.render_widget(annotated, ctx.area);
     }
 }
 

--- a/src/component/status_bar/snapshot_tests.rs
+++ b/src/component/status_bar/snapshot_tests.rs
@@ -11,7 +11,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 1);
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -25,7 +25,7 @@ fn test_snapshot_left_only() {
     let (mut terminal, theme) = test_utils::setup_render(60, 1);
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -38,7 +38,7 @@ fn test_snapshot_center_only() {
     let (mut terminal, theme) = test_utils::setup_render(60, 1);
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -52,7 +52,7 @@ fn test_snapshot_right_only() {
     let (mut terminal, theme) = test_utils::setup_render(60, 1);
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -68,7 +68,7 @@ fn test_snapshot_all_sections() {
     let (mut terminal, theme) = test_utils::setup_render(60, 1);
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -83,7 +83,7 @@ fn test_snapshot_styled_items() {
     let (mut terminal, theme) = test_utils::setup_render(60, 1);
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -105,7 +105,7 @@ fn test_snapshot_counter_item() {
     let (mut terminal, theme) = test_utils::setup_render(60, 1);
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -121,7 +121,7 @@ fn test_snapshot_custom_separator() {
     let (mut terminal, theme) = test_utils::setup_render(60, 1);
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/status_bar/tests/component.rs
+++ b/src/component/status_bar/tests/component.rs
@@ -120,7 +120,7 @@ fn test_view_empty() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -136,7 +136,7 @@ fn test_view_left_only() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -152,7 +152,7 @@ fn test_view_right_only() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -168,7 +168,7 @@ fn test_view_center_only() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -186,7 +186,7 @@ fn test_view_all_sections() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -203,7 +203,7 @@ fn test_view_with_separator() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -220,7 +220,7 @@ fn test_view_custom_separator() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -237,7 +237,7 @@ fn test_view_no_separator_on_last_item() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -254,7 +254,7 @@ fn test_view_styled_items() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -272,7 +272,7 @@ fn test_view_elapsed_time() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -297,7 +297,7 @@ fn test_view_counter_with_label() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -313,7 +313,7 @@ fn test_view_heartbeat() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -332,7 +332,7 @@ fn test_view_left_and_right_no_center() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -351,7 +351,7 @@ fn test_view_many_items_in_section() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -376,7 +376,7 @@ fn test_view_counter_no_label() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -397,7 +397,7 @@ fn test_view_all_styles() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -415,7 +415,7 @@ fn test_view_narrow_width() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -432,7 +432,7 @@ fn test_view_multiple_items_right() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -451,7 +451,7 @@ fn test_view_mixed_dynamic_items() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -517,7 +517,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -544,7 +544,7 @@ fn test_view_overflow_truncates_center() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -574,7 +574,7 @@ fn test_view_severe_overflow_drops_center() {
 
     terminal
         .draw(|frame| {
-            StatusBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 

--- a/src/component/status_log/mod.rs
+++ b/src/component/status_log/mod.rs
@@ -28,12 +28,10 @@ pub mod entry;
 
 pub use entry::{StatusLogEntry, StatusLogLevel};
 
-use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 /// Messages that can be sent to a StatusLog component.
 #[derive(Clone, Debug, PartialEq)]
@@ -692,7 +690,7 @@ impl Component for StatusLog {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -710,14 +708,14 @@ impl Component for StatusLog {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        if area.width == 0 || area.height == 0 {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        if ctx.area.width == 0 || ctx.area.height == 0 {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::new(crate::annotation::WidgetType::StatusLog)
                     .with_id("status_log")
                     .with_meta("entry_count", state.len().to_string()),
@@ -730,7 +728,7 @@ impl Component for StatusLog {
             Block::default().borders(Borders::ALL)
         };
 
-        let inner = block.inner(area);
+        let inner = block.inner(ctx.area);
 
         // Build list items (newest first, with scroll offset)
         let items: Vec<ListItem> = state
@@ -740,13 +738,13 @@ impl Component for StatusLog {
             .map(|entry| {
                 let prefix = entry.level.prefix();
                 let style = if ctx.disabled {
-                    theme.disabled_style()
+                    ctx.theme.disabled_style()
                 } else {
                     match entry.level {
-                        StatusLogLevel::Info => theme.info_style(),
-                        StatusLogLevel::Success => theme.success_style(),
-                        StatusLogLevel::Warning => theme.warning_style(),
-                        StatusLogLevel::Error => theme.error_style(),
+                        StatusLogLevel::Info => ctx.theme.info_style(),
+                        StatusLogLevel::Success => ctx.theme.success_style(),
+                        StatusLogLevel::Warning => ctx.theme.warning_style(),
+                        StatusLogLevel::Error => ctx.theme.error_style(),
                     }
                 };
 
@@ -764,11 +762,11 @@ impl Component for StatusLog {
             })
             .collect();
 
-        frame.render_widget(block, area);
+        ctx.frame.render_widget(block, ctx.area);
 
         if !items.is_empty() {
             let list = List::new(items);
-            frame.render_widget(list, inner);
+            ctx.frame.render_widget(list, inner);
         }
     }
 }

--- a/src/component/status_log/tests.rs
+++ b/src/component/status_log/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use ratatui::style::Color;
 
 // ========================================
 // StatusLogLevel Tests
@@ -480,7 +481,7 @@ fn test_view_empty() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
 
     terminal
-        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| StatusLog::view(&state, &mut RenderContext::new(frame, frame.area(), &theme)))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -495,7 +496,7 @@ fn test_view_with_messages() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
 
     terminal
-        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| StatusLog::view(&state, &mut RenderContext::new(frame, frame.area(), &theme)))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -509,7 +510,7 @@ fn test_view_with_title() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
 
     terminal
-        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| StatusLog::view(&state, &mut RenderContext::new(frame, frame.area(), &theme)))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -523,7 +524,7 @@ fn test_view_with_timestamps() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
     terminal
-        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| StatusLog::view(&state, &mut RenderContext::new(frame, frame.area(), &theme)))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -540,7 +541,7 @@ fn test_view_all_levels() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
 
     terminal
-        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| StatusLog::view(&state, &mut RenderContext::new(frame, frame.area(), &theme)))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -559,10 +560,7 @@ fn test_view_focused() {
         .draw(|frame| {
             StatusLog::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             )
         })
         .unwrap();
@@ -580,7 +578,7 @@ fn test_view_unfocused() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
 
     terminal
-        .draw(|frame| StatusLog::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| StatusLog::view(&state, &mut RenderContext::new(frame, frame.area(), &theme)))
         .unwrap();
 
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -600,12 +598,16 @@ fn test_handle_event_scroll_up() {
     let msg = StatusLog::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StatusLogMessage::ScrollUp));
 
     // Vim 'k' -> ScrollUp
-    let msg = StatusLog::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true));
+    let msg = StatusLog::handle_event(
+        &state,
+        &Event::char('k'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(StatusLogMessage::ScrollUp));
 }
 
@@ -617,12 +619,16 @@ fn test_handle_event_scroll_down() {
     let msg = StatusLog::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StatusLogMessage::ScrollDown));
 
     // Vim 'j' -> ScrollDown
-    let msg = StatusLog::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true));
+    let msg = StatusLog::handle_event(
+        &state,
+        &Event::char('j'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(StatusLogMessage::ScrollDown));
 }
 
@@ -633,7 +639,7 @@ fn test_handle_event_scroll_to_top() {
     let msg = StatusLog::handle_event(
         &state,
         &Event::key(KeyCode::Home),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StatusLogMessage::ScrollToTop));
 }
@@ -645,7 +651,7 @@ fn test_handle_event_scroll_to_bottom() {
     let msg = StatusLog::handle_event(
         &state,
         &Event::key(KeyCode::End),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StatusLogMessage::ScrollToBottom));
 }
@@ -653,7 +659,7 @@ fn test_handle_event_scroll_to_bottom() {
 #[test]
 fn test_handle_event_ignored_when_unfocused() {
     let state = StatusLogState::new();
-    let msg = StatusLog::handle_event(&state, &Event::key(KeyCode::Up), &ViewContext::default());
+    let msg = StatusLog::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -673,7 +679,7 @@ fn test_dispatch_event() {
     StatusLog::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(state.scroll_offset(), 4);
 }
@@ -689,7 +695,7 @@ fn test_instance_methods() {
     let msg = StatusLog::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StatusLogMessage::ScrollUp));
 
@@ -701,7 +707,7 @@ fn test_instance_methods() {
     StatusLog::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(state.scroll_offset(), 2);
 }
@@ -717,35 +723,35 @@ fn test_handle_event_ignored_when_disabled() {
     let msg = StatusLog::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = StatusLog::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = StatusLog::handle_event(
         &state,
         &Event::char('k'),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = StatusLog::handle_event(
         &state,
         &Event::key(KeyCode::Home),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = StatusLog::handle_event(
         &state,
         &Event::key(KeyCode::End),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -761,7 +767,7 @@ fn test_dispatch_event_ignored_when_disabled() {
     let output = StatusLog::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(output, None);
     assert_eq!(state.scroll_offset(), 2);
@@ -801,7 +807,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                StatusLog::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                StatusLog::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/step_indicator/mod.rs
+++ b/src/component/step_indicator/mod.rs
@@ -31,7 +31,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -723,7 +723,7 @@ impl Component for StepIndicator {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -742,10 +742,10 @@ impl Component for StepIndicator {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::new(crate::annotation::WidgetType::StepIndicator)
                     .with_id("step_indicator")
                     .with_focus(ctx.focused)
@@ -757,18 +757,18 @@ impl Component for StepIndicator {
             let mut block = Block::default()
                 .borders(Borders::ALL)
                 .border_style(if ctx.focused {
-                    theme.focused_border_style()
+                    ctx.theme.focused_border_style()
                 } else {
-                    theme.border_style()
+                    ctx.theme.border_style()
                 });
             if let Some(title) = &state.title {
                 block = block.title(format!(" {} ", title));
             }
-            let inner = block.inner(area);
-            frame.render_widget(block, area);
+            let inner = block.inner(ctx.area);
+            ctx.frame.render_widget(block, ctx.area);
             inner
         } else {
-            area
+            ctx.area
         };
 
         if state.steps.is_empty() {
@@ -777,10 +777,10 @@ impl Component for StepIndicator {
 
         match state.orientation {
             StepOrientation::Horizontal => {
-                render_horizontal(state, frame, inner, theme, ctx.focused);
+                render_horizontal(state, ctx.frame, inner, ctx.theme, ctx.focused);
             }
             StepOrientation::Vertical => {
-                render_vertical(state, frame, inner, theme, ctx.focused);
+                render_vertical(state, ctx.frame, inner, ctx.theme, ctx.focused);
             }
         }
     }

--- a/src/component/step_indicator/tests.rs
+++ b/src/component/step_indicator/tests.rs
@@ -500,7 +500,7 @@ fn test_handle_event_right_arrow() {
     let msg = StepIndicator::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StepIndicatorMessage::FocusNext));
 }
@@ -508,8 +508,11 @@ fn test_handle_event_right_arrow() {
 #[test]
 fn test_handle_event_l_key() {
     let state = StepIndicatorState::new(vec![Step::new("A"), Step::new("B")]);
-    let msg =
-        StepIndicator::handle_event(&state, &Event::char('l'), &ViewContext::new().focused(true));
+    let msg = StepIndicator::handle_event(
+        &state,
+        &Event::char('l'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(StepIndicatorMessage::FocusNext));
 }
 
@@ -519,7 +522,7 @@ fn test_handle_event_left_arrow() {
     let msg = StepIndicator::handle_event(
         &state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StepIndicatorMessage::FocusPrev));
 }
@@ -527,8 +530,11 @@ fn test_handle_event_left_arrow() {
 #[test]
 fn test_handle_event_h_key() {
     let state = StepIndicatorState::new(vec![Step::new("A"), Step::new("B")]);
-    let msg =
-        StepIndicator::handle_event(&state, &Event::char('h'), &ViewContext::new().focused(true));
+    let msg = StepIndicator::handle_event(
+        &state,
+        &Event::char('h'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(StepIndicatorMessage::FocusPrev));
 }
 
@@ -538,7 +544,7 @@ fn test_handle_event_home() {
     let msg = StepIndicator::handle_event(
         &state,
         &Event::key(KeyCode::Home),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StepIndicatorMessage::First));
 }
@@ -549,7 +555,7 @@ fn test_handle_event_end() {
     let msg = StepIndicator::handle_event(
         &state,
         &Event::key(KeyCode::End),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StepIndicatorMessage::Last));
 }
@@ -560,7 +566,7 @@ fn test_handle_event_enter() {
     let msg = StepIndicator::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StepIndicatorMessage::Select));
 }
@@ -568,8 +574,11 @@ fn test_handle_event_enter() {
 #[test]
 fn test_handle_event_unfocused_ignored() {
     let state = StepIndicatorState::new(vec![Step::new("A")]);
-    let msg =
-        StepIndicator::handle_event(&state, &Event::key(KeyCode::Right), &ViewContext::default());
+    let msg = StepIndicator::handle_event(
+        &state,
+        &Event::key(KeyCode::Right),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 }
 
@@ -579,7 +588,7 @@ fn test_handle_event_disabled_ignored() {
     let msg = StepIndicator::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -587,8 +596,11 @@ fn test_handle_event_disabled_ignored() {
 #[test]
 fn test_handle_event_unrecognized_key() {
     let state = StepIndicatorState::new(vec![Step::new("A")]);
-    let msg =
-        StepIndicator::handle_event(&state, &Event::char('z'), &ViewContext::new().focused(true));
+    let msg = StepIndicator::handle_event(
+        &state,
+        &Event::char('z'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, None);
 }
 
@@ -600,7 +612,7 @@ fn test_dispatch_event() {
     let output = StepIndicator::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(StepIndicatorOutput::FocusChanged(1)));
     assert_eq!(state.focused_index(), 1);
@@ -627,7 +639,7 @@ fn test_view_horizontal() {
 
     terminal
         .draw(|frame| {
-            StepIndicator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StepIndicator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -647,7 +659,7 @@ fn test_view_vertical() {
 
     terminal
         .draw(|frame| {
-            StepIndicator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StepIndicator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -666,7 +678,7 @@ fn test_view_with_title() {
 
     terminal
         .draw(|frame| {
-            StepIndicator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StepIndicator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -685,10 +697,7 @@ fn test_view_focused_step() {
         .draw(|frame| {
             StepIndicator::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -715,7 +724,7 @@ fn test_view_vertical_with_descriptions() {
 
     terminal
         .draw(|frame| {
-            StepIndicator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StepIndicator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -737,7 +746,7 @@ fn test_view_all_statuses() {
 
     terminal
         .draw(|frame| {
-            StepIndicator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StepIndicator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -752,7 +761,7 @@ fn test_view_empty_steps() {
 
     terminal
         .draw(|frame| {
-            StepIndicator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StepIndicator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -772,7 +781,7 @@ fn test_view_borderless_horizontal() {
 
     terminal
         .draw(|frame| {
-            StepIndicator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StepIndicator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -794,7 +803,7 @@ fn test_view_borderless_vertical() {
 
     terminal
         .draw(|frame| {
-            StepIndicator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StepIndicator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -818,7 +827,7 @@ fn test_view_borderless_one_row() {
 
     terminal
         .draw(|frame| {
-            StepIndicator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StepIndicator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -846,7 +855,7 @@ fn test_view_borderless_drops_title() {
 
     terminal
         .draw(|frame| {
-            StepIndicator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StepIndicator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -885,10 +894,7 @@ fn test_annotation_emission() {
             .draw(|frame| {
                 StepIndicator::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
                 );
             })
             .unwrap();

--- a/src/component/styled_text/mod.rs
+++ b/src/component/styled_text/mod.rs
@@ -39,9 +39,8 @@ pub use content::{StyledBlock, StyledContent, StyledInline};
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
-use crate::theme::Theme;
 
 /// Messages that can be sent to a StyledText component.
 #[derive(Clone, Debug, PartialEq)]
@@ -374,7 +373,7 @@ impl Component for StyledText {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -446,10 +445,10 @@ impl Component for StyledText {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::new(crate::annotation::WidgetType::StyledText)
                     .with_id("styled_text")
                     .with_focus(ctx.focused)
@@ -458,11 +457,11 @@ impl Component for StyledText {
         });
 
         let border_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let (inner, render_area) = if state.show_border {
@@ -474,18 +473,18 @@ impl Component for StyledText {
                 block = block.title(title.as_str());
             }
 
-            let inner = block.inner(area);
-            frame.render_widget(block, area);
+            let inner = block.inner(ctx.area);
+            ctx.frame.render_widget(block, ctx.area);
             (inner, inner)
         } else {
-            (area, area)
+            (ctx.area, ctx.area)
         };
 
         if inner.height == 0 || inner.width == 0 {
             return;
         }
 
-        let rendered_lines = state.content.render_lines(inner.width, theme);
+        let rendered_lines = state.content.render_lines(inner.width, ctx.theme);
         let total_visual_rows = visual_row_count(&rendered_lines, inner.width as usize);
         let visible_lines = inner.height as usize;
         let max_scroll = total_visual_rows.saturating_sub(visible_lines);
@@ -496,7 +495,7 @@ impl Component for StyledText {
             .wrap(Wrap { trim: false })
             .scroll((effective_scroll as u16, 0));
 
-        frame.render_widget(paragraph, render_area);
+        ctx.frame.render_widget(paragraph, render_area);
     }
 }
 

--- a/src/component/styled_text/tests.rs
+++ b/src/component/styled_text/tests.rs
@@ -320,7 +320,7 @@ fn test_handle_event_up() {
     let msg = StyledText::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StyledTextMessage::ScrollUp));
 }
@@ -328,8 +328,11 @@ fn test_handle_event_up() {
 #[test]
 fn test_handle_event_k() {
     let state = StyledTextState::new();
-    let msg =
-        StyledText::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true));
+    let msg = StyledText::handle_event(
+        &state,
+        &Event::char('k'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(StyledTextMessage::ScrollUp));
 }
 
@@ -339,7 +342,7 @@ fn test_handle_event_down() {
     let msg = StyledText::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StyledTextMessage::ScrollDown));
 }
@@ -347,8 +350,11 @@ fn test_handle_event_down() {
 #[test]
 fn test_handle_event_j() {
     let state = StyledTextState::new();
-    let msg =
-        StyledText::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true));
+    let msg = StyledText::handle_event(
+        &state,
+        &Event::char('j'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(StyledTextMessage::ScrollDown));
 }
 
@@ -358,7 +364,7 @@ fn test_handle_event_page_up() {
     let msg = StyledText::handle_event(
         &state,
         &Event::key(KeyCode::PageUp),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StyledTextMessage::PageUp(10)));
 }
@@ -369,7 +375,7 @@ fn test_handle_event_page_down() {
     let msg = StyledText::handle_event(
         &state,
         &Event::key(KeyCode::PageDown),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StyledTextMessage::PageDown(10)));
 }
@@ -377,16 +383,22 @@ fn test_handle_event_page_down() {
 #[test]
 fn test_handle_event_ctrl_u() {
     let state = StyledTextState::new();
-    let msg =
-        StyledText::handle_event(&state, &Event::ctrl('u'), &ViewContext::new().focused(true));
+    let msg = StyledText::handle_event(
+        &state,
+        &Event::ctrl('u'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(StyledTextMessage::PageUp(10)));
 }
 
 #[test]
 fn test_handle_event_ctrl_d() {
     let state = StyledTextState::new();
-    let msg =
-        StyledText::handle_event(&state, &Event::ctrl('d'), &ViewContext::new().focused(true));
+    let msg = StyledText::handle_event(
+        &state,
+        &Event::ctrl('d'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(StyledTextMessage::PageDown(10)));
 }
 
@@ -396,7 +408,7 @@ fn test_handle_event_home() {
     let msg = StyledText::handle_event(
         &state,
         &Event::key(KeyCode::Home),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StyledTextMessage::Home));
 }
@@ -404,8 +416,11 @@ fn test_handle_event_home() {
 #[test]
 fn test_handle_event_g() {
     let state = StyledTextState::new();
-    let msg =
-        StyledText::handle_event(&state, &Event::char('g'), &ViewContext::new().focused(true));
+    let msg = StyledText::handle_event(
+        &state,
+        &Event::char('g'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(StyledTextMessage::Home));
 }
 
@@ -415,7 +430,7 @@ fn test_handle_event_end() {
     let msg = StyledText::handle_event(
         &state,
         &Event::key(KeyCode::End),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StyledTextMessage::End));
 }
@@ -423,7 +438,8 @@ fn test_handle_event_end() {
 #[test]
 fn test_handle_event_unfocused_ignored() {
     let state = StyledTextState::new();
-    let msg = StyledText::handle_event(&state, &Event::key(KeyCode::Down), &ViewContext::default());
+    let msg =
+        StyledText::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -433,7 +449,7 @@ fn test_handle_event_disabled_ignored() {
     let msg = StyledText::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -441,8 +457,11 @@ fn test_handle_event_disabled_ignored() {
 #[test]
 fn test_handle_event_unrecognized() {
     let state = StyledTextState::new();
-    let msg =
-        StyledText::handle_event(&state, &Event::char('z'), &ViewContext::new().focused(true));
+    let msg = StyledText::handle_event(
+        &state,
+        &Event::char('z'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, None);
 }
 
@@ -454,7 +473,7 @@ fn test_dispatch_event() {
     let output = StyledText::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(StyledTextOutput::ScrollChanged(1)));
 }
@@ -486,7 +505,7 @@ fn test_view_heading_and_text() {
 
     terminal
         .draw(|frame| {
-            StyledText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StyledText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -506,7 +525,7 @@ fn test_view_bullet_list() {
 
     terminal
         .draw(|frame| {
-            StyledText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StyledText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -526,7 +545,7 @@ fn test_view_numbered_list() {
 
     terminal
         .draw(|frame| {
-            StyledText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StyledText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -543,7 +562,7 @@ fn test_view_code_block() {
 
     terminal
         .draw(|frame| {
-            StyledText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StyledText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -562,7 +581,7 @@ fn test_view_horizontal_rule() {
 
     terminal
         .draw(|frame| {
-            StyledText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StyledText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -580,7 +599,7 @@ fn test_view_with_title() {
 
     terminal
         .draw(|frame| {
-            StyledText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StyledText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -598,7 +617,7 @@ fn test_view_no_border() {
 
     terminal
         .draw(|frame| {
-            StyledText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StyledText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -613,7 +632,7 @@ fn test_view_empty_content() {
 
     terminal
         .draw(|frame| {
-            StyledText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StyledText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -640,7 +659,7 @@ fn test_view_mixed_content() {
 
     terminal
         .draw(|frame| {
-            StyledText::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            StyledText::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -660,10 +679,7 @@ fn test_annotation_emission() {
             .draw(|frame| {
                 StyledText::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
                 );
             })
             .unwrap();

--- a/src/component/switch/mod.rs
+++ b/src/component/switch/mod.rs
@@ -28,12 +28,10 @@
 //! assert!(!state.is_on());
 //! ```
 
-use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use super::{Component, Toggleable, ViewContext};
+use super::{Component, EventContext, RenderContext, Toggleable};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 /// Messages that can be sent to a Switch.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -327,7 +325,7 @@ impl Component for Switch {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -342,7 +340,7 @@ impl Component for Switch {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         let indicator = if state.on {
             format!("(*) {}", state.on_label)
         } else {
@@ -356,17 +354,17 @@ impl Component for Switch {
         };
 
         let style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if state.on {
             if ctx.focused {
-                theme.focused_style()
+                ctx.theme.focused_style()
             } else {
-                theme.success_style()
+                ctx.theme.success_style()
             }
         } else if ctx.focused {
-            theme.focused_style()
+            ctx.theme.focused_style()
         } else {
-            theme.normal_style()
+            ctx.theme.normal_style()
         };
 
         let paragraph = Paragraph::new(text).style(style);
@@ -380,7 +378,7 @@ impl Component for Switch {
         let annotated = crate::annotation::Annotate::new(paragraph, annotation)
             .focused(ctx.focused)
             .disabled(ctx.disabled);
-        frame.render_widget(annotated, area);
+        ctx.frame.render_widget(annotated, ctx.area);
     }
 }
 

--- a/src/component/switch/tests.rs
+++ b/src/component/switch/tests.rs
@@ -185,7 +185,7 @@ fn test_handle_event_enter_when_focused() {
     let msg = Switch::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SwitchMessage::Toggle));
 }
@@ -193,14 +193,22 @@ fn test_handle_event_enter_when_focused() {
 #[test]
 fn test_handle_event_space_when_focused() {
     let state = SwitchState::new();
-    let msg = Switch::handle_event(&state, &Event::char(' '), &ViewContext::new().focused(true));
+    let msg = Switch::handle_event(
+        &state,
+        &Event::char(' '),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(SwitchMessage::Toggle));
 }
 
 #[test]
 fn test_handle_event_ignored_when_unfocused() {
     let state = SwitchState::new();
-    let msg = Switch::handle_event(&state, &Event::key(KeyCode::Enter), &ViewContext::default());
+    let msg = Switch::handle_event(
+        &state,
+        &Event::key(KeyCode::Enter),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 }
 
@@ -210,7 +218,7 @@ fn test_handle_event_ignored_when_disabled() {
     let msg = Switch::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -218,7 +226,11 @@ fn test_handle_event_ignored_when_disabled() {
 #[test]
 fn test_handle_event_other_key_ignored() {
     let state = SwitchState::new();
-    let msg = Switch::handle_event(&state, &Event::char('a'), &ViewContext::new().focused(true));
+    let msg = Switch::handle_event(
+        &state,
+        &Event::char('a'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, None);
 }
 
@@ -228,7 +240,7 @@ fn test_dispatch_event() {
     let output = Switch::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(SwitchOutput::On));
     assert!(state.is_on());
@@ -240,7 +252,7 @@ fn test_dispatch_event_unfocused() {
     let output = Switch::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::default(),
+        &EventContext::default(),
     );
     assert_eq!(output, None);
     assert!(!state.is_on());
@@ -264,7 +276,7 @@ fn test_view_off() {
 
     terminal
         .draw(|frame| {
-            Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Switch::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -278,7 +290,7 @@ fn test_view_on() {
 
     terminal
         .draw(|frame| {
-            Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Switch::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -294,10 +306,7 @@ fn test_view_focused() {
         .draw(|frame| {
             Switch::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -314,10 +323,7 @@ fn test_view_focused_on() {
         .draw(|frame| {
             Switch::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -333,10 +339,7 @@ fn test_view_disabled_on() {
         .draw(|frame| {
             Switch::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -351,7 +354,7 @@ fn test_view_with_label() {
 
     terminal
         .draw(|frame| {
-            Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Switch::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -365,7 +368,7 @@ fn test_view_with_label_on() {
 
     terminal
         .draw(|frame| {
-            Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Switch::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -382,7 +385,7 @@ fn test_view_custom_labels() {
 
     terminal
         .draw(|frame| {
-            Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Switch::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -454,7 +457,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Switch::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -472,7 +475,7 @@ fn test_annotation_on() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Switch::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -488,7 +491,7 @@ fn test_annotation_with_label() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Switch::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/tab_bar/mod.rs
+++ b/src/component/tab_bar/mod.rs
@@ -29,9 +29,7 @@
 //! assert_eq!(state.active_index(), Some(1));
 //! ```
 
-use ratatui::prelude::*;
-
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
 use crate::theme::Theme;
 
@@ -745,7 +743,7 @@ impl Component for TabBar {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -764,8 +762,15 @@ impl Component for TabBar {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        render::render_tab_bar(state, frame, area, theme, ctx.focused, ctx.disabled);
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        render::render_tab_bar(
+            state,
+            ctx.frame,
+            ctx.area,
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
     }
 }
 

--- a/src/component/tab_bar/tests.rs
+++ b/src/component/tab_bar/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::input::{Event, KeyCode};
+use ratatui::layout::Rect;
 
 // ========== Tab Tests ==========
 
@@ -463,7 +464,7 @@ fn test_handle_event_navigation_keys() {
         TabBar::handle_event(
             &state,
             &Event::key(KeyCode::Right),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(TabBarMessage::NextTab)
     );
@@ -471,7 +472,7 @@ fn test_handle_event_navigation_keys() {
         TabBar::handle_event(
             &state,
             &Event::key(KeyCode::Left),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(TabBarMessage::PrevTab)
     );
@@ -479,7 +480,7 @@ fn test_handle_event_navigation_keys() {
         TabBar::handle_event(
             &state,
             &Event::key(KeyCode::Home),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(TabBarMessage::First)
     );
@@ -487,7 +488,7 @@ fn test_handle_event_navigation_keys() {
         TabBar::handle_event(
             &state,
             &Event::key(KeyCode::End),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(TabBarMessage::Last)
     );
@@ -497,11 +498,19 @@ fn test_handle_event_navigation_keys() {
 fn test_handle_event_vim_keys() {
     let state = TabBarState::new(vec![Tab::new("a", "A"), Tab::new("b", "B")]);
     assert_eq!(
-        TabBar::handle_event(&state, &Event::char('h'), &ViewContext::new().focused(true)),
+        TabBar::handle_event(
+            &state,
+            &Event::char('h'),
+            &EventContext::new().focused(true)
+        ),
         Some(TabBarMessage::PrevTab)
     );
     assert_eq!(
-        TabBar::handle_event(&state, &Event::char('l'), &ViewContext::new().focused(true)),
+        TabBar::handle_event(
+            &state,
+            &Event::char('l'),
+            &EventContext::new().focused(true)
+        ),
         Some(TabBarMessage::NextTab)
     );
 }
@@ -510,7 +519,11 @@ fn test_handle_event_vim_keys() {
 fn test_handle_event_close_key() {
     let state = TabBarState::new(vec![Tab::new("a", "A").with_closable(true)]);
     assert_eq!(
-        TabBar::handle_event(&state, &Event::char('w'), &ViewContext::new().focused(true)),
+        TabBar::handle_event(
+            &state,
+            &Event::char('w'),
+            &EventContext::new().focused(true)
+        ),
         Some(TabBarMessage::CloseActiveTab)
     );
 }
@@ -519,11 +532,15 @@ fn test_handle_event_close_key() {
 fn test_handle_event_unfocused() {
     let state = TabBarState::new(vec![Tab::new("a", "A")]);
     assert_eq!(
-        TabBar::handle_event(&state, &Event::key(KeyCode::Right), &ViewContext::default()),
+        TabBar::handle_event(
+            &state,
+            &Event::key(KeyCode::Right),
+            &EventContext::default()
+        ),
         None
     );
     assert_eq!(
-        TabBar::handle_event(&state, &Event::char('l'), &ViewContext::default()),
+        TabBar::handle_event(&state, &Event::char('l'), &EventContext::default()),
         None
     );
 }
@@ -531,7 +548,11 @@ fn test_handle_event_unfocused() {
 fn test_handle_event_unrecognized_key() {
     let state = TabBarState::new(vec![Tab::new("a", "A")]);
     assert_eq!(
-        TabBar::handle_event(&state, &Event::char('z'), &ViewContext::new().focused(true)),
+        TabBar::handle_event(
+            &state,
+            &Event::char('z'),
+            &EventContext::new().focused(true)
+        ),
         None
     );
 }
@@ -544,7 +565,7 @@ fn test_dispatch_event_next() {
     let output = TabBar::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(TabBarOutput::TabSelected(1)));
     assert_eq!(state.active_index(), Some(1));
@@ -559,7 +580,7 @@ fn test_dispatch_event_close() {
     let output = TabBar::dispatch_event(
         &mut state,
         &Event::char('w'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(TabBarOutput::TabClosed(0)));
     assert_eq!(state.len(), 1);
@@ -574,14 +595,14 @@ fn test_instance_methods() {
     let msg = TabBar::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TabBarMessage::NextTab));
 
     let output = TabBar::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(TabBarOutput::TabSelected(1)));
     assert_eq!(state.active_index(), Some(1));
@@ -611,7 +632,7 @@ fn test_view_renders_basic() {
     ]);
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
     terminal
-        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| TabBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme)))
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -624,10 +645,7 @@ fn test_view_focused() {
         .draw(|frame| {
             TabBar::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             )
         })
         .unwrap();
@@ -638,7 +656,7 @@ fn test_view_empty() {
     let state = TabBarState::new(vec![]);
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
     terminal
-        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| TabBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme)))
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -651,7 +669,7 @@ fn test_view_with_modified() {
     ]);
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
     terminal
-        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| TabBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme)))
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -664,7 +682,7 @@ fn test_view_with_closable() {
     ]);
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
     terminal
-        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| TabBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme)))
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -677,7 +695,7 @@ fn test_view_with_icon() {
     ]);
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
     terminal
-        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| TabBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme)))
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -693,7 +711,7 @@ fn test_view_with_all_decorations() {
     ]);
     let (mut terminal, theme) = crate::component::test_utils::setup_render(50, 1);
     terminal
-        .draw(|frame| TabBar::view(&state, frame, frame.area(), &theme, &ViewContext::default()))
+        .draw(|frame| TabBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme)))
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
 }
@@ -706,10 +724,7 @@ fn test_view_zero_area() {
         .draw(|frame| {
             TabBar::view(
                 &state,
-                frame,
-                Rect::new(0, 0, 0, 0),
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, Rect::new(0, 0, 0, 0), &theme),
             )
         })
         .unwrap();
@@ -798,7 +813,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                TabBar::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+                TabBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
             })
             .unwrap();
     });

--- a/src/component/table/mod.rs
+++ b/src/component/table/mod.rs
@@ -66,7 +66,7 @@ use std::marker::PhantomData;
 
 use ratatui::prelude::*;
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
@@ -926,7 +926,7 @@ impl<T: TableRow + 'static> Component for Table<T> {
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -962,8 +962,15 @@ impl<T: TableRow + 'static> Component for Table<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        render::render_table(state, frame, area, theme, ctx.focused, ctx.disabled);
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        render::render_table(
+            state,
+            ctx.frame,
+            ctx.area,
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
     }
 }
 

--- a/src/component/table/resize_tests.rs
+++ b/src/component/table/resize_tests.rs
@@ -139,7 +139,7 @@ mod key_binding_tests {
         let msg = Table::<TestRow>::handle_event(
             &state,
             &Event::char('+'),
-            &ViewContext::new().focused(true),
+            &EventContext::new().focused(true),
         );
         assert_eq!(msg, Some(TableMessage::IncreaseColumnWidth(0)));
     }
@@ -151,7 +151,7 @@ mod key_binding_tests {
         let msg = Table::<TestRow>::handle_event(
             &state,
             &Event::char('-'),
-            &ViewContext::new().focused(true),
+            &EventContext::new().focused(true),
         );
         assert_eq!(msg, Some(TableMessage::DecreaseColumnWidth(0)));
     }
@@ -166,7 +166,7 @@ mod key_binding_tests {
         let msg = Table::<TestRow>::handle_event(
             &state,
             &Event::char('+'),
-            &ViewContext::new().focused(true),
+            &EventContext::new().focused(true),
         );
         assert_eq!(msg, Some(TableMessage::IncreaseColumnWidth(1)));
     }
@@ -176,11 +176,11 @@ mod key_binding_tests {
         let state = TableState::new(test_rows(), test_columns());
 
         let msg =
-            Table::<TestRow>::handle_event(&state, &Event::char('+'), &ViewContext::default());
+            Table::<TestRow>::handle_event(&state, &Event::char('+'), &EventContext::default());
         assert_eq!(msg, None);
 
         let msg =
-            Table::<TestRow>::handle_event(&state, &Event::char('-'), &ViewContext::default());
+            Table::<TestRow>::handle_event(&state, &Event::char('-'), &EventContext::default());
         assert_eq!(msg, None);
     }
 
@@ -191,7 +191,7 @@ mod key_binding_tests {
         let msg = Table::<TestRow>::handle_event(
             &state,
             &Event::char('+'),
-            &ViewContext::new().focused(true).disabled(true),
+            &EventContext::new().focused(true).disabled(true),
         );
         assert_eq!(msg, None);
     }

--- a/src/component/table/tests.rs
+++ b/src/component/table/tests.rs
@@ -748,7 +748,7 @@ mod handle_event_tests {
     #[test]
     fn test_key_bindings_when_focused() {
         let state = TableState::new(test_rows(), test_columns());
-        let he = |e| Table::<TestRow>::handle_event(&state, &e, &ViewContext::new().focused(true));
+        let he = |e| Table::<TestRow>::handle_event(&state, &e, &EventContext::new().focused(true));
         assert_eq!(he(Event::key(KeyCode::Up)), Some(TableMessage::Up));
         assert_eq!(he(Event::key(KeyCode::Down)), Some(TableMessage::Down));
         assert_eq!(he(Event::key(KeyCode::Home)), Some(TableMessage::First));
@@ -765,7 +765,7 @@ mod handle_event_tests {
             Table::<TestRow>::handle_event(
                 &state,
                 &Event::key(KeyCode::Down),
-                &ViewContext::default()
+                &EventContext::default()
             ),
             None
         );
@@ -773,7 +773,7 @@ mod handle_event_tests {
             Table::<TestRow>::handle_event(
                 &state,
                 &Event::key(KeyCode::Enter),
-                &ViewContext::default()
+                &EventContext::default()
             ),
             None
         );
@@ -786,7 +786,7 @@ mod handle_event_tests {
             Table::<TestRow>::handle_event(
                 &state,
                 &Event::key(KeyCode::Down),
-                &ViewContext::new().focused(true).disabled(true)
+                &EventContext::new().focused(true).disabled(true)
             ),
             None
         );
@@ -798,7 +798,7 @@ mod handle_event_tests {
         let output = Table::<TestRow>::dispatch_event(
             &mut state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true),
+            &EventContext::new().focused(true),
         );
         assert_eq!(output, Some(TableOutput::SelectionChanged(1)));
         assert_eq!(state.selected_index(), Some(1));
@@ -811,7 +811,7 @@ mod handle_event_tests {
         let output = Table::<TestRow>::dispatch_event(
             &mut state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true),
+            &EventContext::new().focused(true),
         );
         assert_eq!(output, Some(TableOutput::SelectionChanged(1)));
 
@@ -821,7 +821,7 @@ mod handle_event_tests {
         let msg = Table::<TestRow>::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true),
+            &EventContext::new().focused(true),
         );
         assert_eq!(msg, Some(TableMessage::Up));
     }
@@ -896,10 +896,7 @@ fn test_annotation_emitted() {
             .draw(|frame| {
                 Table::<TestRow>::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::default(),
+                    &mut RenderContext::new(frame, frame.area(), &theme),
                 );
             })
             .unwrap();

--- a/src/component/table/view_tests.rs
+++ b/src/component/table/view_tests.rs
@@ -45,7 +45,7 @@ fn test_view_renders() {
 
     terminal
         .draw(|frame| {
-            Table::<TestRow>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Table::<TestRow>::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -60,7 +60,7 @@ fn test_view_with_header() {
 
     terminal
         .draw(|frame| {
-            Table::<TestRow>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Table::<TestRow>::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -76,7 +76,7 @@ fn test_view_with_sort_indicator() {
 
     terminal
         .draw(|frame| {
-            Table::<TestRow>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Table::<TestRow>::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -93,10 +93,7 @@ fn test_view_focused() {
         .draw(|frame| {
             Table::<TestRow>::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -111,7 +108,7 @@ fn test_view_empty() {
 
     terminal
         .draw(|frame| {
-            Table::<TestRow>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Table::<TestRow>::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -129,7 +126,7 @@ fn test_view_descending_sort_indicator() {
 
     terminal
         .draw(|frame| {
-            Table::<TestRow>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Table::<TestRow>::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -144,7 +141,7 @@ fn test_view_unfocused() {
 
     terminal
         .draw(|frame| {
-            Table::<TestRow>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Table::<TestRow>::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -162,7 +159,7 @@ fn test_view_multi_column_sort_indicators() {
 
     terminal
         .draw(|frame| {
-            Table::<TestRow>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Table::<TestRow>::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 

--- a/src/component/tabs/mod.rs
+++ b/src/component/tabs/mod.rs
@@ -29,9 +29,8 @@ use std::marker::PhantomData;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 /// Messages that can be sent to a Tabs component.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -432,7 +431,7 @@ impl<T: Clone + Display + 'static> Component for Tabs<T> {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -451,7 +450,7 @@ impl<T: Clone + Display + 'static> Component for Tabs<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         let selected_idx = state.selected.unwrap_or(0);
 
         let titles: Vec<Line> = state
@@ -460,26 +459,26 @@ impl<T: Clone + Display + 'static> Component for Tabs<T> {
             .enumerate()
             .map(|(i, tab)| {
                 let style = if ctx.disabled {
-                    theme.disabled_style()
+                    ctx.theme.disabled_style()
                 } else if i == selected_idx {
-                    theme.selected_style(ctx.focused)
+                    ctx.theme.selected_style(ctx.focused)
                 } else {
-                    theme.normal_style()
+                    ctx.theme.normal_style()
                 };
                 Line::from(Span::styled(format!(" {} ", tab), style))
             })
             .collect();
 
         let border_style = if ctx.focused && !ctx.disabled {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let highlight_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else {
-            theme.selected_style(ctx.focused)
+            ctx.theme.selected_style(ctx.focused)
         };
 
         let tabs_widget = ratatui::widgets::Tabs::new(titles)
@@ -498,7 +497,7 @@ impl<T: Clone + Display + 'static> Component for Tabs<T> {
             .with_selected(true)
             .with_value(selected_idx.to_string());
         let annotated = crate::annotation::Annotate::new(tabs_widget, annotation);
-        frame.render_widget(annotated, area);
+        ctx.frame.render_widget(annotated, ctx.area);
     }
 }
 

--- a/src/component/tabs/tests.rs
+++ b/src/component/tabs/tests.rs
@@ -233,7 +233,7 @@ fn test_view_renders() {
 
     terminal
         .draw(|frame| {
-            Tabs::<&str>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tabs::<&str>::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -250,10 +250,7 @@ fn test_view_focused() {
         .draw(|frame| {
             Tabs::<&str>::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -268,7 +265,7 @@ fn test_view_empty() {
 
     terminal
         .draw(|frame| {
-            Tabs::<&str>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tabs::<&str>::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -408,7 +405,7 @@ fn test_handle_event_left_when_focused() {
     let msg = Tabs::<&str>::handle_event(
         &state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TabsMessage::Left));
 }
@@ -420,7 +417,7 @@ fn test_handle_event_right_when_focused() {
     let msg = Tabs::<&str>::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TabsMessage::Right));
 }
@@ -432,7 +429,7 @@ fn test_handle_event_first_when_focused() {
     let msg = Tabs::<&str>::handle_event(
         &state,
         &Event::key(KeyCode::Home),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TabsMessage::First));
 }
@@ -444,7 +441,7 @@ fn test_handle_event_last_when_focused() {
     let msg = Tabs::<&str>::handle_event(
         &state,
         &Event::key(KeyCode::End),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TabsMessage::Last));
 }
@@ -456,7 +453,7 @@ fn test_handle_event_confirm_when_focused() {
     let msg = Tabs::<&str>::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TabsMessage::Confirm));
 }
@@ -465,12 +462,18 @@ fn test_handle_event_confirm_when_focused() {
 fn test_handle_event_vim_keys() {
     let state = TabsState::new(vec!["A", "B", "C"]);
 
-    let msg_h =
-        Tabs::<&str>::handle_event(&state, &Event::char('h'), &ViewContext::new().focused(true));
+    let msg_h = Tabs::<&str>::handle_event(
+        &state,
+        &Event::char('h'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg_h, Some(TabsMessage::Left));
 
-    let msg_l =
-        Tabs::<&str>::handle_event(&state, &Event::char('l'), &ViewContext::new().focused(true));
+    let msg_l = Tabs::<&str>::handle_event(
+        &state,
+        &Event::char('l'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg_l, Some(TabsMessage::Right));
 }
 
@@ -479,15 +482,21 @@ fn test_handle_event_ignored_when_unfocused() {
     let state = TabsState::new(vec!["A", "B", "C"]);
     // focused is false by default
 
-    let msg =
-        Tabs::<&str>::handle_event(&state, &Event::key(KeyCode::Right), &ViewContext::default());
+    let msg = Tabs::<&str>::handle_event(
+        &state,
+        &Event::key(KeyCode::Right),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 
-    let msg =
-        Tabs::<&str>::handle_event(&state, &Event::key(KeyCode::Enter), &ViewContext::default());
+    let msg = Tabs::<&str>::handle_event(
+        &state,
+        &Event::key(KeyCode::Enter),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 
-    let msg = Tabs::<&str>::handle_event(&state, &Event::char('l'), &ViewContext::default());
+    let msg = Tabs::<&str>::handle_event(&state, &Event::char('l'), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -498,14 +507,14 @@ fn test_handle_event_ignored_when_disabled() {
     let msg = Tabs::<&str>::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Tabs::<&str>::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -520,7 +529,7 @@ fn test_dispatch_event() {
     let output = Tabs::<&str>::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(TabsOutput::SelectionChanged(1)));
     assert_eq!(state.selected_index(), Some(1));
@@ -529,7 +538,7 @@ fn test_dispatch_event() {
     let output = Tabs::<&str>::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(TabsOutput::Confirmed("B")));
 }
@@ -544,7 +553,7 @@ fn test_instance_methods() {
     let output = Tabs::<&str>::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(TabsOutput::SelectionChanged(1)));
     assert_eq!(state.selected_index(), Some(1));
@@ -558,7 +567,7 @@ fn test_instance_methods() {
     let msg = Tabs::<&str>::handle_event(
         &state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TabsMessage::Left));
 }
@@ -645,7 +654,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Tabs::<String>::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Tabs::<String>::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/terminal_output/mod.rs
+++ b/src/component/terminal_output/mod.rs
@@ -45,12 +45,9 @@ mod render;
 
 pub use ansi::{AnsiSegment, parse_ansi};
 
-use ratatui::prelude::*;
-
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
 use crate::scroll::ScrollState;
-use crate::theme::Theme;
 
 /// Messages that can be sent to a TerminalOutput component.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -702,7 +699,7 @@ impl Component for TerminalOutput {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -831,8 +828,15 @@ impl Component for TerminalOutput {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        render::render(state, frame, area, theme, ctx.focused, ctx.disabled);
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        render::render(
+            state,
+            ctx.frame,
+            ctx.area,
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
     }
 }
 

--- a/src/component/terminal_output/tests.rs
+++ b/src/component/terminal_output/tests.rs
@@ -383,7 +383,7 @@ fn test_disabled_ignores_events() {
     let msg = TerminalOutput::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -392,7 +392,7 @@ fn test_disabled_ignores_events() {
 fn test_unfocused_ignores_events() {
     let state = TerminalOutputState::new();
     let msg =
-        TerminalOutput::handle_event(&state, &Event::key(KeyCode::Up), &ViewContext::default());
+        TerminalOutput::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -407,7 +407,7 @@ fn test_handle_event_up() {
         TerminalOutput::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(TerminalOutputMessage::ScrollUp)
     );
@@ -420,7 +420,7 @@ fn test_handle_event_down() {
         TerminalOutput::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(TerminalOutputMessage::ScrollDown)
     );
@@ -430,11 +430,19 @@ fn test_handle_event_down() {
 fn test_handle_event_k_j() {
     let state = focused_state();
     assert_eq!(
-        TerminalOutput::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true)),
+        TerminalOutput::handle_event(
+            &state,
+            &Event::char('k'),
+            &EventContext::new().focused(true)
+        ),
         Some(TerminalOutputMessage::ScrollUp)
     );
     assert_eq!(
-        TerminalOutput::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true)),
+        TerminalOutput::handle_event(
+            &state,
+            &Event::char('j'),
+            &EventContext::new().focused(true)
+        ),
         Some(TerminalOutputMessage::ScrollDown)
     );
 }
@@ -446,7 +454,7 @@ fn test_handle_event_page_up_down() {
         TerminalOutput::handle_event(
             &state,
             &Event::key(KeyCode::PageUp),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(TerminalOutputMessage::PageUp(10))
     );
@@ -454,7 +462,7 @@ fn test_handle_event_page_up_down() {
         TerminalOutput::handle_event(
             &state,
             &Event::key(KeyCode::PageDown),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(TerminalOutputMessage::PageDown(10))
     );
@@ -464,11 +472,19 @@ fn test_handle_event_page_up_down() {
 fn test_handle_event_ctrl_u_d() {
     let state = focused_state();
     assert_eq!(
-        TerminalOutput::handle_event(&state, &Event::ctrl('u'), &ViewContext::new().focused(true)),
+        TerminalOutput::handle_event(
+            &state,
+            &Event::ctrl('u'),
+            &EventContext::new().focused(true)
+        ),
         Some(TerminalOutputMessage::PageUp(10))
     );
     assert_eq!(
-        TerminalOutput::handle_event(&state, &Event::ctrl('d'), &ViewContext::new().focused(true)),
+        TerminalOutput::handle_event(
+            &state,
+            &Event::ctrl('d'),
+            &EventContext::new().focused(true)
+        ),
         Some(TerminalOutputMessage::PageDown(10))
     );
 }
@@ -480,7 +496,7 @@ fn test_handle_event_home_end() {
         TerminalOutput::handle_event(
             &state,
             &Event::key(KeyCode::Home),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(TerminalOutputMessage::Home)
     );
@@ -488,7 +504,7 @@ fn test_handle_event_home_end() {
         TerminalOutput::handle_event(
             &state,
             &Event::key(KeyCode::End),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(TerminalOutputMessage::End)
     );
@@ -499,14 +515,18 @@ fn test_handle_event_home_end() {
 fn test_handle_event_g_and_G() {
     let state = focused_state();
     assert_eq!(
-        TerminalOutput::handle_event(&state, &Event::char('g'), &ViewContext::new().focused(true)),
+        TerminalOutput::handle_event(
+            &state,
+            &Event::char('g'),
+            &EventContext::new().focused(true)
+        ),
         Some(TerminalOutputMessage::Home)
     );
     assert_eq!(
         TerminalOutput::handle_event(
             &state,
             &Event::key_with(KeyCode::Char('G'), KeyModifiers::SHIFT),
-            &ViewContext::new().focused(true),
+            &EventContext::new().focused(true),
         ),
         Some(TerminalOutputMessage::End)
     );
@@ -516,7 +536,11 @@ fn test_handle_event_g_and_G() {
 fn test_handle_event_toggle_auto_scroll() {
     let state = focused_state();
     assert_eq!(
-        TerminalOutput::handle_event(&state, &Event::char('a'), &ViewContext::new().focused(true)),
+        TerminalOutput::handle_event(
+            &state,
+            &Event::char('a'),
+            &EventContext::new().focused(true)
+        ),
         Some(TerminalOutputMessage::ToggleAutoScroll)
     );
 }
@@ -525,7 +549,11 @@ fn test_handle_event_toggle_auto_scroll() {
 fn test_handle_event_toggle_line_numbers() {
     let state = focused_state();
     assert_eq!(
-        TerminalOutput::handle_event(&state, &Event::char('n'), &ViewContext::new().focused(true)),
+        TerminalOutput::handle_event(
+            &state,
+            &Event::char('n'),
+            &EventContext::new().focused(true)
+        ),
         Some(TerminalOutputMessage::ToggleLineNumbers)
     );
 }
@@ -534,7 +562,11 @@ fn test_handle_event_toggle_line_numbers() {
 fn test_handle_event_unrecognized() {
     let state = focused_state();
     assert_eq!(
-        TerminalOutput::handle_event(&state, &Event::char('x'), &ViewContext::new().focused(true)),
+        TerminalOutput::handle_event(
+            &state,
+            &Event::char('x'),
+            &EventContext::new().focused(true)
+        ),
         None
     );
 }
@@ -588,7 +620,7 @@ fn test_view_empty() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TerminalOutput::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -604,7 +636,7 @@ fn test_view_with_content() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TerminalOutput::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -620,7 +652,7 @@ fn test_view_with_ansi_colors() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TerminalOutput::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -636,7 +668,7 @@ fn test_view_with_line_numbers() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TerminalOutput::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -650,7 +682,7 @@ fn test_view_running() {
     let (mut terminal, theme) = test_utils::setup_render(50, 8);
     terminal
         .draw(|frame| {
-            TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TerminalOutput::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -665,7 +697,7 @@ fn test_view_exit_code() {
     let (mut terminal, theme) = test_utils::setup_render(50, 8);
     terminal
         .draw(|frame| {
-            TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TerminalOutput::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -677,7 +709,7 @@ fn test_view_focused() {
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {
-            TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TerminalOutput::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -694,7 +726,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                TerminalOutput::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -715,10 +747,7 @@ fn test_annotation_focused() {
             .draw(|frame| {
                 TerminalOutput::view(
                     &state,
-                    frame,
-                    frame.area(),
-                    &theme,
-                    &ViewContext::new().focused(true),
+                    &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
                 );
             })
             .unwrap();

--- a/src/component/tests.rs
+++ b/src/component/tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::theme::Theme;
 use ratatui::widgets::Paragraph;
 
 // Test component implementation
@@ -42,15 +41,9 @@ impl Component for TestCounter {
         Some(TestCounterOutput::Changed(state.value))
     }
 
-    fn view(
-        state: &Self::State,
-        frame: &mut Frame,
-        area: Rect,
-        _theme: &Theme,
-        _ctx: &ViewContext,
-    ) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         let text = format!("Count: {}", state.value);
-        frame.render_widget(Paragraph::new(text), area);
+        ctx.frame.render_widget(Paragraph::new(text), ctx.area);
     }
 }
 
@@ -97,7 +90,7 @@ fn test_component_view() {
 
     terminal
         .draw(|frame| {
-            TestCounter::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TestCounter::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 

--- a/src/component/text_area/mod.rs
+++ b/src/component/text_area/mod.rs
@@ -27,13 +27,11 @@
 //! assert_eq!(state.line_count(), 2);
 //! ```
 
-use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 use unicode_width::UnicodeWidthStr;
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode, KeyModifiers};
-use crate::theme::Theme;
 use crate::undo::UndoStack;
 
 #[cfg(feature = "clipboard")]
@@ -656,7 +654,7 @@ impl Component for TextArea {
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -726,11 +724,11 @@ impl Component for TextArea {
         state.apply_update(msg)
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         crate::annotation::with_registry(|reg| {
             let first_line = state.lines.first().map_or("", |l| l.as_str());
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::text_area("text_area")
                     .with_value(first_line)
                     .with_focus(ctx.focused)
@@ -738,7 +736,7 @@ impl Component for TextArea {
             );
         });
 
-        let inner_height = area.height.saturating_sub(2) as usize; // Account for borders
+        let inner_height = ctx.area.height.saturating_sub(2) as usize; // Account for borders
 
         // Ensure cursor is visible
         let mut scroll = state.scroll_offset;
@@ -766,19 +764,19 @@ impl Component for TextArea {
         };
 
         let style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_style()
+            ctx.theme.focused_style()
         } else if state.is_empty() && !state.placeholder.is_empty() {
-            theme.placeholder_style()
+            ctx.theme.placeholder_style()
         } else {
-            theme.normal_style()
+            ctx.theme.normal_style()
         };
 
         let border_style = if ctx.focused && !ctx.disabled {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let paragraph = Paragraph::new(display_text).style(style).block(
@@ -787,22 +785,22 @@ impl Component for TextArea {
                 .border_style(border_style),
         );
 
-        frame.render_widget(paragraph, area);
+        ctx.frame.render_widget(paragraph, ctx.area);
 
         // Show cursor when focused
-        if ctx.focused && area.width > 2 && area.height > 2 {
+        if ctx.focused && ctx.area.width > 2 && ctx.area.height > 2 {
             let cursor_row_in_view = state.cursor_row.saturating_sub(scroll);
             let (_, display_col) = state.cursor_display_position();
 
-            let cursor_x = area.x + 1 + display_col as u16;
-            let cursor_y = area.y + 1 + cursor_row_in_view as u16;
+            let cursor_x = ctx.area.x + 1 + display_col as u16;
+            let cursor_y = ctx.area.y + 1 + cursor_row_in_view as u16;
 
-            // Only show cursor if it's within the visible area
-            if cursor_x < area.x + area.width - 1
-                && cursor_y < area.y + area.height - 1
+            // Only show cursor if it's within the visible ctx.area
+            if cursor_x < ctx.area.x + ctx.area.width - 1
+                && cursor_y < ctx.area.y + ctx.area.height - 1
                 && cursor_row_in_view < inner_height
             {
-                frame.set_cursor_position((cursor_x, cursor_y));
+                ctx.frame.set_cursor_position((cursor_x, cursor_y));
             }
         }
     }

--- a/src/component/text_area/selection_tests.rs
+++ b/src/component/text_area/selection_tests.rs
@@ -297,7 +297,7 @@ fn test_shift_left_event() {
     let msg = TextArea::handle_event(
         &state,
         &Event::key_with(KeyCode::Left, KeyModifiers::SHIFT),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::SelectLeft));
 }
@@ -308,7 +308,7 @@ fn test_shift_right_event() {
     let msg = TextArea::handle_event(
         &state,
         &Event::key_with(KeyCode::Right, KeyModifiers::SHIFT),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::SelectRight));
 }
@@ -319,7 +319,7 @@ fn test_shift_up_event() {
     let msg = TextArea::handle_event(
         &state,
         &Event::key_with(KeyCode::Up, KeyModifiers::SHIFT),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::SelectUp));
 }
@@ -330,7 +330,7 @@ fn test_shift_down_event() {
     let msg = TextArea::handle_event(
         &state,
         &Event::key_with(KeyCode::Down, KeyModifiers::SHIFT),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::SelectDown));
 }
@@ -338,21 +338,33 @@ fn test_shift_down_event() {
 #[test]
 fn test_ctrl_c_event() {
     let state = focused_state("hello");
-    let msg = TextArea::handle_event(&state, &Event::ctrl('c'), &ViewContext::new().focused(true));
+    let msg = TextArea::handle_event(
+        &state,
+        &Event::ctrl('c'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(TextAreaMessage::Copy));
 }
 
 #[test]
 fn test_ctrl_x_event() {
     let state = focused_state("hello");
-    let msg = TextArea::handle_event(&state, &Event::ctrl('x'), &ViewContext::new().focused(true));
+    let msg = TextArea::handle_event(
+        &state,
+        &Event::ctrl('x'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(TextAreaMessage::Cut));
 }
 
 #[test]
 fn test_ctrl_a_event() {
     let state = focused_state("hello");
-    let msg = TextArea::handle_event(&state, &Event::ctrl('a'), &ViewContext::new().focused(true));
+    let msg = TextArea::handle_event(
+        &state,
+        &Event::ctrl('a'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(TextAreaMessage::SelectAll));
 }
 
@@ -362,7 +374,7 @@ fn test_paste_event() {
     let msg = TextArea::handle_event(
         &state,
         &Event::Paste("text".into()),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::Paste("text".into())));
 }

--- a/src/component/text_area/tests.rs
+++ b/src/component/text_area/tests.rs
@@ -485,10 +485,7 @@ fn test_view_focused() {
         .draw(|frame| {
             TextArea::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -503,7 +500,7 @@ fn test_view_unfocused() {
 
     terminal
         .draw(|frame| {
-            TextArea::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TextArea::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -517,7 +514,7 @@ fn test_view_placeholder() {
 
     terminal
         .draw(|frame| {
-            TextArea::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TextArea::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -533,7 +530,7 @@ fn test_view_renders() {
 
     terminal
         .draw(|frame| {
-            TextArea::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TextArea::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -691,10 +688,7 @@ fn test_view_with_scroll() {
         .draw(|frame| {
             TextArea::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -713,10 +707,7 @@ fn test_view_cursor_above_scroll() {
         .draw(|frame| {
             TextArea::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -799,7 +790,11 @@ fn test_multiline_mixed_unicode() {
 #[test]
 fn test_handle_event_char_insert() {
     let state = TextArea::init();
-    let msg = TextArea::handle_event(&state, &Event::char('a'), &ViewContext::new().focused(true));
+    let msg = TextArea::handle_event(
+        &state,
+        &Event::char('a'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(TextAreaMessage::Insert('a')));
 }
 
@@ -809,7 +804,7 @@ fn test_handle_event_enter() {
     let msg = TextArea::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::NewLine));
 }
@@ -820,7 +815,7 @@ fn test_handle_event_arrow_up() {
     let msg = TextArea::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::Up));
 }
@@ -831,7 +826,7 @@ fn test_handle_event_arrow_down() {
     let msg = TextArea::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::Down));
 }
@@ -842,7 +837,7 @@ fn test_handle_event_arrow_left() {
     let msg = TextArea::handle_event(
         &state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::Left));
 }
@@ -853,7 +848,7 @@ fn test_handle_event_arrow_right() {
     let msg = TextArea::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::Right));
 }
@@ -864,7 +859,7 @@ fn test_handle_event_ctrl_home() {
     let msg = TextArea::handle_event(
         &state,
         &Event::key_with(KeyCode::Home, KeyModifiers::CONTROL),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::TextStart));
 }
@@ -875,7 +870,7 @@ fn test_handle_event_ctrl_end() {
     let msg = TextArea::handle_event(
         &state,
         &Event::key_with(KeyCode::End, KeyModifiers::CONTROL),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::TextEnd));
 }
@@ -883,21 +878,29 @@ fn test_handle_event_ctrl_end() {
 #[test]
 fn test_handle_event_ctrl_k() {
     let state = TextArea::init();
-    let msg = TextArea::handle_event(&state, &Event::ctrl('k'), &ViewContext::new().focused(true));
+    let msg = TextArea::handle_event(
+        &state,
+        &Event::ctrl('k'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(TextAreaMessage::DeleteToEnd));
 }
 
 #[test]
 fn test_handle_event_ctrl_u() {
     let state = TextArea::init();
-    let msg = TextArea::handle_event(&state, &Event::ctrl('u'), &ViewContext::new().focused(true));
+    let msg = TextArea::handle_event(
+        &state,
+        &Event::ctrl('u'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(TextAreaMessage::DeleteToStart));
 }
 
 #[test]
 fn test_handle_event_ignored_when_unfocused() {
     let state = TextArea::init();
-    let msg = TextArea::handle_event(&state, &Event::char('a'), &ViewContext::default());
+    let msg = TextArea::handle_event(&state, &Event::char('a'), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -907,7 +910,7 @@ fn test_dispatch_event_insert() {
     let output = TextArea::dispatch_event(
         &mut state,
         &Event::char('a'),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert!(matches!(output, Some(TextAreaOutput::Changed(_))));
     assert_eq!(state.value(), "a");
@@ -982,7 +985,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                TextArea::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                TextArea::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/text_area/undo_tests.rs
+++ b/src/component/text_area/undo_tests.rs
@@ -264,14 +264,22 @@ fn test_new_edit_clears_redo() {
 #[test]
 fn test_ctrl_z_maps_to_undo() {
     let state = focused_state("hello");
-    let msg = TextArea::handle_event(&state, &Event::ctrl('z'), &ViewContext::new().focused(true));
+    let msg = TextArea::handle_event(
+        &state,
+        &Event::ctrl('z'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(TextAreaMessage::Undo));
 }
 
 #[test]
 fn test_ctrl_y_maps_to_redo() {
     let state = focused_state("hello");
-    let msg = TextArea::handle_event(&state, &Event::ctrl('y'), &ViewContext::new().focused(true));
+    let msg = TextArea::handle_event(
+        &state,
+        &Event::ctrl('y'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, Some(TextAreaMessage::Redo));
 }
 

--- a/src/component/timeline/mod.rs
+++ b/src/component/timeline/mod.rs
@@ -30,12 +30,10 @@
 
 use std::marker::PhantomData;
 
-use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 pub(crate) mod render;
 mod types;
@@ -628,7 +626,7 @@ impl Component for Timeline {
     fn handle_event(
         state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -731,14 +729,14 @@ impl Component for Timeline {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        if area.height < 3 || area.width < 3 {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        if ctx.area.height < 3 || ctx.area.width < 3 {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::container("timeline")
                     .with_focus(ctx.focused)
                     .with_disabled(ctx.disabled),
@@ -746,11 +744,11 @@ impl Component for Timeline {
         });
 
         let border_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let mut block = Block::default()
@@ -761,14 +759,21 @@ impl Component for Timeline {
             block = block.title(title.as_str());
         }
 
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
+        let inner = block.inner(ctx.area);
+        ctx.frame.render_widget(block, ctx.area);
 
         if inner.height == 0 || inner.width == 0 {
             return;
         }
 
-        render::render_timeline(state, frame, inner, theme, ctx.focused, ctx.disabled);
+        render::render_timeline(
+            state,
+            ctx.frame,
+            inner,
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
     }
 }
 

--- a/src/component/timeline/snapshot_tests.rs
+++ b/src/component/timeline/snapshot_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::component::test_utils;
+use ratatui::style::Color;
 
 fn sample_events() -> Vec<TimelineEvent> {
     vec![
@@ -24,7 +25,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Timeline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -39,7 +40,7 @@ fn test_snapshot_events_only() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Timeline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -54,7 +55,7 @@ fn test_snapshot_spans_only() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Timeline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -70,7 +71,7 @@ fn test_snapshot_full_timeline() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Timeline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -89,10 +90,7 @@ fn test_snapshot_with_selection() {
         .draw(|frame| {
             Timeline::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -111,10 +109,7 @@ fn test_snapshot_disabled() {
         .draw(|frame| {
             Timeline::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -137,10 +132,7 @@ fn test_snapshot_span_selected() {
         .draw(|frame| {
             Timeline::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();

--- a/src/component/timeline/tests.rs
+++ b/src/component/timeline/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::component::test_utils;
+use ratatui::style::Color;
 
 fn sample_events() -> Vec<TimelineEvent> {
     vec![
@@ -506,7 +507,7 @@ fn test_left_maps_to_pan_left() {
         Timeline::handle_event(
             &state,
             &Event::key(KeyCode::Left),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(TimelineMessage::PanLeft)
     );
@@ -516,7 +517,11 @@ fn test_left_maps_to_pan_left() {
 fn test_h_maps_to_pan_left() {
     let state = focused_timeline();
     assert_eq!(
-        Timeline::handle_event(&state, &Event::char('h'), &ViewContext::new().focused(true)),
+        Timeline::handle_event(
+            &state,
+            &Event::char('h'),
+            &EventContext::new().focused(true)
+        ),
         Some(TimelineMessage::PanLeft)
     );
 }
@@ -528,7 +533,7 @@ fn test_right_maps_to_pan_right() {
         Timeline::handle_event(
             &state,
             &Event::key(KeyCode::Right),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(TimelineMessage::PanRight)
     );
@@ -538,7 +543,11 @@ fn test_right_maps_to_pan_right() {
 fn test_l_maps_to_pan_right() {
     let state = focused_timeline();
     assert_eq!(
-        Timeline::handle_event(&state, &Event::char('l'), &ViewContext::new().focused(true)),
+        Timeline::handle_event(
+            &state,
+            &Event::char('l'),
+            &EventContext::new().focused(true)
+        ),
         Some(TimelineMessage::PanRight)
     );
 }
@@ -547,7 +556,11 @@ fn test_l_maps_to_pan_right() {
 fn test_plus_maps_to_zoom_in() {
     let state = focused_timeline();
     assert_eq!(
-        Timeline::handle_event(&state, &Event::char('+'), &ViewContext::new().focused(true)),
+        Timeline::handle_event(
+            &state,
+            &Event::char('+'),
+            &EventContext::new().focused(true)
+        ),
         Some(TimelineMessage::ZoomIn)
     );
 }
@@ -556,7 +569,11 @@ fn test_plus_maps_to_zoom_in() {
 fn test_equals_maps_to_zoom_in() {
     let state = focused_timeline();
     assert_eq!(
-        Timeline::handle_event(&state, &Event::char('='), &ViewContext::new().focused(true)),
+        Timeline::handle_event(
+            &state,
+            &Event::char('='),
+            &EventContext::new().focused(true)
+        ),
         Some(TimelineMessage::ZoomIn)
     );
 }
@@ -565,7 +582,11 @@ fn test_equals_maps_to_zoom_in() {
 fn test_minus_maps_to_zoom_out() {
     let state = focused_timeline();
     assert_eq!(
-        Timeline::handle_event(&state, &Event::char('-'), &ViewContext::new().focused(true)),
+        Timeline::handle_event(
+            &state,
+            &Event::char('-'),
+            &EventContext::new().focused(true)
+        ),
         Some(TimelineMessage::ZoomOut)
     );
 }
@@ -577,7 +598,7 @@ fn test_up_maps_to_select_prev() {
         Timeline::handle_event(
             &state,
             &Event::key(KeyCode::Up),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(TimelineMessage::SelectPrev)
     );
@@ -587,7 +608,11 @@ fn test_up_maps_to_select_prev() {
 fn test_k_maps_to_select_prev() {
     let state = focused_timeline();
     assert_eq!(
-        Timeline::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true)),
+        Timeline::handle_event(
+            &state,
+            &Event::char('k'),
+            &EventContext::new().focused(true)
+        ),
         Some(TimelineMessage::SelectPrev)
     );
 }
@@ -599,7 +624,7 @@ fn test_down_maps_to_select_next() {
         Timeline::handle_event(
             &state,
             &Event::key(KeyCode::Down),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(TimelineMessage::SelectNext)
     );
@@ -609,7 +634,11 @@ fn test_down_maps_to_select_next() {
 fn test_j_maps_to_select_next() {
     let state = focused_timeline();
     assert_eq!(
-        Timeline::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true)),
+        Timeline::handle_event(
+            &state,
+            &Event::char('j'),
+            &EventContext::new().focused(true)
+        ),
         Some(TimelineMessage::SelectNext)
     );
 }
@@ -621,7 +650,7 @@ fn test_home_maps_to_fit_all() {
         Timeline::handle_event(
             &state,
             &Event::key(KeyCode::Home),
-            &ViewContext::new().focused(true)
+            &EventContext::new().focused(true)
         ),
         Some(TimelineMessage::FitAll)
     );
@@ -637,7 +666,7 @@ fn test_disabled_ignores_events() {
     let msg = Timeline::handle_event(
         &state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -647,7 +676,7 @@ fn test_unfocused_ignores_events() {
     let state = TimelineState::new()
         .with_events(sample_events())
         .with_spans(sample_spans());
-    let msg = Timeline::handle_event(&state, &Event::key(KeyCode::Left), &ViewContext::default());
+    let msg = Timeline::handle_event(&state, &Event::key(KeyCode::Left), &EventContext::default());
     assert_eq!(msg, None);
 }
 #[test]
@@ -694,7 +723,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Timeline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -707,7 +736,7 @@ fn test_render_with_events() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Timeline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -720,7 +749,7 @@ fn test_render_with_spans() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Timeline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -735,7 +764,7 @@ fn test_render_with_events_and_spans() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Timeline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -747,7 +776,7 @@ fn test_render_with_selection() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Timeline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -762,10 +791,7 @@ fn test_render_disabled() {
         .draw(|frame| {
             Timeline::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -777,7 +803,7 @@ fn test_render_focused() {
     let (mut terminal, theme) = test_utils::setup_render(60, 15);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Timeline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -788,7 +814,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(60, 2);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Timeline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -799,7 +825,7 @@ fn test_render_minimal_height() {
     let (mut terminal, theme) = test_utils::setup_render(60, 5);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Timeline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -810,7 +836,7 @@ fn test_render_very_wide() {
     let (mut terminal, theme) = test_utils::setup_render(120, 15);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Timeline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -827,7 +853,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Timeline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -869,7 +895,7 @@ fn test_overlapping_spans_same_lane() {
     let (mut terminal, theme) = test_utils::setup_render(60, 12);
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Timeline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }

--- a/src/component/title_card/mod.rs
+++ b/src/component/title_card/mod.rs
@@ -24,8 +24,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use super::{Component, ViewContext};
-use crate::theme::Theme;
+use super::{Component, RenderContext};
 
 /// Messages that can be sent to a TitleCard.
 #[derive(Clone, Debug, PartialEq)]
@@ -436,10 +435,10 @@ impl Component for TitleCard {
         None
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::title_card("title_card")
                     .with_label(state.title.as_str())
                     .with_disabled(ctx.disabled),
@@ -448,20 +447,20 @@ impl Component for TitleCard {
 
         let render_area = if state.bordered {
             let border_style = if ctx.disabled {
-                theme.disabled_style()
+                ctx.theme.disabled_style()
             } else {
-                theme.border_style()
+                ctx.theme.border_style()
             };
 
             let block = Block::default()
                 .borders(Borders::ALL)
                 .border_style(border_style);
 
-            let inner = block.inner(area);
-            frame.render_widget(block, area);
+            let inner = block.inner(ctx.area);
+            ctx.frame.render_widget(block, ctx.area);
             inner
         } else {
-            area
+            ctx.area
         };
 
         if render_area.height == 0 || render_area.width == 0 {
@@ -470,13 +469,13 @@ impl Component for TitleCard {
 
         // Build title line with optional prefix and suffix
         let title_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else {
             state.title_style
         };
 
         let subtitle_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else {
             state.subtitle_style
         };
@@ -506,7 +505,7 @@ impl Component for TitleCard {
 
         if title_area.height > 0 {
             let title_paragraph = Paragraph::new(title_line).alignment(Alignment::Center);
-            frame.render_widget(title_paragraph, title_area);
+            ctx.frame.render_widget(title_paragraph, title_area);
         }
 
         // Render subtitle if present
@@ -518,7 +517,7 @@ impl Component for TitleCard {
                 let subtitle_paragraph =
                     Paragraph::new(Span::styled(subtitle.as_str(), subtitle_style))
                         .alignment(Alignment::Center);
-                frame.render_widget(subtitle_paragraph, subtitle_area);
+                ctx.frame.render_widget(subtitle_paragraph, subtitle_area);
             }
         }
     }

--- a/src/component/title_card/tests.rs
+++ b/src/component/title_card/tests.rs
@@ -240,7 +240,7 @@ fn test_view_basic() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            TitleCard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TitleCard::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -252,7 +252,7 @@ fn test_view_with_subtitle() {
     let (mut terminal, theme) = test_utils::setup_render(40, 6);
     terminal
         .draw(|frame| {
-            TitleCard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TitleCard::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -266,7 +266,7 @@ fn test_view_prefix_suffix() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            TitleCard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TitleCard::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -280,10 +280,7 @@ fn test_view_disabled() {
         .draw(|frame| {
             TitleCard::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -296,7 +293,7 @@ fn test_view_no_border() {
     let (mut terminal, theme) = test_utils::setup_render(40, 5);
     terminal
         .draw(|frame| {
-            TitleCard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TitleCard::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -308,7 +305,7 @@ fn test_view_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(15, 4);
     terminal
         .draw(|frame| {
-            TitleCard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TitleCard::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -324,7 +321,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                TitleCard::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                TitleCard::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/toast/mod.rs
+++ b/src/component/toast/mod.rs
@@ -32,9 +32,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
-use super::Component;
-use super::ViewContext;
-use crate::theme::Theme;
+use super::{Component, RenderContext};
 
 /// Default maximum number of visible toasts.
 const DEFAULT_MAX_VISIBLE: usize = 5;
@@ -567,45 +565,48 @@ impl Component for Toast {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         if state.toasts.is_empty() {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::toast("toast")
                     .with_meta("count", state.toasts.len().to_string()),
             );
         });
 
         // Calculate toast dimensions
-        let toast_width = 40.min(area.width);
+        let toast_width = 40.min(ctx.area.width);
         let toast_height = 3;
         let visible_count = state.toasts.len().min(state.max_visible);
 
         // Render from bottom-right corner, stacking upward
         // Newest toasts appear at the bottom
         for (i, toast) in state.toasts.iter().rev().take(visible_count).enumerate() {
-            let y = area.bottom().saturating_sub((i as u16 + 1) * toast_height);
-            let x = area.right().saturating_sub(toast_width);
+            let y = ctx
+                .area
+                .bottom()
+                .saturating_sub((i as u16 + 1) * toast_height);
+            let x = ctx.area.right().saturating_sub(toast_width);
 
-            if y < area.y {
-                break; // Don't render above the area
+            if y < ctx.area.y {
+                break; // Don't render above the ctx.area
             }
 
-            let toast_area = Rect::new(x, y, toast_width, toast_height.min(area.bottom() - y));
+            let toast_area = Rect::new(x, y, toast_width, toast_height.min(ctx.area.bottom() - y));
 
             let (border_style, prefix) = match toast.level {
-                ToastLevel::Info => (theme.info_style(), "i"),
-                ToastLevel::Success => (theme.success_style(), "+"),
-                ToastLevel::Warning => (theme.warning_style(), "!"),
-                ToastLevel::Error => (theme.error_style(), "x"),
+                ToastLevel::Info => (ctx.theme.info_style(), "i"),
+                ToastLevel::Success => (ctx.theme.success_style(), "+"),
+                ToastLevel::Warning => (ctx.theme.warning_style(), "!"),
+                ToastLevel::Error => (ctx.theme.error_style(), "x"),
             };
 
-            // Clear the area for overlay effect
-            frame.render_widget(Clear, toast_area);
+            // Clear the ctx.area for overlay effect
+            ctx.frame.render_widget(Clear, toast_area);
 
             let block = Block::default()
                 .borders(Borders::ALL)
@@ -614,7 +615,7 @@ impl Component for Toast {
             let text = format!("[{}] {}", prefix, toast.message);
             let paragraph = Paragraph::new(text).block(block).wrap(Wrap { trim: true });
 
-            frame.render_widget(paragraph, toast_area);
+            ctx.frame.render_widget(paragraph, toast_area);
         }
     }
 }

--- a/src/component/toast/tests.rs
+++ b/src/component/toast/tests.rs
@@ -389,7 +389,7 @@ fn test_view_empty() {
 
     terminal
         .draw(|frame| {
-            Toast::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Toast::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -405,7 +405,7 @@ fn test_view_single() {
 
     terminal
         .draw(|frame| {
-            Toast::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Toast::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -423,7 +423,7 @@ fn test_view_multiple() {
 
     terminal
         .draw(|frame| {
-            Toast::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Toast::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -441,7 +441,7 @@ fn test_view_multiple_toasts() {
 
     terminal
         .draw(|frame| {
-            Toast::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Toast::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -459,7 +459,7 @@ fn test_view_max_visible() {
 
     terminal
         .draw(|frame| {
-            Toast::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Toast::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -475,7 +475,7 @@ fn test_view_info_style() {
 
     terminal
         .draw(|frame| {
-            Toast::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Toast::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -491,7 +491,7 @@ fn test_view_success_style() {
 
     terminal
         .draw(|frame| {
-            Toast::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Toast::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -507,7 +507,7 @@ fn test_view_warning_style() {
 
     terminal
         .draw(|frame| {
-            Toast::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Toast::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -523,7 +523,7 @@ fn test_view_error_style() {
 
     terminal
         .draw(|frame| {
-            Toast::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Toast::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -640,7 +640,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Toast::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Toast::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/tooltip/mod.rs
+++ b/src/component/tooltip/mod.rs
@@ -28,8 +28,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
-use super::{Component, Toggleable, ViewContext};
-use crate::theme::Theme;
+use super::{Component, RenderContext, Toggleable};
 
 /// Position of the tooltip relative to its target.
 ///
@@ -641,26 +640,20 @@ impl Component for Tooltip {
         }
     }
 
-    fn view(
-        state: &Self::State,
-        frame: &mut Frame,
-        area: Rect,
-        _theme: &Theme,
-        _ctx: &ViewContext,
-    ) {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
         if state.visible {
             crate::annotation::with_registry(|reg| {
                 reg.register(
-                    area,
+                    ctx.area,
                     crate::annotation::Annotation::tooltip("tooltip")
                         .with_label(state.content.as_str()),
                 );
             });
         }
 
-        // Use the area as both target and bounds for basic view
-        // Note: Tooltip uses its own colors from state rather than theme
-        Self::view_at(state, frame, area, area);
+        // Use the ctx.area as both target and bounds for basic view
+        // Note: Tooltip uses its own colors from state rather than ctx.theme
+        Self::view_at(state, ctx.frame, ctx.area, ctx.area);
     }
 }
 

--- a/src/component/tooltip/tests.rs
+++ b/src/component/tooltip/tests.rs
@@ -648,7 +648,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Tooltip::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Tooltip::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/tree/mod.rs
+++ b/src/component/tree/mod.rs
@@ -25,12 +25,9 @@
 //! Tree::update(&mut state, TreeMessage::Down);
 //! ```
 
-use ratatui::prelude::*;
-
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
 use crate::scroll::ScrollState;
-use crate::theme::Theme;
 
 mod render;
 mod traversal;
@@ -917,7 +914,7 @@ impl<T: Clone + 'static> Component for Tree<T> {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -937,8 +934,8 @@ impl<T: Clone + 'static> Component for Tree<T> {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        render::view(state, frame, area, theme, ctx);
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        render::view(state, ctx);
     }
 }
 

--- a/src/component/tree/render.rs
+++ b/src/component/tree/render.rs
@@ -6,7 +6,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
-use crate::component::ViewContext;
+use crate::component::{EventContext, RenderContext};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
 
@@ -18,7 +18,7 @@ impl<T: Clone + 'static> Tree<T> {
         state: &TreeState<T>,
         width: u16,
         theme: &Theme,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Vec<Line<'static>> {
         let flat = state.flatten();
         let mut lines = Vec::with_capacity(flat.len());
@@ -78,15 +78,10 @@ impl<T: Clone + 'static> Tree<T> {
 }
 
 /// Renders the tree view into `frame` within `area`.
-pub(super) fn view<T: Clone + 'static>(
-    state: &TreeState<T>,
-    frame: &mut Frame,
-    area: Rect,
-    theme: &Theme,
-    ctx: &ViewContext,
-) {
-    let all_lines = Tree::render_lines(state, area.width, theme, ctx);
-    let viewport_height = area.height as usize;
+pub(super) fn view<T: Clone + 'static>(state: &TreeState<T>, ctx: &mut RenderContext<'_, '_>) {
+    let event_ctx = ctx.event_context();
+    let all_lines = Tree::render_lines(state, ctx.area.width, ctx.theme, &event_ctx);
+    let viewport_height = ctx.area.height as usize;
 
     // Use a local ScrollState for scrollbar rendering and virtual scrolling
     let mut bar_scroll = ScrollState::new(all_lines.len());
@@ -110,8 +105,8 @@ pub(super) fn view<T: Clone + 'static>(
         .with_focus(ctx.focused)
         .with_disabled(ctx.disabled);
     let annotated = crate::annotation::Annotate::new(paragraph, annotation);
-    frame.render_widget(annotated, area);
+    ctx.frame.render_widget(annotated, ctx.area);
 
     // Render scrollbar if content exceeds viewport
-    crate::scroll::render_scrollbar(&bar_scroll, frame, area, theme);
+    crate::scroll::render_scrollbar(&bar_scroll, ctx.frame, ctx.area, ctx.theme);
 }

--- a/src/component/tree/snapshot_tests.rs
+++ b/src/component/tree/snapshot_tests.rs
@@ -11,7 +11,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -23,7 +23,7 @@ fn test_snapshot_single_root() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -38,7 +38,7 @@ fn test_snapshot_expanded_with_children() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -53,7 +53,7 @@ fn test_snapshot_collapsed_with_children() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -72,10 +72,7 @@ fn test_snapshot_focused_selected() {
         .draw(|frame| {
             Tree::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -94,7 +91,7 @@ fn test_snapshot_deep_nesting() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -111,10 +108,7 @@ fn test_snapshot_disabled() {
         .draw(|frame| {
             Tree::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -133,7 +127,7 @@ fn test_snapshot_mixed_expanded_collapsed() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/tree/tests/component.rs
+++ b/src/component/tree/tests/component.rs
@@ -220,7 +220,7 @@ fn test_view_empty() {
 
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -236,7 +236,7 @@ fn test_view_single_node() {
 
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -254,7 +254,7 @@ fn test_view_with_children() {
 
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -272,7 +272,7 @@ fn test_view_collapsed_indicator() {
 
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -290,7 +290,7 @@ fn test_view_expanded_indicator() {
 
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -377,10 +377,7 @@ fn test_view_focused_selection() {
         .draw(|frame| {
             Tree::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -397,7 +394,7 @@ fn test_view_unfocused_selection() {
 
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -472,7 +469,7 @@ fn test_view_leaf_node_no_indicator() {
 
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -582,7 +579,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/tree/tests/edge_cases.rs
+++ b/src/component/tree/tests/edge_cases.rs
@@ -265,7 +265,7 @@ fn test_expand_leaf_via_dispatch_event() {
     let output = Tree::<()>::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, None);
 }
@@ -277,7 +277,7 @@ fn test_collapse_leaf_via_dispatch_event() {
     let output = Tree::<()>::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, None);
 }
@@ -288,8 +288,11 @@ fn test_collapse_leaf_via_dispatch_event() {
 fn test_handle_event_unrecognized_key() {
     let state = TreeState::new(vec![TreeNode::new("Root", ())]);
 
-    let msg =
-        Tree::<()>::handle_event(&state, &Event::char('z'), &ViewContext::new().focused(true));
+    let msg = Tree::<()>::handle_event(
+        &state,
+        &Event::char('z'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg, None);
 }
 
@@ -300,7 +303,7 @@ fn test_handle_event_tab_key() {
     let msg = Tree::<()>::handle_event(
         &state,
         &Event::key(KeyCode::Tab),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
 }
@@ -312,7 +315,7 @@ fn test_handle_event_escape_key() {
     let msg = Tree::<()>::handle_event(
         &state,
         &Event::key(KeyCode::Esc),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
 }

--- a/src/component/tree/tests/events.rs
+++ b/src/component/tree/tests/events.rs
@@ -15,7 +15,7 @@ fn test_handle_event_up_when_focused() {
     state.selected_index = Some(1);
 
     let event = Event::key(KeyCode::Up);
-    let msg = Tree::<&str>::handle_event(&state, &event, &ViewContext::new().focused(true));
+    let msg = Tree::<&str>::handle_event(&state, &event, &EventContext::new().focused(true));
     assert_eq!(msg, Some(TreeMessage::Up));
 }
 
@@ -24,7 +24,7 @@ fn test_handle_event_down_when_focused() {
     let state = make_tree_state();
 
     let event = Event::key(KeyCode::Down);
-    let msg = Tree::<&str>::handle_event(&state, &event, &ViewContext::new().focused(true));
+    let msg = Tree::<&str>::handle_event(&state, &event, &EventContext::new().focused(true));
     assert_eq!(msg, Some(TreeMessage::Down));
 }
 
@@ -33,7 +33,7 @@ fn test_handle_event_expand_when_focused() {
     let state = make_tree_state();
 
     let event = Event::key(KeyCode::Right);
-    let msg = Tree::<&str>::handle_event(&state, &event, &ViewContext::new().focused(true));
+    let msg = Tree::<&str>::handle_event(&state, &event, &EventContext::new().focused(true));
     assert_eq!(msg, Some(TreeMessage::Expand));
 }
 
@@ -42,7 +42,7 @@ fn test_handle_event_collapse_when_focused() {
     let state = make_tree_state();
 
     let event = Event::key(KeyCode::Left);
-    let msg = Tree::<&str>::handle_event(&state, &event, &ViewContext::new().focused(true));
+    let msg = Tree::<&str>::handle_event(&state, &event, &EventContext::new().focused(true));
     assert_eq!(msg, Some(TreeMessage::Collapse));
 }
 
@@ -51,7 +51,7 @@ fn test_handle_event_toggle_when_focused() {
     let state = make_tree_state();
 
     let event = Event::char(' ');
-    let msg = Tree::<&str>::handle_event(&state, &event, &ViewContext::new().focused(true));
+    let msg = Tree::<&str>::handle_event(&state, &event, &EventContext::new().focused(true));
     assert_eq!(msg, Some(TreeMessage::Toggle));
 }
 
@@ -60,7 +60,7 @@ fn test_handle_event_select_when_focused() {
     let state = make_tree_state();
 
     let event = Event::key(KeyCode::Enter);
-    let msg = Tree::<&str>::handle_event(&state, &event, &ViewContext::new().focused(true));
+    let msg = Tree::<&str>::handle_event(&state, &event, &EventContext::new().focused(true));
     assert_eq!(msg, Some(TreeMessage::Select));
 }
 
@@ -68,20 +68,32 @@ fn test_handle_event_select_when_focused() {
 fn test_handle_event_vim_keys() {
     let state = make_tree_state();
 
-    let msg_k =
-        Tree::<&str>::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true));
+    let msg_k = Tree::<&str>::handle_event(
+        &state,
+        &Event::char('k'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg_k, Some(TreeMessage::Up));
 
-    let msg_j =
-        Tree::<&str>::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true));
+    let msg_j = Tree::<&str>::handle_event(
+        &state,
+        &Event::char('j'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg_j, Some(TreeMessage::Down));
 
-    let msg_h =
-        Tree::<&str>::handle_event(&state, &Event::char('h'), &ViewContext::new().focused(true));
+    let msg_h = Tree::<&str>::handle_event(
+        &state,
+        &Event::char('h'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg_h, Some(TreeMessage::Collapse));
 
-    let msg_l =
-        Tree::<&str>::handle_event(&state, &Event::char('l'), &ViewContext::new().focused(true));
+    let msg_l = Tree::<&str>::handle_event(
+        &state,
+        &Event::char('l'),
+        &EventContext::new().focused(true),
+    );
     assert_eq!(msg_l, Some(TreeMessage::Expand));
 }
 
@@ -91,14 +103,17 @@ fn test_handle_event_ignored_when_unfocused() {
     // focused is false by default
 
     let msg =
-        Tree::<&str>::handle_event(&state, &Event::key(KeyCode::Down), &ViewContext::default());
+        Tree::<&str>::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
     assert_eq!(msg, None);
 
-    let msg =
-        Tree::<&str>::handle_event(&state, &Event::key(KeyCode::Enter), &ViewContext::default());
+    let msg = Tree::<&str>::handle_event(
+        &state,
+        &Event::key(KeyCode::Enter),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 
-    let msg = Tree::<&str>::handle_event(&state, &Event::char('j'), &ViewContext::default());
+    let msg = Tree::<&str>::handle_event(&state, &Event::char('j'), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -112,7 +127,7 @@ fn test_dispatch_event() {
     let output = Tree::<&str>::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, None); // Down returns None but updates state
     assert_eq!(state.selected_index(), Some(1));
@@ -121,7 +136,7 @@ fn test_dispatch_event() {
     let output = Tree::<&str>::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(TreeOutput::Selected(vec![0, 0])));
 }
@@ -136,7 +151,7 @@ fn test_instance_methods() {
     let output = Tree::<&str>::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, None); // Down returns None but updates state
     assert_eq!(state.selected_index(), Some(1));
@@ -149,7 +164,7 @@ fn test_instance_methods() {
     let msg = Tree::<&str>::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TreeMessage::Up));
 }
@@ -173,49 +188,49 @@ fn test_handle_event_ignored_when_disabled() {
     let msg = Tree::<&str>::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Tree::<&str>::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Tree::<&str>::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Tree::<&str>::handle_event(
         &state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Tree::<&str>::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Tree::<&str>::handle_event(
         &state,
         &Event::char(' '),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Tree::<&str>::handle_event(
         &state,
         &Event::char('j'),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -227,7 +242,7 @@ fn test_dispatch_event_ignored_when_disabled() {
     let output = Tree::<&str>::dispatch_event(
         &mut state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(output, None);
     assert_eq!(state.selected_index(), Some(0)); // Should not have moved

--- a/src/component/tree/tests/snapshot.rs
+++ b/src/component/tree/tests/snapshot.rs
@@ -15,7 +15,7 @@ fn test_view_multiple_roots_collapsed() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -36,7 +36,7 @@ fn test_view_multiple_roots_expanded() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -58,10 +58,7 @@ fn test_view_multiple_roots_focused() {
         .draw(|frame| {
             Tree::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -84,10 +81,7 @@ fn test_view_selection_on_child() {
         .draw(|frame| {
             Tree::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -111,7 +105,7 @@ fn test_view_deep_nesting() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -135,10 +129,7 @@ fn test_view_deep_nesting_selection_at_leaf() {
         .draw(|frame| {
             Tree::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -161,7 +152,7 @@ fn test_view_mixed_expanded_collapsed() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -181,7 +172,7 @@ fn test_view_unicode_labels() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -203,10 +194,7 @@ fn test_view_disabled_with_children() {
         .draw(|frame| {
             Tree::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -229,10 +217,7 @@ fn test_view_focused_expanded_tree() {
         .draw(|frame| {
             Tree::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -251,7 +236,7 @@ fn test_view_unfocused_expanded_tree() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -277,7 +262,7 @@ fn test_view_filtered() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -298,10 +283,7 @@ fn test_view_filtered_focused() {
         .draw(|frame| {
             Tree::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -318,7 +300,7 @@ fn test_view_filtered_no_matches() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -339,7 +321,7 @@ fn test_view_many_siblings() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Tree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Tree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 
@@ -362,10 +344,7 @@ fn test_view_selection_on_last_root() {
         .draw(|frame| {
             Tree::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();

--- a/src/component/treemap/mod.rs
+++ b/src/component/treemap/mod.rs
@@ -30,9 +30,8 @@ use std::marker::PhantomData;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
-use super::{Component, ViewContext};
+use super::{Component, EventContext, RenderContext};
 use crate::input::{Event, KeyCode};
-use crate::theme::Theme;
 
 /// Layout algorithm module.
 pub mod layout;
@@ -660,7 +659,7 @@ impl Component for Treemap {
     fn handle_event(
         _state: &Self::State,
         event: &Event,
-        ctx: &ViewContext,
+        ctx: &EventContext,
     ) -> Option<Self::Message> {
         if !ctx.focused || ctx.disabled {
             return None;
@@ -804,14 +803,14 @@ impl Component for Treemap {
         }
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext) {
-        if area.height < 3 || area.width < 3 {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        if ctx.area.height < 3 || ctx.area.width < 3 {
             return;
         }
 
         crate::annotation::with_registry(|reg| {
             reg.register(
-                area,
+                ctx.area,
                 crate::annotation::Annotation::container("treemap")
                     .with_focus(ctx.focused)
                     .with_disabled(ctx.disabled),
@@ -819,11 +818,11 @@ impl Component for Treemap {
         });
 
         let border_style = if ctx.disabled {
-            theme.disabled_style()
+            ctx.theme.disabled_style()
         } else if ctx.focused {
-            theme.focused_border_style()
+            ctx.theme.focused_border_style()
         } else {
-            theme.border_style()
+            ctx.theme.border_style()
         };
 
         let mut block = Block::default()
@@ -834,14 +833,21 @@ impl Component for Treemap {
             block = block.title(title.as_str());
         }
 
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
+        let inner = block.inner(ctx.area);
+        ctx.frame.render_widget(block, ctx.area);
 
         if inner.height == 0 || inner.width == 0 || state.root.is_none() {
             return;
         }
 
-        render::render_treemap(state, frame, inner, theme, ctx.focused, ctx.disabled);
+        render::render_treemap(
+            state,
+            ctx.frame,
+            inner,
+            ctx.theme,
+            ctx.focused,
+            ctx.disabled,
+        );
     }
 }
 

--- a/src/component/treemap/snapshot_tests.rs
+++ b/src/component/treemap/snapshot_tests.rs
@@ -7,7 +7,7 @@ fn test_snapshot_empty() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Treemap::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -23,7 +23,7 @@ fn test_snapshot_simple() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Treemap::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -42,10 +42,7 @@ fn test_snapshot_focused() {
         .draw(|frame| {
             Treemap::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -63,10 +60,7 @@ fn test_snapshot_disabled() {
         .draw(|frame| {
             Treemap::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -86,7 +80,7 @@ fn test_snapshot_with_values() {
     let (mut terminal, theme) = test_utils::setup_render(40, 12);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Treemap::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -109,10 +103,7 @@ fn test_snapshot_zoomed_in() {
         .draw(|frame| {
             Treemap::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -132,10 +123,7 @@ fn test_snapshot_selection_moved() {
         .draw(|frame| {
             Treemap::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -150,7 +138,7 @@ fn test_snapshot_single_child() {
     let (mut terminal, theme) = test_utils::setup_render(30, 8);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Treemap::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());

--- a/src/component/treemap/tests.rs
+++ b/src/component/treemap/tests.rs
@@ -549,7 +549,7 @@ fn test_right_maps_to_select_next() {
     let msg = Treemap::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TreemapMessage::SelectNext));
 }
@@ -560,7 +560,7 @@ fn test_left_maps_to_select_prev() {
     let msg = Treemap::handle_event(
         &state,
         &Event::key(KeyCode::Left),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TreemapMessage::SelectPrev));
 }
@@ -571,7 +571,7 @@ fn test_down_maps_to_select_child() {
     let msg = Treemap::handle_event(
         &state,
         &Event::key(KeyCode::Down),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TreemapMessage::SelectChild));
 }
@@ -582,7 +582,7 @@ fn test_up_maps_to_select_parent() {
     let msg = Treemap::handle_event(
         &state,
         &Event::key(KeyCode::Up),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TreemapMessage::SelectParent));
 }
@@ -593,7 +593,7 @@ fn test_enter_maps_to_zoom_in() {
     let msg = Treemap::handle_event(
         &state,
         &Event::key(KeyCode::Enter),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TreemapMessage::ZoomIn));
 }
@@ -604,7 +604,7 @@ fn test_esc_maps_to_zoom_out() {
     let msg = Treemap::handle_event(
         &state,
         &Event::key(KeyCode::Esc),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TreemapMessage::ZoomOut));
 }
@@ -615,7 +615,7 @@ fn test_backspace_maps_to_zoom_out() {
     let msg = Treemap::handle_event(
         &state,
         &Event::key(KeyCode::Backspace),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TreemapMessage::ZoomOut));
 }
@@ -626,7 +626,7 @@ fn test_home_maps_to_reset_zoom() {
     let msg = Treemap::handle_event(
         &state,
         &Event::key(KeyCode::Home),
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TreemapMessage::ResetZoom));
 }
@@ -635,19 +635,35 @@ fn test_home_maps_to_reset_zoom() {
 fn test_hjkl_keys() {
     let state = sample_state();
     assert_eq!(
-        Treemap::handle_event(&state, &Event::char('h'), &ViewContext::new().focused(true)),
+        Treemap::handle_event(
+            &state,
+            &Event::char('h'),
+            &EventContext::new().focused(true)
+        ),
         Some(TreemapMessage::SelectPrev)
     );
     assert_eq!(
-        Treemap::handle_event(&state, &Event::char('l'), &ViewContext::new().focused(true)),
+        Treemap::handle_event(
+            &state,
+            &Event::char('l'),
+            &EventContext::new().focused(true)
+        ),
         Some(TreemapMessage::SelectNext)
     );
     assert_eq!(
-        Treemap::handle_event(&state, &Event::char('j'), &ViewContext::new().focused(true)),
+        Treemap::handle_event(
+            &state,
+            &Event::char('j'),
+            &EventContext::new().focused(true)
+        ),
         Some(TreemapMessage::SelectChild)
     );
     assert_eq!(
-        Treemap::handle_event(&state, &Event::char('k'), &ViewContext::new().focused(true)),
+        Treemap::handle_event(
+            &state,
+            &Event::char('k'),
+            &EventContext::new().focused(true)
+        ),
         Some(TreemapMessage::SelectParent)
     );
 }
@@ -662,7 +678,7 @@ fn test_disabled_ignores_events() {
     let msg = Treemap::handle_event(
         &state,
         &Event::key(KeyCode::Right),
-        &ViewContext::new().focused(true).disabled(true),
+        &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 }
@@ -671,7 +687,11 @@ fn test_disabled_ignores_events() {
 fn test_unfocused_ignores_events() {
     let root = TreemapNode::new("root", 0.0).with_child(TreemapNode::new("a", 10.0));
     let state = TreemapState::new().with_root(root);
-    let msg = Treemap::handle_event(&state, &Event::key(KeyCode::Right), &ViewContext::default());
+    let msg = Treemap::handle_event(
+        &state,
+        &Event::key(KeyCode::Right),
+        &EventContext::default(),
+    );
     assert_eq!(msg, None);
 }
 #[test]
@@ -713,7 +733,7 @@ fn test_render_empty() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Treemap::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -728,7 +748,7 @@ fn test_render_simple() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Treemap::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -744,10 +764,7 @@ fn test_render_focused() {
         .draw(|frame| {
             Treemap::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().focused(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).focused(true),
             );
         })
         .unwrap();
@@ -762,10 +779,7 @@ fn test_render_disabled() {
         .draw(|frame| {
             Treemap::view(
                 &state,
-                frame,
-                frame.area(),
-                &theme,
-                &ViewContext::new().disabled(true),
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
             );
         })
         .unwrap();
@@ -780,7 +794,7 @@ fn test_render_with_values() {
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Treemap::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -792,7 +806,7 @@ fn test_render_small_area() {
     let (mut terminal, theme) = test_utils::setup_render(5, 4);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Treemap::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -804,7 +818,7 @@ fn test_render_too_small() {
     let (mut terminal, theme) = test_utils::setup_render(2, 2);
     terminal
         .draw(|frame| {
-            Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Treemap::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -822,7 +836,7 @@ fn test_annotation_emitted() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                Treemap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Treemap::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/component/usage_display/mod.rs
+++ b/src/component/usage_display/mod.rs
@@ -33,7 +33,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use super::{Component, ViewContext};
+use super::{Component, RenderContext};
 use crate::theme::Theme;
 
 /// Layout style for usage metrics display.
@@ -962,15 +962,15 @@ impl Component for UsageDisplay {
         None // Display-only, no output
     }
 
-    fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, _ctx: &ViewContext) {
-        if state.metrics.is_empty() || area.width == 0 || area.height == 0 {
+    fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>) {
+        if state.metrics.is_empty() || ctx.area.width == 0 || ctx.area.height == 0 {
             return;
         }
 
         match state.layout {
-            UsageLayout::Horizontal => Self::view_horizontal(state, frame, area, theme),
-            UsageLayout::Vertical => Self::view_vertical(state, frame, area, theme),
-            UsageLayout::Grid(cols) => Self::view_grid(state, frame, area, theme, cols),
+            UsageLayout::Horizontal => Self::view_horizontal(state, ctx.frame, ctx.area, ctx.theme),
+            UsageLayout::Vertical => Self::view_vertical(state, ctx.frame, ctx.area, ctx.theme),
+            UsageLayout::Grid(cols) => Self::view_grid(state, ctx.frame, ctx.area, ctx.theme, cols),
         }
     }
 }

--- a/src/component/usage_display/tests.rs
+++ b/src/component/usage_display/tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::component::EventContext;
+use ratatui::style::Color;
 
 // ========================================
 // UsageMetric Tests
@@ -460,7 +462,7 @@ fn test_view_empty() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 3);
     terminal
         .draw(|frame| {
-            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            UsageDisplay::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -472,7 +474,7 @@ fn test_view_horizontal_single() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            UsageDisplay::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -487,7 +489,7 @@ fn test_view_horizontal_multiple() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 1);
     terminal
         .draw(|frame| {
-            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            UsageDisplay::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -501,7 +503,7 @@ fn test_view_horizontal_with_color() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 1);
     terminal
         .draw(|frame| {
-            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            UsageDisplay::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -515,7 +517,7 @@ fn test_view_horizontal_with_icon() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 1);
     terminal
         .draw(|frame| {
-            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            UsageDisplay::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -530,7 +532,7 @@ fn test_view_horizontal_custom_separator() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 1);
     terminal
         .draw(|frame| {
-            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            UsageDisplay::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -546,7 +548,7 @@ fn test_view_vertical() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(30, 5);
     terminal
         .draw(|frame| {
-            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            UsageDisplay::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -562,7 +564,7 @@ fn test_view_vertical_with_title() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(30, 4);
     terminal
         .draw(|frame| {
-            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            UsageDisplay::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -579,7 +581,7 @@ fn test_view_grid_2_columns() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(50, 4);
     terminal
         .draw(|frame| {
-            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            UsageDisplay::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -596,7 +598,7 @@ fn test_view_grid_3_columns() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(50, 3);
     terminal
         .draw(|frame| {
-            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            UsageDisplay::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -612,7 +614,7 @@ fn test_view_grid_odd_count() {
     let (mut terminal, theme) = crate::component::test_utils::setup_render(50, 4);
     terminal
         .draw(|frame| {
-            UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default())
+            UsageDisplay::view(&state, &mut RenderContext::new(frame, frame.area(), &theme))
         })
         .unwrap();
     insta::assert_snapshot!(terminal.backend().to_string());
@@ -625,7 +627,7 @@ fn test_view_zero_width() {
     terminal
         .draw(|frame| {
             let area = Rect::new(0, 0, 0, 3);
-            UsageDisplay::view(&state, frame, area, &theme, &ViewContext::default());
+            UsageDisplay::view(&state, &mut RenderContext::new(frame, area, &theme));
         })
         .unwrap();
     // Should not panic
@@ -638,7 +640,7 @@ fn test_view_zero_height() {
     terminal
         .draw(|frame| {
             let area = Rect::new(0, 0, 60, 0);
-            UsageDisplay::view(&state, frame, area, &theme, &ViewContext::default());
+            UsageDisplay::view(&state, &mut RenderContext::new(frame, area, &theme));
         })
         .unwrap();
     // Should not panic
@@ -652,7 +654,7 @@ fn test_view_zero_height() {
 fn test_handle_event_returns_none() {
     let state = UsageDisplayState::new().metric(UsageMetric::new("CPU", "45%"));
     let event = crate::input::Event::key(crate::input::KeyCode::Char('q'));
-    let msg = UsageDisplay::handle_event(&state, &event, &ViewContext::default());
+    let msg = UsageDisplay::handle_event(&state, &event, &EventContext::default());
     assert!(msg.is_none());
 }
 
@@ -660,7 +662,7 @@ fn test_handle_event_returns_none() {
 fn test_dispatch_event_returns_none() {
     let mut state = UsageDisplayState::new().metric(UsageMetric::new("CPU", "45%"));
     let event = crate::input::Event::key(crate::input::KeyCode::Enter);
-    let output = UsageDisplay::dispatch_event(&mut state, &event, &ViewContext::default());
+    let output = UsageDisplay::dispatch_event(&mut state, &event, &EventContext::default());
     assert!(output.is_none());
 }
 
@@ -693,7 +695,7 @@ fn test_annotation_emitted_horizontal() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                UsageDisplay::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -711,7 +713,7 @@ fn test_annotation_emitted_vertical() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                UsageDisplay::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });
@@ -730,7 +732,7 @@ fn test_annotation_emitted_grid() {
     let registry = with_annotations(|| {
         terminal
             .draw(|frame| {
-                UsageDisplay::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                UsageDisplay::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,9 @@ pub use app::{
 };
 pub use backend::{CaptureBackend, EnhancedCell, FrameSnapshot};
 // Core component traits and utilities (always available)
-pub use component::{Component, FocusManager, Toggleable, ViewContext};
+pub use component::{
+    Component, EventContext, FocusManager, RenderContext, Toggleable, ViewContext,
+};
 
 // Input components
 #[cfg(feature = "input-components")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,9 +169,7 @@ pub use app::{
 };
 pub use backend::{CaptureBackend, EnhancedCell, FrameSnapshot};
 // Core component traits and utilities (always available)
-pub use component::{
-    Component, EventContext, FocusManager, RenderContext, Toggleable, ViewContext,
-};
+pub use component::{Component, EventContext, FocusManager, RenderContext, Toggleable};
 
 // Input components
 #[cfg(feature = "input-components")]

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -19,8 +19,9 @@
 //! // Use Dracula theme (purple focused, dark disabled)
 //! let dracula_theme = Theme::dracula();
 //!
-//! // Components use theme in their view() method:
-//! // Component::view(&state, frame, area, &nord_theme, &ViewContext::default());
+//! // Components use theme via RenderContext in their view() method:
+//! // let mut ctx = RenderContext::new(frame, area, &nord_theme);
+//! // Component::view(&state, &mut ctx);
 //! ```
 //!
 //! # Creating Custom Themes
@@ -282,7 +283,8 @@ impl Theme {
     ///
     /// let theme = Theme::nord();
     /// // Use with components:
-    /// // Button::view(&state, frame, area, &theme, &ViewContext::default());
+    /// // let mut ctx = RenderContext::new(frame, area, &theme);
+    /// // Button::view(&state, &mut ctx);
     /// ```
     pub fn nord() -> Self {
         Self {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "full")]
 //! Integration tests exercising multi-component workflows through the public API.
-use envision::ViewContext;
+use envision::{EventContext, RenderContext};
 
 use envision::component::{
     SearchableList, SearchableListMessage, SearchableListOutput, SearchableListState,
@@ -331,7 +331,7 @@ fn test_form_workflow_with_focus_manager() {
         Event::char('e'),
     ];
     for event in &events {
-        InputField::dispatch_event(&mut input, event, &ViewContext::new().focused(true));
+        InputField::dispatch_event(&mut input, event, &EventContext::new().focused(true));
     }
     assert_eq!(input.value(), "Alice");
     assert_eq!(input.cursor_position(), 5);
@@ -347,7 +347,7 @@ fn test_form_workflow_with_focus_manager() {
     let output = Checkbox::dispatch_event(
         &mut checkbox,
         &space_event,
-        &ViewContext::new().focused(true),
+        &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(CheckboxOutput::Toggled(true)));
     assert!(checkbox.is_checked());
@@ -360,8 +360,11 @@ fn test_form_workflow_with_focus_manager() {
 
     // Press Enter on Button via dispatch_event
     let enter_event = Event::key(crossterm::event::KeyCode::Enter);
-    let output =
-        Button::dispatch_event(&mut button, &enter_event, &ViewContext::new().focused(true));
+    let output = Button::dispatch_event(
+        &mut button,
+        &enter_event,
+        &EventContext::new().focused(true),
+    );
     assert_eq!(output, Some(ButtonOutput::Pressed));
 
     // Final state verification: all components retain their state after the workflow
@@ -387,7 +390,7 @@ fn test_selectable_list_stress_10000_items() {
         SelectableList::<String>::dispatch_event(
             &mut state,
             &down_event,
-            &ViewContext::new().focused(true),
+            &EventContext::new().focused(true),
         );
     }
     assert_eq!(state.selected_index(), Some(100));
@@ -443,37 +446,37 @@ fn test_components_handle_zero_size_area() {
     // Button
     assert_view_zero_size("Button", |frame, area, theme| {
         let state = ButtonState::new("Click");
-        Button::view(&state, frame, area, theme, &ViewContext::default());
+        Button::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // Checkbox
     assert_view_zero_size("Checkbox", |frame, area, theme| {
         let state = CheckboxState::new("Check");
-        Checkbox::view(&state, frame, area, theme, &ViewContext::default());
+        Checkbox::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // InputField
     assert_view_zero_size("InputField", |frame, area, theme| {
         let state = InputFieldState::new();
-        InputField::view(&state, frame, area, theme, &ViewContext::default());
+        InputField::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // SelectableList
     assert_view_zero_size("SelectableList", |frame, area, theme| {
         let state = SelectableListState::new(vec!["A".to_string(), "B".to_string()]);
-        SelectableList::<String>::view(&state, frame, area, theme, &ViewContext::default());
+        SelectableList::<String>::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // RadioGroup
     assert_view_zero_size("RadioGroup", |frame, area, theme| {
         let state = RadioGroupState::new(vec!["X".to_string(), "Y".to_string()]);
-        RadioGroup::<String>::view(&state, frame, area, theme, &ViewContext::default());
+        RadioGroup::<String>::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // Tabs
     assert_view_zero_size("Tabs", |frame, area, theme| {
         let state = TabsState::new(vec!["Tab1".to_string(), "Tab2".to_string()]);
-        Tabs::<String>::view(&state, frame, area, theme, &ViewContext::default());
+        Tabs::<String>::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // Table
@@ -483,89 +486,89 @@ fn test_components_handle_zero_size_area() {
         }];
         let columns = vec![Column::new("Name", Constraint::Length(10))];
         let state = TableState::new(rows, columns);
-        Table::<SimpleRow>::view(&state, frame, area, theme, &ViewContext::default());
+        Table::<SimpleRow>::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // Tree
     assert_view_zero_size("Tree", |frame, area, theme| {
         let root = TreeNode::new("root", "root_data".to_string());
         let state = TreeState::new(vec![root]);
-        Tree::<String>::view(&state, frame, area, theme, &ViewContext::default());
+        Tree::<String>::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // Accordion
     assert_view_zero_size("Accordion", |frame, area, theme| {
         let panel = AccordionPanel::new("Panel", "Content");
         let state = AccordionState::new(vec![panel]);
-        Accordion::view(&state, frame, area, theme, &ViewContext::default());
+        Accordion::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // Dialog
     assert_view_zero_size("Dialog", |frame, area, theme| {
         let mut state = DialogState::confirm("Title", "Body");
         Dialog::update(&mut state, DialogMessage::Open);
-        Dialog::view(&state, frame, area, theme, &ViewContext::default());
+        Dialog::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // Menu
     assert_view_zero_size("Menu", |frame, area, theme| {
         let items = vec![MenuItem::new("File"), MenuItem::new("Edit")];
         let state = MenuState::new(items);
-        Menu::view(&state, frame, area, theme, &ViewContext::default());
+        Menu::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // Dropdown
     assert_view_zero_size("Dropdown", |frame, area, theme| {
         let state = DropdownState::new(vec!["Option 1", "Option 2"]);
-        Dropdown::view(&state, frame, area, theme, &ViewContext::default());
+        Dropdown::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // Select
     assert_view_zero_size("Select", |frame, area, theme| {
         let state = SelectState::new(vec!["Opt A", "Opt B"]);
-        Select::view(&state, frame, area, theme, &ViewContext::default());
+        Select::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // TextArea
     assert_view_zero_size("TextArea", |frame, area, theme| {
         let state = TextAreaState::new();
-        TextArea::view(&state, frame, area, theme, &ViewContext::default());
+        TextArea::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // ProgressBar
     assert_view_zero_size("ProgressBar", |frame, area, theme| {
         let state = ProgressBarState::new();
-        ProgressBar::view(&state, frame, area, theme, &ViewContext::default());
+        ProgressBar::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // Spinner
     assert_view_zero_size("Spinner", |frame, area, theme| {
         let state = SpinnerState::new();
-        Spinner::view(&state, frame, area, theme, &ViewContext::default());
+        Spinner::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // Toast
     assert_view_zero_size("Toast", |frame, area, theme| {
         let state = ToastState::new();
-        Toast::view(&state, frame, area, theme, &ViewContext::default());
+        Toast::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // Tooltip
     assert_view_zero_size("Tooltip", |frame, area, theme| {
         let state = TooltipState::new("Tip content");
-        Tooltip::view(&state, frame, area, theme, &ViewContext::default());
+        Tooltip::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // StatusBar
     assert_view_zero_size("StatusBar", |frame, area, theme| {
         let state = StatusBarState::new();
-        StatusBar::view(&state, frame, area, theme, &ViewContext::default());
+        StatusBar::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // StatusLog
     assert_view_zero_size("StatusLog", |frame, area, theme| {
         let state = StatusLogState::new();
-        StatusLog::view(&state, frame, area, theme, &ViewContext::default());
+        StatusLog::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // Breadcrumb
@@ -575,43 +578,43 @@ fn test_components_handle_zero_size_area() {
             BreadcrumbSegment::new("Settings"),
         ];
         let state = BreadcrumbState::new(segments);
-        Breadcrumb::view(&state, frame, area, theme, &ViewContext::default());
+        Breadcrumb::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // KeyHints
     assert_view_zero_size("KeyHints", |frame, area, theme| {
         let state = KeyHintsState::with_hints(vec![KeyHint::new("q", "Quit")]);
-        KeyHints::view(&state, frame, area, theme, &ViewContext::default());
+        KeyHints::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // MultiProgress
     assert_view_zero_size("MultiProgress", |frame, area, theme| {
         let state = MultiProgressState::new();
-        MultiProgress::view(&state, frame, area, theme, &ViewContext::default());
+        MultiProgress::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // LoadingList
     assert_view_zero_size("LoadingList", |frame, area, theme| {
         let state: LoadingListState<String> = LoadingListState::new();
-        LoadingList::<String>::view(&state, frame, area, theme, &ViewContext::default());
+        LoadingList::<String>::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // ScrollableText
     assert_view_zero_size("ScrollableText", |frame, area, theme| {
         let state = ScrollableTextState::new();
-        ScrollableText::view(&state, frame, area, theme, &ViewContext::default());
+        ScrollableText::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // TitleCard
     assert_view_zero_size("TitleCard", |frame, area, theme| {
         let state = TitleCardState::new("Title");
-        TitleCard::view(&state, frame, area, theme, &ViewContext::default());
+        TitleCard::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // LineInput
     assert_view_zero_size("LineInput", |frame, area, theme| {
         let state = LineInputState::new();
-        LineInput::view(&state, frame, area, theme, &ViewContext::default());
+        LineInput::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 }
 

--- a/tests/integration_new_components.rs
+++ b/tests/integration_new_components.rs
@@ -6,7 +6,7 @@
 //! Tests 1-14 live here. Tests 15-30 are in integration_new_components_2.rs.
 
 use envision::CaptureBackend;
-use envision::ViewContext;
+use envision::RenderContext;
 use envision::component::{
     // Observability
     AlertMetric,
@@ -123,7 +123,7 @@ fn test_sparkline_push_data_and_bounded_eviction() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            Sparkline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Sparkline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -162,7 +162,7 @@ fn test_gauge_threshold_color_transitions() {
         let theme = envision::Theme::default();
         terminal
             .draw(|frame| {
-                Gauge::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+                Gauge::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
             })
             .unwrap();
     }
@@ -273,7 +273,7 @@ fn test_heatmap_cell_navigation_and_selection() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            Heatmap::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Heatmap::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -333,7 +333,7 @@ fn test_chart_area_scatter_with_thresholds() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            Chart::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Chart::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -400,7 +400,7 @@ fn test_timeline_events_spans_and_zoom() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            Timeline::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Timeline::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -463,7 +463,7 @@ fn test_span_tree_expand_collapse_navigate() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            SpanTree::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            SpanTree::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -534,7 +534,7 @@ fn test_flame_graph_navigation_zoom_search() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            FlameGraph::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            FlameGraph::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -689,7 +689,7 @@ fn test_alert_panel_state_transitions() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            AlertPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            AlertPanel::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -811,7 +811,7 @@ fn test_calendar_navigation_and_selection() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            Calendar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Calendar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -911,7 +911,7 @@ fn test_switch_toggle_workflow() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            Switch::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Switch::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }

--- a/tests/integration_new_components_2.rs
+++ b/tests/integration_new_components_2.rs
@@ -5,7 +5,6 @@
 //! the 1000-line file limit. Tests 15-30 live here.
 
 use envision::CaptureBackend;
-use envision::ViewContext;
 use envision::component::code_block::highlight::Language;
 use envision::component::{
     // Observability
@@ -79,6 +78,7 @@ use envision::component::{
     TerminalOutputState,
     ThresholdZone,
 };
+use envision::{EventContext, RenderContext};
 use ratatui::Terminal;
 use ratatui::prelude::*;
 
@@ -139,7 +139,7 @@ fn test_paginator_boundary_navigation() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            Paginator::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            Paginator::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -216,7 +216,7 @@ fn test_help_panel_scroll_and_groups() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            HelpPanel::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            HelpPanel::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -281,7 +281,7 @@ fn test_code_block_set_code_language_scroll() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            CodeBlock::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            CodeBlock::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -359,7 +359,7 @@ fn test_terminal_output_append_and_auto_scroll() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            TerminalOutput::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TerminalOutput::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -429,7 +429,7 @@ fn test_conversation_view_messages_and_collapse() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            ConversationView::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            ConversationView::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -510,7 +510,7 @@ fn test_tab_bar_add_close_navigate() {
     let theme = envision::Theme::default();
     terminal
         .draw(|frame| {
-            TabBar::view(&state, frame, frame.area(), &theme, &ViewContext::default());
+            TabBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
         })
         .unwrap();
 }
@@ -710,23 +710,23 @@ fn test_slider_dispatch_event_keyboard() {
 
     // Right arrow should increment
     let event = envision::input::Event::key(crossterm::event::KeyCode::Right);
-    Slider::dispatch_event(&mut state, &event, &ViewContext::new().focused(true));
+    Slider::dispatch_event(&mut state, &event, &EventContext::new().focused(true));
     assert_eq!(state.value(), 5.0);
 
     // Left arrow should decrement
     let event = envision::input::Event::key(crossterm::event::KeyCode::Left);
-    Slider::dispatch_event(&mut state, &event, &ViewContext::new().focused(true));
+    Slider::dispatch_event(&mut state, &event, &EventContext::new().focused(true));
     assert_eq!(state.value(), 0.0);
 
     // Home should go to min
     Slider::update(&mut state, SliderMessage::SetValue(50.0));
     let event = envision::input::Event::key(crossterm::event::KeyCode::Home);
-    Slider::dispatch_event(&mut state, &event, &ViewContext::new().focused(true));
+    Slider::dispatch_event(&mut state, &event, &EventContext::new().focused(true));
     assert_eq!(state.value(), 0.0);
 
     // End should go to max
     let event = envision::input::Event::key(crossterm::event::KeyCode::End);
-    Slider::dispatch_event(&mut state, &event, &ViewContext::new().focused(true));
+    Slider::dispatch_event(&mut state, &event, &EventContext::new().focused(true));
     assert_eq!(state.value(), 100.0);
 }
 
@@ -754,49 +754,49 @@ fn test_new_components_handle_zero_size_area() {
     // Sparkline
     assert_view_zero_size("Sparkline", |frame, area, theme| {
         let state = SparklineState::with_data(vec![1.0, 2.0, 3.0]);
-        Sparkline::view(&state, frame, area, theme, &ViewContext::default());
+        Sparkline::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // Gauge
     assert_view_zero_size("Gauge", |frame, area, theme| {
         let state = GaugeState::new(50.0, 100.0);
-        Gauge::view(&state, frame, area, theme, &ViewContext::default());
+        Gauge::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // Calendar
     assert_view_zero_size("Calendar", |frame, area, theme| {
         let state = CalendarState::new(2026, 3);
-        Calendar::view(&state, frame, area, theme, &ViewContext::default());
+        Calendar::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // Slider
     assert_view_zero_size("Slider", |frame, area, theme| {
         let state = SliderState::new(0.0, 100.0);
-        Slider::view(&state, frame, area, theme, &ViewContext::default());
+        Slider::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // Switch
     assert_view_zero_size("Switch", |frame, area, theme| {
         let state = SwitchState::new();
-        Switch::view(&state, frame, area, theme, &ViewContext::default());
+        Switch::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // Paginator
     assert_view_zero_size("Paginator", |frame, area, theme| {
         let state = PaginatorState::new(5);
-        Paginator::view(&state, frame, area, theme, &ViewContext::default());
+        Paginator::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // CodeBlock
     assert_view_zero_size("CodeBlock", |frame, area, theme| {
         let state = CodeBlockState::new().with_code("fn main() {}");
-        CodeBlock::view(&state, frame, area, theme, &ViewContext::default());
+        CodeBlock::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 
     // TabBar
     assert_view_zero_size("TabBar", |frame, area, theme| {
         let state = TabBarState::new(vec![Tab::new("a", "Tab A")]);
-        TabBar::view(&state, frame, area, theme, &ViewContext::default());
+        TabBar::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 }
 
@@ -946,25 +946,16 @@ fn test_dashboard_workflow_with_mixed_new_components() {
 
             Gauge::view(
                 &cpu_gauge,
-                frame,
-                chunks[0],
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, chunks[0], &theme),
             );
             Sparkline::view(
                 &mem_sparkline,
-                frame,
-                chunks[1],
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, chunks[1], &theme),
             );
-            AlertPanel::view(&alerts, frame, chunks[2], &theme, &ViewContext::default());
+            AlertPanel::view(&alerts, &mut RenderContext::new(frame, chunks[2], &theme));
             Paginator::view(
                 &paginator,
-                frame,
-                chunks[3],
-                &theme,
-                &ViewContext::default(),
+                &mut RenderContext::new(frame, chunks[3], &theme),
             );
         })
         .unwrap();

--- a/tests/integration_stress.rs
+++ b/tests/integration_stress.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "full")]
 //! Stress tests exercising components with large datasets (10,000+ items).
-use envision::ViewContext;
+use envision::RenderContext;
 
 use envision::component::{DataGrid, DataGridMessage, DataGridState};
 use envision::{
@@ -96,7 +96,7 @@ fn test_table_stress_10000_rows() {
 
     // Render to verify no panics with large dataset
     assert_renders_ok("Table-10k", 80, 24, |frame, area, theme| {
-        Table::<StressRow>::view(&state, frame, area, theme, &ViewContext::default());
+        Table::<StressRow>::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 }
 
@@ -154,7 +154,7 @@ fn test_tree_stress_10000_nodes() {
 
     // Render to verify no panics with large tree
     assert_renders_ok("Tree-11k", 100, 40, |frame, area, theme| {
-        Tree::<String>::view(&state, frame, area, theme, &ViewContext::default());
+        Tree::<String>::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 }
 
@@ -208,7 +208,7 @@ fn test_loading_list_stress_10000_items() {
 
     // Render to verify no panics
     assert_renders_ok("LoadingList-10k", 80, 30, |frame, area, theme| {
-        LoadingList::<String>::view(&state, frame, area, theme, &ViewContext::default());
+        LoadingList::<String>::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 }
 
@@ -250,7 +250,7 @@ fn test_selectable_list_stress_50000_items() {
 
     // Render to verify no panics with massive list
     assert_renders_ok("SelectableList-50k", 80, 24, |frame, area, theme| {
-        SelectableList::<String>::view(&state, frame, area, theme, &ViewContext::default());
+        SelectableList::<String>::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 }
 
@@ -289,7 +289,7 @@ fn test_accordion_stress_1000_panels() {
 
     // Render to verify no panics
     assert_renders_ok("Accordion-1k", 80, 40, |frame, area, theme| {
-        Accordion::view(&state, frame, area, theme, &ViewContext::default());
+        Accordion::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 }
 
@@ -329,7 +329,7 @@ fn test_data_grid_stress_10000_rows() {
 
     // Render to verify no panics
     assert_renders_ok("DataGrid-10k", 120, 40, |frame, area, theme| {
-        DataGrid::<StressRow>::view(&state, frame, area, theme, &ViewContext::default());
+        DataGrid::<StressRow>::view(&state, &mut RenderContext::new(frame, area, theme));
     });
 }
 
@@ -346,7 +346,7 @@ fn test_rapid_input_10000_events() {
     let down = envision::Event::key(crossterm::event::KeyCode::Down);
     let up = envision::Event::key(crossterm::event::KeyCode::Up);
 
-    let ctx = envision::ViewContext::new().focused(true);
+    let ctx = envision::EventContext::new().focused(true);
     for i in 0..10_000 {
         if i % 2 == 0 {
             envision::SelectableList::<String>::dispatch_event(&mut state, &down, &ctx);


### PR DESCRIPTION
## Summary

**Breaking change for 0.14.0.** Refactors `Component::view` from 5 parameters to 2 by introducing `RenderContext`, which bundles `frame`, `area`, `theme`, `focused`, and `disabled` into a single value.

**Before:**
\`\`\`rust
fn view(state: &Self::State, frame: &mut Frame, area: Rect, theme: &Theme, ctx: &ViewContext);
\`\`\`

**After:**
\`\`\`rust
fn view(state: &Self::State, ctx: &mut RenderContext<'_, '_>);
\`\`\`

Also renames `ViewContext` → `EventContext` since it is now used only by `handle_event`, not by `view`.

## What changed

- New types: `RenderContext<'frame, 'buf>` and `EventContext` in `src/component/context.rs`
- `Component::view` and `Component::traced_view` use `&mut RenderContext<'_, '_>`
- `Component::handle_event` uses `&EventContext` (renamed from `ViewContext`)
- All 73 components migrated to the new signatures
- All 89 examples updated
- Integration tests, doc tests, benchmarks, AppHarness, and runtime updated
- `ChartGrid::render`, `Router::view`, `ConversationView::view_from` (inherent methods) also migrated for API consistency
- `loading_list/mod.rs` and `file_browser/mod.rs` split into smaller files to stay under 1000 lines
- `CONTRIBUTING.md` and `README.md` updated to reference the new API
- `MIGRATION.md` has a 0.14.0 section with before/after upgrade examples
- `CHANGELOG.md` documents all breaking changes

## Why

The 5-parameter `view()` signature was the audit's #1 trust-eroding finding. Users implementing custom components had to understand and propagate ratatui's `Frame` and `Rect` plus the framework's `Theme` and `ViewContext`. The new `RenderContext` simplifies the signature, provides a place for future render-time fields without breaking changes, and matches how mature TUI/UI frameworks bundle render state.

Design spec: \`docs/superpowers/specs/2026-04-11-render-context-design.md\`
Implementation plan: \`docs/superpowers/plans/2026-04-11-render-context-refactor.md\`

## Notable design points

- **Two-lifetime form** \`RenderContext<'frame, 'buf>\`. The single-lifetime form was attempted but \`&'a mut Frame<'a>\` is invariant over \`'a\` which prevents \`with_area\` from returning a shorter-lived reborrow. Two lifetimes is the standard Rust solution. Most callers use \`RenderContext<'_, '_>\` and let elision handle both.
- **\`with_area(&mut self) -> RenderContext<'_, 'buf>\`** lets parent components hand a child a context with a different area while keeping the parent valid after the child returns.
- **\`render_widget(widget)\` shortcut** for the common pattern \`ctx.frame.render_widget(widget, ctx.area)\`.
- **\`From<&RenderContext> for EventContext\`** + \`event_context()\` slice method so parent components can call child \`handle_event\` from inside their own \`view()\`.
- **Snapshot byte-identity:** all 179 snapshot tests produce byte-identical output. This is the strongest possible regression guarantee that the refactor is purely mechanical.

## Test plan

- [x] All 7166 unit/integration tests pass
- [x] All 1979 doc tests pass
- [x] All 89 examples compile (\`cargo build --examples --all-features\`)
- [x] All snapshot tests byte-identical (\`git diff -- 'src/component/*/snapshots/'\` empty)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt\` clean
- [x] Zero \`ViewContext\` references in src/, tests/, examples/, benches/
- [x] Zero \`#[allow(unused_imports)]\` suppressions
- [x] Zero files exceed 1000 lines
- [x] All commits signed
- [x] CONTRIBUTING.md and README.md updated to reference new API

## Migration

See MIGRATION.md for the 0.14.0 upgrade path with before/after code samples for:
1. Simple component view
2. handle_event signature
3. Sub-area rendering with with_area
4. Test code calling Component::view directly
5. AppHarness usage
6. App::view (unchanged)
7. Inherent method migrations (ChartGrid, Router, ConversationView::view_from)

🤖 Generated with [Claude Code](https://claude.com/claude-code)