### PR TITLE
Replace crossterm events with envision-owned input types (BREAKING, 0.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **Crossterm event types replaced with envision-owned types.**
+  `KeyCode` is now `Key`, `KeyModifiers` is now `Modifiers`, and
+  `KeyEvent`/`MouseEvent` are envision-defined structs. Letter keys
+  are normalized to lowercase; use `raw_char` for text input.
+  `BackTab` is replaced by `Tab` with `modifiers.shift()`.
+  See MIGRATION.md for the upgrade path.
+- **`TerminalEventSubscription` handler now receives `Event`**
+  instead of `crossterm::event::Event`. The subscription converts
+  crossterm events internally before invoking the handler.
 - **`Component::view` signature changed** from
   `(state, frame, area, theme, ctx)` to `(state, ctx)`. The new
   `ctx: &mut RenderContext<'_, '_>` bundles `frame`, `area`, `theme`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,12 +119,12 @@ fn test_view_focused() {
 ### Event Testing
 
 ```rust
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 #[test]
 fn test_handle_event_focused() {
     let state = MyState::new();
-    let event = Event::key(KeyCode::Enter);
+    let event = Event::key(Key::Enter);
     let ctx = EventContext::new().focused(true);
     let msg = MyComponent::handle_event(&state, &event, &ctx);
     assert_eq!(msg, Some(MyMessage::Confirm));

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,121 @@
 
 ## v0.13.x to v0.14.0
 
+### Envision-owned input types
+
+0.14.0 replaces crossterm event re-exports with envision-owned types. The
+key changes:
+
+| Before (v0.13.x) | After (v0.14.0) |
+|---|---|
+| `KeyCode` | `Key` |
+| `KeyModifiers` | `Modifiers` |
+| `key.code` | `key.key` |
+| `KeyCode::Char('a')` | `Key::Char('a')` |
+| `KeyCode::BackTab` | `Key::Tab` with `key.modifiers.shift()` |
+| `key.modifiers.contains(KeyModifiers::SHIFT)` | `key.modifiers.shift()` |
+| `key.modifiers.contains(KeyModifiers::CONTROL)` | `key.modifiers.ctrl()` |
+| `Event::key(KeyCode::Enter)` | `Event::key(Key::Enter)` |
+| `use envision::input::KeyCode` | `use envision::input::Key` |
+| `use envision::input::KeyModifiers` | `use envision::input::Modifiers` |
+
+#### Imports
+
+```rust
+// Before
+use envision::input::{Event, KeyCode, KeyModifiers};
+
+// After
+use envision::input::{Event, Key, Modifiers};
+```
+
+#### Keybindings (handle_event match arms)
+
+```rust
+// Before
+match key.code {
+    KeyCode::Enter => Some(Msg::Submit),
+    KeyCode::Char('q') => Some(Msg::Quit),
+    KeyCode::BackTab => Some(Msg::FocusPrev),
+    _ => None,
+}
+
+// After
+match key.key {
+    Key::Enter => Some(Msg::Submit),
+    Key::Char('q') => Some(Msg::Quit),
+    Key::Tab if key.modifiers.shift() => Some(Msg::FocusPrev),
+    _ => None,
+}
+```
+
+#### Modifier checking
+
+```rust
+// Before
+let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+
+// After
+let ctrl = key.modifiers.ctrl();
+let shift = key.modifiers.shift();
+```
+
+#### Text input (Insert(c) patterns)
+
+ASCII letter keys are normalized to lowercase in `key.key`. For text
+input, use `key.raw_char` which preserves the original character:
+
+```rust
+// Before
+KeyCode::Char(c) if !ctrl => Some(Msg::Insert(c)),
+
+// After
+Key::Char(_) if !ctrl => key.raw_char.map(Msg::Insert),
+```
+
+#### Shift+G (scroll-to-bottom) pattern
+
+With normalization, `Key::Char('G')` becomes `Key::Char('g')` with
+`modifiers.shift()`. Place the shift-guarded arm before the plain arm:
+
+```rust
+// Before
+KeyCode::Home | KeyCode::Char('g') => Some(Msg::Top),
+KeyCode::End | KeyCode::Char('G') if shift || key.code == KeyCode::End => Some(Msg::Bottom),
+
+// After
+Key::Char('g') if key.modifiers.shift() => Some(Msg::Bottom),
+Key::Home | Key::Char('g') => Some(Msg::Top),
+Key::End => Some(Msg::Bottom),
+```
+
+#### TerminalEventSubscription
+
+The handler now receives `Event` (envision's) instead of
+`crossterm::event::Event`:
+
+```rust
+// Before
+use crossterm::event::{Event, KeyCode, KeyEvent};
+let sub = terminal_events(|event| {
+    if let Event::Key(KeyEvent { code: KeyCode::Char('q'), .. }) = event {
+        Some(Msg::Quit)
+    } else { None }
+});
+
+// After
+use envision::input::{Event, Key};
+let sub = terminal_events(|event| {
+    if let Some(key) = event.as_key() {
+        if key.key == Key::Char('q') { return Some(Msg::Quit); }
+    }
+    None
+});
+```
+
+### RenderContext refactor
+
 0.14.0 introduces a large, cascading breakage around component rendering.
 `Component::view` now takes a single `&mut RenderContext<'_, '_>` argument
 instead of five separate arguments, and `ViewContext` has been renamed to

--- a/benches/component_events.rs
+++ b/benches/component_events.rs
@@ -9,7 +9,7 @@ use envision::component::{
     Column, Component, EventContext, InputField, InputFieldState, SelectableList,
     SelectableListState, Table, TableRow, TableState, TextArea, TextAreaState,
 };
-use envision::input::{Event, KeyCode};
+use envision::input::{Event, Key};
 use ratatui::layout::Constraint;
 
 // ========================================
@@ -57,7 +57,7 @@ fn bench_handle_event(c: &mut Criterion) {
     for size in [100, 1000] {
         // ---- SelectableList ----
         let items: Vec<String> = (0..size).map(|i| format!("Item {}", i)).collect();
-        let event = Event::key(KeyCode::Down);
+        let event = Event::key(Key::Down);
 
         // Focused (processes the event)
         let state = SelectableListState::new(items.clone());
@@ -93,7 +93,7 @@ fn bench_handle_event(c: &mut Criterion) {
         // ---- Table ----
         let rows = make_bench_rows(size as u32);
         let columns = make_table_columns();
-        let event = Event::key(KeyCode::Down);
+        let event = Event::key(Key::Down);
 
         // Focused
         let state = TableState::new(rows.clone(), columns.clone());
@@ -124,7 +124,7 @@ fn bench_handle_event(c: &mut Criterion) {
             .map(|i| format!("Line {} with some text content", i))
             .collect::<Vec<_>>()
             .join("\n");
-        let event = Event::key(KeyCode::Down);
+        let event = Event::key(Key::Down);
 
         // Focused
         let state = TextAreaState::new().with_value(&content);
@@ -183,7 +183,7 @@ fn bench_handle_event(c: &mut Criterion) {
         );
 
         // Backspace event (focused)
-        let event_backspace = Event::key(KeyCode::Backspace);
+        let event_backspace = Event::key(Key::Backspace);
         group.bench_with_input(
             BenchmarkId::new("input_field/focused/backspace", size),
             &size,
@@ -227,7 +227,7 @@ fn bench_dispatch_event(c: &mut Criterion) {
     for size in [100, 1000] {
         // ---- SelectableList ----
         let items: Vec<String> = (0..size).map(|i| format!("Item {}", i)).collect();
-        let event = Event::key(KeyCode::Down);
+        let event = Event::key(Key::Down);
 
         group.bench_with_input(
             BenchmarkId::new("selectable_list/focused", size),
@@ -247,7 +247,7 @@ fn bench_dispatch_event(c: &mut Criterion) {
         // ---- Table ----
         let rows = make_bench_rows(size as u32);
         let columns = make_table_columns();
-        let event = Event::key(KeyCode::Down);
+        let event = Event::key(Key::Down);
 
         group.bench_with_input(BenchmarkId::new("table/focused", size), &size, |b, _| {
             let mut state = TableState::new(rows.clone(), columns.clone());
@@ -265,7 +265,7 @@ fn bench_dispatch_event(c: &mut Criterion) {
             .map(|i| format!("Line {} with some text content", i))
             .collect::<Vec<_>>()
             .join("\n");
-        let event_down = Event::key(KeyCode::Down);
+        let event_down = Event::key(Key::Down);
 
         group.bench_with_input(
             BenchmarkId::new("text_area/focused", size),
@@ -308,7 +308,7 @@ fn bench_dispatch_event(c: &mut Criterion) {
         );
 
         // Backspace dispatch
-        let event_backspace = Event::key(KeyCode::Backspace);
+        let event_backspace = Event::key(Key::Backspace);
         group.bench_with_input(
             BenchmarkId::new("input_field/focused/backspace", size),
             &size,

--- a/docs/superpowers/plans/2026-04-11-envision-owned-input-types.md
+++ b/docs/superpowers/plans/2026-04-11-envision-owned-input-types.md
@@ -1,0 +1,1379 @@
+# Envision-Owned Input Types Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace crossterm re-exports with envision-owned input types (`Key`, `KeyEvent`, `Modifiers`, `MouseEvent`), normalizing letter keys to lowercase with `raw_char` preserving the original terminal character.
+
+**Architecture:** Three-phase approach: (1) define new types with unit tests (compilable alongside crossterm), (2) add private crossterm→envision converters with normalization tests, (3) atomic switch — rewire Event enum, migrate all 73 components, 89 examples, tests, benchmarks, runtime, and subscriptions in one commit.
+
+**Tech Stack:** Rust (edition 2024), ratatui, crossterm (still a dependency, just hidden), cargo-nextest.
+
+**Spec:** `docs/superpowers/specs/2026-04-11-envision-owned-input-types-design.md`
+
+**Target version:** 0.14.0 (breaking)
+
+---
+
+## Project Context
+
+- **Working branch:** `envision-owned-input-types` (created from main, spec committed at `228b8fc`).
+- **Previous refactor context:** The RenderContext refactor (PR #407) just landed on main. Components now use `ctx: &mut RenderContext<'_, '_>` for view and `ctx: &EventContext` for handle_event. This plan builds on that.
+- **Atomic strategy:** Tasks 1-2 add types/converters non-destructively. Task 3 is the atomic switch — same pattern as the RenderContext refactor.
+- **Signed commits required.** `commit.gpgsign=true`.
+- **No warnings allowed.** `cargo clippy --all-targets -- -D warnings`.
+
+---
+
+## File Structure
+
+**New files:**
+- `src/input/key.rs` — `Key`, `KeyEvent`, `KeyEventKind`, `Modifiers` + unit tests
+- `src/input/mouse.rs` — `MouseEvent`, `MouseEventKind`, `MouseButton` + unit tests
+- `src/input/convert.rs` — private crossterm→envision converters + normalization tests
+
+**Modified files (core):**
+- `src/input/mod.rs` — re-exports change from crossterm to envision types
+- `src/input/events/mod.rs` — `Event` enum uses envision types, `From` impls removed
+- `src/input/queue/mod.rs` — uses envision types
+- `src/app/runtime/terminal.rs` — uses `from_crossterm_event()` converter
+- `src/app/subscription/terminal.rs` — handler bound changes to `Fn(Event)`
+- `src/lib.rs` — re-exports `Key` and `Modifiers` instead of `KeyCode` and `KeyModifiers`
+
+**Modified files (cascade):**
+- 73 component `mod.rs` files + their test files
+- 89 example files
+- Integration test files in `tests/`
+- Benchmark files in `benches/`
+- `CHANGELOG.md`, `MIGRATION.md`, `CONTRIBUTING.md`
+
+---
+
+## Task 1: Define envision-owned types (TDD)
+
+**Goal:** Create `src/input/key.rs` and `src/input/mouse.rs` with all type definitions and unit tests. These coexist with crossterm types — nothing references them yet.
+
+**Files:**
+- Create: `src/input/key.rs`
+- Create: `src/input/mouse.rs`
+- Modify: `src/input/mod.rs` (add module declarations, NOT re-exports yet)
+
+---
+
+- [ ] **Step 1.1: Create `src/input/key.rs` with all key types**
+
+Create the file with the full type definitions. Include doc comments, derives, and all impl blocks:
+
+```rust
+//! Envision-owned keyboard input types.
+//!
+//! These types replace the crossterm re-exports that envision previously
+//! used for keyboard events. Letter keys are normalized to lowercase;
+//! use [`KeyEvent::raw_char`] for the actual terminal character.
+
+use std::ops::{BitAnd, BitOr, BitOrAssign};
+
+/// A keyboard key, normalized.
+///
+/// For ASCII letters, the `Char` variant always contains the lowercase
+/// form regardless of shift or caps lock state. Check
+/// [`KeyEvent::modifiers`] for shift state, and [`KeyEvent::raw_char`]
+/// for the character the terminal actually sent.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::input::Key;
+///
+/// // Pattern-match on normalized keys for keybindings
+/// let key = Key::Char('q');
+/// assert!(matches!(key, Key::Char('q')));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Key {
+    /// A character key. Always lowercase for ASCII letters.
+    Char(char),
+    /// A function key (F1 through F24).
+    F(u8),
+    Backspace,
+    Enter,
+    Left,
+    Right,
+    Up,
+    Down,
+    Home,
+    End,
+    PageUp,
+    PageDown,
+    Tab,
+    Delete,
+    Insert,
+    Esc,
+}
+
+/// A keyboard event with normalization and raw character preservation.
+///
+/// # Two views of the same keypress
+///
+/// - **`key`**: normalized for keybindings. ASCII letters are always
+///   lowercase. Use this for `match` arms in `handle_event`.
+/// - **`raw_char`**: the character the terminal actually sent. Preserves
+///   case (uppercase for Shift or Caps Lock). Use this for text input.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::input::{Key, KeyEvent, Modifiers};
+///
+/// // Constructors normalize automatically
+/// let event = KeyEvent::char('A');
+/// assert_eq!(event.key, Key::Char('a'));        // normalized
+/// assert!(event.modifiers.shift());             // shift inferred
+/// assert_eq!(event.raw_char, Some('A'));         // original preserved
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeyEvent {
+    /// The key, normalized. ASCII letters are always lowercase.
+    pub key: Key,
+    /// Modifier keys held during the event.
+    pub modifiers: Modifiers,
+    /// Whether this is a press, release, or repeat.
+    pub kind: KeyEventKind,
+    /// The character the terminal actually sent, if this was a
+    /// character key. `None` for non-character keys.
+    pub raw_char: Option<char>,
+}
+
+impl KeyEvent {
+    /// Creates a key press event with no modifiers.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::{Key, KeyEvent};
+    ///
+    /// let event = KeyEvent::new(Key::Enter);
+    /// assert_eq!(event.key, Key::Enter);
+    /// assert!(event.modifiers.is_none());
+    /// assert!(event.raw_char.is_none());
+    /// ```
+    pub fn new(key: Key) -> Self {
+        Self {
+            key,
+            modifiers: Modifiers::NONE,
+            kind: KeyEventKind::Press,
+            raw_char: None,
+        }
+    }
+
+    /// Creates a normalized character key press.
+    ///
+    /// Uppercase letters are normalized: `char('A')` produces
+    /// `key=Char('a')`, `modifiers=SHIFT`, `raw_char=Some('A')`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::{Key, KeyEvent, Modifiers};
+    ///
+    /// let lower = KeyEvent::char('a');
+    /// assert_eq!(lower.key, Key::Char('a'));
+    /// assert!(lower.modifiers.is_none());
+    /// assert_eq!(lower.raw_char, Some('a'));
+    ///
+    /// let upper = KeyEvent::char('A');
+    /// assert_eq!(upper.key, Key::Char('a'));
+    /// assert!(upper.modifiers.shift());
+    /// assert_eq!(upper.raw_char, Some('A'));
+    /// ```
+    pub fn char(c: char) -> Self {
+        if c.is_ascii_uppercase() {
+            Self {
+                key: Key::Char(c.to_ascii_lowercase()),
+                modifiers: Modifiers::SHIFT,
+                kind: KeyEventKind::Press,
+                raw_char: Some(c),
+            }
+        } else {
+            Self {
+                key: Key::Char(c),
+                modifiers: Modifiers::NONE,
+                kind: KeyEventKind::Press,
+                raw_char: Some(c),
+            }
+        }
+    }
+
+    /// Creates a Ctrl+character key press.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::{Key, KeyEvent, Modifiers};
+    ///
+    /// let event = KeyEvent::ctrl('c');
+    /// assert_eq!(event.key, Key::Char('c'));
+    /// assert!(event.modifiers.ctrl());
+    /// ```
+    pub fn ctrl(c: char) -> Self {
+        Self {
+            key: Key::Char(c.to_ascii_lowercase()),
+            modifiers: Modifiers::CONTROL,
+            kind: KeyEventKind::Press,
+            raw_char: Some(c),
+        }
+    }
+
+    /// Returns true if this is a press event.
+    pub fn is_press(&self) -> bool {
+        self.kind == KeyEventKind::Press
+    }
+
+    /// Returns true if this is a release event.
+    pub fn is_release(&self) -> bool {
+        self.kind == KeyEventKind::Release
+    }
+}
+
+/// The kind of key event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum KeyEventKind {
+    /// A key was pressed.
+    Press,
+    /// A key was released (not supported by all terminals).
+    Release,
+    /// A key is being held and is repeating.
+    Repeat,
+}
+
+/// Modifier keys held during an input event.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::input::Modifiers;
+///
+/// let mods = Modifiers::CONTROL | Modifiers::SHIFT;
+/// assert!(mods.ctrl());
+/// assert!(mods.shift());
+/// assert!(!mods.alt());
+/// ```
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct Modifiers(u8);
+
+impl Modifiers {
+    /// No modifier keys held.
+    pub const NONE: Self = Self(0);
+    /// Shift key held.
+    pub const SHIFT: Self = Self(1 << 0);
+    /// Control key held.
+    pub const CONTROL: Self = Self(1 << 1);
+    /// Alt/Option key held.
+    pub const ALT: Self = Self(1 << 2);
+    /// Super/Cmd/Win key held.
+    pub const SUPER: Self = Self(1 << 3);
+
+    /// Returns true if the shift key is held.
+    pub fn shift(self) -> bool {
+        self.0 & Self::SHIFT.0 != 0
+    }
+
+    /// Returns true if the control key is held.
+    pub fn ctrl(self) -> bool {
+        self.0 & Self::CONTROL.0 != 0
+    }
+
+    /// Returns true if the alt/option key is held.
+    pub fn alt(self) -> bool {
+        self.0 & Self::ALT.0 != 0
+    }
+
+    /// Returns true if the super/cmd/win key is held.
+    pub fn super_key(self) -> bool {
+        self.0 & Self::SUPER.0 != 0
+    }
+
+    /// Returns true if no modifier keys are held.
+    pub fn is_none(self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl BitOr for Modifiers {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl BitOrAssign for Modifiers {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+impl BitAnd for Modifiers {
+    type Output = Self;
+    fn bitand(self, rhs: Self) -> Self {
+        Self(self.0 & rhs.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_key_equality() {
+        assert_eq!(Key::Char('a'), Key::Char('a'));
+        assert_ne!(Key::Char('a'), Key::Char('b'));
+        assert_ne!(Key::Char('a'), Key::Enter);
+        assert_eq!(Key::F(5), Key::F(5));
+        assert_ne!(Key::F(5), Key::F(6));
+    }
+
+    #[test]
+    fn test_key_event_new() {
+        let event = KeyEvent::new(Key::Enter);
+        assert_eq!(event.key, Key::Enter);
+        assert!(event.modifiers.is_none());
+        assert_eq!(event.kind, KeyEventKind::Press);
+        assert!(event.raw_char.is_none());
+    }
+
+    #[test]
+    fn test_key_event_char_lowercase() {
+        let event = KeyEvent::char('a');
+        assert_eq!(event.key, Key::Char('a'));
+        assert!(event.modifiers.is_none());
+        assert_eq!(event.raw_char, Some('a'));
+    }
+
+    #[test]
+    fn test_key_event_char_uppercase_normalizes() {
+        let event = KeyEvent::char('A');
+        assert_eq!(event.key, Key::Char('a'));
+        assert!(event.modifiers.shift());
+        assert_eq!(event.raw_char, Some('A'));
+    }
+
+    #[test]
+    fn test_key_event_ctrl() {
+        let event = KeyEvent::ctrl('c');
+        assert_eq!(event.key, Key::Char('c'));
+        assert!(event.modifiers.ctrl());
+        assert!(!event.modifiers.shift());
+        assert_eq!(event.raw_char, Some('c'));
+    }
+
+    #[test]
+    fn test_key_event_is_press_release() {
+        let press = KeyEvent::new(Key::Enter);
+        assert!(press.is_press());
+        assert!(!press.is_release());
+
+        let release = KeyEvent {
+            kind: KeyEventKind::Release,
+            ..KeyEvent::new(Key::Enter)
+        };
+        assert!(!release.is_press());
+        assert!(release.is_release());
+    }
+
+    #[test]
+    fn test_modifiers_default() {
+        let m = Modifiers::default();
+        assert!(m.is_none());
+        assert!(!m.shift());
+        assert!(!m.ctrl());
+        assert!(!m.alt());
+        assert!(!m.super_key());
+    }
+
+    #[test]
+    fn test_modifiers_individual() {
+        assert!(Modifiers::SHIFT.shift());
+        assert!(!Modifiers::SHIFT.ctrl());
+        assert!(Modifiers::CONTROL.ctrl());
+        assert!(!Modifiers::CONTROL.shift());
+        assert!(Modifiers::ALT.alt());
+        assert!(Modifiers::SUPER.super_key());
+    }
+
+    #[test]
+    fn test_modifiers_bitor() {
+        let mods = Modifiers::CONTROL | Modifiers::SHIFT;
+        assert!(mods.ctrl());
+        assert!(mods.shift());
+        assert!(!mods.alt());
+    }
+
+    #[test]
+    fn test_modifiers_bitor_assign() {
+        let mut mods = Modifiers::NONE;
+        mods |= Modifiers::ALT;
+        assert!(mods.alt());
+        assert!(!mods.ctrl());
+    }
+
+    #[test]
+    fn test_modifiers_bitand() {
+        let mods = Modifiers::CONTROL | Modifiers::SHIFT;
+        let masked = mods & Modifiers::CONTROL;
+        assert!(masked.ctrl());
+        assert!(!masked.shift());
+    }
+
+    #[test]
+    fn test_key_event_kind_equality() {
+        assert_eq!(KeyEventKind::Press, KeyEventKind::Press);
+        assert_ne!(KeyEventKind::Press, KeyEventKind::Release);
+    }
+}
+```
+
+- [ ] **Step 1.2: Create `src/input/mouse.rs` with all mouse types**
+
+```rust
+//! Envision-owned mouse input types.
+
+use super::key::Modifiers;
+
+/// A mouse event.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::input::{MouseEvent, MouseEventKind, MouseButton, Modifiers};
+///
+/// let event = MouseEvent {
+///     kind: MouseEventKind::Down(MouseButton::Left),
+///     column: 10,
+///     row: 5,
+///     modifiers: Modifiers::NONE,
+/// };
+/// assert_eq!(event.column, 10);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MouseEvent {
+    /// The kind of mouse event.
+    pub kind: MouseEventKind,
+    /// The column (x coordinate).
+    pub column: u16,
+    /// The row (y coordinate).
+    pub row: u16,
+    /// Modifier keys held during the event.
+    pub modifiers: Modifiers,
+}
+
+/// The kind of mouse event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MouseEventKind {
+    /// A button was pressed.
+    Down(MouseButton),
+    /// A button was released.
+    Up(MouseButton),
+    /// The mouse was dragged while a button was held.
+    Drag(MouseButton),
+    /// The mouse was moved (no button held).
+    Moved,
+    /// Scroll wheel up.
+    ScrollUp,
+    /// Scroll wheel down.
+    ScrollDown,
+    /// Scroll wheel left.
+    ScrollLeft,
+    /// Scroll wheel right.
+    ScrollRight,
+}
+
+/// A mouse button.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MouseButton {
+    /// The left mouse button.
+    Left,
+    /// The right mouse button.
+    Right,
+    /// The middle mouse button.
+    Middle,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mouse_event_construction() {
+        let event = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 10,
+            row: 5,
+            modifiers: Modifiers::NONE,
+        };
+        assert_eq!(event.column, 10);
+        assert_eq!(event.row, 5);
+        assert!(event.modifiers.is_none());
+    }
+
+    #[test]
+    fn test_mouse_event_kind_equality() {
+        assert_eq!(
+            MouseEventKind::Down(MouseButton::Left),
+            MouseEventKind::Down(MouseButton::Left),
+        );
+        assert_ne!(
+            MouseEventKind::Down(MouseButton::Left),
+            MouseEventKind::Down(MouseButton::Right),
+        );
+        assert_ne!(
+            MouseEventKind::Down(MouseButton::Left),
+            MouseEventKind::Up(MouseButton::Left),
+        );
+    }
+
+    #[test]
+    fn test_mouse_button_equality() {
+        assert_eq!(MouseButton::Left, MouseButton::Left);
+        assert_ne!(MouseButton::Left, MouseButton::Right);
+    }
+
+    #[test]
+    fn test_mouse_with_modifiers() {
+        let event = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 0,
+            row: 0,
+            modifiers: Modifiers::CONTROL | Modifiers::SHIFT,
+        };
+        assert!(event.modifiers.ctrl());
+        assert!(event.modifiers.shift());
+    }
+}
+```
+
+- [ ] **Step 1.3: Wire modules into `src/input/mod.rs` (declarations only, NOT re-exports yet)**
+
+Add module declarations to `src/input/mod.rs` WITHOUT changing any existing re-exports. The new modules coexist with crossterm:
+
+Add these lines after the existing `mod queue;` declaration:
+
+```rust
+pub mod key;
+pub mod mouse;
+```
+
+Leave the existing `pub use crossterm::event::*` lines untouched.
+
+- [ ] **Step 1.4: Verify compilation and run tests**
+
+```bash
+cargo check -p envision 2>&1 | tail -5
+cargo nextest run -p envision input::key::tests input::mouse::tests 2>&1 | tail -10
+cargo test --doc -p envision Key KeyEvent Modifiers MouseEvent MouseButton 2>&1 | tail -10
+```
+
+Expected: all compile, all tests pass (new tests + existing tests unaffected).
+
+- [ ] **Step 1.5: Format, lint, commit**
+
+```bash
+cargo fmt
+cargo clippy -p envision -- -D warnings 2>&1 | tail -3
+git add src/input/key.rs src/input/mouse.rs src/input/mod.rs
+git commit -S -m "$(cat <<'EOF'
+Add envision-owned Key, KeyEvent, Modifiers, and mouse types
+
+Defines envision's own input types alongside the existing crossterm
+re-exports. Key normalizes ASCII letters to lowercase; KeyEvent
+carries raw_char preserving the original terminal character. Modifiers
+is a plain u8 struct with shift/ctrl/alt/super flags.
+
+Types coexist with crossterm — the Event enum still wraps crossterm
+types. The atomic switch happens in a follow-up commit.
+
+Part of docs/superpowers/specs/2026-04-11-envision-owned-input-types-design.md
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Add crossterm conversion layer (TDD)
+
+**Goal:** Create `src/input/convert.rs` with private converters from crossterm events to envision events. Heavily tested — the normalization logic is the riskiest new code.
+
+**Files:**
+- Create: `src/input/convert.rs`
+- Modify: `src/input/mod.rs` (add module declaration)
+
+---
+
+- [ ] **Step 2.1: Create `src/input/convert.rs` with converters and tests**
+
+This is the core of the refactor. The converters must be correct for every case in the normalization table from the spec.
+
+```rust
+//! Private converters from crossterm event types to envision event types.
+//!
+//! These functions are `pub(crate)` so the runtime and subscription modules
+//! can call them, but they are not part of envision's public API.
+
+use super::events::Event;
+use super::key::{Key, KeyEvent, KeyEventKind, Modifiers};
+use super::mouse::{MouseButton, MouseEvent, MouseEventKind};
+
+/// Converts a crossterm event to an envision event.
+///
+/// Returns `None` for events that envision doesn't model (e.g., media keys,
+/// modifier-only events, null keys).
+pub(crate) fn from_crossterm_event(event: crossterm::event::Event) -> Option<Event> {
+    match event {
+        crossterm::event::Event::Key(key) => {
+            from_crossterm_key(key).map(Event::Key)
+        }
+        crossterm::event::Event::Mouse(mouse) => {
+            Some(Event::Mouse(from_crossterm_mouse(mouse)))
+        }
+        crossterm::event::Event::Resize(w, h) => Some(Event::Resize(w, h)),
+        crossterm::event::Event::FocusGained => Some(Event::FocusGained),
+        crossterm::event::Event::FocusLost => Some(Event::FocusLost),
+        crossterm::event::Event::Paste(s) => Some(Event::Paste(s)),
+    }
+}
+
+/// Converts a crossterm key event to an envision key event.
+///
+/// Returns `None` for key codes that envision doesn't model.
+pub(crate) fn from_crossterm_key(key: crossterm::event::KeyEvent) -> Option<KeyEvent> {
+    let mut modifiers = from_crossterm_modifiers(key.modifiers);
+    let kind = from_crossterm_key_kind(key.kind);
+
+    let (envision_key, raw_char) = match key.code {
+        crossterm::event::KeyCode::Char(c) => {
+            // Normalize control characters (Ctrl+letter sends 0x01-0x1A)
+            if c.is_ascii_control() && c != '\t' && c != '\r' && c != '\n' {
+                let letter = (c as u8 + b'a' - 1) as char;
+                modifiers |= Modifiers::CONTROL;
+                (Key::Char(letter), Some(c))
+            }
+            // Normalize uppercase ASCII letters to lowercase
+            else if c.is_ascii_uppercase() {
+                (Key::Char(c.to_ascii_lowercase()), Some(c))
+            }
+            // Everything else passes through
+            else {
+                (Key::Char(c), Some(c))
+            }
+        }
+        crossterm::event::KeyCode::F(n) => (Key::F(n), None),
+        crossterm::event::KeyCode::Backspace => (Key::Backspace, None),
+        crossterm::event::KeyCode::Enter => (Key::Enter, None),
+        crossterm::event::KeyCode::Left => (Key::Left, None),
+        crossterm::event::KeyCode::Right => (Key::Right, None),
+        crossterm::event::KeyCode::Up => (Key::Up, None),
+        crossterm::event::KeyCode::Down => (Key::Down, None),
+        crossterm::event::KeyCode::Home => (Key::Home, None),
+        crossterm::event::KeyCode::End => (Key::End, None),
+        crossterm::event::KeyCode::PageUp => (Key::PageUp, None),
+        crossterm::event::KeyCode::PageDown => (Key::PageDown, None),
+        crossterm::event::KeyCode::Tab => (Key::Tab, None),
+        crossterm::event::KeyCode::BackTab => {
+            modifiers |= Modifiers::SHIFT;
+            (Key::Tab, None)
+        }
+        crossterm::event::KeyCode::Delete => (Key::Delete, None),
+        crossterm::event::KeyCode::Insert => (Key::Insert, None),
+        crossterm::event::KeyCode::Esc => (Key::Esc, None),
+        // Dropped variants: Null, CapsLock, ScrollLock, NumLock,
+        // PrintScreen, Pause, Menu, KeypadBegin, Media, Modifier
+        _ => return None,
+    };
+
+    Some(KeyEvent {
+        key: envision_key,
+        modifiers,
+        kind,
+        raw_char,
+    })
+}
+
+/// Converts a crossterm mouse event to an envision mouse event.
+pub(crate) fn from_crossterm_mouse(mouse: crossterm::event::MouseEvent) -> MouseEvent {
+    MouseEvent {
+        kind: from_crossterm_mouse_kind(mouse.kind),
+        column: mouse.column,
+        row: mouse.row,
+        modifiers: from_crossterm_modifiers(mouse.modifiers),
+    }
+}
+
+/// Converts crossterm key modifiers to envision modifiers.
+pub(crate) fn from_crossterm_modifiers(mods: crossterm::event::KeyModifiers) -> Modifiers {
+    let mut result = Modifiers::NONE;
+    if mods.contains(crossterm::event::KeyModifiers::SHIFT) {
+        result |= Modifiers::SHIFT;
+    }
+    if mods.contains(crossterm::event::KeyModifiers::CONTROL) {
+        result |= Modifiers::CONTROL;
+    }
+    if mods.contains(crossterm::event::KeyModifiers::ALT) {
+        result |= Modifiers::ALT;
+    }
+    if mods.contains(crossterm::event::KeyModifiers::SUPER) {
+        result |= Modifiers::SUPER;
+    }
+    result
+}
+
+fn from_crossterm_key_kind(kind: crossterm::event::KeyEventKind) -> KeyEventKind {
+    match kind {
+        crossterm::event::KeyEventKind::Press => KeyEventKind::Press,
+        crossterm::event::KeyEventKind::Release => KeyEventKind::Release,
+        crossterm::event::KeyEventKind::Repeat => KeyEventKind::Repeat,
+    }
+}
+
+fn from_crossterm_mouse_kind(kind: crossterm::event::MouseEventKind) -> MouseEventKind {
+    match kind {
+        crossterm::event::MouseEventKind::Down(b) => {
+            MouseEventKind::Down(from_crossterm_button(b))
+        }
+        crossterm::event::MouseEventKind::Up(b) => {
+            MouseEventKind::Up(from_crossterm_button(b))
+        }
+        crossterm::event::MouseEventKind::Drag(b) => {
+            MouseEventKind::Drag(from_crossterm_button(b))
+        }
+        crossterm::event::MouseEventKind::Moved => MouseEventKind::Moved,
+        crossterm::event::MouseEventKind::ScrollDown => MouseEventKind::ScrollDown,
+        crossterm::event::MouseEventKind::ScrollUp => MouseEventKind::ScrollUp,
+        crossterm::event::MouseEventKind::ScrollLeft => MouseEventKind::ScrollLeft,
+        crossterm::event::MouseEventKind::ScrollRight => MouseEventKind::ScrollRight,
+    }
+}
+
+fn from_crossterm_button(button: crossterm::event::MouseButton) -> MouseButton {
+    match button {
+        crossterm::event::MouseButton::Left => MouseButton::Left,
+        crossterm::event::MouseButton::Right => MouseButton::Right,
+        crossterm::event::MouseButton::Middle => MouseButton::Middle,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event as ct;
+
+    fn ct_key(code: ct::KeyCode) -> ct::KeyEvent {
+        ct::KeyEvent::new(code, ct::KeyModifiers::empty())
+    }
+
+    fn ct_key_with_mods(code: ct::KeyCode, mods: ct::KeyModifiers) -> ct::KeyEvent {
+        ct::KeyEvent::new(code, mods)
+    }
+
+    // ========== Key normalization tests ==========
+
+    #[test]
+    fn test_lowercase_char() {
+        let result = from_crossterm_key(ct_key(ct::KeyCode::Char('a'))).unwrap();
+        assert_eq!(result.key, Key::Char('a'));
+        assert!(result.modifiers.is_none());
+        assert_eq!(result.raw_char, Some('a'));
+    }
+
+    #[test]
+    fn test_uppercase_with_shift_normalizes() {
+        let result = from_crossterm_key(ct_key_with_mods(
+            ct::KeyCode::Char('A'),
+            ct::KeyModifiers::SHIFT,
+        )).unwrap();
+        assert_eq!(result.key, Key::Char('a'));
+        assert!(result.modifiers.shift());
+        assert_eq!(result.raw_char, Some('A'));
+    }
+
+    #[test]
+    fn test_uppercase_without_shift_caps_lock() {
+        // Caps lock sends uppercase without SHIFT modifier
+        let result = from_crossterm_key(ct_key(ct::KeyCode::Char('A'))).unwrap();
+        assert_eq!(result.key, Key::Char('a'));
+        assert!(!result.modifiers.shift());
+        assert_eq!(result.raw_char, Some('A'));
+    }
+
+    #[test]
+    fn test_symbol_with_shift_preserved() {
+        let result = from_crossterm_key(ct_key_with_mods(
+            ct::KeyCode::Char('!'),
+            ct::KeyModifiers::SHIFT,
+        )).unwrap();
+        assert_eq!(result.key, Key::Char('!'));
+        assert!(result.modifiers.shift());
+        assert_eq!(result.raw_char, Some('!'));
+    }
+
+    #[test]
+    fn test_ctrl_c_from_modifier() {
+        let result = from_crossterm_key(ct_key_with_mods(
+            ct::KeyCode::Char('c'),
+            ct::KeyModifiers::CONTROL,
+        )).unwrap();
+        assert_eq!(result.key, Key::Char('c'));
+        assert!(result.modifiers.ctrl());
+        assert_eq!(result.raw_char, Some('c'));
+    }
+
+    #[test]
+    fn test_ctrl_c_from_raw_control_char() {
+        // Some terminals send '\x03' instead of 'c' + CONTROL
+        let result = from_crossterm_key(ct_key(ct::KeyCode::Char('\x03'))).unwrap();
+        assert_eq!(result.key, Key::Char('c'));
+        assert!(result.modifiers.ctrl());
+        assert_eq!(result.raw_char, Some('\x03'));
+    }
+
+    #[test]
+    fn test_backtab_becomes_tab_with_shift() {
+        let result = from_crossterm_key(ct_key(ct::KeyCode::BackTab)).unwrap();
+        assert_eq!(result.key, Key::Tab);
+        assert!(result.modifiers.shift());
+        assert!(result.raw_char.is_none());
+    }
+
+    #[test]
+    fn test_enter() {
+        let result = from_crossterm_key(ct_key(ct::KeyCode::Enter)).unwrap();
+        assert_eq!(result.key, Key::Enter);
+        assert!(result.modifiers.is_none());
+        assert!(result.raw_char.is_none());
+    }
+
+    #[test]
+    fn test_function_key() {
+        let result = from_crossterm_key(ct_key(ct::KeyCode::F(5))).unwrap();
+        assert_eq!(result.key, Key::F(5));
+        assert!(result.raw_char.is_none());
+    }
+
+    #[test]
+    fn test_arrows() {
+        assert_eq!(from_crossterm_key(ct_key(ct::KeyCode::Left)).unwrap().key, Key::Left);
+        assert_eq!(from_crossterm_key(ct_key(ct::KeyCode::Right)).unwrap().key, Key::Right);
+        assert_eq!(from_crossterm_key(ct_key(ct::KeyCode::Up)).unwrap().key, Key::Up);
+        assert_eq!(from_crossterm_key(ct_key(ct::KeyCode::Down)).unwrap().key, Key::Down);
+    }
+
+    #[test]
+    fn test_navigation_keys() {
+        assert_eq!(from_crossterm_key(ct_key(ct::KeyCode::Home)).unwrap().key, Key::Home);
+        assert_eq!(from_crossterm_key(ct_key(ct::KeyCode::End)).unwrap().key, Key::End);
+        assert_eq!(from_crossterm_key(ct_key(ct::KeyCode::PageUp)).unwrap().key, Key::PageUp);
+        assert_eq!(from_crossterm_key(ct_key(ct::KeyCode::PageDown)).unwrap().key, Key::PageDown);
+    }
+
+    #[test]
+    fn test_editing_keys() {
+        assert_eq!(from_crossterm_key(ct_key(ct::KeyCode::Backspace)).unwrap().key, Key::Backspace);
+        assert_eq!(from_crossterm_key(ct_key(ct::KeyCode::Delete)).unwrap().key, Key::Delete);
+        assert_eq!(from_crossterm_key(ct_key(ct::KeyCode::Insert)).unwrap().key, Key::Insert);
+        assert_eq!(from_crossterm_key(ct_key(ct::KeyCode::Tab)).unwrap().key, Key::Tab);
+        assert_eq!(from_crossterm_key(ct_key(ct::KeyCode::Esc)).unwrap().key, Key::Esc);
+    }
+
+    #[test]
+    fn test_dropped_keys_return_none() {
+        assert!(from_crossterm_key(ct_key(ct::KeyCode::Null)).is_none());
+        assert!(from_crossterm_key(ct_key(ct::KeyCode::CapsLock)).is_none());
+        assert!(from_crossterm_key(ct_key(ct::KeyCode::NumLock)).is_none());
+        assert!(from_crossterm_key(ct_key(ct::KeyCode::ScrollLock)).is_none());
+        assert!(from_crossterm_key(ct_key(ct::KeyCode::PrintScreen)).is_none());
+        assert!(from_crossterm_key(ct_key(ct::KeyCode::Pause)).is_none());
+        assert!(from_crossterm_key(ct_key(ct::KeyCode::Menu)).is_none());
+        assert!(from_crossterm_key(ct_key(ct::KeyCode::KeypadBegin)).is_none());
+    }
+
+    #[test]
+    fn test_key_event_kind_mapping() {
+        let press = ct::KeyEvent {
+            kind: ct::KeyEventKind::Press,
+            ..ct_key(ct::KeyCode::Enter)
+        };
+        assert_eq!(from_crossterm_key(press).unwrap().kind, KeyEventKind::Press);
+
+        let release = ct::KeyEvent {
+            kind: ct::KeyEventKind::Release,
+            ..ct_key(ct::KeyCode::Enter)
+        };
+        assert_eq!(from_crossterm_key(release).unwrap().kind, KeyEventKind::Release);
+
+        let repeat = ct::KeyEvent {
+            kind: ct::KeyEventKind::Repeat,
+            ..ct_key(ct::KeyCode::Enter)
+        };
+        assert_eq!(from_crossterm_key(repeat).unwrap().kind, KeyEventKind::Repeat);
+    }
+
+    // ========== Modifier conversion tests ==========
+
+    #[test]
+    fn test_modifier_mapping() {
+        let shift = from_crossterm_modifiers(ct::KeyModifiers::SHIFT);
+        assert!(shift.shift());
+        assert!(!shift.ctrl());
+
+        let ctrl = from_crossterm_modifiers(ct::KeyModifiers::CONTROL);
+        assert!(ctrl.ctrl());
+        assert!(!ctrl.shift());
+
+        let alt = from_crossterm_modifiers(ct::KeyModifiers::ALT);
+        assert!(alt.alt());
+
+        let sup = from_crossterm_modifiers(ct::KeyModifiers::SUPER);
+        assert!(sup.super_key());
+    }
+
+    #[test]
+    fn test_combined_modifiers() {
+        let mods = from_crossterm_modifiers(
+            ct::KeyModifiers::SHIFT | ct::KeyModifiers::CONTROL,
+        );
+        assert!(mods.shift());
+        assert!(mods.ctrl());
+        assert!(!mods.alt());
+    }
+
+    #[test]
+    fn test_empty_modifiers() {
+        let mods = from_crossterm_modifiers(ct::KeyModifiers::empty());
+        assert!(mods.is_none());
+    }
+
+    // ========== Mouse conversion tests ==========
+
+    #[test]
+    fn test_mouse_button_mapping() {
+        let ct_mouse = ct::MouseEvent {
+            kind: ct::MouseEventKind::Down(ct::MouseButton::Left),
+            column: 10,
+            row: 5,
+            modifiers: ct::KeyModifiers::empty(),
+        };
+        let result = from_crossterm_mouse(ct_mouse);
+        assert_eq!(result.kind, MouseEventKind::Down(MouseButton::Left));
+        assert_eq!(result.column, 10);
+        assert_eq!(result.row, 5);
+        assert!(result.modifiers.is_none());
+    }
+
+    #[test]
+    fn test_mouse_scroll() {
+        let ct_mouse = ct::MouseEvent {
+            kind: ct::MouseEventKind::ScrollUp,
+            column: 0,
+            row: 0,
+            modifiers: ct::KeyModifiers::empty(),
+        };
+        assert_eq!(from_crossterm_mouse(ct_mouse).kind, MouseEventKind::ScrollUp);
+    }
+
+    #[test]
+    fn test_mouse_with_modifiers() {
+        let ct_mouse = ct::MouseEvent {
+            kind: ct::MouseEventKind::Down(ct::MouseButton::Left),
+            column: 0,
+            row: 0,
+            modifiers: ct::KeyModifiers::CONTROL,
+        };
+        let result = from_crossterm_mouse(ct_mouse);
+        assert!(result.modifiers.ctrl());
+    }
+
+    // ========== Full event conversion tests ==========
+
+    #[test]
+    fn test_event_key() {
+        let ct_event = ct::Event::Key(ct_key(ct::KeyCode::Enter));
+        let result = from_crossterm_event(ct_event).unwrap();
+        assert!(matches!(result, Event::Key(k) if k.key == Key::Enter));
+    }
+
+    #[test]
+    fn test_event_resize() {
+        let ct_event = ct::Event::Resize(80, 24);
+        assert_eq!(from_crossterm_event(ct_event), Some(Event::Resize(80, 24)));
+    }
+
+    #[test]
+    fn test_event_focus() {
+        assert_eq!(
+            from_crossterm_event(ct::Event::FocusGained),
+            Some(Event::FocusGained),
+        );
+        assert_eq!(
+            from_crossterm_event(ct::Event::FocusLost),
+            Some(Event::FocusLost),
+        );
+    }
+
+    #[test]
+    fn test_event_paste() {
+        let ct_event = ct::Event::Paste("hello".to_string());
+        assert_eq!(
+            from_crossterm_event(ct_event),
+            Some(Event::Paste("hello".to_string())),
+        );
+    }
+}
+```
+
+- [ ] **Step 2.2: Wire the module in `src/input/mod.rs`**
+
+Add after existing module declarations:
+
+```rust
+pub(crate) mod convert;
+```
+
+- [ ] **Step 2.3: Verify compilation and run tests**
+
+```bash
+cargo check -p envision 2>&1 | tail -5
+cargo nextest run -p envision input::convert::tests 2>&1 | tail -10
+```
+
+Expected: all compile, all converter tests pass. Note: `from_crossterm_event` references `Event::Key(...)` etc. which currently uses crossterm's `KeyEvent`. This will cause a type mismatch because the `Event` enum still uses crossterm types. 
+
+**IMPORTANT:** This means convert.rs can't compile yet because it produces envision `KeyEvent` but `Event::Key` expects crossterm's `KeyEvent`. There are two solutions:
+
+**Solution A:** Have convert.rs return envision types NOT wrapped in Event — just `fn from_crossterm_key(ct::KeyEvent) -> Option<KeyEvent>` and `fn from_crossterm_mouse(ct::MouseEvent) -> MouseEvent`. The `from_crossterm_event` function that wraps them in `Event` is added in Task 3 when the Event enum switches.
+
+**Solution B:** Have convert.rs define its own temporary `ConvertedEvent` type that wraps envision types. Delete it in Task 3.
+
+**Go with Solution A** — simpler. Remove `from_crossterm_event` from this task. Only implement the individual type converters (`from_crossterm_key`, `from_crossterm_mouse`, `from_crossterm_modifiers`). The `from_crossterm_event` function is added in Task 3 alongside the Event enum switch.
+
+Update the file accordingly: remove `from_crossterm_event`, remove the `use super::events::Event;` import, remove the event-level tests (`test_event_key`, `test_event_resize`, etc.). Keep only the key, mouse, and modifier converter functions and their tests.
+
+- [ ] **Step 2.4: Re-run verification**
+
+```bash
+cargo check -p envision 2>&1 | tail -5
+cargo nextest run -p envision input::convert::tests input::key::tests input::mouse::tests 2>&1 | tail -10
+```
+
+Expected: clean compile, all tests pass.
+
+- [ ] **Step 2.5: Format, lint, commit**
+
+```bash
+cargo fmt
+cargo clippy -p envision -- -D warnings 2>&1 | tail -3
+git add src/input/convert.rs src/input/mod.rs
+git commit -S -m "$(cat <<'EOF'
+Add crossterm-to-envision input type converters
+
+Private converter functions that normalize crossterm events into
+envision's owned types: lowercase letters, BackTab → Tab+SHIFT,
+control chars → letter+CONTROL, dropped niche keys. Includes 25+
+normalization tests covering all cases from the spec table.
+
+The from_crossterm_event wrapper is added in the atomic switch
+commit when the Event enum changes to use envision types.
+
+Part of docs/superpowers/specs/2026-04-11-envision-owned-input-types-design.md
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Atomic switch — Event enum + all callers (one commit)
+
+**Goal:** Switch `Event` to use envision types, remove crossterm re-exports, add `from_crossterm_event`, and cascade through all components, examples, tests, benchmarks, runtime, and subscriptions.
+
+**Files:** ~180 files. Same atomic strategy as the RenderContext refactor.
+
+---
+
+- [ ] **Step 3.1: Switch the `Event` enum in `src/input/events/mod.rs`**
+
+Replace crossterm imports with envision imports. Update the `Event` enum variants. Remove all `From<crossterm::*>` impls. Add `from_crossterm_event` to `src/input/convert.rs`. Update convenience methods (`Event::char`, `Event::ctrl`, `Event::key`, `as_key`, `as_mouse`) to use envision types.
+
+The `Event` enum becomes:
+
+```rust
+use super::key::{Key, KeyEvent, KeyEventKind, Modifiers};
+use super::mouse::{MouseButton, MouseEvent, MouseEventKind};
+
+pub enum Event {
+    Key(KeyEvent),       // envision's KeyEvent
+    Mouse(MouseEvent),   // envision's MouseEvent
+    Resize(u16, u16),
+    FocusGained,
+    FocusLost,
+    Paste(String),
+}
+```
+
+Update `Event::char(c)` to delegate to `KeyEvent::char(c)`:
+
+```rust
+pub fn char(c: char) -> Self {
+    Self::Key(KeyEvent::char(c))
+}
+```
+
+Update `Event::ctrl(c)` to delegate to `KeyEvent::ctrl(c)`.
+
+Update `Event::key(key: Key)` (was `Event::key(code: KeyCode)`):
+
+```rust
+pub fn key(key: Key) -> Self {
+    Self::Key(KeyEvent::new(key))
+}
+```
+
+Update `as_key()` to return `Option<&KeyEvent>` (envision's).
+
+Remove `KeyEventBuilder` and `MouseEventBuilder` classes OR rewrite them to produce envision types.
+
+- [ ] **Step 3.2: Update `src/input/mod.rs` re-exports**
+
+Replace:
+```rust
+pub use crossterm::event::{
+    KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton, MouseEvent,
+    MouseEventKind,
+};
+```
+
+With:
+```rust
+pub use key::{Key, KeyEvent, KeyEventKind, Modifiers};
+pub use mouse::{MouseButton, MouseEvent, MouseEventKind};
+```
+
+Update the module doc example to use envision types.
+
+- [ ] **Step 3.3: Update `src/input/queue/mod.rs`**
+
+Replace `crossterm::event::KeyCode` and `crossterm::event::MouseButton` with envision types. Update the `key()`, `char()`, `ctrl()`, `type_str()`, `drag()`, etc. helper methods.
+
+- [ ] **Step 3.4: Add `from_crossterm_event` to `src/input/convert.rs`**
+
+Now that the `Event` enum uses envision types, add the top-level converter:
+
+```rust
+pub(crate) fn from_crossterm_event(event: crossterm::event::Event) -> Option<Event> {
+    match event {
+        crossterm::event::Event::Key(key) => from_crossterm_key(key).map(Event::Key),
+        crossterm::event::Event::Mouse(mouse) => Some(Event::Mouse(from_crossterm_mouse(mouse))),
+        crossterm::event::Event::Resize(w, h) => Some(Event::Resize(w, h)),
+        crossterm::event::Event::FocusGained => Some(Event::FocusGained),
+        crossterm::event::Event::FocusLost => Some(Event::FocusLost),
+        crossterm::event::Event::Paste(s) => Some(Event::Paste(s)),
+    }
+}
+```
+
+Add tests for event-level conversion.
+
+- [ ] **Step 3.5: Update `src/app/runtime/terminal.rs`**
+
+Replace `Self::convert_crossterm_event(&event)` with `crate::input::convert::from_crossterm_event(event)`. Delete the private `convert_crossterm_event` method.
+
+- [ ] **Step 3.6: Update `src/app/subscription/terminal.rs`**
+
+Change handler bound from `Fn(crossterm::event::Event) -> Option<M>` to `Fn(Event) -> Option<M>`. The subscription's event loop calls `from_crossterm_event` before invoking the handler.
+
+- [ ] **Step 3.7: Update `src/lib.rs` re-exports**
+
+Replace `KeyCode` with `Key` and `KeyModifiers` with `Modifiers` in the lib.rs re-export blocks and prelude. Remove any `crossterm::event::*` re-exports.
+
+- [ ] **Step 3.8: Cascade through all 73 components**
+
+For each component, apply these substitutions in `handle_event`:
+
+1. `use crate::input::{Event, KeyCode}` → `use crate::input::{Event, Key}`
+2. `use crate::input::{Event, KeyCode, KeyModifiers}` → `use crate::input::{Event, Key, Modifiers}`
+3. `key.code` → `key.key` in match expressions
+4. `KeyCode::X` → `Key::X` for all mapped variants
+5. `KeyCode::BackTab` → `Key::Tab` with `if key.modifiers.shift()` guard
+6. `KeyCode::Char(c) => { buffer.insert(c) }` in text input components → `Key::Char(_) => { if let Some(c) = key.raw_char { buffer.insert(c) } }`
+7. `key.modifiers.contains(KeyModifiers::SHIFT)` → `key.modifiers.shift()`
+8. `key.modifiers.contains(KeyModifiers::CONTROL)` → `key.modifiers.ctrl()`
+9. `KeyCode::Char('G') if shift` patterns (used by scrollable components for Shift+G = go to end) → `Key::Char('g') if key.modifiers.shift()`
+
+Work alphabetically through all 73 components. After each batch of ~10, run `cargo check` to track progress.
+
+- [ ] **Step 3.9: Update all test files**
+
+Component test files use `Event::key(KeyCode::Enter)` → `Event::key(Key::Enter)`, `Event::char('q')` stays the same, tests that construct crossterm events directly → use envision constructors.
+
+Tests that do `use crossterm::event::KeyCode` → `use crate::input::Key`.
+
+- [ ] **Step 3.10: Update all 89 example files**
+
+Any example handling key events: `KeyCode` → `Key`, `key.code` → `key.key`, etc.
+
+- [ ] **Step 3.11: Update integration tests in `tests/`**
+
+Same substitutions as component tests.
+
+- [ ] **Step 3.12: Update benchmarks in `benches/`**
+
+`component_events.rs`, `memory.rs` — update event construction.
+
+- [ ] **Step 3.13: Update doc tests in source files**
+
+Search for `KeyCode` in `///` doc comments and update. Also update doc examples in `src/input/mod.rs`.
+
+- [ ] **Step 3.14: Update `CHANGELOG.md`**
+
+Add under `## [Unreleased]` → `### Breaking`:
+
+```markdown
+- **Crossterm event types replaced with envision-owned types.** 
+  `KeyCode` is now `Key`, `KeyModifiers` is now `Modifiers`, and
+  `KeyEvent`/`MouseEvent` are envision-defined structs. Letter keys
+  are normalized to lowercase; use `raw_char` for text input.
+  `BackTab` is replaced by `Tab` with `modifiers.shift()`.
+  See MIGRATION.md for the upgrade path.
+
+- **`TerminalEventSubscription` handler now receives `Event`**
+  instead of `crossterm::event::Event`. Raw crossterm access is
+  no longer part of the public API.
+```
+
+- [ ] **Step 3.15: Update `MIGRATION.md`**
+
+Add a section for the input type migration with before/after examples:
+1. Basic keybinding (`KeyCode::Enter` → `Key::Enter`)
+2. Character matching (`KeyCode::Char('q')` → `Key::Char('q')`)
+3. BackTab handling (`KeyCode::BackTab` → `Key::Tab if modifiers.shift()`)
+4. Text input (`KeyCode::Char(c) => insert(c)` → `Key::Char(_) => insert(raw_char)`)
+5. Modifier checking (`contains(KeyModifiers::SHIFT)` → `modifiers.shift()`)
+6. Import changes (`use envision::input::{KeyCode, KeyModifiers}` → `{Key, Modifiers}`)
+
+- [ ] **Step 3.16: Update `CONTRIBUTING.md`**
+
+Replace any remaining `KeyCode` references with `Key`.
+
+- [ ] **Step 3.17: Full verification**
+
+```bash
+cargo check -p envision --all-targets 2>&1 | tail -5
+cargo nextest run -p envision 2>&1 | tail -5
+cargo test --doc -p envision 2>&1 | tail -5
+cargo build --examples --all-features 2>&1 | tail -5
+cargo clippy -p envision --all-targets -- -D warnings 2>&1 | tail -3
+cargo fmt --check
+
+# No crossterm types in public API:
+grep -rn "crossterm" src/input/mod.rs src/lib.rs | grep "pub use"
+# Expected: empty
+
+# No KeyCode references remain:
+grep -rn "KeyCode" src/ tests/ examples/ benches/ | grep -v "convert.rs\|//\|doc" | head -5
+# Expected: empty (only in convert.rs which uses crossterm internally)
+```
+
+- [ ] **Step 3.18: Commit (atomic, signed)**
+
+```bash
+git add -A
+git commit -S -m "$(cat <<'EOF'
+Replace crossterm event types with envision-owned input types
+
+BREAKING CHANGE for 0.14.0.
+
+Replaces crossterm re-exports with envision's own Key, KeyEvent,
+Modifiers, MouseEvent types. ASCII letter keys are normalized to
+lowercase; raw_char preserves the terminal's original character for
+text input. BackTab becomes Tab+SHIFT. Niche keys (Media, Modifier,
+lock keys) are dropped. Crossterm conversions are private.
+
+Cascade through all 73 components, 89 examples, integration tests,
+benchmarks, runtime, and subscriptions. CHANGELOG and MIGRATION
+updated.
+
+Part of docs/superpowers/specs/2026-04-11-envision-owned-input-types-design.md
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Push and open PR
+
+- [ ] **Step 4.1: Push**
+
+```bash
+git push -u origin envision-owned-input-types
+```
+
+- [ ] **Step 4.2: Open PR**
+
+```bash
+gh pr create --title "Replace crossterm events with envision-owned input types (BREAKING, 0.14.0)" --body "$(cat <<'EOF'
+## Summary
+
+**Breaking change for 0.14.0.** Replaces crossterm re-exports with envision-owned input types.
+
+**Key changes:**
+- `KeyCode` → `Key` (16-variant enum, normalized)
+- `KeyModifiers` → `Modifiers` (plain struct with shift/ctrl/alt/super flags)
+- `KeyEvent` — envision-owned, with `raw_char` preserving the terminal character
+- `MouseEvent` / `MouseEventKind` / `MouseButton` — envision-owned, mirroring crossterm's shape
+- `BackTab` → `Tab` with `modifiers.shift()`
+- Letter keys always normalized to lowercase (key field); original preserved in raw_char
+- All crossterm types removed from public API
+- `TerminalEventSubscription` handler now receives `Event` not `crossterm::event::Event`
+
+Design spec: `docs/superpowers/specs/2026-04-11-envision-owned-input-types-design.md`
+
+## Test plan
+
+- [x] All existing tests pass
+- [x] Normalization test suite (25+ tests for key conversion edge cases)
+- [x] All 89 examples compile
+- [x] `cargo clippy --all-targets -- -D warnings` clean
+- [x] Zero crossterm types in public re-exports
+- [x] CHANGELOG and MIGRATION updated
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4.3: Check CI**
+
+```bash
+gh pr checks $(gh pr view --json number -q .number)
+```
+
+---
+
+## Definition of done
+
+- [ ] `Key`, `KeyEvent`, `KeyEventKind`, `Modifiers` exist in `src/input/key.rs`
+- [ ] `MouseEvent`, `MouseEventKind`, `MouseButton` exist in `src/input/mouse.rs`
+- [ ] Private converters exist in `src/input/convert.rs` with 25+ normalization tests
+- [ ] `Event` enum uses envision types
+- [ ] `src/input/mod.rs` re-exports envision types, NOT crossterm
+- [ ] `src/lib.rs` re-exports `Key` and `Modifiers` (not `KeyCode` and `KeyModifiers`)
+- [ ] `TerminalEventSubscription` handler takes `Fn(Event)`
+- [ ] All 73 components migrated (`KeyCode` → `Key`, `key.code` → `key.key`)
+- [ ] Text input components use `raw_char` for character insertion
+- [ ] `BackTab` patterns converted to `Tab + shift()` guards
+- [ ] All examples, integration tests, and benchmarks updated
+- [ ] Zero `KeyCode` references outside `convert.rs`
+- [ ] Zero `pub use crossterm` in `src/input/mod.rs` or `src/lib.rs`
+- [ ] CHANGELOG, MIGRATION, CONTRIBUTING updated
+- [ ] PR opened, CI green

--- a/docs/superpowers/specs/2026-04-11-envision-owned-input-types-design.md
+++ b/docs/superpowers/specs/2026-04-11-envision-owned-input-types-design.md
@@ -1,0 +1,500 @@
+# Envision-owned input types — design
+
+**Status:** approved
+**Date:** 2026-04-11
+**Target version:** 0.14.0 (breaking)
+**Source:** backend abstraction investigation — decouple envision's
+public API from crossterm's event types
+
+## Problem
+
+Envision's `Event` enum wraps crossterm's `KeyEvent` and `MouseEvent`
+structs directly as variant payloads. `src/input/mod.rs` re-exports 8
+crossterm types (`KeyCode`, `KeyEvent`, `KeyModifiers`, etc.) as
+envision's public API. Every component that pattern-matches on key
+codes is matching on crossterm's enum, and every downstream user who
+writes `KeyCode::Char('q')` depends on a crossterm type even though
+they imported it from `envision::input`.
+
+Additionally, crossterm's key handling has known ambiguities:
+- `Shift+A` sometimes arrives as `Char('A')` with SHIFT modifier,
+  sometimes as `Char('A')` with no modifier
+- `BackTab` exists as a separate variant instead of `Tab + SHIFT`
+- Lock key state (`CapsLock`, `NumLock`) is mixed into event types
+  that most TUI apps don't need
+- Media keys, modifier-only keys, and other niche variants bloat the
+  enum for no practical TUI benefit
+
+## Goal
+
+Define envision-owned input types (`Key`, `KeyEvent`, `Modifiers`,
+`MouseEvent`, etc.) that:
+
+1. Remove all crossterm types from the public API
+2. Normalize key events so keybindings are unambiguous
+3. Preserve the raw character for text input via `raw_char`
+4. Drop niche key variants (Media, Modifier-only, lock keys) silently
+5. Provide convenience constructors for the common case
+6. Enable a future backend abstraction (0.15.0+) where the input
+   types are backend-independent
+
+Non-goals:
+- Supporting alternative backends (termion, termwiz) in this PR.
+  The types ARE backend-agnostic but the only converter implemented
+  is `from_crossterm_*`. Additional converters land later.
+- Full Unicode / IME / dead-key text input handling. `raw_char`
+  preserves what the terminal sends; locale-aware composition is a
+  separate project.
+- Changing the `Event` enum's top-level variants (Key, Mouse, Resize,
+  FocusGained, FocusLost, Paste). Only the inner payload types change.
+
+## Design
+
+### New module layout
+
+```
+src/input/
+  mod.rs          — re-exports envision types (no crossterm)
+  key.rs          — Key, KeyEvent, KeyEventKind, Modifiers (NEW)
+  mouse.rs        — MouseEvent, MouseEventKind, MouseButton (NEW)
+  convert.rs      — private crossterm→envision converters (NEW)
+  events/mod.rs   — Event enum (MODIFIED: uses envision types)
+  queue/mod.rs    — EventQueue (MODIFIED: uses envision types)
+```
+
+### `Key` enum
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Key {
+    /// A character key, always normalized to lowercase for ASCII letters.
+    /// Check `modifiers.shift()` to detect uppercase intent.
+    /// Read `raw_char` on `KeyEvent` for the actual terminal character.
+    Char(char),
+    /// Function key (F1 through F24).
+    F(u8),
+    Backspace,
+    Enter,
+    Left,
+    Right,
+    Up,
+    Down,
+    Home,
+    End,
+    PageUp,
+    PageDown,
+    Tab,
+    Delete,
+    Insert,
+    Esc,
+}
+```
+
+16 variants. Crossterm's `BackTab`, `Null`, `CapsLock`, `ScrollLock`,
+`NumLock`, `PrintScreen`, `Pause`, `Menu`, `KeypadBegin`,
+`Media(MediaKeyCode)`, and `Modifier(ModifierKeyCode)` are all
+dropped. Unknown keys produce `None` from the converter and are
+silently ignored.
+
+### `KeyEvent` struct
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeyEvent {
+    /// The key that was pressed, normalized.
+    /// For ASCII letters, always lowercase regardless of shift or
+    /// caps lock. Use `raw_char` for the actual terminal character.
+    pub key: Key,
+    /// Modifier keys held during the event.
+    pub modifiers: Modifiers,
+    /// Whether this is a press, release, or repeat.
+    pub kind: KeyEventKind,
+    /// The character the terminal actually sent, if this was a
+    /// character key. Preserves case (uppercase for Shift+A or
+    /// caps-lock A). `None` for non-character keys (Enter, arrows,
+    /// function keys, etc.).
+    ///
+    /// Use this for text input. Use `key` for keybindings.
+    pub raw_char: Option<char>,
+}
+```
+
+Convenience constructors:
+
+```rust
+impl KeyEvent {
+    /// Creates a press event with no modifiers.
+    pub fn new(key: Key) -> Self;
+
+    /// Creates a normalized Char press event.
+    /// `char('A')` produces key=Char('a'), modifiers=SHIFT,
+    /// raw_char=Some('A').
+    pub fn char(c: char) -> Self;
+
+    /// Creates a Ctrl+char press event.
+    /// `ctrl('c')` produces key=Char('c'), modifiers=CONTROL,
+    /// raw_char=Some('c').
+    pub fn ctrl(c: char) -> Self;
+
+    /// Returns true if this is a press event.
+    pub fn is_press(&self) -> bool;
+
+    /// Returns true if this is a release event.
+    pub fn is_release(&self) -> bool;
+}
+```
+
+### `KeyEventKind` enum
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum KeyEventKind {
+    Press,
+    Release,
+    Repeat,
+}
+```
+
+### `Modifiers` struct
+
+```rust
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct Modifiers(u8);
+
+impl Modifiers {
+    pub const NONE: Self = Self(0);
+    pub const SHIFT: Self = Self(1 << 0);
+    pub const CONTROL: Self = Self(1 << 1);
+    pub const ALT: Self = Self(1 << 2);
+    pub const SUPER: Self = Self(1 << 3);
+
+    pub fn shift(self) -> bool;
+    pub fn ctrl(self) -> bool;
+    pub fn alt(self) -> bool;
+    pub fn super_key(self) -> bool;
+    pub fn is_none(self) -> bool;
+}
+
+impl BitOr for Modifiers { ... }
+impl BitAnd for Modifiers { ... }
+impl BitOrAssign for Modifiers { ... }
+```
+
+### Mouse types
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MouseEvent {
+    pub kind: MouseEventKind,
+    pub column: u16,
+    pub row: u16,
+    pub modifiers: Modifiers,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MouseEventKind {
+    Down(MouseButton),
+    Up(MouseButton),
+    Drag(MouseButton),
+    Moved,
+    ScrollUp,
+    ScrollDown,
+    ScrollLeft,
+    ScrollRight,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MouseButton {
+    Left,
+    Right,
+    Middle,
+}
+```
+
+### `Event` enum (modified)
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Event {
+    Key(KeyEvent),
+    Mouse(MouseEvent),
+    Resize(u16, u16),
+    FocusGained,
+    FocusLost,
+    Paste(String),
+}
+```
+
+Convenience methods (existing API surface, updated types):
+
+```rust
+impl Event {
+    pub fn key(key: Key) -> Self;
+    pub fn char(c: char) -> Self;
+    pub fn ctrl(c: char) -> Self;
+    pub fn as_key(&self) -> Option<&KeyEvent>;
+    pub fn as_mouse(&self) -> Option<&MouseEvent>;
+}
+```
+
+### Conversion layer (all private)
+
+New file `src/input/convert.rs`:
+
+```rust
+pub(crate) fn from_crossterm_event(
+    e: crossterm::event::Event,
+) -> Option<Event>;
+
+pub(crate) fn from_crossterm_key(
+    e: crossterm::event::KeyEvent,
+) -> Option<KeyEvent>;
+
+pub(crate) fn from_crossterm_mouse(
+    e: crossterm::event::MouseEvent,
+) -> MouseEvent;
+
+pub(crate) fn from_crossterm_modifiers(
+    m: crossterm::event::KeyModifiers,
+) -> Modifiers;
+```
+
+Normalization rules in `from_crossterm_key`:
+
+| Crossterm input | Envision output |
+|-----------------|-----------------|
+| `Char('A')` + SHIFT | `key=Char('a')`, `mods=SHIFT`, `raw_char=Some('A')` |
+| `Char('A')` + no SHIFT (caps lock) | `key=Char('a')`, `mods=NONE`, `raw_char=Some('A')` |
+| `Char('a')` + no mods | `key=Char('a')`, `mods=NONE`, `raw_char=Some('a')` |
+| `Char('!')` + SHIFT | `key=Char('!')`, `mods=SHIFT`, `raw_char=Some('!')` |
+| `BackTab` | `key=Tab`, `mods=SHIFT`, `raw_char=None` |
+| `Char('\x03')` (raw Ctrl+C) | `key=Char('c')`, `mods=CONTROL`, `raw_char=Some('\x03')` |
+| `Enter` | `key=Enter`, `mods=NONE`, `raw_char=None` |
+| `F(5)` | `key=F(5)`, `mods=NONE`, `raw_char=None` |
+| `Media(Play)` | `None` (dropped) |
+| `Modifier(LeftShift)` | `None` (dropped) |
+| `Null` | `None` (dropped) |
+
+Key normalization rule for letters: if `c.is_ascii_uppercase()`,
+lowercase it regardless of whether SHIFT is set. The SHIFT modifier
+from crossterm is preserved as-is. `raw_char` always gets the
+original character.
+
+For non-letter chars (symbols, digits): no normalization. `Char('!')`
+stays as `Char('!')`. We don't try to infer the base key because
+that's keyboard-layout-dependent.
+
+For control characters (`'\x01'` through `'\x1a'`): convert to the
+corresponding letter. `'\x03'` → `Char('c') + CONTROL`.
+
+### What's removed from public API
+
+1. All `pub use crossterm::event::*` re-exports from `src/input/mod.rs`
+2. `From<crossterm::event::Event> for Event` (replaced by private function)
+3. `From<Event> for crossterm::event::Event` (dropped — lossy after normalization)
+4. `From<crossterm::event::KeyEvent> for Event` (dropped)
+5. `From<crossterm::event::MouseEvent> for Event` (dropped)
+6. `KeyEventBuilder` / `MouseEventBuilder` (rewritten to produce envision types)
+
+### What changes in `src/input/mod.rs`
+
+```rust
+// BEFORE
+pub use crossterm::event::{
+    KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers,
+    MouseButton, MouseEvent, MouseEventKind,
+};
+
+// AFTER
+pub use key::{Key, KeyEvent, KeyEventKind, Modifiers};
+pub use mouse::{MouseButton, MouseEvent, MouseEventKind};
+```
+
+### What changes in `TerminalEventSubscription`
+
+```rust
+// BEFORE (src/app/subscription/terminal.rs)
+pub struct TerminalEventSubscription<M, F>
+where
+    F: Fn(crossterm::event::Event) -> Option<M> + Send + 'static,
+
+// AFTER
+pub struct TerminalEventSubscription<M, F>
+where
+    F: Fn(Event) -> Option<M> + Send + 'static,
+```
+
+The subscription's event loop calls `from_crossterm_event(raw)`
+before passing to the handler. Unknown events (Media, etc.) are
+filtered out before the handler sees them.
+
+### What changes in `src/app/runtime/terminal.rs`
+
+```rust
+// BEFORE
+if let Some(envision_event) = Self::convert_crossterm_event(&event) {
+
+// AFTER
+if let Some(envision_event) = crate::input::convert::from_crossterm_event(event) {
+```
+
+The private `convert_crossterm_event` method is deleted. The converter
+lives in `src/input/convert.rs` and is shared by the runtime and the
+terminal subscription.
+
+## Component migration
+
+### Pattern changes
+
+```rust
+// BEFORE
+use crate::input::{Event, KeyCode};
+
+fn handle_event(state: &Self::State, event: &Event, ctx: &EventContext) -> Option<Self::Message> {
+    if let Some(key) = event.as_key() {
+        match key.code {
+            KeyCode::Enter => Some(Msg::Submit),
+            KeyCode::Char('j') | KeyCode::Down => Some(Msg::Down),
+            KeyCode::BackTab => Some(Msg::FocusPrev),
+            _ => None,
+        }
+    } else { None }
+}
+
+// AFTER
+use crate::input::{Event, Key};
+
+fn handle_event(state: &Self::State, event: &Event, ctx: &EventContext) -> Option<Self::Message> {
+    if let Some(key) = event.as_key() {
+        match key.key {
+            Key::Enter => Some(Msg::Submit),
+            Key::Char('j') | Key::Down => Some(Msg::Down),
+            Key::Tab if key.modifiers.shift() => Some(Msg::FocusPrev),
+            _ => None,
+        }
+    } else { None }
+}
+```
+
+Substitution rules:
+1. `use crate::input::{Event, KeyCode}` → `use crate::input::{Event, Key}`
+2. `key.code` → `key.key`
+3. `KeyCode::X` → `Key::X` (for all kept variants)
+4. `KeyCode::BackTab` → `Key::Tab if key.modifiers.shift()`
+5. `KeyCode::Char(c)` → `Key::Char(c)` (identical for lowercase; uppercase patterns need review — `Char('A')` in existing code may mean "user typed A" which now normalizes to `Char('a') + SHIFT`)
+6. `KeyModifiers` references → `Modifiers`
+7. `key.modifiers.contains(KeyModifiers::SHIFT)` → `key.modifiers.shift()`
+8. `key.modifiers.contains(KeyModifiers::CONTROL)` → `key.modifiers.ctrl()`
+
+### Text input components
+
+Components that insert characters into a buffer (LineInput, TextArea,
+InputField, NumberInput, SearchableList's search field, CommandPalette's
+search field):
+
+```rust
+// BEFORE
+KeyCode::Char(c) => { buffer.insert(c); }
+
+// AFTER
+Key::Char(_) => {
+    if let Some(c) = key.raw_char {
+        buffer.insert(c);
+    }
+}
+```
+
+These components read `raw_char` instead of the normalized `key` char
+to preserve the user's actual input (uppercase from shift or caps lock,
+symbols as typed).
+
+## Files affected
+
+**New files (~3):**
+- `src/input/key.rs`
+- `src/input/mouse.rs`
+- `src/input/convert.rs`
+
+**Core modifications (~6):**
+- `src/input/mod.rs` — re-exports
+- `src/input/events/mod.rs` — Event enum, remove From impls
+- `src/input/queue/mod.rs` — use envision types
+- `src/app/runtime/terminal.rs` — use converter
+- `src/app/subscription/terminal.rs` — handler bound
+- `src/lib.rs` — re-exports (KeyCode → Key, KeyModifiers → Modifiers)
+
+**Component cascade (~73):**
+- Every component's `handle_event` impl
+- Text input components additionally change char insertion path
+
+**Tests (~100+):**
+- Component test files (KeyCode → Key, key.code → key.key)
+- Integration tests
+- Input module tests
+- Tests that bypass the facade with direct crossterm imports
+
+**Examples (~89):**
+- Any example that handles key events
+
+**Benchmarks (~3):**
+- component_events.rs, memory.rs (construct key events)
+
+**Documentation:**
+- CHANGELOG.md — breaking changes
+- MIGRATION.md — input type migration section
+- CONTRIBUTING.md — update key handling examples
+- README.md — if it references KeyCode
+
+## PR strategy
+
+**One atomic PR.** Same rationale as RenderContext: partial updates
+won't compile because the framework passes `KeyEvent` to components
+and the types must match.
+
+Estimated: ~3000 lines changed across ~180 files. The per-file
+transformation is smaller than RenderContext (mostly `KeyCode` → `Key`
+and `key.code` → `key.key`).
+
+## Testing
+
+### Regression coverage
+
+All existing tests must pass. Component behavior tests exercise the
+full event→message→update cycle and are the primary regression guards.
+Snapshot tests are unaffected (they test rendering, not input).
+
+### New tests for input types
+
+**Key/KeyEvent/Modifiers unit tests:**
+- Construction, equality, Debug output
+- `KeyEvent::char('A')` normalizes to `Key::Char('a')` + SHIFT + `raw_char=Some('A')`
+- `KeyEvent::ctrl('c')` produces CONTROL modifier
+- `KeyEvent::new(Key::Enter)` has no modifiers, no raw_char
+- `Modifiers` flag operations: OR, AND, individual checks, is_none
+
+**Normalization tests (the critical ones):**
+- Shift+A → lowercase + SHIFT + raw uppercase
+- Caps-lock A (no shift) → lowercase + no SHIFT + raw uppercase
+- Plain a → lowercase + no mods + raw lowercase
+- Ctrl+C (as '\x03') → Char('c') + CONTROL + raw '\x03'
+- BackTab → Tab + SHIFT
+- Symbols (Shift+1='!') → Char('!') + SHIFT (no base-key inference)
+- Unknown keys (Media, Modifier) → None
+- All 16 Key variants mapped from crossterm equivalents
+
+**Mouse conversion tests:**
+- Button mapping, modifier mapping, coordinate preservation
+
+**Event convenience tests:**
+- `Event::char('q')` → `Event::Key(KeyEvent { key: Char('q'), ... })`
+- `Event::ctrl('c')` → correct
+- `as_key()`, `as_mouse()` extractors
+
+## Risk and rollback
+
+**Risk: medium.** Comparable to RenderContext — many files, mechanical
+transformation. The key normalization logic is the riskiest new code
+(easy to get wrong for edge cases). The normalization test suite is
+the primary defense.
+
+**Rollback:** revert the single PR.

--- a/examples/accordion.rs
+++ b/examples/accordion.rs
@@ -103,7 +103,7 @@ impl App for AccordionApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/alert_panel.rs
+++ b/examples/alert_panel.rs
@@ -91,7 +91,7 @@ impl App for AlertPanelApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/beautiful_dashboard.rs
+++ b/examples/beautiful_dashboard.rs
@@ -288,7 +288,7 @@ impl App for DashboardApp {
             }
             Msg::ChartNextSeries => {
                 // Toggle active series via chart message
-                let event = Event::key(KeyCode::Tab);
+                let event = Event::key(Key::Tab);
                 Chart::dispatch_event(&mut state.chart, &event, &EventContext::default());
             }
             Msg::Quit => {
@@ -340,16 +340,17 @@ impl App for DashboardApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => Some(Msg::Quit),
-                KeyCode::Tab => Some(Msg::FocusNext),
-                KeyCode::BackTab => Some(Msg::FocusPrev),
-                KeyCode::Left | KeyCode::Char('h') => Some(Msg::Left),
-                KeyCode::Right | KeyCode::Char('l') => Some(Msg::Right),
-                KeyCode::Up | KeyCode::Char('k') => Some(Msg::Up),
-                KeyCode::Down | KeyCode::Char('j') => Some(Msg::Down),
-                KeyCode::Enter => Some(Msg::Select),
-                KeyCode::Char('s') => Some(Msg::ChartNextSeries),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
+                Key::Tab if key.modifiers.shift() => Some(Msg::FocusPrev),
+
+                Key::Tab => Some(Msg::FocusNext),
+                Key::Left | Key::Char('h') => Some(Msg::Left),
+                Key::Right | Key::Char('l') => Some(Msg::Right),
+                Key::Up | Key::Char('k') => Some(Msg::Up),
+                Key::Down | Key::Char('j') => Some(Msg::Down),
+                Key::Enter => Some(Msg::Select),
+                Key::Char('s') => Some(Msg::ChartNextSeries),
                 _ => None,
             }
         } else {

--- a/examples/big_text.rs
+++ b/examples/big_text.rs
@@ -107,8 +107,8 @@ impl App for BigTextApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }
         } else {

--- a/examples/box_plot.rs
+++ b/examples/box_plot.rs
@@ -67,8 +67,8 @@ impl App for BoxPlotApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }
         } else {

--- a/examples/breadcrumb.rs
+++ b/examples/breadcrumb.rs
@@ -107,7 +107,7 @@ impl App for BreadcrumbApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -139,10 +139,10 @@ impl App for ButtonApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => return Some(Msg::Quit),
-                KeyCode::Tab => return Some(Msg::FocusNext),
-                KeyCode::BackTab => return Some(Msg::FocusPrev),
+            match key.key {
+                Key::Char('q') | Key::Esc => return Some(Msg::Quit),
+                Key::Tab if key.modifiers.shift() => return Some(Msg::FocusPrev),
+                Key::Tab => return Some(Msg::FocusNext),
                 _ => {}
             }
         }

--- a/examples/calendar.rs
+++ b/examples/calendar.rs
@@ -79,7 +79,7 @@ impl App for CalendarApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -101,8 +101,8 @@ impl App for CanvasApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }
         } else {

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -78,8 +78,8 @@ impl App for ChartApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }
         } else {

--- a/examples/chart_enhanced.rs
+++ b/examples/chart_enhanced.rs
@@ -90,8 +90,8 @@ impl App for ChartEnhancedApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }
         } else {

--- a/examples/chat_client.rs
+++ b/examples/chat_client.rs
@@ -372,7 +372,7 @@ impl App for ChatClient {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         let key = event.as_key()?;
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let ctrl = key.modifiers.ctrl();
 
         // Command palette gets priority
         if state.palette.is_visible() {
@@ -381,25 +381,25 @@ impl App for ChatClient {
         }
 
         // Global shortcuts
-        match key.code {
-            KeyCode::Char('q') if ctrl => return Some(Msg::Quit),
-            KeyCode::Char('p') if ctrl => return Some(Msg::TogglePalette),
-            KeyCode::Char('n') if ctrl => return Some(Msg::NewTab),
-            KeyCode::Char('w') if ctrl => return Some(Msg::CloseTab),
-            KeyCode::Char('l') if ctrl => {
+        match key.key {
+            Key::Char('q') if ctrl => return Some(Msg::Quit),
+            Key::Char('p') if ctrl => return Some(Msg::TogglePalette),
+            Key::Char('n') if ctrl => return Some(Msg::NewTab),
+            Key::Char('w') if ctrl => return Some(Msg::CloseTab),
+            Key::Char('l') if ctrl => {
                 state
                     .conversations
                     .get(state.active_tab)
                     .map(|_| Msg::Palette(CommandPaletteMessage::Confirm));
             }
-            KeyCode::Tab => return Some(Msg::FocusToggle),
-            KeyCode::Esc => return Some(Msg::Quit),
+            Key::Tab => return Some(Msg::FocusToggle),
+            Key::Esc => return Some(Msg::Quit),
             _ => {}
         }
 
         // Input-focused: Ctrl+Enter submits, other keys go to TextArea
         if state.focus.is_focused(&Focus::Input) {
-            if ctrl && key.code == KeyCode::Enter {
+            if ctrl && key.key == Key::Enter {
                 return Some(Msg::SubmitInput);
             }
             return TextArea::handle_event(&state.input, event, &EventContext::default())

--- a/examples/checkbox.rs
+++ b/examples/checkbox.rs
@@ -136,10 +136,11 @@ impl App for CheckboxApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => return Some(Msg::Quit),
-                KeyCode::Tab => return Some(Msg::FocusNext),
-                KeyCode::BackTab => return Some(Msg::FocusPrev),
+            match key.key {
+                Key::Char('q') | Key::Esc => return Some(Msg::Quit),
+                Key::Tab if key.modifiers.shift() => return Some(Msg::FocusPrev),
+
+                Key::Tab => return Some(Msg::FocusNext),
                 _ => {}
             }
         }

--- a/examples/code_block.rs
+++ b/examples/code_block.rs
@@ -112,7 +112,7 @@ fn main() {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/collapsible.rs
+++ b/examples/collapsible.rs
@@ -90,7 +90,7 @@ impl App for CollapsibleApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/command_palette.rs
+++ b/examples/command_palette.rs
@@ -154,13 +154,10 @@ impl App for CommandPaletteApp {
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         // Global key bindings
         if let Some(key) = event.as_key() {
-            if key.code == KeyCode::Esc && !state.palette.is_visible() {
+            if key.key == Key::Esc && !state.palette.is_visible() {
                 return Some(Msg::Quit);
             }
-            if key.code == KeyCode::Char('p')
-                && key.modifiers.contains(KeyModifiers::CONTROL)
-                && !state.palette.is_visible()
-            {
+            if key.key == Key::Char('p') && key.modifiers.ctrl() && !state.palette.is_visible() {
                 return Some(Msg::TogglePalette);
             }
         }

--- a/examples/component_showcase.rs
+++ b/examples/component_showcase.rs
@@ -565,13 +565,14 @@ impl App for ShowcaseApp {
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {
-        use crossterm::event::KeyCode;
+        use envision::input::Key;
 
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => Some(Msg::Quit),
-                KeyCode::Tab => Some(Msg::FocusNext),
-                KeyCode::BackTab => Some(Msg::FocusPrev),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
+                Key::Tab if key.modifiers.shift() => Some(Msg::FocusPrev),
+
+                Key::Tab => Some(Msg::FocusNext),
                 // All other keys are forwarded as ComponentEvent
                 _ => Some(Msg::ComponentEvent(event.clone())),
             }
@@ -795,18 +796,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{}\n", vt.display_ansi());
 
     // Navigate menu via ComponentEvent
-    vt.dispatch(Msg::ComponentEvent(Event::key(
-        crossterm::event::KeyCode::Right,
-    )));
-    vt.dispatch(Msg::ComponentEvent(Event::key(
-        crossterm::event::KeyCode::Enter,
-    )));
+    vt.dispatch(Msg::ComponentEvent(Event::key(envision::input::Key::Right)));
+    vt.dispatch(Msg::ComponentEvent(Event::key(envision::input::Key::Enter)));
 
     // Switch focus to Tabs, then navigate
     vt.dispatch(Msg::FocusNext);
-    vt.dispatch(Msg::ComponentEvent(Event::key(
-        crossterm::event::KeyCode::Right,
-    )));
+    vt.dispatch(Msg::ComponentEvent(Event::key(envision::input::Key::Right)));
     vt.tick()?;
     println!("--- Data Panel ---");
     println!("{}\n", vt.display_ansi());
@@ -817,21 +812,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     vt.dispatch(Msg::FocusNext); // -> Radio
     vt.dispatch(Msg::FocusNext); // -> SubmitButton
     vt.dispatch(Msg::FocusNext); // -> List
-    vt.dispatch(Msg::ComponentEvent(Event::key(
-        crossterm::event::KeyCode::Down,
-    )));
-    vt.dispatch(Msg::ComponentEvent(Event::key(
-        crossterm::event::KeyCode::Down,
-    )));
+    vt.dispatch(Msg::ComponentEvent(Event::key(envision::input::Key::Down)));
+    vt.dispatch(Msg::ComponentEvent(Event::key(envision::input::Key::Down)));
 
     // Focus the table, select a row
     vt.dispatch(Msg::FocusNext); // -> Table
-    vt.dispatch(Msg::ComponentEvent(Event::key(
-        crossterm::event::KeyCode::Down,
-    )));
-    vt.dispatch(Msg::ComponentEvent(Event::key(
-        crossterm::event::KeyCode::Enter,
-    )));
+    vt.dispatch(Msg::ComponentEvent(Event::key(envision::input::Key::Down)));
+    vt.dispatch(Msg::ComponentEvent(Event::key(envision::input::Key::Enter)));
     vt.tick()?;
     println!("--- Data Panel (after navigation) ---");
     println!("{}\n", vt.display_ansi());
@@ -840,9 +827,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     vt.dispatch(Msg::FocusNext); // -> Progress
     vt.dispatch(Msg::FocusNext); // -> Menu (wraps)
     vt.dispatch(Msg::FocusNext); // -> Tabs
-    vt.dispatch(Msg::ComponentEvent(Event::key(
-        crossterm::event::KeyCode::Right,
-    )));
+    vt.dispatch(Msg::ComponentEvent(Event::key(envision::input::Key::Right)));
     vt.dispatch(Msg::SpinnerTick);
     vt.dispatch(Msg::ToastTick);
     vt.tick()?;
@@ -850,32 +835,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{}\n", vt.display_ansi());
 
     // Go back to Form and submit
-    vt.dispatch(Msg::ComponentEvent(Event::key(
-        crossterm::event::KeyCode::Left,
-    )));
-    vt.dispatch(Msg::ComponentEvent(Event::key(
-        crossterm::event::KeyCode::Left,
-    )));
+    vt.dispatch(Msg::ComponentEvent(Event::key(envision::input::Key::Left)));
+    vt.dispatch(Msg::ComponentEvent(Event::key(envision::input::Key::Left)));
 
     // Focus the submit button and press it
     vt.dispatch(Msg::FocusNext); // -> Input
     vt.dispatch(Msg::FocusNext); // -> Checkbox
     vt.dispatch(Msg::FocusNext); // -> Radio
     vt.dispatch(Msg::FocusNext); // -> SubmitButton
-    vt.dispatch(Msg::ComponentEvent(Event::key(
-        crossterm::event::KeyCode::Enter,
-    )));
+    vt.dispatch(Msg::ComponentEvent(Event::key(envision::input::Key::Enter)));
     vt.tick()?;
     println!("--- Form Panel with Dialog Overlay ---");
     println!("{}\n", vt.display_ansi());
 
     // Confirm dialog via dispatch_event (Tab to OK, Enter to confirm)
-    vt.dispatch(Msg::ComponentEvent(Event::key(
-        crossterm::event::KeyCode::Tab,
-    )));
-    vt.dispatch(Msg::ComponentEvent(Event::key(
-        crossterm::event::KeyCode::Enter,
-    )));
+    vt.dispatch(Msg::ComponentEvent(Event::key(envision::input::Key::Tab)));
+    vt.dispatch(Msg::ComponentEvent(Event::key(envision::input::Key::Enter)));
     vt.tick()?;
     println!("--- After Submission (toast notification) ---");
     println!("{}\n", vt.display_ansi());
@@ -891,15 +866,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     vt.dispatch(Msg::FocusNext); // -> Menu (wraps)
     vt.dispatch(Msg::FocusNext); // -> Tabs
     // Navigate right three times to reach Viz tab
-    vt.dispatch(Msg::ComponentEvent(Event::key(
-        crossterm::event::KeyCode::Right,
-    )));
-    vt.dispatch(Msg::ComponentEvent(Event::key(
-        crossterm::event::KeyCode::Right,
-    )));
-    vt.dispatch(Msg::ComponentEvent(Event::key(
-        crossterm::event::KeyCode::Right,
-    )));
+    vt.dispatch(Msg::ComponentEvent(Event::key(envision::input::Key::Right)));
+    vt.dispatch(Msg::ComponentEvent(Event::key(envision::input::Key::Right)));
+    vt.dispatch(Msg::ComponentEvent(Event::key(envision::input::Key::Right)));
     vt.tick()?;
     println!("--- Viz Panel (Sparkline, Gauge, Heatmap, Timeline, CommandPalette, CodeBlock) ---");
     println!("{}\n", vt.display_ansi());

--- a/examples/confirm_dialog.rs
+++ b/examples/confirm_dialog.rs
@@ -138,10 +138,10 @@ impl App for ConfirmDialogApp {
         }
 
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
-                KeyCode::Char('d') => Some(Msg::ShowDeleteDialog),
-                KeyCode::Char('s') => Some(Msg::ShowSaveDialog),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
+                Key::Char('d') => Some(Msg::ShowDeleteDialog),
+                Key::Char('s') => Some(Msg::ShowSaveDialog),
                 _ => None,
             }
         } else {

--- a/examples/conversation_view.rs
+++ b/examples/conversation_view.rs
@@ -155,7 +155,7 @@ impl App for ConversationApp {
 
     fn handle_event_with_state(state: &Self::State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Esc) {
+            if matches!(key.key, Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/counter_app.rs
+++ b/examples/counter_app.rs
@@ -149,14 +149,14 @@ impl App for CounterApp {
 
     /// Handle terminal events
     fn handle_event(event: &Event) -> Option<Msg> {
-        use crossterm::event::KeyCode;
+        use envision::input::Key;
 
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('+') | KeyCode::Up => Some(Msg::Increment),
-                KeyCode::Char('-') | KeyCode::Down => Some(Msg::Decrement),
-                KeyCode::Char('r') | KeyCode::Char('R') => Some(Msg::Reset),
-                KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => Some(Msg::Quit),
+            match key.key {
+                Key::Char('+') | Key::Up => Some(Msg::Increment),
+                Key::Char('-') | Key::Down => Some(Msg::Decrement),
+                Key::Char('r') => Some(Msg::Reset),
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }
         } else {

--- a/examples/dashboard_builder.rs
+++ b/examples/dashboard_builder.rs
@@ -310,10 +310,10 @@ impl App for Dashboard {
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         let key = event.as_key()?;
 
-        match key.code {
-            KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
-            KeyCode::Left | KeyCode::Char('h') => Some(Msg::Tab(TabsMessage::Left)),
-            KeyCode::Right | KeyCode::Char('l') => Some(Msg::Tab(TabsMessage::Right)),
+        match key.key {
+            Key::Char('q') | Key::Esc => Some(Msg::Quit),
+            Key::Left | Key::Char('h') => Some(Msg::Tab(TabsMessage::Left)),
+            Key::Right | Key::Char('l') => Some(Msg::Tab(TabsMessage::Right)),
             _ => {
                 // Route to active tab's component
                 let active_tab = state.tabs.selected_item();

--- a/examples/dashboard_demo.rs
+++ b/examples/dashboard_demo.rs
@@ -376,16 +376,16 @@ impl App for DashboardApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if key.code == KeyCode::Char('t') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            if key.key == Key::Char('t') && key.modifiers.ctrl() {
                 return Some(Msg::CycleTheme);
             }
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => return Some(Msg::Quit),
-                KeyCode::Char(' ') => return Some(Msg::StartBuild),
-                KeyCode::Char('1') => return Some(Msg::AddToast(ToastLevel::Info)),
-                KeyCode::Char('2') => return Some(Msg::AddToast(ToastLevel::Success)),
-                KeyCode::Char('3') => return Some(Msg::AddToast(ToastLevel::Warning)),
-                KeyCode::Char('4') => return Some(Msg::AddToast(ToastLevel::Error)),
+            match key.key {
+                Key::Char('q') | Key::Esc => return Some(Msg::Quit),
+                Key::Char(' ') => return Some(Msg::StartBuild),
+                Key::Char('1') => return Some(Msg::AddToast(ToastLevel::Info)),
+                Key::Char('2') => return Some(Msg::AddToast(ToastLevel::Success)),
+                Key::Char('3') => return Some(Msg::AddToast(ToastLevel::Warning)),
+                Key::Char('4') => return Some(Msg::AddToast(ToastLevel::Error)),
                 _ => {}
             }
         }

--- a/examples/data_grid.rs
+++ b/examples/data_grid.rs
@@ -110,7 +110,7 @@ impl App for DataGridApp {
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if !state.grid.is_editing() {
             if let Some(key) = event.as_key() {
-                if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+                if matches!(key.key, Key::Char('q') | Key::Esc) {
                     return Some(Msg::Quit);
                 }
             }

--- a/examples/dependency_graph.rs
+++ b/examples/dependency_graph.rs
@@ -132,7 +132,7 @@ impl App for DependencyGraphApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q')) {
+            if matches!(key.key, Key::Char('q')) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/dialog.rs
+++ b/examples/dialog.rs
@@ -100,9 +100,9 @@ impl App for DialogApp {
                 .map(Msg::Dialog);
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
-                KeyCode::Char('d') => Some(Msg::ShowDialog),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
+                Key::Char('d') => Some(Msg::ShowDialog),
                 _ => None,
             }
         } else {

--- a/examples/diff_viewer.rs
+++ b/examples/diff_viewer.rs
@@ -101,7 +101,7 @@ fn main() {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/divider.rs
+++ b/examples/divider.rs
@@ -90,8 +90,8 @@ impl App for DividerApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }
         } else {

--- a/examples/dropdown.rs
+++ b/examples/dropdown.rs
@@ -75,7 +75,7 @@ impl App for DropdownApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if key.code == KeyCode::Esc && !state.language.is_open() {
+            if key.key == Key::Esc && !state.language.is_open() {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/event_stream.rs
+++ b/examples/event_stream.rs
@@ -183,7 +183,7 @@ impl App for EventStreamApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if key.code == KeyCode::Char('q') && !state.stream.is_search_focused() {
+            if key.key == Key::Char('q') && !state.stream.is_search_focused() {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/file_browser.rs
+++ b/examples/file_browser.rs
@@ -102,7 +102,7 @@ impl App for FileBrowserApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc)
+            if matches!(key.key, Key::Char('q') | Key::Esc)
                 && state.browser.filter_text().is_empty()
             {
                 return Some(Msg::Quit);

--- a/examples/file_manager.rs
+++ b/examples/file_manager.rs
@@ -305,7 +305,7 @@ impl App for FileManager {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         let key = event.as_key()?;
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let ctrl = key.modifiers.ctrl();
 
         // Command palette gets priority
         if state.palette.is_visible() {
@@ -314,15 +314,15 @@ impl App for FileManager {
         }
 
         // Global shortcuts
-        match key.code {
-            KeyCode::Char('q') if ctrl => return Some(Msg::Quit),
-            KeyCode::Char('p') if ctrl => return Some(Msg::TogglePalette),
-            KeyCode::Char('h') if ctrl => {
+        match key.key {
+            Key::Char('q') if ctrl => return Some(Msg::Quit),
+            Key::Char('p') if ctrl => return Some(Msg::TogglePalette),
+            Key::Char('h') if ctrl => {
                 return Some(Msg::Palette(CommandPaletteMessage::Confirm));
             }
-            KeyCode::Char('d') if ctrl => return Some(Msg::TogglePreviewMode),
-            KeyCode::Tab => return Some(Msg::FocusToggle),
-            KeyCode::Esc => return Some(Msg::Quit),
+            Key::Char('d') if ctrl => return Some(Msg::TogglePreviewMode),
+            Key::Tab => return Some(Msg::FocusToggle),
+            Key::Esc => return Some(Msg::Quit),
             _ => {}
         }
 

--- a/examples/flame_graph.rs
+++ b/examples/flame_graph.rs
@@ -109,7 +109,7 @@ impl App for FlameGraphApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q')) {
+            if matches!(key.key, Key::Char('q')) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/focus_manager.rs
+++ b/examples/focus_manager.rs
@@ -165,19 +165,18 @@ impl App for FocusManagerApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => return Some(Msg::Quit),
-                KeyCode::Tab => return Some(Msg::FocusNext),
-                KeyCode::BackTab => return Some(Msg::FocusPrev),
-                KeyCode::Up if state.focus.is_focused(&Panel::Sidebar) => {
+            match key.key {
+                Key::Char('q') | Key::Esc => return Some(Msg::Quit),
+                Key::Tab if key.modifiers.shift() => return Some(Msg::FocusPrev),
+
+                Key::Tab => return Some(Msg::FocusNext),
+                Key::Up if state.focus.is_focused(&Panel::Sidebar) => {
                     return Some(Msg::SidebarUp);
                 }
-                KeyCode::Down if state.focus.is_focused(&Panel::Sidebar) => {
+                Key::Down if state.focus.is_focused(&Panel::Sidebar) => {
                     return Some(Msg::SidebarDown);
                 }
-                KeyCode::Enter | KeyCode::Char(' ')
-                    if state.focus.is_focused(&Panel::ButtonBar) =>
-                {
+                Key::Enter | Key::Char(' ') if state.focus.is_focused(&Panel::ButtonBar) => {
                     return Some(Msg::ButtonAction);
                 }
                 _ => {}

--- a/examples/form.rs
+++ b/examples/form.rs
@@ -104,7 +104,7 @@ impl App for FormApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if key.code == KeyCode::Esc {
+            if key.key == Key::Esc {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -111,8 +111,8 @@ impl App for GaugeApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }
         } else {

--- a/examples/heatmap.rs
+++ b/examples/heatmap.rs
@@ -69,8 +69,8 @@ impl App for HeatmapApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => return Some(Msg::Quit),
+            match key.key {
+                Key::Char('q') | Key::Esc => return Some(Msg::Quit),
                 _ => {}
             }
         }
@@ -89,9 +89,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{}\n", vt.display());
 
     // Navigate to a cell
-    vt.send(Event::key(KeyCode::Down));
-    vt.send(Event::key(KeyCode::Right));
-    vt.send(Event::key(KeyCode::Right));
+    vt.send(Event::key(Key::Down));
+    vt.send(Event::key(Key::Right));
+    vt.send(Event::key(Key::Right));
     vt.tick()?;
     println!("After navigating to (1, 2):");
     println!("{}\n", vt.display());

--- a/examples/help_panel.rs
+++ b/examples/help_panel.rs
@@ -109,7 +109,7 @@ impl App for HelpPanelApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/histogram.rs
+++ b/examples/histogram.rs
@@ -62,8 +62,8 @@ impl App for HistogramApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }
         } else {

--- a/examples/input_field.rs
+++ b/examples/input_field.rs
@@ -103,7 +103,7 @@ impl App for InputFieldApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if key.code == KeyCode::Esc {
+            if key.key == Key::Esc {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/key_hints.rs
+++ b/examples/key_hints.rs
@@ -106,10 +106,10 @@ impl App for KeyHintsApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') => Some(Msg::Quit),
-                KeyCode::Char('e') => Some(Msg::SwitchToEdit),
-                KeyCode::Esc => Some(Msg::SwitchToNormal),
+            match key.key {
+                Key::Char('q') => Some(Msg::Quit),
+                Key::Char('e') => Some(Msg::SwitchToEdit),
+                Key::Esc => Some(Msg::SwitchToNormal),
                 _ => None,
             }
         } else {

--- a/examples/line_input.rs
+++ b/examples/line_input.rs
@@ -91,7 +91,7 @@ impl App for LineInputApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Esc) {
+            if matches!(key.key, Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/loading_list.rs
+++ b/examples/loading_list.rs
@@ -91,7 +91,7 @@ impl App for LoadingListApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/log_correlation.rs
+++ b/examples/log_correlation.rs
@@ -156,7 +156,7 @@ impl App for LogCorrelationApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if key.code == KeyCode::Char('q') {
+            if key.key == Key::Char('q') {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/log_explorer.rs
+++ b/examples/log_explorer.rs
@@ -342,16 +342,16 @@ impl App for LogExplorer {
         }
 
         // Global shortcuts (always active)
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-        match key.code {
-            KeyCode::Char('q') | KeyCode::Esc => return Some(Msg::Quit),
-            KeyCode::Tab => return Some(Msg::FocusNext),
-            KeyCode::Char('p') if ctrl => return Some(Msg::TogglePalette),
-            KeyCode::Char('l') if ctrl => return Some(Msg::ClearAll),
-            KeyCode::Char('1') => {
+        let ctrl = key.modifiers.ctrl();
+        match key.key {
+            Key::Char('q') | Key::Esc => return Some(Msg::Quit),
+            Key::Tab => return Some(Msg::FocusNext),
+            Key::Char('p') if ctrl => return Some(Msg::TogglePalette),
+            Key::Char('l') if ctrl => return Some(Msg::ClearAll),
+            Key::Char('1') => {
                 return Some(Msg::Log(LogViewerMessage::ScrollToTop));
             }
-            KeyCode::Char('2') => {
+            Key::Char('2') => {
                 return Some(Msg::Event(EventStreamMessage::ScrollToTop));
             }
             _ => {}
@@ -374,11 +374,11 @@ impl App for LogExplorer {
         }
 
         // SplitPanel resize (Shift+Left/Right)
-        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+        let shift = key.modifiers.shift();
         if shift {
-            match key.code {
-                KeyCode::Left => return Some(Msg::Split(SplitPanelMessage::ShrinkFirst)),
-                KeyCode::Right => return Some(Msg::Split(SplitPanelMessage::GrowFirst)),
+            match key.key {
+                Key::Left => return Some(Msg::Split(SplitPanelMessage::ShrinkFirst)),
+                Key::Right => return Some(Msg::Split(SplitPanelMessage::GrowFirst)),
                 _ => {}
             }
         }

--- a/examples/log_viewer.rs
+++ b/examples/log_viewer.rs
@@ -94,7 +94,7 @@ impl App for LogViewerApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if key.code == KeyCode::Char('q') && !state.viewer.is_search_focused() {
+            if key.key == Key::Char('q') && !state.viewer.is_search_focused() {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/markdown_renderer.rs
+++ b/examples/markdown_renderer.rs
@@ -124,7 +124,7 @@ impl App for MarkdownRendererApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -91,7 +91,7 @@ impl App for MenuApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/metrics_dashboard.rs
+++ b/examples/metrics_dashboard.rs
@@ -78,7 +78,7 @@ impl App for MetricsDashboardApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/multi_progress.rs
+++ b/examples/multi_progress.rs
@@ -74,7 +74,7 @@ impl App for MultiProgressApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/number_input.rs
+++ b/examples/number_input.rs
@@ -131,10 +131,11 @@ impl App for NumberInputApp {
 
         if let Some(key) = event.as_key() {
             if !any_editing {
-                match key.code {
-                    KeyCode::Char('q') | KeyCode::Esc => return Some(Msg::Quit),
-                    KeyCode::Tab => return Some(Msg::FocusNext),
-                    KeyCode::BackTab => return Some(Msg::FocusPrev),
+                match key.key {
+                    Key::Char('q') | Key::Esc => return Some(Msg::Quit),
+                    Key::Tab if key.modifiers.shift() => return Some(Msg::FocusPrev),
+
+                    Key::Tab => return Some(Msg::FocusNext),
                     _ => {}
                 }
             }

--- a/examples/paginator.rs
+++ b/examples/paginator.rs
@@ -127,10 +127,10 @@ impl App for PaginatorApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
-                KeyCode::Right | KeyCode::Char('l') => Some(Msg::Next),
-                KeyCode::Left | KeyCode::Char('h') => Some(Msg::Prev),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
+                Key::Right | Key::Char('l') => Some(Msg::Next),
+                Key::Left | Key::Char('h') => Some(Msg::Prev),
                 _ => None,
             }
         } else {

--- a/examples/pane_layout.rs
+++ b/examples/pane_layout.rs
@@ -109,9 +109,9 @@ impl App for PaneLayoutApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => return Some(Msg::Quit),
-                KeyCode::Char('r') => {
+            match key.key {
+                Key::Char('q') | Key::Esc => return Some(Msg::Quit),
+                Key::Char('r') => {
                     return Some(Msg::Layout(PaneLayoutMessage::ResetProportions));
                 }
                 _ => {}

--- a/examples/production_app.rs
+++ b/examples/production_app.rs
@@ -252,8 +252,8 @@ impl App for ProcessorApp {
 
     fn handle_event_with_state(state: &Self::State, event: &Event) -> Option<Self::Message> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => {
+            match key.key {
+                Key::Char('q') | Key::Esc => {
                     return Some(ProcessorMsg::Quit);
                 }
                 _ => {}

--- a/examples/progress_bar.rs
+++ b/examples/progress_bar.rs
@@ -84,8 +84,8 @@ impl App for ProgressBarApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }
         } else {

--- a/examples/radio_group.rs
+++ b/examples/radio_group.rs
@@ -86,7 +86,7 @@ impl App for RadioGroupApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/router.rs
+++ b/examples/router.rs
@@ -120,13 +120,13 @@ impl App for RouterApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
-                KeyCode::Char('s') => Some(Msg::Navigate(Screen::Settings)),
-                KeyCode::Char('p') => Some(Msg::Navigate(Screen::Profile)),
-                KeyCode::Char('a') => Some(Msg::Navigate(Screen::About)),
-                KeyCode::Backspace => Some(Msg::Back),
-                KeyCode::Char('r') => Some(Msg::Reset),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
+                Key::Char('s') => Some(Msg::Navigate(Screen::Settings)),
+                Key::Char('p') => Some(Msg::Navigate(Screen::Profile)),
+                Key::Char('a') => Some(Msg::Navigate(Screen::About)),
+                Key::Backspace => Some(Msg::Back),
+                Key::Char('r') => Some(Msg::Reset),
                 _ => None,
             }
         } else {

--- a/examples/scroll_view.rs
+++ b/examples/scroll_view.rs
@@ -91,7 +91,7 @@ impl App for ScrollViewApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/scrollable_text.rs
+++ b/examples/scrollable_text.rs
@@ -77,7 +77,7 @@ impl App for ScrollableTextApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/searchable_list.rs
+++ b/examples/searchable_list.rs
@@ -112,7 +112,7 @@ impl App for SearchableListApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if key.code == KeyCode::Esc {
+            if key.key == Key::Esc {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -121,10 +121,11 @@ impl App for SelectApp {
             // Only allow quit/tab when dropdown is closed
             let any_open = state.color.is_open() || state.size.is_open();
             if !any_open {
-                match key.code {
-                    KeyCode::Char('q') | KeyCode::Esc => return Some(Msg::Quit),
-                    KeyCode::Tab => return Some(Msg::FocusNext),
-                    KeyCode::BackTab => return Some(Msg::FocusPrev),
+                match key.key {
+                    Key::Char('q') | Key::Esc => return Some(Msg::Quit),
+                    Key::Tab if key.modifiers.shift() => return Some(Msg::FocusPrev),
+
+                    Key::Tab => return Some(Msg::FocusNext),
                     _ => {}
                 }
             }

--- a/examples/selectable_list.rs
+++ b/examples/selectable_list.rs
@@ -79,7 +79,7 @@ impl App for SelectableListApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/slider.rs
+++ b/examples/slider.rs
@@ -139,10 +139,11 @@ impl App for SliderApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => return Some(Msg::Quit),
-                KeyCode::Tab => return Some(Msg::FocusNext),
-                KeyCode::BackTab => return Some(Msg::FocusPrev),
+            match key.key {
+                Key::Char('q') | Key::Esc => return Some(Msg::Quit),
+                Key::Tab if key.modifiers.shift() => return Some(Msg::FocusPrev),
+
+                Key::Tab => return Some(Msg::FocusNext),
                 _ => {}
             }
         }

--- a/examples/span_tree.rs
+++ b/examples/span_tree.rs
@@ -100,7 +100,7 @@ impl App for SpanTreeApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/sparkline.rs
+++ b/examples/sparkline.rs
@@ -83,8 +83,8 @@ impl App for SparklineApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }
         } else {

--- a/examples/spinner.rs
+++ b/examples/spinner.rs
@@ -90,8 +90,8 @@ impl App for SpinnerApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }
         } else {

--- a/examples/split_panel.rs
+++ b/examples/split_panel.rs
@@ -100,7 +100,7 @@ impl App for SplitPanelApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/status_bar.rs
+++ b/examples/status_bar.rs
@@ -117,15 +117,15 @@ impl App for StatusBarApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') => Some(Msg::Quit),
-                KeyCode::Char('i') => Some(Msg::SwitchToInsert),
-                KeyCode::Esc => Some(Msg::SwitchToNormal),
-                KeyCode::Char('+') => Some(Msg::StatusBar(StatusBarMessage::IncrementCounter {
+            match key.key {
+                Key::Char('q') => Some(Msg::Quit),
+                Key::Char('i') => Some(Msg::SwitchToInsert),
+                Key::Esc => Some(Msg::SwitchToNormal),
+                Key::Char('+') => Some(Msg::StatusBar(StatusBarMessage::IncrementCounter {
                     section: Section::Right,
                     index: 0,
                 })),
-                KeyCode::Char('-') => Some(Msg::StatusBar(StatusBarMessage::DecrementCounter {
+                Key::Char('-') => Some(Msg::StatusBar(StatusBarMessage::DecrementCounter {
                     section: Section::Right,
                     index: 0,
                 })),

--- a/examples/status_log.rs
+++ b/examples/status_log.rs
@@ -70,7 +70,7 @@ impl App for StatusLogApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/step_indicator.rs
+++ b/examples/step_indicator.rs
@@ -127,17 +127,17 @@ impl App for StepIndicatorApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => return Some(Msg::Quit),
-                KeyCode::Char('c') => return Some(Msg::Step(StepIndicatorMessage::CompleteActive)),
-                KeyCode::Char('n') => return Some(Msg::Step(StepIndicatorMessage::ActivateNext)),
-                KeyCode::Char('f') => return Some(Msg::Step(StepIndicatorMessage::FailActive)),
-                KeyCode::Char('s') => {
+            match key.key {
+                Key::Char('q') | Key::Esc => return Some(Msg::Quit),
+                Key::Char('c') => return Some(Msg::Step(StepIndicatorMessage::CompleteActive)),
+                Key::Char('n') => return Some(Msg::Step(StepIndicatorMessage::ActivateNext)),
+                Key::Char('f') => return Some(Msg::Step(StepIndicatorMessage::FailActive)),
+                Key::Char('s') => {
                     if let Some(idx) = state.pipeline.active_step_index() {
                         return Some(Msg::Step(StepIndicatorMessage::Skip(idx)));
                     }
                 }
-                KeyCode::Char('r') => return Some(Msg::ResetPipeline),
+                Key::Char('r') => return Some(Msg::ResetPipeline),
                 _ => {}
             }
         }

--- a/examples/styled_text.rs
+++ b/examples/styled_text.rs
@@ -149,7 +149,7 @@ impl App for StyledTextApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/styling_showcase.rs
+++ b/examples/styling_showcase.rs
@@ -313,12 +313,12 @@ impl App for StylingShowcaseApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if key.code == KeyCode::Char('t') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            if key.key == Key::Char('t') && key.modifiers.ctrl() {
                 return Some(Msg::CycleTheme);
             }
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => return Some(Msg::Quit),
-                KeyCode::Tab => return Some(Msg::TogglePanel),
+            match key.key {
+                Key::Char('q') | Key::Esc => return Some(Msg::Quit),
+                Key::Tab => return Some(Msg::TogglePanel),
                 _ => {}
             }
         }

--- a/examples/switch.rs
+++ b/examples/switch.rs
@@ -169,10 +169,11 @@ impl App for SwitchApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => return Some(Msg::Quit),
-                KeyCode::Tab => return Some(Msg::FocusNext),
-                KeyCode::BackTab => return Some(Msg::FocusPrev),
+            match key.key {
+                Key::Char('q') | Key::Esc => return Some(Msg::Quit),
+                Key::Tab if key.modifiers.shift() => return Some(Msg::FocusPrev),
+
+                Key::Tab => return Some(Msg::FocusNext),
                 _ => {}
             }
         }

--- a/examples/tab_bar.rs
+++ b/examples/tab_bar.rs
@@ -114,10 +114,10 @@ impl App for TabBarApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
-            if matches!(key.code, KeyCode::Char('n')) {
+            if matches!(key.key, Key::Char('n')) {
                 return Some(Msg::AddNewTab);
             }
         }

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -118,9 +118,9 @@ impl App for TableApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => return Some(Msg::Quit),
-                KeyCode::Char('s') => return Some(Msg::Table(TableMessage::SortBy(0))),
+            match key.key {
+                Key::Char('q') | Key::Esc => return Some(Msg::Quit),
+                Key::Char('s') => return Some(Msg::Table(TableMessage::SortBy(0))),
                 _ => {}
             }
         }

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -91,7 +91,7 @@ impl App for TabsApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/terminal_output.rs
+++ b/examples/terminal_output.rs
@@ -92,7 +92,7 @@ impl App for TerminalOutputApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/text_area.rs
+++ b/examples/text_area.rs
@@ -65,7 +65,7 @@ impl App for TextAreaApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if key.code == KeyCode::Esc {
+            if key.key == Key::Esc {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/themed_app.rs
+++ b/examples/themed_app.rs
@@ -260,18 +260,18 @@ impl App for ThemedApp {
     }
 
     fn handle_event(event: &Event) -> Option<Msg> {
-        use crossterm::event::KeyCode;
+        use envision::input::Key;
 
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('t') | KeyCode::Char('T') => Some(Msg::ToggleTheme),
-                KeyCode::Char(' ') => Some(Msg::CheckboxToggled),
-                KeyCode::Char('+') | KeyCode::Char('=') => Some(Msg::IncreaseProgress),
-                KeyCode::Char('-') => Some(Msg::DecreaseProgress),
-                KeyCode::Up | KeyCode::Char('k') => Some(Msg::PrevItem),
-                KeyCode::Down | KeyCode::Char('j') => Some(Msg::NextItem),
-                KeyCode::Enter => Some(Msg::ButtonPressed),
-                KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => Some(Msg::Quit),
+            match key.key {
+                Key::Char('t') => Some(Msg::ToggleTheme),
+                Key::Char(' ') => Some(Msg::CheckboxToggled),
+                Key::Char('+') | Key::Char('=') => Some(Msg::IncreaseProgress),
+                Key::Char('-') => Some(Msg::DecreaseProgress),
+                Key::Up | Key::Char('k') => Some(Msg::PrevItem),
+                Key::Down | Key::Char('j') => Some(Msg::NextItem),
+                Key::Enter => Some(Msg::ButtonPressed),
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }
         } else {

--- a/examples/timeline.rs
+++ b/examples/timeline.rs
@@ -86,8 +86,8 @@ impl App for TimelineApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }
         } else {
@@ -107,14 +107,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{}\n", vt.display());
 
     // Select first event
-    vt.send(Event::key(KeyCode::Down));
+    vt.send(Event::key(Key::Down));
     vt.tick()?;
     println!("After selecting first event:");
     println!("{}\n", vt.display());
 
     // Navigate to a span
     for _ in 0..5 {
-        vt.send(Event::key(KeyCode::Down));
+        vt.send(Event::key(Key::Down));
         vt.tick()?;
     }
     println!("After selecting a span:");

--- a/examples/title_card.rs
+++ b/examples/title_card.rs
@@ -104,8 +104,8 @@ impl App for TitleCardApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }
         } else {

--- a/examples/toast.rs
+++ b/examples/toast.rs
@@ -79,11 +79,11 @@ impl App for ToastApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
-                KeyCode::Char('s') => Some(Msg::AddSuccess),
-                KeyCode::Char('w') => Some(Msg::AddWarning),
-                KeyCode::Char('e') => Some(Msg::AddError),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
+                Key::Char('s') => Some(Msg::AddSuccess),
+                Key::Char('w') => Some(Msg::AddWarning),
+                Key::Char('e') => Some(Msg::AddError),
                 _ => None,
             }
         } else {

--- a/examples/tooltip.rs
+++ b/examples/tooltip.rs
@@ -114,11 +114,11 @@ impl App for TooltipApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => Some(Msg::Quit),
-                KeyCode::Char('h') => Some(Msg::ShowHelp),
-                KeyCode::Char('w') => Some(Msg::ShowWarning),
-                KeyCode::Char('t') => Some(Msg::Tooltip(TooltipMessage::Toggle)),
+            match key.key {
+                Key::Char('q') | Key::Esc => Some(Msg::Quit),
+                Key::Char('h') => Some(Msg::ShowHelp),
+                Key::Char('w') => Some(Msg::ShowWarning),
+                Key::Char('t') => Some(Msg::Tooltip(TooltipMessage::Toggle)),
                 _ => None,
             }
         } else {

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -87,7 +87,7 @@ impl App for TreeApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+            if matches!(key.key, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/treemap.rs
+++ b/examples/treemap.rs
@@ -89,7 +89,7 @@ impl App for TreemapApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if let KeyCode::Char('q') = key.code {
+            if let Key::Char('q') = key.key {
                 return Some(Msg::Quit);
             }
         }
@@ -117,21 +117,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{}\n", vt.display());
 
     // Navigate to next sibling.
-    vt.send(Event::key(KeyCode::Right));
+    vt.send(Event::key(Key::Right));
     vt.tick()?;
     println!("After selecting next sibling:");
     println!("{}\n", vt.display());
 
     // Zoom into first node (src).
-    vt.send(Event::key(KeyCode::Left));
+    vt.send(Event::key(Key::Left));
     vt.tick()?;
-    vt.send(Event::key(KeyCode::Enter));
+    vt.send(Event::key(Key::Enter));
     vt.tick()?;
     println!("After zooming into 'src':");
     println!("{}\n", vt.display());
 
     // Zoom out.
-    vt.send(Event::key(KeyCode::Esc));
+    vt.send(Event::key(Key::Esc));
     vt.tick()?;
     println!("After zooming out:");
     println!("{}\n", vt.display());

--- a/examples/usage_display.rs
+++ b/examples/usage_display.rs
@@ -104,8 +104,8 @@ impl App for UsageDisplayApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char('q') => Some(Msg::Quit),
+            match key.key {
+                Key::Char('q') => Some(Msg::Quit),
                 _ => None,
             }
         } else {

--- a/src/app/model/tests.rs
+++ b/src/app/model/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::input::Key;
 use ratatui::widgets::Paragraph;
 
 struct TestApp;
@@ -146,9 +147,8 @@ impl App for CustomApp {
     fn view(_state: &Self::State, _frame: &mut Frame) {}
 
     fn handle_event(event: &Event) -> Option<Self::Message> {
-        use crossterm::event::KeyCode;
         if let Some(key) = event.as_key() {
-            if let KeyCode::Char(c) = key.code {
+            if let Key::Char(c) = key.key {
                 if c == 'q' {
                     return Some(CustomMsg::Quit);
                 }
@@ -270,15 +270,15 @@ fn test_message_clone() {
 fn test_handle_event_with_state_default_delegation() {
     // CustomApp overrides handle_event but NOT handle_event_with_state.
     // Calling handle_event_with_state should delegate to handle_event.
-    use crossterm::event::KeyCode;
+    use crate::input::Key;
 
     let (state, _) = CustomApp::init();
 
-    let event = Event::key(KeyCode::Char('q'));
+    let event = Event::key(Key::Char('q'));
     let msg = CustomApp::handle_event_with_state(&state, &event);
     assert!(matches!(msg, Some(CustomMsg::Quit)));
 
-    let event = Event::key(KeyCode::Char('a'));
+    let event = Event::key(Key::Char('a'));
     let msg = CustomApp::handle_event_with_state(&state, &event);
     assert!(matches!(msg, Some(CustomMsg::KeyPressed('a'))));
 }

--- a/src/app/runtime/mod.rs
+++ b/src/app/runtime/mod.rs
@@ -56,7 +56,7 @@
 //! #     fn view(state: &MyState, frame: &mut Frame) {}
 //! # }
 //! let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
-//! vt.send(Event::key(KeyCode::Char('j')));
+//! vt.send(Event::key(Key::Char('j')));
 //! vt.tick()?;
 //! println!("{}", vt.display());
 //! # Ok::<(), envision::EnvisionError>(())
@@ -672,7 +672,7 @@ impl<A: App, B: Backend> Runtime<A, B> {
     /// #     fn view(state: &MyState, frame: &mut Frame) {}
     /// # }
     /// let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
-    /// vt.send(Event::key(KeyCode::Char('j')));
+    /// vt.send(Event::key(Key::Char('j')));
     /// vt.tick()?; // processes the 'j' event and re-renders
     /// # Ok::<(), envision::EnvisionError>(())
     /// ```

--- a/src/app/runtime/terminal.rs
+++ b/src/app/runtime/terminal.rs
@@ -8,9 +8,7 @@ use std::io::{self, Stdout};
 use crate::error;
 
 use crossterm::ExecutableCommand;
-use crossterm::event::{
-    DisableMouseCapture, EnableMouseCapture, Event as CrosstermEvent, KeyEventKind,
-};
+use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
@@ -20,7 +18,6 @@ use super::Runtime;
 use super::config::RuntimeConfig;
 use crate::app::command::Command;
 use crate::app::model::App;
-use crate::input::Event;
 use crate::overlay::OverlayAction;
 
 // =============================================================================
@@ -196,7 +193,7 @@ impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
                 maybe_event = event_stream.next() => {
                     match maybe_event {
                         Some(Ok(event)) => {
-                            if let Some(envision_event) = Self::convert_crossterm_event(&event) {
+                            if let Some(envision_event) = crate::input::convert::from_crossterm_event(event) {
                                 #[cfg(feature = "tracing")]
                                 tracing::debug!(event = ?envision_event, "terminal received event");
 
@@ -350,25 +347,6 @@ impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
         }
 
         Ok(CrosstermBackend::new(stdout))
-    }
-
-    /// Converts a crossterm event to our Event type.
-    fn convert_crossterm_event(event: &CrosstermEvent) -> Option<Event> {
-        match event {
-            CrosstermEvent::Key(key_event) => {
-                // Only handle key press events, not release or repeat
-                if key_event.kind == KeyEventKind::Press {
-                    Some(Event::Key(*key_event))
-                } else {
-                    None
-                }
-            }
-            CrosstermEvent::Mouse(mouse_event) => Some(Event::Mouse(*mouse_event)),
-            CrosstermEvent::Resize(width, height) => Some(Event::Resize(*width, *height)),
-            CrosstermEvent::FocusGained => Some(Event::FocusGained),
-            CrosstermEvent::FocusLost => Some(Event::FocusLost),
-            CrosstermEvent::Paste(text) => Some(Event::Paste(text.clone())),
-        }
     }
 
     /// Cleans up terminal state.

--- a/src/app/runtime/tests/mod.rs
+++ b/src/app/runtime/tests/mod.rs
@@ -371,9 +371,9 @@ impl App for EventApp {
     }
 
     fn handle_event(event: &crate::input::Event) -> Option<Self::Message> {
-        use crossterm::event::KeyCode;
+        use crate::input::Key;
         if let Some(key) = event.as_key() {
-            if let KeyCode::Char(c) = key.code {
+            if let Key::Char(c) = key.key {
                 if c == 'q' {
                     return Some(EventMsg::Quit);
                 }
@@ -641,9 +641,9 @@ mod overlay_tests {
     use super::*;
     use crate::app::Command;
     use crate::input::Event;
+    use crate::input::Key;
     use crate::overlay::{Overlay, OverlayAction};
     use crate::theme::Theme;
-    use crossterm::event::KeyCode;
     use ratatui::Frame;
     use ratatui::layout::Rect;
 
@@ -673,9 +673,9 @@ mod overlay_tests {
     impl Overlay<EventMsg> for DialogOverlay {
         fn handle_event(&mut self, event: &Event) -> OverlayAction<EventMsg> {
             if let Some(key) = event.as_key() {
-                match key.code {
-                    KeyCode::Esc => OverlayAction::Dismiss,
-                    KeyCode::Enter => OverlayAction::DismissWithMessage(EventMsg::KeyPressed('!')),
+                match key.key {
+                    Key::Esc => OverlayAction::Dismiss,
+                    Key::Enter => OverlayAction::DismissWithMessage(EventMsg::KeyPressed('!')),
                     _ => OverlayAction::Consumed,
                 }
             } else {
@@ -752,7 +752,7 @@ mod overlay_tests {
         assert_eq!(vt.overlay_count(), 1);
 
         // Esc dismisses the overlay
-        vt.send(Event::key(KeyCode::Esc));
+        vt.send(Event::key(Key::Esc));
         vt.tick().unwrap();
 
         assert_eq!(vt.overlay_count(), 0);
@@ -765,7 +765,7 @@ mod overlay_tests {
         vt.push_overlay(Box::new(DialogOverlay));
 
         // Enter dismisses with a message
-        vt.send(Event::key(KeyCode::Enter));
+        vt.send(Event::key(Key::Enter));
         vt.tick().unwrap();
 
         assert_eq!(vt.overlay_count(), 0);

--- a/src/app/runtime/virtual_terminal.rs
+++ b/src/app/runtime/virtual_terminal.rs
@@ -52,7 +52,7 @@ impl<A: App> Runtime<A, CaptureBackend> {
     /// #     fn view(state: &MyState, frame: &mut Frame) {}
     /// # }
     /// let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
-    /// vt.send(Event::key(KeyCode::Char('j')));
+    /// vt.send(Event::key(Key::Char('j')));
     /// vt.tick()?;
     /// # Ok::<(), envision::EnvisionError>(())
     /// ```
@@ -173,7 +173,7 @@ impl<A: App> Runtime<A, CaptureBackend> {
     /// #     fn view(state: &MyState, frame: &mut Frame) {}
     /// # }
     /// let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
-    /// vt.send(Event::key(KeyCode::Enter));
+    /// vt.send(Event::key(Key::Enter));
     /// vt.tick()?;
     /// # Ok::<(), envision::EnvisionError>(())
     /// ```

--- a/src/app/runtime_core/tests.rs
+++ b/src/app/runtime_core/tests.rs
@@ -1,11 +1,10 @@
 use super::*;
 
-use crossterm::event::KeyCode;
 use ratatui::layout::Rect;
 use ratatui::widgets::Paragraph;
 
 use crate::backend::CaptureBackend;
-use crate::input::Event;
+use crate::input::{Event, Key};
 use crate::overlay::{Overlay, OverlayAction};
 use crate::theme::Theme;
 
@@ -54,7 +53,7 @@ impl App for TestApp {
 
     fn handle_event(event: &Event) -> Option<Self::Message> {
         if let Some(key) = event.as_key() {
-            if let KeyCode::Char(c) = key.code {
+            if let Key::Char(c) = key.key {
                 return Some(TestMsg::Set(c.to_string()));
             }
         }

--- a/src/app/subscription/terminal.rs
+++ b/src/app/subscription/terminal.rs
@@ -4,6 +4,7 @@ use tokio_stream::Stream;
 use tokio_util::sync::CancellationToken;
 
 use super::Subscription;
+use crate::input::Event;
 
 /// A subscription that reads terminal input events from crossterm.
 ///
@@ -15,14 +16,14 @@ use super::Subscription;
 ///
 /// ```rust
 /// use envision::app::TerminalEventSubscription;
-/// use crossterm::event::{Event, KeyCode, KeyEvent};
+/// use envision::input::{Event, Key};
 ///
 /// let sub = TerminalEventSubscription::new(|event| {
-///     match event {
-///         Event::Key(KeyEvent { code: KeyCode::Char('q'), .. }) => {
+///     match &event {
+///         Event::Key(key) if key.key == Key::Char('q') => {
 ///             Some("quit".to_string())
 ///         }
-///         Event::Key(KeyEvent { code: KeyCode::Up, .. }) => {
+///         Event::Key(key) if key.key == Key::Up => {
 ///             Some("up".to_string())
 ///         }
 ///         _ => None,
@@ -31,7 +32,7 @@ use super::Subscription;
 /// ```
 pub struct TerminalEventSubscription<M, F>
 where
-    F: Fn(crossterm::event::Event) -> Option<M> + Send + 'static,
+    F: Fn(Event) -> Option<M> + Send + 'static,
 {
     pub(crate) event_handler: F,
     _phantom: std::marker::PhantomData<M>,
@@ -39,7 +40,7 @@ where
 
 impl<M, F> TerminalEventSubscription<M, F>
 where
-    F: Fn(crossterm::event::Event) -> Option<M> + Send + 'static,
+    F: Fn(Event) -> Option<M> + Send + 'static,
 {
     /// Creates a new terminal event subscription.
     pub fn new(event_handler: F) -> Self {
@@ -53,7 +54,7 @@ where
 impl<M, F> Subscription<M> for TerminalEventSubscription<M, F>
 where
     M: Send + 'static,
-    F: Fn(crossterm::event::Event) -> Option<M> + Send + 'static,
+    F: Fn(Event) -> Option<M> + Send + 'static,
 {
     fn into_stream(
         self: Box<Self>,
@@ -70,9 +71,11 @@ where
                 tokio::select! {
                     maybe_event = reader.next() => {
                         match maybe_event {
-                            Some(Ok(event)) => {
-                                if let Some(msg) = (handler)(event) {
-                                    yield msg;
+                            Some(Ok(ct_event)) => {
+                                if let Some(event) = crate::input::convert::from_crossterm_event(ct_event) {
+                                    if let Some(msg) = (handler)(event) {
+                                        yield msg;
+                                    }
                                 }
                             }
                             Some(Err(_)) => break,
@@ -94,19 +97,20 @@ where
 ///
 /// ```rust
 /// use envision::app::terminal_events;
-/// use crossterm::event::{Event, KeyCode, KeyEvent};
+/// use envision::input::{Event, Key};
 ///
 /// let sub = terminal_events(|event| {
-///     if let Event::Key(KeyEvent { code: KeyCode::Char('q'), .. }) = event {
-///         Some("quit".to_string())
-///     } else {
-///         None
+///     if let Event::Key(key) = &event {
+///         if key.key == Key::Char('q') {
+///             return Some("quit".to_string());
+///         }
 ///     }
+///     None
 /// });
 /// ```
 pub fn terminal_events<M, F>(handler: F) -> TerminalEventSubscription<M, F>
 where
-    F: Fn(crossterm::event::Event) -> Option<M> + Send + 'static,
+    F: Fn(Event) -> Option<M> + Send + 'static,
 {
     TerminalEventSubscription::new(handler)
 }

--- a/src/app/subscription/tests/terminal_events.rs
+++ b/src/app/subscription/tests/terminal_events.rs
@@ -1,121 +1,72 @@
 use super::*;
+use crate::input::{Event, Key};
 
 #[test]
 fn test_terminal_event_subscription_creation() {
-    use crossterm::event::{Event, KeyCode, KeyEvent};
-
     // Test that we can create a TerminalEventSubscription
-    let _sub = TerminalEventSubscription::new(|event| {
-        if let Event::Key(KeyEvent {
-            code: KeyCode::Char('q'),
-            ..
-        }) = event
-        {
-            Some(TestMsg::Quit)
-        } else {
-            None
+    let _sub = TerminalEventSubscription::new(|event: Event| {
+        if let Some(key) = event.as_key() {
+            if key.key == Key::Char('q') {
+                return Some(TestMsg::Quit);
+            }
         }
+        None
     });
 
     // Test the convenience function
-    let _sub2 = terminal_events(|event| {
-        if let Event::Key(KeyEvent {
-            code: KeyCode::Enter,
-            ..
-        }) = event
-        {
-            Some(TestMsg::Tick)
-        } else {
-            None
+    let _sub2 = terminal_events(|event: Event| {
+        if let Some(key) = event.as_key() {
+            if key.key == Key::Enter {
+                return Some(TestMsg::Tick);
+            }
         }
+        None
     });
 }
 
 #[test]
 fn test_terminal_event_handler_filters_events() {
-    use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
-
     // Create handler that only responds to 'q'
     let handler = |event: Event| -> Option<TestMsg> {
-        if let Event::Key(KeyEvent {
-            code: KeyCode::Char('q'),
-            ..
-        }) = event
-        {
-            Some(TestMsg::Quit)
-        } else {
-            None
+        if let Some(key) = event.as_key() {
+            if key.key == Key::Char('q') {
+                return Some(TestMsg::Quit);
+            }
         }
+        None
     };
 
     // Test q key
-    let q_event = Event::Key(KeyEvent {
-        code: KeyCode::Char('q'),
-        modifiers: KeyModifiers::empty(),
-        kind: KeyEventKind::Press,
-        state: crossterm::event::KeyEventState::empty(),
-    });
-    assert_eq!(handler(q_event), Some(TestMsg::Quit));
+    assert_eq!(handler(Event::char('q')), Some(TestMsg::Quit));
 
     // Test other key (should be None)
-    let a_event = Event::Key(KeyEvent {
-        code: KeyCode::Char('a'),
-        modifiers: KeyModifiers::empty(),
-        kind: KeyEventKind::Press,
-        state: crossterm::event::KeyEventState::empty(),
-    });
-    assert_eq!(handler(a_event), None);
+    assert_eq!(handler(Event::char('a')), None);
 
     // Test resize event (should be None)
-    let resize_event = Event::Resize(80, 24);
-    assert_eq!(handler(resize_event), None);
+    assert_eq!(handler(Event::Resize(80, 24)), None);
 }
 
 #[test]
 fn test_terminal_event_handler_with_modifiers() {
-    use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
-
     // Create handler that responds to Ctrl+C
     let handler = |event: Event| -> Option<TestMsg> {
-        if let Event::Key(KeyEvent {
-            code: KeyCode::Char('c'),
-            modifiers,
-            ..
-        }) = event
-        {
-            if modifiers.contains(KeyModifiers::CONTROL) {
-                Some(TestMsg::Quit)
-            } else {
-                None
+        if let Some(key) = event.as_key() {
+            if key.key == Key::Char('c') && key.modifiers.ctrl() {
+                return Some(TestMsg::Quit);
             }
-        } else {
-            None
         }
+        None
     };
 
     // Test Ctrl+C
-    let ctrl_c = Event::Key(KeyEvent {
-        code: KeyCode::Char('c'),
-        modifiers: KeyModifiers::CONTROL,
-        kind: KeyEventKind::Press,
-        state: crossterm::event::KeyEventState::empty(),
-    });
-    assert_eq!(handler(ctrl_c), Some(TestMsg::Quit));
+    assert_eq!(handler(Event::ctrl('c')), Some(TestMsg::Quit));
 
     // Test plain 'c' (should be None)
-    let plain_c = Event::Key(KeyEvent {
-        code: KeyCode::Char('c'),
-        modifiers: KeyModifiers::empty(),
-        kind: KeyEventKind::Press,
-        state: crossterm::event::KeyEventState::empty(),
-    });
-    assert_eq!(handler(plain_c), None);
+    assert_eq!(handler(Event::char('c')), None);
 }
 
 #[test]
 fn test_terminal_event_handler_resize() {
-    use crossterm::event::Event;
-
     #[derive(Debug, Clone, PartialEq)]
     enum ResizeMsg {
         Resize(u16, u16),
@@ -133,13 +84,7 @@ fn test_terminal_event_handler_resize() {
     assert_eq!(handler(resize_event), Some(ResizeMsg::Resize(120, 40)));
 
     // Key event should be None
-    let key_event = Event::Key(crossterm::event::KeyEvent {
-        code: crossterm::event::KeyCode::Enter,
-        modifiers: crossterm::event::KeyModifiers::empty(),
-        kind: crossterm::event::KeyEventKind::Press,
-        state: crossterm::event::KeyEventState::empty(),
-    });
-    assert_eq!(handler(key_event), None);
+    assert_eq!(handler(Event::key(Key::Enter)), None);
 }
 
 // Note: We can't test TerminalEventSubscription::into_stream in unit tests
@@ -155,28 +100,25 @@ enum TestMsgWithQuit {
 
 #[test]
 fn test_terminal_events_convenience_function() {
-    use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
-
     let sub = terminal_events(|event: Event| -> Option<TestMsgWithQuit> {
-        match event {
-            Event::Key(KeyEvent {
-                code: KeyCode::Char('q'),
-                ..
-            }) => Some(TestMsgWithQuit::Quit),
-            Event::Key(KeyEvent {
-                code: KeyCode::Char(c),
-                ..
-            }) => Some(TestMsgWithQuit::Key(c)),
-            _ => None,
+        if let Some(key) = event.as_key() {
+            if key.key == Key::Char('q') {
+                return Some(TestMsgWithQuit::Quit);
+            }
+            if let Some(c) = key.raw_char {
+                return Some(TestMsgWithQuit::Key(c));
+            }
         }
+        None
     });
 
     // Verify the handler works correctly by testing it directly
-    let q_event = Event::Key(KeyEvent {
-        code: KeyCode::Char('q'),
-        modifiers: KeyModifiers::empty(),
-        kind: KeyEventKind::Press,
-        state: crossterm::event::KeyEventState::empty(),
-    });
-    assert_eq!((sub.event_handler)(q_event), Some(TestMsgWithQuit::Quit));
+    assert_eq!(
+        (sub.event_handler)(Event::char('q')),
+        Some(TestMsgWithQuit::Quit)
+    );
+    assert_eq!(
+        (sub.event_handler)(Event::char('a')),
+        Some(TestMsgWithQuit::Key('a'))
+    );
 }

--- a/src/component/accordion/mod.rs
+++ b/src/component/accordion/mod.rs
@@ -36,7 +36,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 /// A single accordion panel with a title and content.
 ///
@@ -739,12 +739,12 @@ impl Component for Accordion {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Up | KeyCode::Char('k') => Some(AccordionMessage::Up),
-                KeyCode::Down | KeyCode::Char('j') => Some(AccordionMessage::Down),
-                KeyCode::Enter | KeyCode::Char(' ') => Some(AccordionMessage::Toggle),
-                KeyCode::Home => Some(AccordionMessage::First),
-                KeyCode::End => Some(AccordionMessage::Last),
+            match key.key {
+                Key::Up | Key::Char('k') => Some(AccordionMessage::Up),
+                Key::Down | Key::Char('j') => Some(AccordionMessage::Down),
+                Key::Enter | Key::Char(' ') => Some(AccordionMessage::Toggle),
+                Key::Home => Some(AccordionMessage::First),
+                Key::End => Some(AccordionMessage::Last),
                 _ => None,
             }
         } else {

--- a/src/component/accordion/tests.rs
+++ b/src/component/accordion/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 // ========== AccordionPanel Tests ==========
 
@@ -563,7 +563,7 @@ fn test_handle_event_up_when_focused() {
 
     let msg = Accordion::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(AccordionMessage::Up));
@@ -575,7 +575,7 @@ fn test_handle_event_down_when_focused() {
 
     let msg = Accordion::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(AccordionMessage::Down));
@@ -587,7 +587,7 @@ fn test_handle_event_toggle_when_focused() {
 
     let msg = Accordion::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(AccordionMessage::Toggle));
@@ -599,7 +599,7 @@ fn test_handle_event_first_when_focused() {
 
     let msg = Accordion::handle_event(
         &state,
-        &Event::key(KeyCode::Home),
+        &Event::key(Key::Home),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(AccordionMessage::First));
@@ -611,7 +611,7 @@ fn test_handle_event_last_when_focused() {
 
     let msg = Accordion::handle_event(
         &state,
-        &Event::key(KeyCode::End),
+        &Event::key(Key::End),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(AccordionMessage::Last));
@@ -653,14 +653,10 @@ fn test_handle_event_ignored_when_unfocused() {
     let state = AccordionState::from_pairs(vec![("A", "1"), ("B", "2")]);
     // Not focused by default
 
-    let msg = Accordion::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
+    let msg = Accordion::handle_event(&state, &Event::key(Key::Down), &EventContext::default());
     assert_eq!(msg, None);
 
-    let msg = Accordion::handle_event(
-        &state,
-        &Event::key(KeyCode::Enter),
-        &EventContext::default(),
-    );
+    let msg = Accordion::handle_event(&state, &Event::key(Key::Enter), &EventContext::default());
     assert_eq!(msg, None);
 
     let msg = Accordion::handle_event(&state, &Event::char('j'), &EventContext::default());
@@ -673,14 +669,14 @@ fn test_handle_event_ignored_when_disabled() {
 
     let msg = Accordion::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Accordion::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -695,7 +691,7 @@ fn test_dispatch_event() {
     // Dispatch Down: should move focus from 0 to 1
     let output = Accordion::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(AccordionOutput::FocusChanged(1)));
@@ -704,7 +700,7 @@ fn test_dispatch_event() {
     // Dispatch Enter: should toggle the focused panel
     let output = Accordion::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(AccordionOutput::Expanded(1)));
@@ -720,7 +716,7 @@ fn test_instance_update() {
     // Navigate down via dispatch_event
     let output = Accordion::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(AccordionOutput::FocusChanged(1)));

--- a/src/component/alert_panel/mod.rs
+++ b/src/component/alert_panel/mod.rs
@@ -43,7 +43,7 @@ pub use metric::{AlertMetric, AlertState, AlertThreshold};
 use std::marker::PhantomData;
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 /// Messages that can be sent to an AlertPanel.
 ///
@@ -695,12 +695,12 @@ impl Component for AlertPanel {
 
         let key = event.as_key()?;
 
-        match key.code {
-            KeyCode::Left | KeyCode::Char('h') => Some(AlertPanelMessage::SelectPrev),
-            KeyCode::Right | KeyCode::Char('l') => Some(AlertPanelMessage::SelectNext),
-            KeyCode::Up | KeyCode::Char('k') => Some(AlertPanelMessage::SelectUp),
-            KeyCode::Down | KeyCode::Char('j') => Some(AlertPanelMessage::SelectDown),
-            KeyCode::Enter => Some(AlertPanelMessage::Select),
+        match key.key {
+            Key::Left | Key::Char('h') => Some(AlertPanelMessage::SelectPrev),
+            Key::Right | Key::Char('l') => Some(AlertPanelMessage::SelectNext),
+            Key::Up | Key::Char('k') => Some(AlertPanelMessage::SelectUp),
+            Key::Down | Key::Char('j') => Some(AlertPanelMessage::SelectDown),
+            Key::Enter => Some(AlertPanelMessage::Select),
             _ => None,
         }
     }

--- a/src/component/alert_panel/tests.rs
+++ b/src/component/alert_panel/tests.rs
@@ -565,7 +565,7 @@ fn test_key_maps() {
     assert_eq!(
         AlertPanel::handle_event(
             &state,
-            &Event::key(KeyCode::Left),
+            &Event::key(Key::Left),
             &EventContext::new().focused(true)
         ),
         Some(AlertPanelMessage::SelectPrev)
@@ -573,7 +573,7 @@ fn test_key_maps() {
     assert_eq!(
         AlertPanel::handle_event(
             &state,
-            &Event::key(KeyCode::Right),
+            &Event::key(Key::Right),
             &EventContext::new().focused(true)
         ),
         Some(AlertPanelMessage::SelectNext)
@@ -581,7 +581,7 @@ fn test_key_maps() {
     assert_eq!(
         AlertPanel::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true)
         ),
         Some(AlertPanelMessage::SelectUp)
@@ -589,7 +589,7 @@ fn test_key_maps() {
     assert_eq!(
         AlertPanel::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true)
         ),
         Some(AlertPanelMessage::SelectDown)
@@ -597,7 +597,7 @@ fn test_key_maps() {
     assert_eq!(
         AlertPanel::handle_event(
             &state,
-            &Event::key(KeyCode::Enter),
+            &Event::key(Key::Enter),
             &EventContext::new().focused(true)
         ),
         Some(AlertPanelMessage::Select)
@@ -650,7 +650,7 @@ fn test_disabled_ignores_events() {
     let state = focused_state();
     let msg = AlertPanel::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -663,11 +663,7 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = AlertPanelState::new().with_metrics(sample_metrics());
-    let msg = AlertPanel::handle_event(
-        &state,
-        &Event::key(KeyCode::Right),
-        &EventContext::default(),
-    );
+    let msg = AlertPanel::handle_event(&state, &Event::key(Key::Right), &EventContext::default());
     assert_eq!(msg, None);
 }
 

--- a/src/component/big_text/mod.rs
+++ b/src/component/big_text/mod.rs
@@ -319,11 +319,10 @@ impl BigTextState {
     ///
     /// ```rust
     /// use envision::component::BigTextState;
-    /// use envision::input::Event;
-    /// use crossterm::event::KeyCode;
+    /// use envision::input::{Event, Key};
     ///
     /// let state = BigTextState::new("42");
-    /// assert_eq!(state.handle_event(&Event::key(KeyCode::Enter)), None);
+    /// assert_eq!(state.handle_event(&Event::key(Key::Enter)), None);
     /// ```
     pub fn handle_event(&self, event: &crate::input::Event) -> Option<BigTextMessage> {
         BigText::handle_event(self, event, &EventContext::default())
@@ -353,11 +352,10 @@ impl BigTextState {
     ///
     /// ```rust
     /// use envision::component::BigTextState;
-    /// use envision::input::Event;
-    /// use crossterm::event::KeyCode;
+    /// use envision::input::{Event, Key};
     ///
     /// let mut state = BigTextState::new("42");
-    /// assert_eq!(state.dispatch_event(&Event::key(KeyCode::Enter)), None);
+    /// assert_eq!(state.dispatch_event(&Event::key(Key::Enter)), None);
     /// ```
     pub fn dispatch_event(&mut self, event: &crate::input::Event) -> Option<()> {
         BigText::dispatch_event(self, event, &EventContext::default())

--- a/src/component/big_text/tests.rs
+++ b/src/component/big_text/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::component::test_utils;
 use crate::input::Event;
-use crossterm::event::KeyCode;
+use crate::input::Key;
 
 // =============================================================================
 // Construction
@@ -133,15 +133,11 @@ fn test_instance_update() {
 fn test_handle_event_returns_none() {
     let state = BigTextState::new("42");
     assert_eq!(
-        BigText::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default()),
+        BigText::handle_event(&state, &Event::key(Key::Up), &EventContext::default()),
         None
     );
     assert_eq!(
-        BigText::handle_event(
-            &state,
-            &Event::key(KeyCode::Enter),
-            &EventContext::default()
-        ),
+        BigText::handle_event(&state, &Event::key(Key::Enter), &EventContext::default()),
         None
     );
     assert_eq!(

--- a/src/component/box_plot/mod.rs
+++ b/src/component/box_plot/mod.rs
@@ -25,7 +25,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 mod render;
 
@@ -838,10 +838,10 @@ impl Component for BoxPlot {
 
         let key = event.as_key()?;
 
-        match key.code {
-            KeyCode::Right | KeyCode::Char('l') => Some(BoxPlotMessage::NextDataset),
-            KeyCode::Left | KeyCode::Char('h') => Some(BoxPlotMessage::PrevDataset),
-            KeyCode::Char('o') => Some(BoxPlotMessage::ToggleOutliers),
+        match key.key {
+            Key::Right | Key::Char('l') => Some(BoxPlotMessage::NextDataset),
+            Key::Left | Key::Char('h') => Some(BoxPlotMessage::PrevDataset),
+            Key::Char('o') => Some(BoxPlotMessage::ToggleOutliers),
             _ => None,
         }
     }

--- a/src/component/box_plot/tests.rs
+++ b/src/component/box_plot/tests.rs
@@ -412,7 +412,7 @@ fn test_handle_event_not_focused() {
     let state = BoxPlotState::default();
     let msg = BoxPlot::handle_event(
         &state,
-        &Event::key(crate::input::KeyCode::Right),
+        &Event::key(crate::input::Key::Right),
         &EventContext::default(),
     );
     assert!(msg.is_none());
@@ -423,7 +423,7 @@ fn test_handle_event_disabled() {
     let state = BoxPlotState::default();
     let msg = BoxPlot::handle_event(
         &state,
-        &Event::key(crate::input::KeyCode::Right),
+        &Event::key(crate::input::Key::Right),
         &EventContext::new().focused(true).disabled(true),
     );
     assert!(msg.is_none());
@@ -437,7 +437,7 @@ fn test_handle_event_right_arrow() {
     ]);
     let msg = BoxPlot::handle_event(
         &state,
-        &Event::key(crate::input::KeyCode::Right),
+        &Event::key(crate::input::Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(BoxPlotMessage::NextDataset));
@@ -451,7 +451,7 @@ fn test_handle_event_left_arrow() {
     ]);
     let msg = BoxPlot::handle_event(
         &state,
-        &Event::key(crate::input::KeyCode::Left),
+        &Event::key(crate::input::Key::Left),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(BoxPlotMessage::PrevDataset));

--- a/src/component/breadcrumb/mod.rs
+++ b/src/component/breadcrumb/mod.rs
@@ -37,7 +37,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 /// A single breadcrumb segment.
 ///
@@ -648,12 +648,12 @@ impl Component for Breadcrumb {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Left | KeyCode::Char('h') => Some(BreadcrumbMessage::Left),
-                KeyCode::Right | KeyCode::Char('l') => Some(BreadcrumbMessage::Right),
-                KeyCode::Home => Some(BreadcrumbMessage::First),
-                KeyCode::End => Some(BreadcrumbMessage::Last),
-                KeyCode::Enter => Some(BreadcrumbMessage::Select),
+            match key.key {
+                Key::Left | Key::Char('h') => Some(BreadcrumbMessage::Left),
+                Key::Right | Key::Char('l') => Some(BreadcrumbMessage::Right),
+                Key::Home => Some(BreadcrumbMessage::First),
+                Key::End => Some(BreadcrumbMessage::Last),
+                Key::Enter => Some(BreadcrumbMessage::Select),
                 _ => None,
             }
         } else {

--- a/src/component/breadcrumb/tests.rs
+++ b/src/component/breadcrumb/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 // ==================== BreadcrumbSegment Tests ====================
 
@@ -560,7 +560,7 @@ fn test_handle_event_left_when_focused() {
 
     let msg = Breadcrumb::handle_event(
         &state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(BreadcrumbMessage::Left));
@@ -572,7 +572,7 @@ fn test_handle_event_right_when_focused() {
 
     let msg = Breadcrumb::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(BreadcrumbMessage::Right));
@@ -584,7 +584,7 @@ fn test_handle_event_first_when_focused() {
 
     let msg = Breadcrumb::handle_event(
         &state,
-        &Event::key(KeyCode::Home),
+        &Event::key(Key::Home),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(BreadcrumbMessage::First));
@@ -596,7 +596,7 @@ fn test_handle_event_last_when_focused() {
 
     let msg = Breadcrumb::handle_event(
         &state,
-        &Event::key(KeyCode::End),
+        &Event::key(Key::End),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(BreadcrumbMessage::Last));
@@ -608,7 +608,7 @@ fn test_handle_event_select_when_focused() {
 
     let msg = Breadcrumb::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(BreadcrumbMessage::Select));
@@ -638,18 +638,10 @@ fn test_handle_event_ignored_when_unfocused() {
     let state = BreadcrumbState::from_labels(vec!["A", "B", "C"]);
     // Not focused by default
 
-    let msg = Breadcrumb::handle_event(
-        &state,
-        &Event::key(KeyCode::Right),
-        &EventContext::default(),
-    );
+    let msg = Breadcrumb::handle_event(&state, &Event::key(Key::Right), &EventContext::default());
     assert_eq!(msg, None);
 
-    let msg = Breadcrumb::handle_event(
-        &state,
-        &Event::key(KeyCode::Enter),
-        &EventContext::default(),
-    );
+    let msg = Breadcrumb::handle_event(&state, &Event::key(Key::Enter), &EventContext::default());
     assert_eq!(msg, None);
 
     let msg = Breadcrumb::handle_event(&state, &Event::char('l'), &EventContext::default());
@@ -662,14 +654,14 @@ fn test_handle_event_ignored_when_disabled() {
 
     let msg = Breadcrumb::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Breadcrumb::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -684,7 +676,7 @@ fn test_dispatch_event() {
     // Dispatch Right: should move focus from 0 to 1
     let output = Breadcrumb::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(BreadcrumbOutput::FocusChanged(1)));
@@ -693,7 +685,7 @@ fn test_dispatch_event() {
     // Dispatch Enter: should select the focused segment
     let output = Breadcrumb::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(BreadcrumbOutput::Selected(1)));

--- a/src/component/button/mod.rs
+++ b/src/component/button/mod.rs
@@ -24,7 +24,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 /// Messages that can be sent to a Button.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -183,8 +183,8 @@ impl Component for Button {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Enter | KeyCode::Char(' ') => Some(ButtonMessage::Press),
+            match key.key {
+                Key::Enter | Key::Char(' ') => Some(ButtonMessage::Press),
                 _ => None,
             }
         } else {

--- a/src/component/button/tests.rs
+++ b/src/component/button/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 #[test]
 fn test_new() {
@@ -82,7 +82,7 @@ fn test_handle_event_enter_when_focused() {
     let state = ButtonState::new("OK");
     let msg = Button::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(ButtonMessage::Press));
@@ -102,11 +102,7 @@ fn test_handle_event_space_when_focused() {
 #[test]
 fn test_handle_event_ignored_when_unfocused() {
     let state = ButtonState::new("OK");
-    let msg = Button::handle_event(
-        &state,
-        &Event::key(KeyCode::Enter),
-        &EventContext::default(),
-    );
+    let msg = Button::handle_event(&state, &Event::key(Key::Enter), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -115,7 +111,7 @@ fn test_handle_event_ignored_when_disabled() {
     let state = ButtonState::new("OK");
     let msg = Button::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -137,7 +133,7 @@ fn test_dispatch_event() {
     let mut state = ButtonState::new("OK");
     let output = Button::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(ButtonOutput::Pressed));

--- a/src/component/calendar/mod.rs
+++ b/src/component/calendar/mod.rs
@@ -43,7 +43,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 // ---------------------------------------------------------------------------
 // Date math helpers (private)
@@ -684,14 +684,14 @@ impl Component for Calendar {
         }
 
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Left | KeyCode::Char('h') => Some(CalendarMessage::SelectPrevDay),
-                KeyCode::Right | KeyCode::Char('l') => Some(CalendarMessage::SelectNextDay),
-                KeyCode::Up | KeyCode::Char('k') => Some(CalendarMessage::SelectPrevWeek),
-                KeyCode::Down | KeyCode::Char('j') => Some(CalendarMessage::SelectNextWeek),
-                KeyCode::PageUp => Some(CalendarMessage::PrevMonth),
-                KeyCode::PageDown => Some(CalendarMessage::NextMonth),
-                KeyCode::Enter | KeyCode::Char(' ') => Some(CalendarMessage::ConfirmSelection),
+            match key.key {
+                Key::Left | Key::Char('h') => Some(CalendarMessage::SelectPrevDay),
+                Key::Right | Key::Char('l') => Some(CalendarMessage::SelectNextDay),
+                Key::Up | Key::Char('k') => Some(CalendarMessage::SelectPrevWeek),
+                Key::Down | Key::Char('j') => Some(CalendarMessage::SelectNextWeek),
+                Key::PageUp => Some(CalendarMessage::PrevMonth),
+                Key::PageDown => Some(CalendarMessage::NextMonth),
+                Key::Enter | Key::Char(' ') => Some(CalendarMessage::ConfirmSelection),
                 _ => None,
             }
         } else {

--- a/src/component/calendar/tests.rs
+++ b/src/component/calendar/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 // ========== Date Math Helper Tests ==========
 
@@ -517,7 +517,7 @@ fn test_handle_event_navigation_keys() {
     assert_eq!(
         Calendar::handle_event(
             &state,
-            &Event::key(KeyCode::Left),
+            &Event::key(Key::Left),
             &EventContext::new().focused(true)
         ),
         Some(CalendarMessage::SelectPrevDay)
@@ -533,7 +533,7 @@ fn test_handle_event_navigation_keys() {
     assert_eq!(
         Calendar::handle_event(
             &state,
-            &Event::key(KeyCode::Right),
+            &Event::key(Key::Right),
             &EventContext::new().focused(true)
         ),
         Some(CalendarMessage::SelectNextDay)
@@ -549,7 +549,7 @@ fn test_handle_event_navigation_keys() {
     assert_eq!(
         Calendar::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true)
         ),
         Some(CalendarMessage::SelectPrevWeek)
@@ -565,7 +565,7 @@ fn test_handle_event_navigation_keys() {
     assert_eq!(
         Calendar::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true)
         ),
         Some(CalendarMessage::SelectNextWeek)
@@ -581,7 +581,7 @@ fn test_handle_event_navigation_keys() {
     assert_eq!(
         Calendar::handle_event(
             &state,
-            &Event::key(KeyCode::PageUp),
+            &Event::key(Key::PageUp),
             &EventContext::new().focused(true)
         ),
         Some(CalendarMessage::PrevMonth)
@@ -589,7 +589,7 @@ fn test_handle_event_navigation_keys() {
     assert_eq!(
         Calendar::handle_event(
             &state,
-            &Event::key(KeyCode::PageDown),
+            &Event::key(Key::PageDown),
             &EventContext::new().focused(true)
         ),
         Some(CalendarMessage::NextMonth)
@@ -603,7 +603,7 @@ fn test_handle_event_confirm_keys() {
     assert_eq!(
         Calendar::handle_event(
             &state,
-            &Event::key(KeyCode::Enter),
+            &Event::key(Key::Enter),
             &EventContext::new().focused(true)
         ),
         Some(CalendarMessage::ConfirmSelection)
@@ -622,23 +622,15 @@ fn test_handle_event_confirm_keys() {
 fn test_handle_event_unfocused_ignores_events() {
     let state = CalendarState::new(2026, 3).with_selected_day(15);
     assert_eq!(
-        Calendar::handle_event(&state, &Event::key(KeyCode::Left), &EventContext::default()),
+        Calendar::handle_event(&state, &Event::key(Key::Left), &EventContext::default()),
         None
     );
     assert_eq!(
-        Calendar::handle_event(
-            &state,
-            &Event::key(KeyCode::Enter),
-            &EventContext::default()
-        ),
+        Calendar::handle_event(&state, &Event::key(Key::Enter), &EventContext::default()),
         None
     );
     assert_eq!(
-        Calendar::handle_event(
-            &state,
-            &Event::key(KeyCode::PageUp),
-            &EventContext::default()
-        ),
+        Calendar::handle_event(&state, &Event::key(Key::PageUp), &EventContext::default()),
         None
     );
 }
@@ -649,7 +641,7 @@ fn test_handle_event_disabled_ignores_events() {
     assert_eq!(
         Calendar::handle_event(
             &state,
-            &Event::key(KeyCode::Left),
+            &Event::key(Key::Left),
             &EventContext::new().focused(true).disabled(true)
         ),
         None
@@ -657,7 +649,7 @@ fn test_handle_event_disabled_ignores_events() {
     assert_eq!(
         Calendar::handle_event(
             &state,
-            &Event::key(KeyCode::Enter),
+            &Event::key(Key::Enter),
             &EventContext::new().focused(true).disabled(true)
         ),
         None
@@ -684,7 +676,7 @@ fn test_dispatch_event_navigation() {
     let mut state = CalendarState::new(2026, 3).with_selected_day(15);
     let output = Calendar::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(state.selected_day(), Some(16));
@@ -692,7 +684,7 @@ fn test_dispatch_event_navigation() {
 
     let output = Calendar::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true),
     );
     assert_eq!(state.selected_day(), Some(15));
@@ -704,7 +696,7 @@ fn test_dispatch_event_enter_confirms() {
     let mut state = CalendarState::new(2026, 3).with_selected_day(15);
     let output = Calendar::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(CalendarOutput::DateSelected(2026, 3, 15)));
@@ -715,7 +707,7 @@ fn test_dispatch_event_page_navigation() {
     let mut state = CalendarState::new(2026, 3);
     let output = Calendar::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::PageUp),
+        &Event::key(Key::PageUp),
         &EventContext::new().focused(true),
     );
     assert_eq!(state.month(), 2);
@@ -723,7 +715,7 @@ fn test_dispatch_event_page_navigation() {
 
     let output = Calendar::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::PageDown),
+        &Event::key(Key::PageDown),
         &EventContext::new().focused(true),
     );
     assert_eq!(state.month(), 3);
@@ -735,7 +727,7 @@ fn test_dispatch_event_unfocused_returns_none() {
     let mut state = CalendarState::new(2026, 3).with_selected_day(15);
     let output = Calendar::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::default(),
     );
     assert_eq!(output, None);

--- a/src/component/chart/enhancement_tests.rs
+++ b/src/component/chart/enhancement_tests.rs
@@ -618,11 +618,11 @@ fn test_cursor_key_bindings() {
     let ctx = EventContext::new().focused(true);
 
     assert_eq!(
-        Chart::handle_event(&state, &Event::key(KeyCode::Left), &ctx),
+        Chart::handle_event(&state, &Event::key(Key::Left), &ctx),
         Some(ChartMessage::CursorLeft)
     );
     assert_eq!(
-        Chart::handle_event(&state, &Event::key(KeyCode::Right), &ctx),
+        Chart::handle_event(&state, &Event::key(Key::Right), &ctx),
         Some(ChartMessage::CursorRight)
     );
     assert_eq!(
@@ -634,11 +634,11 @@ fn test_cursor_key_bindings() {
         Some(ChartMessage::CursorRight)
     );
     assert_eq!(
-        Chart::handle_event(&state, &Event::key(KeyCode::Home), &ctx),
+        Chart::handle_event(&state, &Event::key(Key::Home), &ctx),
         Some(ChartMessage::CursorHome)
     );
     assert_eq!(
-        Chart::handle_event(&state, &Event::key(KeyCode::End), &ctx),
+        Chart::handle_event(&state, &Event::key(Key::End), &ctx),
         Some(ChartMessage::CursorEnd)
     );
     assert_eq!(
@@ -653,7 +653,7 @@ fn test_cursor_unfocused_ignored() {
     let ctx = EventContext::default();
 
     assert_eq!(
-        Chart::handle_event(&state, &Event::key(KeyCode::Left), &ctx),
+        Chart::handle_event(&state, &Event::key(Key::Left), &ctx),
         None
     );
 }

--- a/src/component/chart/mod.rs
+++ b/src/component/chart/mod.rs
@@ -27,7 +27,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 mod annotations;
 pub(crate) mod downsample;
@@ -741,15 +741,15 @@ impl Component for Chart {
 
         let key = event.as_key()?;
 
-        match key.code {
-            KeyCode::Tab => Some(ChartMessage::NextSeries),
-            KeyCode::BackTab => Some(ChartMessage::PrevSeries),
-            KeyCode::Left | KeyCode::Char('h') => Some(ChartMessage::CursorLeft),
-            KeyCode::Right | KeyCode::Char('l') => Some(ChartMessage::CursorRight),
-            KeyCode::Home => Some(ChartMessage::CursorHome),
-            KeyCode::End => Some(ChartMessage::CursorEnd),
-            KeyCode::Char('c') => Some(ChartMessage::ToggleCrosshair),
-            KeyCode::Char('g') => Some(ChartMessage::ToggleGrid),
+        match key.key {
+            Key::Tab if key.modifiers.shift() => Some(ChartMessage::PrevSeries),
+            Key::Tab => Some(ChartMessage::NextSeries),
+            Key::Left | Key::Char('h') => Some(ChartMessage::CursorLeft),
+            Key::Right | Key::Char('l') => Some(ChartMessage::CursorRight),
+            Key::Home => Some(ChartMessage::CursorHome),
+            Key::End => Some(ChartMessage::CursorEnd),
+            Key::Char('c') => Some(ChartMessage::ToggleCrosshair),
+            Key::Char('g') => Some(ChartMessage::ToggleGrid),
             _ => None,
         }
     }

--- a/src/component/chart/tests.rs
+++ b/src/component/chart/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::component::test_utils;
+use crate::input::Modifiers;
 
 fn sample_series() -> Vec<DataSeries> {
     vec![
@@ -323,7 +324,7 @@ fn test_disabled_ignores_events() {
     let state = focused_line_chart();
     let msg = Chart::handle_event(
         &state,
-        &Event::key(KeyCode::Tab),
+        &Event::key(Key::Tab),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -336,7 +337,7 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = ChartState::line(sample_series());
-    let msg = Chart::handle_event(&state, &Event::key(KeyCode::Tab), &EventContext::default());
+    let msg = Chart::handle_event(&state, &Event::key(Key::Tab), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -350,7 +351,7 @@ fn test_tab_maps_to_next() {
     assert_eq!(
         Chart::handle_event(
             &state,
-            &Event::key(KeyCode::Tab),
+            &Event::key(Key::Tab),
             &EventContext::new().focused(true)
         ),
         Some(ChartMessage::NextSeries)
@@ -363,7 +364,7 @@ fn test_backtab_maps_to_prev() {
     assert_eq!(
         Chart::handle_event(
             &state,
-            &Event::key(KeyCode::BackTab),
+            &Event::key_with(Key::Tab, Modifiers::SHIFT),
             &EventContext::new().focused(true)
         ),
         Some(ChartMessage::PrevSeries)

--- a/src/component/checkbox/mod.rs
+++ b/src/component/checkbox/mod.rs
@@ -29,7 +29,7 @@
 use ratatui::widgets::Paragraph;
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 /// Messages that can be sent to a Checkbox.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -250,8 +250,8 @@ impl Component for Checkbox {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Enter | KeyCode::Char(' ') => Some(CheckboxMessage::Toggle),
+            match key.key {
+                Key::Enter | Key::Char(' ') => Some(CheckboxMessage::Toggle),
                 _ => None,
             }
         } else {

--- a/src/component/checkbox/tests.rs
+++ b/src/component/checkbox/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 #[test]
 fn test_new() {
@@ -133,7 +133,7 @@ fn test_handle_event_enter_when_focused() {
     let state = CheckboxState::new("Test");
     let msg = Checkbox::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CheckboxMessage::Toggle));
@@ -153,11 +153,7 @@ fn test_handle_event_space_when_focused() {
 #[test]
 fn test_handle_event_ignored_when_unfocused() {
     let state = CheckboxState::new("Test");
-    let msg = Checkbox::handle_event(
-        &state,
-        &Event::key(KeyCode::Enter),
-        &EventContext::default(),
-    );
+    let msg = Checkbox::handle_event(&state, &Event::key(Key::Enter), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -166,7 +162,7 @@ fn test_handle_event_ignored_when_disabled() {
     let state = CheckboxState::new("Test");
     let msg = Checkbox::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -177,7 +173,7 @@ fn test_dispatch_event() {
     let mut state = CheckboxState::new("Test");
     let output = Checkbox::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(CheckboxOutput::Toggled(true)));

--- a/src/component/code_block/mod.rs
+++ b/src/component/code_block/mod.rs
@@ -40,7 +40,7 @@ use std::collections::HashSet;
 
 pub use self::highlight::Language;
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 use crate::scroll::ScrollState;
 
 /// Messages that can be sent to a CodeBlock.
@@ -553,23 +553,23 @@ impl Component for CodeBlock {
         }
 
         let key = event.as_key()?;
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+        let ctrl = key.modifiers.ctrl();
+        let shift = key.modifiers.shift();
 
-        match key.code {
-            KeyCode::Up | KeyCode::Char('k') if !ctrl => Some(CodeBlockMessage::ScrollUp),
-            KeyCode::Down | KeyCode::Char('j') if !ctrl => Some(CodeBlockMessage::ScrollDown),
-            KeyCode::Left | KeyCode::Char('h') if !ctrl => Some(CodeBlockMessage::ScrollLeft),
-            KeyCode::Right | KeyCode::Char('l') if !ctrl => Some(CodeBlockMessage::ScrollRight),
-            KeyCode::PageUp => Some(CodeBlockMessage::PageUp(10)),
-            KeyCode::PageDown => Some(CodeBlockMessage::PageDown(10)),
-            KeyCode::Char('u') if ctrl => Some(CodeBlockMessage::PageUp(10)),
-            KeyCode::Char('d') if ctrl => Some(CodeBlockMessage::PageDown(10)),
-            KeyCode::Home | KeyCode::Char('g') if !shift => Some(CodeBlockMessage::Home),
-            KeyCode::End | KeyCode::Char('G') if shift || key.code == KeyCode::End => {
+        match key.key {
+            Key::Up | Key::Char('k') if !ctrl => Some(CodeBlockMessage::ScrollUp),
+            Key::Down | Key::Char('j') if !ctrl => Some(CodeBlockMessage::ScrollDown),
+            Key::Left | Key::Char('h') if !ctrl => Some(CodeBlockMessage::ScrollLeft),
+            Key::Right | Key::Char('l') if !ctrl => Some(CodeBlockMessage::ScrollRight),
+            Key::PageUp => Some(CodeBlockMessage::PageUp(10)),
+            Key::PageDown => Some(CodeBlockMessage::PageDown(10)),
+            Key::Char('u') if ctrl => Some(CodeBlockMessage::PageUp(10)),
+            Key::Char('d') if ctrl => Some(CodeBlockMessage::PageDown(10)),
+            Key::Home | Key::Char('g') if !shift => Some(CodeBlockMessage::Home),
+            Key::End | Key::Char('g') if key.modifiers.shift() || key.key == Key::End => {
                 Some(CodeBlockMessage::End)
             }
-            KeyCode::Char('n') if !ctrl => Some(CodeBlockMessage::ToggleLineNumbers),
+            Key::Char('n') if !ctrl => Some(CodeBlockMessage::ToggleLineNumbers),
             _ => None,
         }
     }

--- a/src/component/code_block/tests.rs
+++ b/src/component/code_block/tests.rs
@@ -1,6 +1,7 @@
 use super::highlight::Language;
 use super::*;
 use crate::component::test_utils;
+use crate::input::Modifiers;
 
 fn focused_state() -> CodeBlockState {
     CodeBlockState::new()
@@ -334,7 +335,7 @@ fn test_disabled_ignores_events() {
     let state = focused_state();
     let msg = CodeBlock::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -343,7 +344,7 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = CodeBlockState::new();
-    let msg = CodeBlock::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default());
+    let msg = CodeBlock::handle_event(&state, &Event::key(Key::Up), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -357,7 +358,7 @@ fn test_handle_event_up() {
     assert_eq!(
         CodeBlock::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true)
         ),
         Some(CodeBlockMessage::ScrollUp)
@@ -370,7 +371,7 @@ fn test_handle_event_down() {
     assert_eq!(
         CodeBlock::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true)
         ),
         Some(CodeBlockMessage::ScrollDown)
@@ -404,7 +405,7 @@ fn test_handle_event_page_up_down() {
     assert_eq!(
         CodeBlock::handle_event(
             &state,
-            &Event::key(KeyCode::PageUp),
+            &Event::key(Key::PageUp),
             &EventContext::new().focused(true)
         ),
         Some(CodeBlockMessage::PageUp(10))
@@ -412,7 +413,7 @@ fn test_handle_event_page_up_down() {
     assert_eq!(
         CodeBlock::handle_event(
             &state,
-            &Event::key(KeyCode::PageDown),
+            &Event::key(Key::PageDown),
             &EventContext::new().focused(true)
         ),
         Some(CodeBlockMessage::PageDown(10))
@@ -446,7 +447,7 @@ fn test_handle_event_home_end() {
     assert_eq!(
         CodeBlock::handle_event(
             &state,
-            &Event::key(KeyCode::Home),
+            &Event::key(Key::Home),
             &EventContext::new().focused(true)
         ),
         Some(CodeBlockMessage::Home)
@@ -454,7 +455,7 @@ fn test_handle_event_home_end() {
     assert_eq!(
         CodeBlock::handle_event(
             &state,
-            &Event::key(KeyCode::End),
+            &Event::key(Key::End),
             &EventContext::new().focused(true)
         ),
         Some(CodeBlockMessage::End)
@@ -476,7 +477,7 @@ fn test_handle_event_g_and_G() {
     assert_eq!(
         CodeBlock::handle_event(
             &state,
-            &Event::key_with(KeyCode::Char('G'), KeyModifiers::SHIFT),
+            &Event::key_with(Key::Char('g'), Modifiers::SHIFT),
             &EventContext::new().focused(true),
         ),
         Some(CodeBlockMessage::End)
@@ -843,7 +844,7 @@ fn test_horizontal_scroll_key_bindings() {
     // Left arrow
     let msg = CodeBlock::handle_event(
         &state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CodeBlockMessage::ScrollLeft));
@@ -851,7 +852,7 @@ fn test_horizontal_scroll_key_bindings() {
     // Right arrow
     let msg = CodeBlock::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CodeBlockMessage::ScrollRight));

--- a/src/component/collapsible/mod.rs
+++ b/src/component/collapsible/mod.rs
@@ -37,7 +37,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use super::{Component, EventContext, RenderContext, Toggleable};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 /// Messages that can be sent to a Collapsible.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -424,10 +424,10 @@ impl Component for Collapsible {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Char(' ') | KeyCode::Enter => Some(CollapsibleMessage::Toggle),
-                KeyCode::Right => Some(CollapsibleMessage::Expand),
-                KeyCode::Left => Some(CollapsibleMessage::Collapse),
+            match key.key {
+                Key::Char(' ') | Key::Enter => Some(CollapsibleMessage::Toggle),
+                Key::Right => Some(CollapsibleMessage::Expand),
+                Key::Left => Some(CollapsibleMessage::Collapse),
                 _ => None,
             }
         } else {

--- a/src/component/collapsible/tests.rs
+++ b/src/component/collapsible/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 // ========== Construction Tests ==========
 
@@ -262,7 +262,7 @@ fn test_handle_event_enter_toggles() {
     let state = CollapsibleState::new("Details");
     let msg = Collapsible::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CollapsibleMessage::Toggle));
@@ -273,7 +273,7 @@ fn test_handle_event_right_expands() {
     let state = CollapsibleState::new("Details");
     let msg = Collapsible::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CollapsibleMessage::Expand));
@@ -284,7 +284,7 @@ fn test_handle_event_left_collapses() {
     let state = CollapsibleState::new("Details");
     let msg = Collapsible::handle_event(
         &state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CollapsibleMessage::Collapse));
@@ -297,22 +297,13 @@ fn test_handle_event_unfocused_ignores_events() {
     let msg = Collapsible::handle_event(&state, &Event::char(' '), &EventContext::default());
     assert_eq!(msg, None);
 
-    let msg = Collapsible::handle_event(
-        &state,
-        &Event::key(KeyCode::Enter),
-        &EventContext::default(),
-    );
+    let msg = Collapsible::handle_event(&state, &Event::key(Key::Enter), &EventContext::default());
     assert_eq!(msg, None);
 
-    let msg = Collapsible::handle_event(
-        &state,
-        &Event::key(KeyCode::Right),
-        &EventContext::default(),
-    );
+    let msg = Collapsible::handle_event(&state, &Event::key(Key::Right), &EventContext::default());
     assert_eq!(msg, None);
 
-    let msg =
-        Collapsible::handle_event(&state, &Event::key(KeyCode::Left), &EventContext::default());
+    let msg = Collapsible::handle_event(&state, &Event::key(Key::Left), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -329,21 +320,21 @@ fn test_handle_event_disabled_ignores_events() {
 
     let msg = Collapsible::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Collapsible::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Collapsible::handle_event(
         &state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -379,7 +370,7 @@ fn test_dispatch_event_enter_toggles() {
     let mut state = CollapsibleState::new("Details").with_expanded(false);
     let output = Collapsible::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(CollapsibleOutput::Toggled(true)));
@@ -391,7 +382,7 @@ fn test_dispatch_event_right_expands() {
     let mut state = CollapsibleState::new("Details").with_expanded(false);
     let output = Collapsible::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(CollapsibleOutput::Expanded));
@@ -403,7 +394,7 @@ fn test_dispatch_event_left_collapses() {
     let mut state = CollapsibleState::new("Details");
     let output = Collapsible::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(CollapsibleOutput::Collapsed));

--- a/src/component/command_palette/event_tests.rs
+++ b/src/component/command_palette/event_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::KeyCode;
+use crate::input::Key;
 
 fn sample_items() -> Vec<PaletteItem> {
     vec![
@@ -29,9 +29,10 @@ fn test_char_maps_to_type_char() {
 #[test]
 fn test_uppercase_char_maps_to_type_char() {
     let state = active_state();
+    // Event::char('A') normalizes to Key::Char('a') with SHIFT and raw_char='A'
     let msg = CommandPalette::handle_event(
         &state,
-        &Event::key_with(KeyCode::Char('A'), crate::input::KeyModifiers::SHIFT),
+        &Event::char('A'),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CommandPaletteMessage::TypeChar('A')));
@@ -42,7 +43,7 @@ fn test_backspace_maps_to_backspace() {
     let state = active_state();
     let msg = CommandPalette::handle_event(
         &state,
-        &Event::key(KeyCode::Backspace),
+        &Event::key(Key::Backspace),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CommandPaletteMessage::Backspace));
@@ -53,7 +54,7 @@ fn test_enter_maps_to_confirm() {
     let state = active_state();
     let msg = CommandPalette::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CommandPaletteMessage::Confirm));
@@ -64,7 +65,7 @@ fn test_escape_maps_to_dismiss() {
     let state = active_state();
     let msg = CommandPalette::handle_event(
         &state,
-        &Event::key(KeyCode::Esc),
+        &Event::key(Key::Esc),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CommandPaletteMessage::Dismiss));
@@ -75,7 +76,7 @@ fn test_up_maps_to_select_prev() {
     let state = active_state();
     let msg = CommandPalette::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CommandPaletteMessage::SelectPrev));
@@ -86,7 +87,7 @@ fn test_down_maps_to_select_next() {
     let state = active_state();
     let msg = CommandPalette::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(CommandPaletteMessage::SelectNext));
@@ -136,15 +137,11 @@ fn test_unfocused_ignores_all_events() {
         None
     );
     assert_eq!(
-        CommandPalette::handle_event(
-            &state,
-            &Event::key(KeyCode::Enter),
-            &EventContext::default()
-        ),
+        CommandPalette::handle_event(&state, &Event::key(Key::Enter), &EventContext::default()),
         None
     );
     assert_eq!(
-        CommandPalette::handle_event(&state, &Event::key(KeyCode::Esc), &EventContext::default()),
+        CommandPalette::handle_event(&state, &Event::key(Key::Esc), &EventContext::default()),
         None
     );
 }
@@ -164,7 +161,7 @@ fn test_disabled_ignores_all_events() {
     assert_eq!(
         CommandPalette::handle_event(
             &state,
-            &Event::key(KeyCode::Enter),
+            &Event::key(Key::Enter),
             &EventContext::new().focused(true).disabled(true)
         ),
         None
@@ -187,7 +184,7 @@ fn test_hidden_ignores_all_events() {
     assert_eq!(
         CommandPalette::handle_event(
             &state,
-            &Event::key(KeyCode::Enter),
+            &Event::key(Key::Enter),
             &EventContext::new().focused(true)
         ),
         None
@@ -199,7 +196,7 @@ fn test_unrecognized_key_returns_none() {
     let state = active_state();
     let msg = CommandPalette::handle_event(
         &state,
-        &Event::key(KeyCode::F(1)),
+        &Event::key(Key::F(1)),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);

--- a/src/component/command_palette/mod.rs
+++ b/src/component/command_palette/mod.rs
@@ -39,7 +39,7 @@ mod render;
 pub use item::{PaletteItem, fuzzy_score};
 
 use super::{Component, EventContext, RenderContext, Toggleable};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 use crate::scroll::ScrollState;
 
 /// Messages that can be sent to a CommandPalette.
@@ -626,26 +626,17 @@ impl Component for CommandPalette {
         }
 
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Esc => Some(CommandPaletteMessage::Dismiss),
-                KeyCode::Enter => Some(CommandPaletteMessage::Confirm),
-                KeyCode::Backspace => Some(CommandPaletteMessage::Backspace),
-                KeyCode::Up => Some(CommandPaletteMessage::SelectPrev),
-                KeyCode::Down => Some(CommandPaletteMessage::SelectNext),
-                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    Some(CommandPaletteMessage::SelectPrev)
-                }
-                KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    Some(CommandPaletteMessage::SelectNext)
-                }
-                KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    Some(CommandPaletteMessage::ClearQuery)
-                }
-                KeyCode::Char(c) if key.modifiers == KeyModifiers::NONE => {
-                    Some(CommandPaletteMessage::TypeChar(c))
-                }
-                KeyCode::Char(c) if key.modifiers == KeyModifiers::SHIFT => {
-                    Some(CommandPaletteMessage::TypeChar(c))
+            match key.key {
+                Key::Esc => Some(CommandPaletteMessage::Dismiss),
+                Key::Enter => Some(CommandPaletteMessage::Confirm),
+                Key::Backspace => Some(CommandPaletteMessage::Backspace),
+                Key::Up => Some(CommandPaletteMessage::SelectPrev),
+                Key::Down => Some(CommandPaletteMessage::SelectNext),
+                Key::Char('p') if key.modifiers.ctrl() => Some(CommandPaletteMessage::SelectPrev),
+                Key::Char('n') if key.modifiers.ctrl() => Some(CommandPaletteMessage::SelectNext),
+                Key::Char('u') if key.modifiers.ctrl() => Some(CommandPaletteMessage::ClearQuery),
+                Key::Char(_) if !key.modifiers.ctrl() && !key.modifiers.alt() => {
+                    key.raw_char.map(CommandPaletteMessage::TypeChar)
                 }
                 _ => None,
             }

--- a/src/component/confirm_dialog/mod.rs
+++ b/src/component/confirm_dialog/mod.rs
@@ -32,7 +32,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
 use super::{Component, EventContext, RenderContext, Toggleable};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 use crate::theme::Theme;
 
 /// Preset button configurations for the confirm dialog.
@@ -414,11 +414,11 @@ impl ConfirmDialogState {
     ///
     /// ```rust
     /// use envision::component::{ConfirmDialogState, ConfirmDialogMessage};
-    /// use envision::input::{Event, KeyCode};
+    /// use envision::input::{Event, Key};
     ///
     /// let mut state = ConfirmDialogState::yes_no("Delete?", "Sure?");
     /// state.set_visible(true);
-    /// let event = Event::key(KeyCode::Esc);
+    /// let event = Event::key(Key::Esc);
     /// assert_eq!(state.handle_event(&event), Some(ConfirmDialogMessage::Close));
     /// ```
     pub fn handle_event(&self, event: &Event) -> Option<ConfirmDialogMessage> {
@@ -431,11 +431,11 @@ impl ConfirmDialogState {
     ///
     /// ```rust
     /// use envision::component::{ConfirmDialogState, ConfirmDialogOutput};
-    /// use envision::input::{Event, KeyCode};
+    /// use envision::input::{Event, Key};
     ///
     /// let mut state = ConfirmDialogState::new("Info", "Done.");
     /// state.set_visible(true);
-    /// let event = Event::key(KeyCode::Esc);
+    /// let event = Event::key(Key::Esc);
     /// let output = state.dispatch_event(&event);
     /// assert_eq!(output, Some(ConfirmDialogOutput::Closed));
     /// assert!(!state.is_visible());
@@ -574,15 +574,15 @@ impl Component for ConfirmDialog {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Tab => Some(ConfirmDialogMessage::FocusNext),
-                KeyCode::BackTab => Some(ConfirmDialogMessage::FocusPrev),
-                KeyCode::Enter => Some(ConfirmDialogMessage::Press),
-                KeyCode::Esc => Some(ConfirmDialogMessage::Close),
-                KeyCode::Char('y') | KeyCode::Char('Y') if state.button_config.has_yes_no() => {
+            match key.key {
+                Key::Tab if key.modifiers.shift() => Some(ConfirmDialogMessage::FocusPrev),
+                Key::Tab => Some(ConfirmDialogMessage::FocusNext),
+                Key::Enter => Some(ConfirmDialogMessage::Press),
+                Key::Esc => Some(ConfirmDialogMessage::Close),
+                Key::Char('y') if state.button_config.has_yes_no() => {
                     Some(ConfirmDialogMessage::SelectResult(ConfirmDialogResult::Yes))
                 }
-                KeyCode::Char('n') | KeyCode::Char('N') if state.button_config.has_yes_no() => {
+                Key::Char('n') if state.button_config.has_yes_no() => {
                     Some(ConfirmDialogMessage::SelectResult(ConfirmDialogResult::No))
                 }
                 _ => None,

--- a/src/component/confirm_dialog/tests.rs
+++ b/src/component/confirm_dialog/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::input::Event;
+use crate::input::Modifiers;
 
 // Construction tests
 
@@ -218,7 +219,7 @@ fn test_tab_key() {
 
     let msg = ConfirmDialog::handle_event(
         &state,
-        &Event::key(KeyCode::Tab),
+        &Event::key(Key::Tab),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(ConfirmDialogMessage::FocusNext));
@@ -230,7 +231,7 @@ fn test_backtab_key() {
 
     let msg = ConfirmDialog::handle_event(
         &state,
-        &Event::key(KeyCode::BackTab),
+        &Event::key_with(Key::Tab, Modifiers::SHIFT),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(ConfirmDialogMessage::FocusPrev));
@@ -242,7 +243,7 @@ fn test_enter_key() {
 
     let msg = ConfirmDialog::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(ConfirmDialogMessage::Press));
@@ -254,7 +255,7 @@ fn test_esc_key() {
 
     let msg = ConfirmDialog::handle_event(
         &state,
-        &Event::key(KeyCode::Esc),
+        &Event::key(Key::Esc),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(ConfirmDialogMessage::Close));
@@ -299,11 +300,8 @@ fn test_open_resets_focus() {
 #[test]
 fn test_not_visible_ignores_events() {
     let state = ConfirmDialogState::ok("T", "M");
-    let msg = ConfirmDialog::handle_event(
-        &state,
-        &Event::key(KeyCode::Enter),
-        &EventContext::default(),
-    );
+    let msg =
+        ConfirmDialog::handle_event(&state, &Event::key(Key::Enter), &EventContext::default());
     assert_eq!(msg, None);
 }
 

--- a/src/component/conversation_view/mod.rs
+++ b/src/component/conversation_view/mod.rs
@@ -47,7 +47,7 @@ use std::marker::PhantomData;
 use ratatui::prelude::*;
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 use crate::scroll::ScrollState;
 
 impl MessageSource for ConversationViewState {
@@ -814,17 +814,17 @@ impl Component for ConversationView {
         }
 
         let key = event.as_key()?;
-        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
 
-        match key.code {
-            KeyCode::Up | KeyCode::Char('k') => Some(ConversationViewMessage::ScrollUp),
-            KeyCode::Down | KeyCode::Char('j') => Some(ConversationViewMessage::ScrollDown),
-            KeyCode::Home | KeyCode::Char('g') => Some(ConversationViewMessage::ScrollToTop),
-            KeyCode::End if shift => Some(ConversationViewMessage::ScrollToBottom),
-            KeyCode::End => Some(ConversationViewMessage::ScrollToBottom),
-            KeyCode::Char('G') => Some(ConversationViewMessage::ScrollToBottom),
-            KeyCode::PageUp => Some(ConversationViewMessage::PageUp),
-            KeyCode::PageDown => Some(ConversationViewMessage::PageDown),
+        match key.key {
+            Key::Up | Key::Char('k') => Some(ConversationViewMessage::ScrollUp),
+            Key::Down | Key::Char('j') => Some(ConversationViewMessage::ScrollDown),
+            Key::Char('g') if key.modifiers.shift() => {
+                Some(ConversationViewMessage::ScrollToBottom)
+            }
+            Key::Home | Key::Char('g') => Some(ConversationViewMessage::ScrollToTop),
+            Key::End => Some(ConversationViewMessage::ScrollToBottom),
+            Key::PageUp => Some(ConversationViewMessage::PageUp),
+            Key::PageDown => Some(ConversationViewMessage::PageDown),
             _ => None,
         }
     }

--- a/src/component/conversation_view/tests/events.rs
+++ b/src/component/conversation_view/tests/events.rs
@@ -32,7 +32,7 @@ fn test_scroll_up_event() {
     assert_eq!(
         ConversationView::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true)
         ),
         Some(ConversationViewMessage::ScrollUp)
@@ -53,7 +53,7 @@ fn test_scroll_down_event() {
     assert_eq!(
         ConversationView::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true)
         ),
         Some(ConversationViewMessage::ScrollDown)
@@ -74,7 +74,7 @@ fn test_scroll_to_top_event() {
     assert_eq!(
         ConversationView::handle_event(
             &state,
-            &Event::key(KeyCode::Home),
+            &Event::key(Key::Home),
             &EventContext::new().focused(true)
         ),
         Some(ConversationViewMessage::ScrollToTop)
@@ -95,7 +95,7 @@ fn test_scroll_to_bottom_event() {
     assert_eq!(
         ConversationView::handle_event(
             &state,
-            &Event::key(KeyCode::End),
+            &Event::key(Key::End),
             &EventContext::new().focused(true)
         ),
         Some(ConversationViewMessage::ScrollToBottom)
@@ -116,7 +116,7 @@ fn test_page_up_event() {
     assert_eq!(
         ConversationView::handle_event(
             &state,
-            &Event::key(KeyCode::PageUp),
+            &Event::key(Key::PageUp),
             &EventContext::new().focused(true)
         ),
         Some(ConversationViewMessage::PageUp)
@@ -129,7 +129,7 @@ fn test_page_down_event() {
     assert_eq!(
         ConversationView::handle_event(
             &state,
-            &Event::key(KeyCode::PageDown),
+            &Event::key(Key::PageDown),
             &EventContext::new().focused(true)
         ),
         Some(ConversationViewMessage::PageDown)

--- a/src/component/conversation_view/tests/mod.rs
+++ b/src/component/conversation_view/tests/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 fn focused_state() -> ConversationViewState {
     ConversationViewState::new()

--- a/src/component/data_grid/mod.rs
+++ b/src/component/data_grid/mod.rs
@@ -46,7 +46,7 @@ use ratatui::widgets::{Block, Borders, Row, Table as RatatuiTable};
 use super::{
     Column, Component, EventContext, InputFieldMessage, InputFieldState, RenderContext, TableRow,
 };
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 use crate::scroll::ScrollState;
 
 /// Messages that can be sent to a DataGrid.
@@ -633,27 +633,27 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
         if let Some(key) = event.as_key() {
             if state.editing {
                 // Editing mode key bindings
-                match key.code {
-                    KeyCode::Enter => Some(DataGridMessage::Enter),
-                    KeyCode::Esc => Some(DataGridMessage::Cancel),
-                    KeyCode::Char(c) => Some(DataGridMessage::Input(c)),
-                    KeyCode::Backspace => Some(DataGridMessage::Backspace),
-                    KeyCode::Delete => Some(DataGridMessage::Delete),
-                    KeyCode::Home => Some(DataGridMessage::Home),
-                    KeyCode::End => Some(DataGridMessage::End),
+                match key.key {
+                    Key::Enter => Some(DataGridMessage::Enter),
+                    Key::Esc => Some(DataGridMessage::Cancel),
+                    Key::Char(_) => key.raw_char.map(DataGridMessage::Input),
+                    Key::Backspace => Some(DataGridMessage::Backspace),
+                    Key::Delete => Some(DataGridMessage::Delete),
+                    Key::Home => Some(DataGridMessage::Home),
+                    Key::End => Some(DataGridMessage::End),
                     _ => None,
                 }
             } else {
                 // Navigation mode key bindings
-                match key.code {
-                    KeyCode::Up | KeyCode::Char('k') => Some(DataGridMessage::Up),
-                    KeyCode::Down | KeyCode::Char('j') => Some(DataGridMessage::Down),
-                    KeyCode::Left | KeyCode::Char('h') => Some(DataGridMessage::Left),
-                    KeyCode::Right | KeyCode::Char('l') => Some(DataGridMessage::Right),
-                    KeyCode::Home => Some(DataGridMessage::First),
-                    KeyCode::End => Some(DataGridMessage::Last),
-                    KeyCode::Enter => Some(DataGridMessage::Enter),
-                    KeyCode::Esc => Some(DataGridMessage::Cancel),
+                match key.key {
+                    Key::Up | Key::Char('k') => Some(DataGridMessage::Up),
+                    Key::Down | Key::Char('j') => Some(DataGridMessage::Down),
+                    Key::Left | Key::Char('h') => Some(DataGridMessage::Left),
+                    Key::Right | Key::Char('l') => Some(DataGridMessage::Right),
+                    Key::Home => Some(DataGridMessage::First),
+                    Key::End => Some(DataGridMessage::Last),
+                    Key::Enter => Some(DataGridMessage::Enter),
+                    Key::Esc => Some(DataGridMessage::Cancel),
                     _ => None,
                 }
             }

--- a/src/component/data_grid/tests.rs
+++ b/src/component/data_grid/tests.rs
@@ -307,7 +307,7 @@ fn test_disabled_ignores_events() {
     let state = focused_grid();
     let msg = DataGrid::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -320,7 +320,7 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = DataGridState::new(sample_rows(), sample_columns());
-    let msg = DataGrid::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
+    let msg = DataGrid::handle_event(&state, &Event::key(Key::Down), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -334,7 +334,7 @@ fn test_up_key_maps() {
     assert_eq!(
         DataGrid::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true)
         ),
         Some(DataGridMessage::Up)
@@ -355,7 +355,7 @@ fn test_down_key_maps() {
     assert_eq!(
         DataGrid::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true)
         ),
         Some(DataGridMessage::Down)
@@ -376,7 +376,7 @@ fn test_left_right_key_maps() {
     assert_eq!(
         DataGrid::handle_event(
             &state,
-            &Event::key(KeyCode::Left),
+            &Event::key(Key::Left),
             &EventContext::new().focused(true)
         ),
         Some(DataGridMessage::Left)
@@ -384,7 +384,7 @@ fn test_left_right_key_maps() {
     assert_eq!(
         DataGrid::handle_event(
             &state,
-            &Event::key(KeyCode::Right),
+            &Event::key(Key::Right),
             &EventContext::new().focused(true)
         ),
         Some(DataGridMessage::Right)
@@ -413,7 +413,7 @@ fn test_home_end_key_maps() {
     assert_eq!(
         DataGrid::handle_event(
             &state,
-            &Event::key(KeyCode::Home),
+            &Event::key(Key::Home),
             &EventContext::new().focused(true)
         ),
         Some(DataGridMessage::First)
@@ -421,7 +421,7 @@ fn test_home_end_key_maps() {
     assert_eq!(
         DataGrid::handle_event(
             &state,
-            &Event::key(KeyCode::End),
+            &Event::key(Key::End),
             &EventContext::new().focused(true)
         ),
         Some(DataGridMessage::Last)
@@ -434,7 +434,7 @@ fn test_enter_key_maps() {
     assert_eq!(
         DataGrid::handle_event(
             &state,
-            &Event::key(KeyCode::Enter),
+            &Event::key(Key::Enter),
             &EventContext::new().focused(true)
         ),
         Some(DataGridMessage::Enter)
@@ -469,7 +469,7 @@ fn test_editing_enter_maps() {
     assert_eq!(
         DataGrid::handle_event(
             &state,
-            &Event::key(KeyCode::Enter),
+            &Event::key(Key::Enter),
             &EventContext::new().focused(true)
         ),
         Some(DataGridMessage::Enter)
@@ -484,7 +484,7 @@ fn test_editing_esc_maps_to_cancel() {
     assert_eq!(
         DataGrid::handle_event(
             &state,
-            &Event::key(KeyCode::Esc),
+            &Event::key(Key::Esc),
             &EventContext::new().focused(true)
         ),
         Some(DataGridMessage::Cancel)
@@ -499,7 +499,7 @@ fn test_editing_backspace_maps() {
     assert_eq!(
         DataGrid::handle_event(
             &state,
-            &Event::key(KeyCode::Backspace),
+            &Event::key(Key::Backspace),
             &EventContext::new().focused(true)
         ),
         Some(DataGridMessage::Backspace)

--- a/src/component/dependency_graph/mod.rs
+++ b/src/component/dependency_graph/mod.rs
@@ -28,7 +28,7 @@
 //! ```
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 pub mod layout;
 mod render;
@@ -797,14 +797,11 @@ impl Component for DependencyGraph {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Down | KeyCode::Char('j') | KeyCode::Tab => {
-                    Some(DependencyGraphMessage::SelectNext)
-                }
-                KeyCode::Up | KeyCode::Char('k') | KeyCode::BackTab => {
-                    Some(DependencyGraphMessage::SelectPrev)
-                }
-                KeyCode::Enter | KeyCode::Char('l') | KeyCode::Right => {
+            match key.key {
+                Key::Tab if key.modifiers.shift() => Some(DependencyGraphMessage::SelectPrev),
+                Key::Down | Key::Char('j') | Key::Tab => Some(DependencyGraphMessage::SelectNext),
+                Key::Up | Key::Char('k') => Some(DependencyGraphMessage::SelectPrev),
+                Key::Enter | Key::Char('l') | Key::Right => {
                     Some(DependencyGraphMessage::SelectConnected)
                 }
                 _ => None,

--- a/src/component/dependency_graph/tests.rs
+++ b/src/component/dependency_graph/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::component::Component;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key, Modifiers};
 use ratatui::style::Color;
 
 // =============================================================================
@@ -365,7 +365,7 @@ fn test_selected_node_some() {
 fn test_handle_event_not_focused() {
     let state = DependencyGraphState::new().with_node(GraphNode::new("a", "A"));
     let msg =
-        DependencyGraph::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
+        DependencyGraph::handle_event(&state, &Event::key(Key::Down), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -373,7 +373,7 @@ fn test_handle_event_not_focused() {
 fn test_handle_event_disabled() {
     let state = DependencyGraphState::new().with_node(GraphNode::new("a", "A"));
     let msg =
-        DependencyGraph::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
+        DependencyGraph::handle_event(&state, &Event::key(Key::Down), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -383,7 +383,7 @@ fn test_handle_event_down() {
     assert_eq!(
         DependencyGraph::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true)
         ),
         Some(DependencyGraphMessage::SelectNext)
@@ -409,7 +409,7 @@ fn test_handle_event_tab() {
     assert_eq!(
         DependencyGraph::handle_event(
             &state,
-            &Event::key(KeyCode::Tab),
+            &Event::key(Key::Tab),
             &EventContext::new().focused(true)
         ),
         Some(DependencyGraphMessage::SelectNext)
@@ -422,7 +422,7 @@ fn test_handle_event_up() {
     assert_eq!(
         DependencyGraph::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true)
         ),
         Some(DependencyGraphMessage::SelectPrev)
@@ -448,7 +448,7 @@ fn test_handle_event_backtab() {
     assert_eq!(
         DependencyGraph::handle_event(
             &state,
-            &Event::key(KeyCode::BackTab),
+            &Event::key_with(Key::Tab, Modifiers::SHIFT),
             &EventContext::new().focused(true)
         ),
         Some(DependencyGraphMessage::SelectPrev)
@@ -461,7 +461,7 @@ fn test_handle_event_enter() {
     assert_eq!(
         DependencyGraph::handle_event(
             &state,
-            &Event::key(KeyCode::Enter),
+            &Event::key(Key::Enter),
             &EventContext::new().focused(true)
         ),
         Some(DependencyGraphMessage::SelectConnected)
@@ -487,7 +487,7 @@ fn test_handle_event_right() {
     assert_eq!(
         DependencyGraph::handle_event(
             &state,
-            &Event::key(KeyCode::Right),
+            &Event::key(Key::Right),
             &EventContext::new().focused(true)
         ),
         Some(DependencyGraphMessage::SelectConnected)
@@ -689,7 +689,7 @@ fn test_dispatch_event() {
 
     let output = DependencyGraph::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(

--- a/src/component/dialog/mod.rs
+++ b/src/component/dialog/mod.rs
@@ -28,7 +28,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
 use super::{Component, EventContext, RenderContext, Toggleable};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 use crate::theme::Theme;
 
 /// A button configuration for a dialog.
@@ -511,11 +511,11 @@ impl DialogState {
     ///
     /// ```rust
     /// use envision::component::{DialogMessage, DialogState, Toggleable, Dialog};
-    /// use envision::input::{Event, KeyCode};
+    /// use envision::input::{Event, Key};
     ///
     /// let mut state = DialogState::alert("Info", "Done.");
     /// Dialog::show(&mut state);
-    /// let event = Event::key(KeyCode::Enter);
+    /// let event = Event::key(Key::Enter);
     /// assert_eq!(state.handle_event(&event), Some(DialogMessage::Press));
     /// ```
     pub fn handle_event(&self, event: &Event) -> Option<DialogMessage> {
@@ -528,11 +528,11 @@ impl DialogState {
     ///
     /// ```rust
     /// use envision::component::{DialogOutput, DialogState, Toggleable, Dialog};
-    /// use envision::input::{Event, KeyCode};
+    /// use envision::input::{Event, Key};
     ///
     /// let mut state = DialogState::alert("Info", "Done.");
     /// Dialog::show(&mut state);
-    /// let event = Event::key(KeyCode::Enter);
+    /// let event = Event::key(Key::Enter);
     /// let output = state.dispatch_event(&event);
     /// assert_eq!(output, Some(DialogOutput::ButtonPressed("ok".into())));
     /// ```
@@ -663,11 +663,11 @@ impl Component for Dialog {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Tab => Some(DialogMessage::FocusNext),
-                KeyCode::BackTab => Some(DialogMessage::FocusPrev),
-                KeyCode::Enter => Some(DialogMessage::Press),
-                KeyCode::Esc => Some(DialogMessage::Close),
+            match key.key {
+                Key::Tab if key.modifiers.shift() => Some(DialogMessage::FocusPrev),
+                Key::Tab => Some(DialogMessage::FocusNext),
+                Key::Enter => Some(DialogMessage::Press),
+                Key::Esc => Some(DialogMessage::Close),
                 _ => None,
             }
         } else {

--- a/src/component/dialog/tests.rs
+++ b/src/component/dialog/tests.rs
@@ -503,14 +503,14 @@ fn test_show_resets_focus_to_primary() {
 // handle_event Tests
 // ========================================
 
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key, Modifiers};
 
 #[test]
 fn test_handle_event_tab() {
     let mut state = DialogState::confirm("T", "M");
     Dialog::show(&mut state);
 
-    let msg = Dialog::handle_event(&state, &Event::key(KeyCode::Tab), &EventContext::default());
+    let msg = Dialog::handle_event(&state, &Event::key(Key::Tab), &EventContext::default());
     assert_eq!(msg, Some(DialogMessage::FocusNext));
 }
 
@@ -521,7 +521,7 @@ fn test_handle_event_backtab() {
 
     let msg = Dialog::handle_event(
         &state,
-        &Event::key(KeyCode::BackTab),
+        &Event::key_with(Key::Tab, Modifiers::SHIFT),
         &EventContext::default(),
     );
     assert_eq!(msg, Some(DialogMessage::FocusPrev));
@@ -532,11 +532,7 @@ fn test_handle_event_enter() {
     let mut state = DialogState::confirm("T", "M");
     Dialog::show(&mut state);
 
-    let msg = Dialog::handle_event(
-        &state,
-        &Event::key(KeyCode::Enter),
-        &EventContext::default(),
-    );
+    let msg = Dialog::handle_event(&state, &Event::key(Key::Enter), &EventContext::default());
     assert_eq!(msg, Some(DialogMessage::Press));
 }
 
@@ -545,7 +541,7 @@ fn test_handle_event_escape() {
     let mut state = DialogState::confirm("T", "M");
     Dialog::show(&mut state);
 
-    let msg = Dialog::handle_event(&state, &Event::key(KeyCode::Esc), &EventContext::default());
+    let msg = Dialog::handle_event(&state, &Event::key(Key::Esc), &EventContext::default());
     assert_eq!(msg, Some(DialogMessage::Close));
 }
 
@@ -555,11 +551,7 @@ fn test_handle_event_ignored_when_not_visible() {
     // Not visible by default
     assert!(!Dialog::is_visible(&state));
 
-    let msg = Dialog::handle_event(
-        &state,
-        &Event::key(KeyCode::Enter),
-        &EventContext::default(),
-    );
+    let msg = Dialog::handle_event(&state, &Event::key(Key::Enter), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -575,7 +567,7 @@ fn test_dispatch_event() {
     // Enter dispatches Press, which presses the OK button
     let output = Dialog::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::default(),
     );
     assert_eq!(output, Some(DialogOutput::ButtonPressed("ok".into())));

--- a/src/component/diff_viewer/mod.rs
+++ b/src/component/diff_viewer/mod.rs
@@ -38,7 +38,7 @@ pub mod parser;
 mod render;
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 use crate::scroll::ScrollState;
 
 /// Display mode for the diff.
@@ -756,24 +756,24 @@ impl Component for DiffViewer {
         }
 
         let key = event.as_key()?;
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+        let ctrl = key.modifiers.ctrl();
+        let shift = key.modifiers.shift();
 
-        match key.code {
-            KeyCode::Up | KeyCode::Char('k') if !ctrl => Some(DiffViewerMessage::ScrollUp),
-            KeyCode::Down | KeyCode::Char('j') if !ctrl => Some(DiffViewerMessage::ScrollDown),
-            KeyCode::Char('n') if !shift && !ctrl => Some(DiffViewerMessage::NextHunk),
-            KeyCode::Char('N') if shift => Some(DiffViewerMessage::PrevHunk),
-            KeyCode::Char('p') if !ctrl => Some(DiffViewerMessage::PrevHunk),
-            KeyCode::PageUp => Some(DiffViewerMessage::PageUp(10)),
-            KeyCode::PageDown => Some(DiffViewerMessage::PageDown(10)),
-            KeyCode::Char('u') if ctrl => Some(DiffViewerMessage::PageUp(10)),
-            KeyCode::Char('d') if ctrl => Some(DiffViewerMessage::PageDown(10)),
-            KeyCode::Home | KeyCode::Char('g') if !shift => Some(DiffViewerMessage::Home),
-            KeyCode::End | KeyCode::Char('G') if shift || key.code == KeyCode::End => {
+        match key.key {
+            Key::Up | Key::Char('k') if !ctrl => Some(DiffViewerMessage::ScrollUp),
+            Key::Down | Key::Char('j') if !ctrl => Some(DiffViewerMessage::ScrollDown),
+            Key::Char('n') if !shift && !ctrl => Some(DiffViewerMessage::NextHunk),
+            Key::Char('n') if key.modifiers.shift() => Some(DiffViewerMessage::PrevHunk),
+            Key::Char('p') if !ctrl => Some(DiffViewerMessage::PrevHunk),
+            Key::PageUp => Some(DiffViewerMessage::PageUp(10)),
+            Key::PageDown => Some(DiffViewerMessage::PageDown(10)),
+            Key::Char('u') if ctrl => Some(DiffViewerMessage::PageUp(10)),
+            Key::Char('d') if ctrl => Some(DiffViewerMessage::PageDown(10)),
+            Key::Home | Key::Char('g') if !shift => Some(DiffViewerMessage::Home),
+            Key::End | Key::Char('g') if key.modifiers.shift() || key.key == Key::End => {
                 Some(DiffViewerMessage::End)
             }
-            KeyCode::Char('m') if !ctrl => Some(DiffViewerMessage::ToggleMode),
+            Key::Char('m') if !ctrl => Some(DiffViewerMessage::ToggleMode),
             _ => None,
         }
     }

--- a/src/component/diff_viewer/tests.rs
+++ b/src/component/diff_viewer/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::component::test_utils;
 use crate::input::Event;
+use crate::input::Modifiers;
 
 fn focused_state() -> DiffViewerState {
     DiffViewerState::new()
@@ -406,7 +407,7 @@ fn test_disabled_ignores_events() {
     let state = focused_state();
     let msg = DiffViewer::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -415,7 +416,7 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = DiffViewerState::new();
-    let msg = DiffViewer::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default());
+    let msg = DiffViewer::handle_event(&state, &Event::key(Key::Up), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -429,7 +430,7 @@ fn test_handle_event_up() {
     assert_eq!(
         DiffViewer::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true)
         ),
         Some(DiffViewerMessage::ScrollUp)
@@ -442,7 +443,7 @@ fn test_handle_event_down() {
     assert_eq!(
         DiffViewer::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true)
         ),
         Some(DiffViewerMessage::ScrollDown)
@@ -489,7 +490,7 @@ fn test_handle_event_shift_n_for_prev_hunk() {
     assert_eq!(
         DiffViewer::handle_event(
             &state,
-            &Event::key_with(KeyCode::Char('N'), KeyModifiers::SHIFT),
+            &Event::key_with(Key::Char('n'), Modifiers::SHIFT),
             &EventContext::new().focused(true),
         ),
         Some(DiffViewerMessage::PrevHunk)
@@ -515,7 +516,7 @@ fn test_handle_event_page_up_down() {
     assert_eq!(
         DiffViewer::handle_event(
             &state,
-            &Event::key(KeyCode::PageUp),
+            &Event::key(Key::PageUp),
             &EventContext::new().focused(true)
         ),
         Some(DiffViewerMessage::PageUp(10))
@@ -523,7 +524,7 @@ fn test_handle_event_page_up_down() {
     assert_eq!(
         DiffViewer::handle_event(
             &state,
-            &Event::key(KeyCode::PageDown),
+            &Event::key(Key::PageDown),
             &EventContext::new().focused(true)
         ),
         Some(DiffViewerMessage::PageDown(10))
@@ -557,7 +558,7 @@ fn test_handle_event_home_end() {
     assert_eq!(
         DiffViewer::handle_event(
             &state,
-            &Event::key(KeyCode::Home),
+            &Event::key(Key::Home),
             &EventContext::new().focused(true)
         ),
         Some(DiffViewerMessage::Home)
@@ -565,7 +566,7 @@ fn test_handle_event_home_end() {
     assert_eq!(
         DiffViewer::handle_event(
             &state,
-            &Event::key(KeyCode::End),
+            &Event::key(Key::End),
             &EventContext::new().focused(true)
         ),
         Some(DiffViewerMessage::End)
@@ -587,7 +588,7 @@ fn test_handle_event_g_and_G() {
     assert_eq!(
         DiffViewer::handle_event(
             &state,
-            &Event::key_with(KeyCode::Char('G'), KeyModifiers::SHIFT),
+            &Event::key_with(Key::Char('g'), Modifiers::SHIFT),
             &EventContext::new().focused(true),
         ),
         Some(DiffViewerMessage::End)

--- a/src/component/divider/mod.rs
+++ b/src/component/divider/mod.rs
@@ -322,11 +322,10 @@ impl DividerState {
     ///
     /// ```rust
     /// use envision::component::DividerState;
-    /// use envision::input::Event;
-    /// use ratatui::crossterm::event::KeyCode;
+    /// use envision::input::{Event, Key};
     ///
     /// let state = DividerState::new();
-    /// assert!(state.handle_event(&Event::key(KeyCode::Enter)).is_none());
+    /// assert!(state.handle_event(&Event::key(Key::Enter)).is_none());
     /// ```
     pub fn handle_event(&self, event: &Event) -> Option<DividerMessage> {
         Divider::handle_event(self, event, &EventContext::default())
@@ -341,11 +340,10 @@ impl DividerState {
     ///
     /// ```rust
     /// use envision::component::DividerState;
-    /// use envision::input::Event;
-    /// use ratatui::crossterm::event::KeyCode;
+    /// use envision::input::{Event, Key};
     ///
     /// let mut state = DividerState::new();
-    /// assert!(state.dispatch_event(&Event::key(KeyCode::Enter)).is_none());
+    /// assert!(state.dispatch_event(&Event::key(Key::Enter)).is_none());
     /// ```
     pub fn dispatch_event(&mut self, event: &Event) -> Option<()> {
         Divider::dispatch_event(self, event, &EventContext::default())

--- a/src/component/dropdown/mod.rs
+++ b/src/component/dropdown/mod.rs
@@ -33,7 +33,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 
 /// Messages that can be sent to a Dropdown.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -655,20 +655,18 @@ impl Component for Dropdown {
         }
         if let Some(key) = event.as_key() {
             if state.is_open {
-                match key.code {
-                    KeyCode::Enter => Some(DropdownMessage::Confirm),
-                    KeyCode::Esc => Some(DropdownMessage::Close),
-                    KeyCode::Up => Some(DropdownMessage::Up),
-                    KeyCode::Down => Some(DropdownMessage::Down),
-                    KeyCode::Char(c) if key.modifiers == KeyModifiers::NONE => {
-                        Some(DropdownMessage::Insert(c))
-                    }
-                    KeyCode::Backspace => Some(DropdownMessage::Backspace),
+                match key.key {
+                    Key::Enter => Some(DropdownMessage::Confirm),
+                    Key::Esc => Some(DropdownMessage::Close),
+                    Key::Up => Some(DropdownMessage::Up),
+                    Key::Down => Some(DropdownMessage::Down),
+                    Key::Char(c) if key.modifiers.is_none() => Some(DropdownMessage::Insert(c)),
+                    Key::Backspace => Some(DropdownMessage::Backspace),
                     _ => None,
                 }
             } else {
-                match key.code {
-                    KeyCode::Enter => Some(DropdownMessage::Toggle),
+                match key.key {
+                    Key::Enter => Some(DropdownMessage::Toggle),
                     _ => None,
                 }
             }

--- a/src/component/dropdown/tests.rs
+++ b/src/component/dropdown/tests.rs
@@ -619,7 +619,7 @@ fn test_large_dropdown_navigation() {
 // handle_event Tests
 // ========================================
 
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 #[test]
 fn test_handle_event_toggle_when_closed() {
@@ -627,7 +627,7 @@ fn test_handle_event_toggle_when_closed() {
 
     let msg = Dropdown::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(DropdownMessage::Toggle));
@@ -640,7 +640,7 @@ fn test_handle_event_confirm_when_open() {
 
     let msg = Dropdown::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(DropdownMessage::Confirm));
@@ -653,7 +653,7 @@ fn test_handle_event_close_when_open() {
 
     let msg = Dropdown::handle_event(
         &state,
-        &Event::key(KeyCode::Esc),
+        &Event::key(Key::Esc),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(DropdownMessage::Close));
@@ -666,7 +666,7 @@ fn test_handle_event_up_when_open() {
 
     let msg = Dropdown::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(DropdownMessage::Up));
@@ -679,7 +679,7 @@ fn test_handle_event_down_when_open() {
 
     let msg = Dropdown::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(DropdownMessage::Down));
@@ -705,7 +705,7 @@ fn test_handle_event_backspace_when_open() {
 
     let msg = Dropdown::handle_event(
         &state,
-        &Event::key(KeyCode::Backspace),
+        &Event::key(Key::Backspace),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(DropdownMessage::Backspace));
@@ -714,11 +714,7 @@ fn test_handle_event_backspace_when_open() {
 #[test]
 fn test_handle_event_ignored_when_unfocused() {
     let state = DropdownState::new(vec!["A", "B", "C"]);
-    let msg = Dropdown::handle_event(
-        &state,
-        &Event::key(KeyCode::Enter),
-        &EventContext::default(),
-    );
+    let msg = Dropdown::handle_event(&state, &Event::key(Key::Enter), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -727,7 +723,7 @@ fn test_handle_event_ignored_when_disabled() {
     let state = DropdownState::new(vec!["A", "B", "C"]);
     let msg = Dropdown::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -746,7 +742,7 @@ fn test_dispatch_event() {
     // Enter when open dispatches Confirm, which selects the item
     let output = Dropdown::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(DropdownOutput::Selected("B".to_string())));

--- a/src/component/event_stream/event_tests.rs
+++ b/src/component/event_stream/event_tests.rs
@@ -66,7 +66,7 @@ fn test_list_mode_up_key() {
     assert_eq!(
         EventStream::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::ScrollUp)
@@ -87,7 +87,7 @@ fn test_list_mode_down_key() {
     assert_eq!(
         EventStream::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::ScrollDown)
@@ -108,7 +108,7 @@ fn test_list_mode_home_g() {
     assert_eq!(
         EventStream::handle_event(
             &state,
-            &Event::key(KeyCode::Home),
+            &Event::key(Key::Home),
             &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::ScrollToTop)
@@ -129,7 +129,7 @@ fn test_list_mode_end_shift_g() {
     assert_eq!(
         EventStream::handle_event(
             &state,
-            &Event::key(KeyCode::End),
+            &Event::key(Key::End),
             &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::ScrollToBottom)
@@ -240,7 +240,7 @@ fn test_search_mode_esc() {
     assert_eq!(
         EventStream::handle_event(
             &state,
-            &Event::key(KeyCode::Esc),
+            &Event::key(Key::Esc),
             &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::ClearSearch)
@@ -254,7 +254,7 @@ fn test_search_mode_enter() {
     assert_eq!(
         EventStream::handle_event(
             &state,
-            &Event::key(KeyCode::Enter),
+            &Event::key(Key::Enter),
             &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::FocusList)
@@ -268,7 +268,7 @@ fn test_search_mode_backspace() {
     assert_eq!(
         EventStream::handle_event(
             &state,
-            &Event::key(KeyCode::Backspace),
+            &Event::key(Key::Backspace),
             &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::SearchBackspace)
@@ -282,7 +282,7 @@ fn test_search_mode_delete() {
     assert_eq!(
         EventStream::handle_event(
             &state,
-            &Event::key(KeyCode::Delete),
+            &Event::key(Key::Delete),
             &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::SearchDelete)
@@ -296,7 +296,7 @@ fn test_search_mode_left_right() {
     assert_eq!(
         EventStream::handle_event(
             &state,
-            &Event::key(KeyCode::Left),
+            &Event::key(Key::Left),
             &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::SearchLeft)
@@ -304,7 +304,7 @@ fn test_search_mode_left_right() {
     assert_eq!(
         EventStream::handle_event(
             &state,
-            &Event::key(KeyCode::Right),
+            &Event::key(Key::Right),
             &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::SearchRight)
@@ -318,7 +318,7 @@ fn test_search_mode_home_end() {
     assert_eq!(
         EventStream::handle_event(
             &state,
-            &Event::key(KeyCode::Home),
+            &Event::key(Key::Home),
             &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::SearchHome)
@@ -326,7 +326,7 @@ fn test_search_mode_home_end() {
     assert_eq!(
         EventStream::handle_event(
             &state,
-            &Event::key(KeyCode::End),
+            &Event::key(Key::End),
             &EventContext::new().focused(true)
         ),
         Some(EventStreamMessage::SearchEnd)

--- a/src/component/event_stream/mod.rs
+++ b/src/component/event_stream/mod.rs
@@ -37,7 +37,7 @@ mod types;
 use std::marker::PhantomData;
 
 use super::{Component, EventContext, InputFieldMessage, RenderContext};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 
 pub use state::EventStreamState;
 pub use types::{EventLevel, StreamEvent};
@@ -174,37 +174,37 @@ impl Component for EventStream {
         let key = event.as_key()?;
 
         match state.focus {
-            Focus::List => match key.code {
-                KeyCode::Up | KeyCode::Char('k') => Some(EventStreamMessage::ScrollUp),
-                KeyCode::Down | KeyCode::Char('j') => Some(EventStreamMessage::ScrollDown),
-                KeyCode::Home | KeyCode::Char('g') => Some(EventStreamMessage::ScrollToTop),
-                KeyCode::End => Some(EventStreamMessage::ScrollToBottom),
-                KeyCode::Char('G') => Some(EventStreamMessage::ScrollToBottom),
-                KeyCode::Char('/') => Some(EventStreamMessage::FocusSearch),
-                KeyCode::Char('1') => Some(EventStreamMessage::QuickLevelFilter(1)),
-                KeyCode::Char('2') => Some(EventStreamMessage::QuickLevelFilter(2)),
-                KeyCode::Char('3') => Some(EventStreamMessage::QuickLevelFilter(3)),
-                KeyCode::Char('4') => Some(EventStreamMessage::QuickLevelFilter(4)),
-                KeyCode::Char('5') => Some(EventStreamMessage::QuickLevelFilter(5)),
-                KeyCode::Char('f') => Some(EventStreamMessage::ToggleAutoScroll),
+            Focus::List => match key.key {
+                Key::Up | Key::Char('k') => Some(EventStreamMessage::ScrollUp),
+                Key::Down | Key::Char('j') => Some(EventStreamMessage::ScrollDown),
+                Key::Char('g') if key.modifiers.shift() => Some(EventStreamMessage::ScrollToBottom),
+                Key::Home | Key::Char('g') => Some(EventStreamMessage::ScrollToTop),
+                Key::End => Some(EventStreamMessage::ScrollToBottom),
+                Key::Char('/') => Some(EventStreamMessage::FocusSearch),
+                Key::Char('1') => Some(EventStreamMessage::QuickLevelFilter(1)),
+                Key::Char('2') => Some(EventStreamMessage::QuickLevelFilter(2)),
+                Key::Char('3') => Some(EventStreamMessage::QuickLevelFilter(3)),
+                Key::Char('4') => Some(EventStreamMessage::QuickLevelFilter(4)),
+                Key::Char('5') => Some(EventStreamMessage::QuickLevelFilter(5)),
+                Key::Char('f') => Some(EventStreamMessage::ToggleAutoScroll),
                 _ => None,
             },
-            Focus::Search => match key.code {
-                KeyCode::Esc => Some(EventStreamMessage::ClearSearch),
-                KeyCode::Enter => Some(EventStreamMessage::FocusList),
-                KeyCode::Char(c) => {
-                    if key.modifiers.contains(KeyModifiers::CONTROL) {
+            Focus::Search => match key.key {
+                Key::Esc => Some(EventStreamMessage::ClearSearch),
+                Key::Enter => Some(EventStreamMessage::FocusList),
+                Key::Char(c) => {
+                    if key.modifiers.ctrl() {
                         None
                     } else {
                         Some(EventStreamMessage::SearchInput(c))
                     }
                 }
-                KeyCode::Backspace => Some(EventStreamMessage::SearchBackspace),
-                KeyCode::Delete => Some(EventStreamMessage::SearchDelete),
-                KeyCode::Left => Some(EventStreamMessage::SearchLeft),
-                KeyCode::Right => Some(EventStreamMessage::SearchRight),
-                KeyCode::Home => Some(EventStreamMessage::SearchHome),
-                KeyCode::End => Some(EventStreamMessage::SearchEnd),
+                Key::Backspace => Some(EventStreamMessage::SearchBackspace),
+                Key::Delete => Some(EventStreamMessage::SearchDelete),
+                Key::Left => Some(EventStreamMessage::SearchLeft),
+                Key::Right => Some(EventStreamMessage::SearchRight),
+                Key::Home => Some(EventStreamMessage::SearchHome),
+                Key::End => Some(EventStreamMessage::SearchEnd),
                 _ => None,
             },
         }

--- a/src/component/event_stream/tests.rs
+++ b/src/component/event_stream/tests.rs
@@ -735,7 +735,7 @@ fn test_disabled_ignores_events() {
     let state = focused_state();
     let msg = EventStream::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -744,8 +744,7 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = sample_state();
-    let msg =
-        EventStream::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
+    let msg = EventStream::handle_event(&state, &Event::key(Key::Down), &EventContext::default());
     assert_eq!(msg, None);
 }
 

--- a/src/component/file_browser/helper_tests.rs
+++ b/src/component/file_browser/helper_tests.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use super::*;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 fn sample_entries() -> Vec<FileEntry> {
     vec![
@@ -150,7 +150,7 @@ fn test_pathbar_focus_only_handles_tab() {
     assert!(
         FileBrowser::handle_event(
             &state,
-            &Event::key(KeyCode::Enter),
+            &Event::key(Key::Enter),
             &EventContext::new().focused(true)
         )
         .is_none()
@@ -158,7 +158,7 @@ fn test_pathbar_focus_only_handles_tab() {
     // Tab still works
     let msg = FileBrowser::handle_event(
         &state,
-        &Event::key(KeyCode::Tab),
+        &Event::key(Key::Tab),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::CycleFocus));
@@ -188,7 +188,7 @@ fn test_filter_focus_backspace() {
     FileBrowser::update(&mut state, FileBrowserMessage::CycleFocus);
     let msg = FileBrowser::handle_event(
         &state,
-        &Event::key(KeyCode::Backspace),
+        &Event::key(Key::Backspace),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::FilterBackspace));
@@ -200,7 +200,7 @@ fn test_filter_focus_esc() {
     FileBrowser::update(&mut state, FileBrowserMessage::CycleFocus);
     let msg = FileBrowser::handle_event(
         &state,
-        &Event::key(KeyCode::Esc),
+        &Event::key(Key::Esc),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::FilterClear));

--- a/src/component/file_browser/mod.rs
+++ b/src/component/file_browser/mod.rs
@@ -37,7 +37,7 @@ use std::sync::Arc;
 use ratatui::widgets::ListState;
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 use types::{FileBrowserFocus, compute_segments};
 
 /// Trait for providing directory listings.
@@ -651,45 +651,41 @@ impl Component for FileBrowser {
         }
 
         let key = event.as_key()?;
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+        let ctrl = key.modifiers.ctrl();
+        let shift = key.modifiers.shift();
 
         match state.internal_focus {
-            FileBrowserFocus::FileList => match key.code {
-                KeyCode::Up | KeyCode::Char('k') if !ctrl => Some(FileBrowserMessage::Up),
-                KeyCode::Down | KeyCode::Char('j') if !ctrl => Some(FileBrowserMessage::Down),
-                KeyCode::Home | KeyCode::Char('g') if !shift => Some(FileBrowserMessage::First),
-                KeyCode::End | KeyCode::Char('G') if shift || key.code == KeyCode::End => {
+            FileBrowserFocus::FileList => match key.key {
+                Key::Up | Key::Char('k') if !ctrl => Some(FileBrowserMessage::Up),
+                Key::Down | Key::Char('j') if !ctrl => Some(FileBrowserMessage::Down),
+                Key::Home | Key::Char('g') if !shift => Some(FileBrowserMessage::First),
+                Key::End | Key::Char('g') if key.modifiers.shift() || key.key == Key::End => {
                     Some(FileBrowserMessage::Last)
                 }
-                KeyCode::PageUp => Some(FileBrowserMessage::PageUp(10)),
-                KeyCode::PageDown => Some(FileBrowserMessage::PageDown(10)),
-                KeyCode::Enter => Some(FileBrowserMessage::Enter),
-                KeyCode::Backspace if state.filter_text.is_empty() => {
-                    Some(FileBrowserMessage::Back)
-                }
-                KeyCode::Backspace => Some(FileBrowserMessage::FilterBackspace),
-                KeyCode::Char(' ') => Some(FileBrowserMessage::ToggleSelect),
-                KeyCode::Char('h') if ctrl => Some(FileBrowserMessage::ToggleHidden),
-                KeyCode::Tab => Some(FileBrowserMessage::CycleFocus),
-                KeyCode::BackTab => Some(FileBrowserMessage::CycleFocus),
-                KeyCode::Esc => Some(FileBrowserMessage::FilterClear),
-                KeyCode::Char(c)
-                    if !ctrl && c.is_alphanumeric() || c == '.' || c == '_' || c == '-' =>
-                {
-                    Some(FileBrowserMessage::FilterChar(c))
-                }
+                Key::PageUp => Some(FileBrowserMessage::PageUp(10)),
+                Key::PageDown => Some(FileBrowserMessage::PageDown(10)),
+                Key::Enter => Some(FileBrowserMessage::Enter),
+                Key::Backspace if state.filter_text.is_empty() => Some(FileBrowserMessage::Back),
+                Key::Backspace => Some(FileBrowserMessage::FilterBackspace),
+                Key::Char(' ') => Some(FileBrowserMessage::ToggleSelect),
+                Key::Char('h') if ctrl => Some(FileBrowserMessage::ToggleHidden),
+                Key::Tab => Some(FileBrowserMessage::CycleFocus),
+                Key::Esc => Some(FileBrowserMessage::FilterClear),
+                Key::Char(_) if !ctrl => key
+                    .raw_char
+                    .filter(|c| c.is_alphanumeric() || *c == '.' || *c == '_' || *c == '-')
+                    .map(FileBrowserMessage::FilterChar),
                 _ => None,
             },
-            FileBrowserFocus::PathBar => match key.code {
-                KeyCode::Tab | KeyCode::BackTab => Some(FileBrowserMessage::CycleFocus),
+            FileBrowserFocus::PathBar => match key.key {
+                Key::Tab => Some(FileBrowserMessage::CycleFocus),
                 _ => None,
             },
-            FileBrowserFocus::Filter => match key.code {
-                KeyCode::Tab | KeyCode::BackTab => Some(FileBrowserMessage::CycleFocus),
-                KeyCode::Backspace => Some(FileBrowserMessage::FilterBackspace),
-                KeyCode::Esc => Some(FileBrowserMessage::FilterClear),
-                KeyCode::Char(c) if !ctrl => Some(FileBrowserMessage::FilterChar(c)),
+            FileBrowserFocus::Filter => match key.key {
+                Key::Tab => Some(FileBrowserMessage::CycleFocus),
+                Key::Backspace => Some(FileBrowserMessage::FilterBackspace),
+                Key::Esc => Some(FileBrowserMessage::FilterClear),
+                Key::Char(_) if !ctrl => key.raw_char.map(FileBrowserMessage::FilterChar),
                 _ => None,
             },
         }

--- a/src/component/file_browser/tests.rs
+++ b/src/component/file_browser/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 fn sample_entries() -> Vec<FileEntry> {
     vec![
@@ -604,7 +604,7 @@ fn test_cycle_focus() {
 fn test_unfocused_ignores_events() {
     let state = FileBrowserState::new("/", sample_entries());
     assert!(
-        FileBrowser::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default())
+        FileBrowser::handle_event(&state, &Event::key(Key::Down), &EventContext::default())
             .is_none()
     );
     assert!(
@@ -618,7 +618,7 @@ fn test_disabled_ignores_events() {
     assert!(
         FileBrowser::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true).disabled(true)
         )
         .is_none()
@@ -634,7 +634,7 @@ fn test_key_up() {
     let state = focused_state();
     let msg = FileBrowser::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::Up));
@@ -656,7 +656,7 @@ fn test_key_down() {
     let state = focused_state();
     let msg = FileBrowser::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::Down));
@@ -678,7 +678,7 @@ fn test_key_home_maps_to_first() {
     let state = focused_state();
     let msg = FileBrowser::handle_event(
         &state,
-        &Event::key(KeyCode::Home),
+        &Event::key(Key::Home),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::First));
@@ -689,7 +689,7 @@ fn test_key_end_maps_to_last() {
     let state = focused_state();
     let msg = FileBrowser::handle_event(
         &state,
-        &Event::key(KeyCode::End),
+        &Event::key(Key::End),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::Last));
@@ -700,7 +700,7 @@ fn test_key_enter_maps_to_enter() {
     let state = focused_state();
     let msg = FileBrowser::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::Enter));
@@ -711,7 +711,7 @@ fn test_key_backspace_maps_to_back_when_filter_empty() {
     let state = focused_state();
     let msg = FileBrowser::handle_event(
         &state,
-        &Event::key(KeyCode::Backspace),
+        &Event::key(Key::Backspace),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::Back));
@@ -723,7 +723,7 @@ fn test_key_backspace_maps_to_filter_backspace_when_filter_active() {
     FileBrowser::update(&mut state, FileBrowserMessage::FilterChar('a'));
     let msg = FileBrowser::handle_event(
         &state,
-        &Event::key(KeyCode::Backspace),
+        &Event::key(Key::Backspace),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::FilterBackspace));
@@ -756,7 +756,7 @@ fn test_key_tab_maps_to_cycle_focus() {
     let state = focused_state();
     let msg = FileBrowser::handle_event(
         &state,
-        &Event::key(KeyCode::Tab),
+        &Event::key(Key::Tab),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::CycleFocus));
@@ -767,7 +767,7 @@ fn test_key_esc_maps_to_filter_clear() {
     let state = focused_state();
     let msg = FileBrowser::handle_event(
         &state,
-        &Event::key(KeyCode::Esc),
+        &Event::key(Key::Esc),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FileBrowserMessage::FilterClear));

--- a/src/component/flame_graph/mod.rs
+++ b/src/component/flame_graph/mod.rs
@@ -31,7 +31,7 @@
 //! ```
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 mod node;
 mod render;
@@ -864,15 +864,15 @@ impl Component for FlameGraph {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Up | KeyCode::Char('k') => Some(FlameGraphMessage::SelectUp),
-                KeyCode::Down | KeyCode::Char('j') => Some(FlameGraphMessage::SelectDown),
-                KeyCode::Left | KeyCode::Char('h') => Some(FlameGraphMessage::SelectLeft),
-                KeyCode::Right | KeyCode::Char('l') => Some(FlameGraphMessage::SelectRight),
-                KeyCode::Enter => Some(FlameGraphMessage::ZoomIn),
-                KeyCode::Esc | KeyCode::Backspace => Some(FlameGraphMessage::ZoomOut),
-                KeyCode::Home => Some(FlameGraphMessage::ResetZoom),
-                KeyCode::Char('/') => Some(FlameGraphMessage::SetSearch(String::new())),
+            match key.key {
+                Key::Up | Key::Char('k') => Some(FlameGraphMessage::SelectUp),
+                Key::Down | Key::Char('j') => Some(FlameGraphMessage::SelectDown),
+                Key::Left | Key::Char('h') => Some(FlameGraphMessage::SelectLeft),
+                Key::Right | Key::Char('l') => Some(FlameGraphMessage::SelectRight),
+                Key::Enter => Some(FlameGraphMessage::ZoomIn),
+                Key::Esc | Key::Backspace => Some(FlameGraphMessage::ZoomOut),
+                Key::Home => Some(FlameGraphMessage::ResetZoom),
+                Key::Char('/') => Some(FlameGraphMessage::SetSearch(String::new())),
                 _ => None,
             }
         } else {

--- a/src/component/flame_graph/tests.rs
+++ b/src/component/flame_graph/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::component::Component;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 use ratatui::style::Color;
 
 // =============================================================================
@@ -484,8 +484,7 @@ fn test_max_depth_empty() {
 #[test]
 fn test_handle_event_not_focused() {
     let state = FlameGraphState::with_root(FlameNode::new("main()", 500));
-    let msg =
-        FlameGraph::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
+    let msg = FlameGraph::handle_event(&state, &Event::key(Key::Down), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -494,7 +493,7 @@ fn test_handle_event_disabled() {
     let state = FlameGraphState::with_root(FlameNode::new("main()", 500));
     let msg = FlameGraph::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -507,7 +506,7 @@ fn test_handle_event_down() {
     assert_eq!(
         FlameGraph::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true)
         ),
         Some(FlameGraphMessage::SelectDown)
@@ -529,7 +528,7 @@ fn test_handle_event_up() {
     assert_eq!(
         FlameGraph::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true)
         ),
         Some(FlameGraphMessage::SelectUp)
@@ -551,7 +550,7 @@ fn test_handle_event_left() {
     assert_eq!(
         FlameGraph::handle_event(
             &state,
-            &Event::key(KeyCode::Left),
+            &Event::key(Key::Left),
             &EventContext::new().focused(true)
         ),
         Some(FlameGraphMessage::SelectLeft)
@@ -573,7 +572,7 @@ fn test_handle_event_right() {
     assert_eq!(
         FlameGraph::handle_event(
             &state,
-            &Event::key(KeyCode::Right),
+            &Event::key(Key::Right),
             &EventContext::new().focused(true)
         ),
         Some(FlameGraphMessage::SelectRight)
@@ -595,7 +594,7 @@ fn test_handle_event_enter_zoom_in() {
     assert_eq!(
         FlameGraph::handle_event(
             &state,
-            &Event::key(KeyCode::Enter),
+            &Event::key(Key::Enter),
             &EventContext::new().focused(true)
         ),
         Some(FlameGraphMessage::ZoomIn)
@@ -609,7 +608,7 @@ fn test_handle_event_escape_zoom_out() {
     assert_eq!(
         FlameGraph::handle_event(
             &state,
-            &Event::key(KeyCode::Esc),
+            &Event::key(Key::Esc),
             &EventContext::new().focused(true)
         ),
         Some(FlameGraphMessage::ZoomOut)
@@ -617,7 +616,7 @@ fn test_handle_event_escape_zoom_out() {
     assert_eq!(
         FlameGraph::handle_event(
             &state,
-            &Event::key(KeyCode::Backspace),
+            &Event::key(Key::Backspace),
             &EventContext::new().focused(true)
         ),
         Some(FlameGraphMessage::ZoomOut)
@@ -631,7 +630,7 @@ fn test_handle_event_home_reset_zoom() {
     assert_eq!(
         FlameGraph::handle_event(
             &state,
-            &Event::key(KeyCode::Home),
+            &Event::key(Key::Home),
             &EventContext::new().focused(true)
         ),
         Some(FlameGraphMessage::ResetZoom)

--- a/src/component/form/mod.rs
+++ b/src/component/form/mod.rs
@@ -46,7 +46,7 @@ use super::{
     Checkbox, CheckboxMessage, CheckboxState, Component, EventContext, InputField,
     InputFieldMessage, InputFieldState, RenderContext, Select, SelectMessage, SelectState,
 };
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 use crate::theme::Theme;
 
 /// Internal representation of a field's widget state.
@@ -460,48 +460,46 @@ impl Component for Form {
 
         if let Some(key) = event.as_key() {
             // Global keys (regardless of field type)
-            if key.code == KeyCode::Tab {
-                return Some(FormMessage::FocusNext);
-            }
-            if key.code == KeyCode::BackTab {
+            if key.key == Key::Tab && key.modifiers.shift() {
                 return Some(FormMessage::FocusPrev);
+            }
+            if key.key == Key::Tab {
+                return Some(FormMessage::FocusNext);
             }
 
             // Ctrl+Enter submits the form
-            if key.code == KeyCode::Enter
-                && key.modifiers.contains(crate::input::KeyModifiers::CONTROL)
-            {
+            if key.key == Key::Enter && key.modifiers.ctrl() {
                 return Some(FormMessage::Submit);
             }
 
             // Field-specific keys
             match &state.states.get(state.focused_index)? {
-                FieldState::Text(_) => match key.code {
-                    KeyCode::Char(c) => Some(FormMessage::Input(c)),
-                    KeyCode::Backspace => Some(FormMessage::Backspace),
-                    KeyCode::Delete => Some(FormMessage::Delete),
-                    KeyCode::Left => Some(FormMessage::Left),
-                    KeyCode::Right => Some(FormMessage::Right),
-                    KeyCode::Home => Some(FormMessage::Home),
-                    KeyCode::End => Some(FormMessage::End),
+                FieldState::Text(_) => match key.key {
+                    Key::Char(c) => Some(FormMessage::Input(c)),
+                    Key::Backspace => Some(FormMessage::Backspace),
+                    Key::Delete => Some(FormMessage::Delete),
+                    Key::Left => Some(FormMessage::Left),
+                    Key::Right => Some(FormMessage::Right),
+                    Key::Home => Some(FormMessage::Home),
+                    Key::End => Some(FormMessage::End),
                     _ => None,
                 },
-                FieldState::Checkbox(_) => match key.code {
-                    KeyCode::Char(' ') | KeyCode::Enter => Some(FormMessage::Toggle),
+                FieldState::Checkbox(_) => match key.key {
+                    Key::Char(' ') | Key::Enter => Some(FormMessage::Toggle),
                     _ => None,
                 },
                 FieldState::Select(s) => {
                     if s.is_open() {
-                        match key.code {
-                            KeyCode::Up | KeyCode::Char('k') => Some(FormMessage::SelectUp),
-                            KeyCode::Down | KeyCode::Char('j') => Some(FormMessage::SelectDown),
-                            KeyCode::Enter => Some(FormMessage::SelectConfirm),
-                            KeyCode::Esc => Some(FormMessage::Toggle),
+                        match key.key {
+                            Key::Up | Key::Char('k') => Some(FormMessage::SelectUp),
+                            Key::Down | Key::Char('j') => Some(FormMessage::SelectDown),
+                            Key::Enter => Some(FormMessage::SelectConfirm),
+                            Key::Esc => Some(FormMessage::Toggle),
                             _ => None,
                         }
                     } else {
-                        match key.code {
-                            KeyCode::Enter | KeyCode::Char(' ') => Some(FormMessage::Toggle),
+                        match key.key {
+                            Key::Enter | Key::Char(' ') => Some(FormMessage::Toggle),
                             _ => None,
                         }
                     }

--- a/src/component/form/tests.rs
+++ b/src/component/form/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::component::test_utils;
+use crate::input::Modifiers;
 
 fn sample_form() -> FormState {
     FormState::new(vec![
@@ -380,7 +381,7 @@ fn test_tab_maps_to_focus_next() {
     let state = focused_form();
     let msg = Form::handle_event(
         &state,
-        &Event::key(KeyCode::Tab),
+        &Event::key(Key::Tab),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FormMessage::FocusNext));
@@ -391,7 +392,7 @@ fn test_backtab_maps_to_focus_prev() {
     let state = focused_form();
     let msg = Form::handle_event(
         &state,
-        &Event::key(KeyCode::BackTab),
+        &Event::key_with(Key::Tab, Modifiers::SHIFT),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FormMessage::FocusPrev));
@@ -408,7 +409,7 @@ fn test_ctrl_enter_maps_to_submit() {
     // Ctrl+Enter on terminal may send ctrl('\n'). Test via explicit key_with.
     let msg = Form::handle_event(
         &state,
-        &Event::key_with(KeyCode::Enter, crate::input::KeyModifiers::CONTROL),
+        &Event::key_with(Key::Enter, crate::input::Modifiers::CONTROL),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FormMessage::Submit));
@@ -430,7 +431,7 @@ fn test_backspace_in_text_field_maps() {
     let state = focused_form();
     let msg = Form::handle_event(
         &state,
-        &Event::key(KeyCode::Backspace),
+        &Event::key(Key::Backspace),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FormMessage::Backspace));
@@ -454,7 +455,7 @@ fn test_enter_in_checkbox_maps_to_toggle() {
     Form::update(&mut state, FormMessage::FocusNext);
     let msg = Form::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FormMessage::Toggle));
@@ -467,7 +468,7 @@ fn test_enter_in_closed_select_maps_to_toggle() {
     Form::update(&mut state, FormMessage::FocusNext);
     let msg = Form::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FormMessage::Toggle));
@@ -482,21 +483,21 @@ fn test_arrow_keys_in_open_select() {
 
     let msg = Form::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FormMessage::SelectDown));
 
     let msg = Form::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FormMessage::SelectUp));
 
     let msg = Form::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FormMessage::SelectConfirm));
@@ -511,7 +512,7 @@ fn test_esc_in_open_select_maps_to_toggle() {
 
     let msg = Form::handle_event(
         &state,
-        &Event::key(KeyCode::Esc),
+        &Event::key(Key::Esc),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(FormMessage::Toggle));

--- a/src/component/heatmap/mod.rs
+++ b/src/component/heatmap/mod.rs
@@ -27,7 +27,7 @@ use std::marker::PhantomData;
 use ratatui::widgets::{Block, Borders};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 mod color;
 pub mod distribution;
@@ -625,12 +625,12 @@ impl Component for Heatmap {
 
         let key = event.as_key()?;
 
-        match key.code {
-            KeyCode::Up | KeyCode::Char('k') => Some(HeatmapMessage::SelectUp),
-            KeyCode::Down | KeyCode::Char('j') => Some(HeatmapMessage::SelectDown),
-            KeyCode::Left | KeyCode::Char('h') => Some(HeatmapMessage::SelectLeft),
-            KeyCode::Right | KeyCode::Char('l') => Some(HeatmapMessage::SelectRight),
-            KeyCode::Enter => {
+        match key.key {
+            Key::Up | Key::Char('k') => Some(HeatmapMessage::SelectUp),
+            Key::Down | Key::Char('j') => Some(HeatmapMessage::SelectDown),
+            Key::Left | Key::Char('h') => Some(HeatmapMessage::SelectLeft),
+            Key::Right | Key::Char('l') => Some(HeatmapMessage::SelectRight),
+            Key::Enter => {
                 // Confirm selection -- handled in update to produce CellSelected output
                 if let Some((row, col)) = state.selected() {
                     if let Some(value) = state.get(row, col) {

--- a/src/component/heatmap/tests.rs
+++ b/src/component/heatmap/tests.rs
@@ -290,7 +290,7 @@ fn test_arrow_up_maps_to_select_up() {
     let state = focused_3x3();
     let msg = Heatmap::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(HeatmapMessage::SelectUp));
@@ -301,7 +301,7 @@ fn test_arrow_down_maps_to_select_down() {
     let state = focused_3x3();
     let msg = Heatmap::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(HeatmapMessage::SelectDown));
@@ -312,7 +312,7 @@ fn test_arrow_left_maps_to_select_left() {
     let state = focused_3x3();
     let msg = Heatmap::handle_event(
         &state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(HeatmapMessage::SelectLeft));
@@ -323,7 +323,7 @@ fn test_arrow_right_maps_to_select_right() {
     let state = focused_3x3();
     let msg = Heatmap::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(HeatmapMessage::SelectRight));
@@ -371,7 +371,7 @@ fn test_enter_emits_cell_selected() {
     let mut state = focused_3x3();
     let output = Heatmap::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(
@@ -393,7 +393,7 @@ fn test_disabled_ignores_events() {
     let state = focused_3x3();
     let msg = Heatmap::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -402,7 +402,7 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = HeatmapState::with_data(vec![vec![1.0]]);
-    let msg = Heatmap::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
+    let msg = Heatmap::handle_event(&state, &Event::key(Key::Down), &EventContext::default());
     assert_eq!(msg, None);
 }
 

--- a/src/component/help_panel/mod.rs
+++ b/src/component/help_panel/mod.rs
@@ -38,7 +38,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
 use super::{Component, EventContext, RenderContext, Toggleable};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
 
@@ -632,18 +632,18 @@ impl Component for HelpPanel {
         }
 
         let key = event.as_key()?;
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+        let ctrl = key.modifiers.ctrl();
+        let shift = key.modifiers.shift();
 
-        match key.code {
-            KeyCode::Up | KeyCode::Char('k') if !ctrl => Some(HelpPanelMessage::ScrollUp),
-            KeyCode::Down | KeyCode::Char('j') if !ctrl => Some(HelpPanelMessage::ScrollDown),
-            KeyCode::PageUp => Some(HelpPanelMessage::PageUp(10)),
-            KeyCode::PageDown => Some(HelpPanelMessage::PageDown(10)),
-            KeyCode::Char('u') if ctrl => Some(HelpPanelMessage::PageUp(10)),
-            KeyCode::Char('d') if ctrl => Some(HelpPanelMessage::PageDown(10)),
-            KeyCode::Home | KeyCode::Char('g') if !shift => Some(HelpPanelMessage::Home),
-            KeyCode::End | KeyCode::Char('G') if shift || key.code == KeyCode::End => {
+        match key.key {
+            Key::Up | Key::Char('k') if !ctrl => Some(HelpPanelMessage::ScrollUp),
+            Key::Down | Key::Char('j') if !ctrl => Some(HelpPanelMessage::ScrollDown),
+            Key::PageUp => Some(HelpPanelMessage::PageUp(10)),
+            Key::PageDown => Some(HelpPanelMessage::PageDown(10)),
+            Key::Char('u') if ctrl => Some(HelpPanelMessage::PageUp(10)),
+            Key::Char('d') if ctrl => Some(HelpPanelMessage::PageDown(10)),
+            Key::Home | Key::Char('g') if !shift => Some(HelpPanelMessage::Home),
+            Key::End | Key::Char('g') if key.modifiers.shift() || key.key == Key::End => {
                 Some(HelpPanelMessage::End)
             }
             _ => None,

--- a/src/component/help_panel/tests.rs
+++ b/src/component/help_panel/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::component::test_utils;
-use crate::input::KeyCode;
+use crate::input::Key;
+use crate::input::Modifiers;
 
 fn sample_groups() -> Vec<KeyBindingGroup> {
     vec![
@@ -312,7 +313,7 @@ fn test_handle_event_up() {
     assert_eq!(
         HelpPanel::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true)
         ),
         Some(HelpPanelMessage::ScrollUp)
@@ -325,7 +326,7 @@ fn test_handle_event_down() {
     assert_eq!(
         HelpPanel::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true)
         ),
         Some(HelpPanelMessage::ScrollDown)
@@ -359,7 +360,7 @@ fn test_handle_event_page_up_down() {
     assert_eq!(
         HelpPanel::handle_event(
             &state,
-            &Event::key(KeyCode::PageUp),
+            &Event::key(Key::PageUp),
             &EventContext::new().focused(true)
         ),
         Some(HelpPanelMessage::PageUp(10))
@@ -367,7 +368,7 @@ fn test_handle_event_page_up_down() {
     assert_eq!(
         HelpPanel::handle_event(
             &state,
-            &Event::key(KeyCode::PageDown),
+            &Event::key(Key::PageDown),
             &EventContext::new().focused(true)
         ),
         Some(HelpPanelMessage::PageDown(10))
@@ -401,7 +402,7 @@ fn test_handle_event_home_end() {
     assert_eq!(
         HelpPanel::handle_event(
             &state,
-            &Event::key(KeyCode::Home),
+            &Event::key(Key::Home),
             &EventContext::new().focused(true)
         ),
         Some(HelpPanelMessage::Home)
@@ -409,7 +410,7 @@ fn test_handle_event_home_end() {
     assert_eq!(
         HelpPanel::handle_event(
             &state,
-            &Event::key(KeyCode::End),
+            &Event::key(Key::End),
             &EventContext::new().focused(true)
         ),
         Some(HelpPanelMessage::End)
@@ -431,7 +432,7 @@ fn test_handle_event_g_and_G() {
     assert_eq!(
         HelpPanel::handle_event(
             &state,
-            &Event::key_with(KeyCode::Char('G'), KeyModifiers::SHIFT),
+            &Event::key_with(Key::Char('g'), Modifiers::SHIFT),
             &EventContext::new().focused(true)
         ),
         Some(HelpPanelMessage::End)
@@ -461,7 +462,7 @@ fn test_disabled_ignores_events() {
     assert_eq!(
         HelpPanel::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true).disabled(true)
         ),
         None
@@ -472,7 +473,7 @@ fn test_disabled_ignores_events() {
 fn test_unfocused_ignores_events() {
     let state = HelpPanelState::new();
     assert_eq!(
-        HelpPanel::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default()),
+        HelpPanel::handle_event(&state, &Event::key(Key::Up), &EventContext::default()),
         None
     );
 }

--- a/src/component/input_field/mod.rs
+++ b/src/component/input_field/mod.rs
@@ -30,7 +30,7 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 use unicode_width::UnicodeWidthStr;
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 use crate::undo::{EditKind, UndoStack};
 
 mod editing;
@@ -788,16 +788,16 @@ impl Component for InputField {
         }
 
         if let Some(key) = event.as_key() {
-            let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-            let shift = key.modifiers.contains(KeyModifiers::SHIFT);
-            match key.code {
+            let ctrl = key.modifiers.ctrl();
+            let shift = key.modifiers.shift();
+            match key.key {
                 // Undo/redo
-                KeyCode::Char('z') if ctrl => Some(InputFieldMessage::Undo),
-                KeyCode::Char('y') if ctrl => Some(InputFieldMessage::Redo),
+                Key::Char('z') if ctrl => Some(InputFieldMessage::Undo),
+                Key::Char('y') if ctrl => Some(InputFieldMessage::Redo),
                 // Clipboard operations
-                KeyCode::Char('c') if ctrl => Some(InputFieldMessage::Copy),
-                KeyCode::Char('x') if ctrl => Some(InputFieldMessage::Cut),
-                KeyCode::Char('v') if ctrl => {
+                Key::Char('c') if ctrl => Some(InputFieldMessage::Copy),
+                Key::Char('x') if ctrl => Some(InputFieldMessage::Cut),
+                Key::Char('v') if ctrl => {
                     // Try system clipboard first, fall back to internal
                     #[cfg(feature = "clipboard")]
                     if let Some(text) = system_clipboard_get() {
@@ -809,29 +809,29 @@ impl Component for InputField {
                         Some(InputFieldMessage::Paste(state.clipboard.clone()))
                     }
                 }
-                KeyCode::Char('a') if ctrl => Some(InputFieldMessage::SelectAll),
+                Key::Char('a') if ctrl => Some(InputFieldMessage::SelectAll),
                 // Character input (only when no ctrl modifier)
-                KeyCode::Char(c) if !ctrl => Some(InputFieldMessage::Insert(c)),
+                Key::Char(_) if !ctrl => key.raw_char.map(InputFieldMessage::Insert),
                 // Selection movement (shift+key)
-                KeyCode::Left if ctrl && shift => Some(InputFieldMessage::SelectWordLeft),
-                KeyCode::Right if ctrl && shift => Some(InputFieldMessage::SelectWordRight),
-                KeyCode::Left if shift => Some(InputFieldMessage::SelectLeft),
-                KeyCode::Right if shift => Some(InputFieldMessage::SelectRight),
-                KeyCode::Home if shift => Some(InputFieldMessage::SelectHome),
-                KeyCode::End if shift => Some(InputFieldMessage::SelectEnd),
+                Key::Left if ctrl && shift => Some(InputFieldMessage::SelectWordLeft),
+                Key::Right if ctrl && shift => Some(InputFieldMessage::SelectWordRight),
+                Key::Left if shift => Some(InputFieldMessage::SelectLeft),
+                Key::Right if shift => Some(InputFieldMessage::SelectRight),
+                Key::Home if shift => Some(InputFieldMessage::SelectHome),
+                Key::End if shift => Some(InputFieldMessage::SelectEnd),
                 // Deletion
-                KeyCode::Backspace if ctrl => Some(InputFieldMessage::DeleteWordBack),
-                KeyCode::Delete if ctrl => Some(InputFieldMessage::DeleteWordForward),
-                KeyCode::Backspace => Some(InputFieldMessage::Backspace),
-                KeyCode::Delete => Some(InputFieldMessage::Delete),
+                Key::Backspace if ctrl => Some(InputFieldMessage::DeleteWordBack),
+                Key::Delete if ctrl => Some(InputFieldMessage::DeleteWordForward),
+                Key::Backspace => Some(InputFieldMessage::Backspace),
+                Key::Delete => Some(InputFieldMessage::Delete),
                 // Navigation (clears selection)
-                KeyCode::Left if ctrl => Some(InputFieldMessage::WordLeft),
-                KeyCode::Right if ctrl => Some(InputFieldMessage::WordRight),
-                KeyCode::Left => Some(InputFieldMessage::Left),
-                KeyCode::Right => Some(InputFieldMessage::Right),
-                KeyCode::Home => Some(InputFieldMessage::Home),
-                KeyCode::End => Some(InputFieldMessage::End),
-                KeyCode::Enter => Some(InputFieldMessage::Submit),
+                Key::Left if ctrl => Some(InputFieldMessage::WordLeft),
+                Key::Right if ctrl => Some(InputFieldMessage::WordRight),
+                Key::Left => Some(InputFieldMessage::Left),
+                Key::Right => Some(InputFieldMessage::Right),
+                Key::Home => Some(InputFieldMessage::Home),
+                Key::End => Some(InputFieldMessage::End),
+                Key::Enter => Some(InputFieldMessage::Submit),
                 _ => None,
             }
         } else {

--- a/src/component/input_field/selection_tests.rs
+++ b/src/component/input_field/selection_tests.rs
@@ -364,7 +364,7 @@ fn test_shift_left_event() {
     let state = focused_state("hello");
     let msg = InputField::handle_event(
         &state,
-        &Event::key_with(KeyCode::Left, KeyModifiers::SHIFT),
+        &Event::key_with(Key::Left, Modifiers::SHIFT),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::SelectLeft));
@@ -375,7 +375,7 @@ fn test_shift_right_event() {
     let state = focused_state("hello");
     let msg = InputField::handle_event(
         &state,
-        &Event::key_with(KeyCode::Right, KeyModifiers::SHIFT),
+        &Event::key_with(Key::Right, Modifiers::SHIFT),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::SelectRight));
@@ -386,7 +386,7 @@ fn test_shift_home_event() {
     let state = focused_state("hello");
     let msg = InputField::handle_event(
         &state,
-        &Event::key_with(KeyCode::Home, KeyModifiers::SHIFT),
+        &Event::key_with(Key::Home, Modifiers::SHIFT),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::SelectHome));
@@ -397,7 +397,7 @@ fn test_shift_end_event() {
     let state = focused_state("hello");
     let msg = InputField::handle_event(
         &state,
-        &Event::key_with(KeyCode::End, KeyModifiers::SHIFT),
+        &Event::key_with(Key::End, Modifiers::SHIFT),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::SelectEnd));
@@ -408,7 +408,7 @@ fn test_ctrl_shift_left_event() {
     let state = focused_state("hello");
     let msg = InputField::handle_event(
         &state,
-        &Event::key_with(KeyCode::Left, KeyModifiers::CONTROL | KeyModifiers::SHIFT),
+        &Event::key_with(Key::Left, Modifiers::CONTROL | Modifiers::SHIFT),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::SelectWordLeft));
@@ -419,7 +419,7 @@ fn test_ctrl_shift_right_event() {
     let state = focused_state("hello");
     let msg = InputField::handle_event(
         &state,
-        &Event::key_with(KeyCode::Right, KeyModifiers::CONTROL | KeyModifiers::SHIFT),
+        &Event::key_with(Key::Right, Modifiers::CONTROL | Modifiers::SHIFT),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::SelectWordRight));

--- a/src/component/input_field/tests.rs
+++ b/src/component/input_field/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key, Modifiers};
 
 #[path = "selection_tests.rs"]
 mod selection_tests;
@@ -410,7 +410,7 @@ fn test_handle_event_backspace() {
 
     let msg = InputField::handle_event(
         &state,
-        &Event::key(KeyCode::Backspace),
+        &Event::key(Key::Backspace),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::Backspace));
@@ -422,7 +422,7 @@ fn test_handle_event_delete() {
 
     let msg = InputField::handle_event(
         &state,
-        &Event::key(KeyCode::Delete),
+        &Event::key(Key::Delete),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::Delete));
@@ -434,7 +434,7 @@ fn test_handle_event_left() {
 
     let msg = InputField::handle_event(
         &state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::Left));
@@ -446,7 +446,7 @@ fn test_handle_event_right() {
 
     let msg = InputField::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::Right));
@@ -458,7 +458,7 @@ fn test_handle_event_home() {
 
     let msg = InputField::handle_event(
         &state,
-        &Event::key(KeyCode::Home),
+        &Event::key(Key::Home),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::Home));
@@ -470,7 +470,7 @@ fn test_handle_event_end() {
 
     let msg = InputField::handle_event(
         &state,
-        &Event::key(KeyCode::End),
+        &Event::key(Key::End),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::End));
@@ -482,7 +482,7 @@ fn test_handle_event_enter() {
 
     let msg = InputField::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::Submit));
@@ -494,7 +494,7 @@ fn test_handle_event_ctrl_left() {
 
     let msg = InputField::handle_event(
         &state,
-        &Event::key_with(KeyCode::Left, KeyModifiers::CONTROL),
+        &Event::key_with(Key::Left, Modifiers::CONTROL),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::WordLeft));
@@ -506,7 +506,7 @@ fn test_handle_event_ctrl_right() {
 
     let msg = InputField::handle_event(
         &state,
-        &Event::key_with(KeyCode::Right, KeyModifiers::CONTROL),
+        &Event::key_with(Key::Right, Modifiers::CONTROL),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(InputFieldMessage::WordRight));
@@ -546,21 +546,21 @@ fn test_handle_event_ignored_when_disabled() {
 
     let msg = InputField::handle_event(
         &state,
-        &Event::key(KeyCode::Backspace),
+        &Event::key(Key::Backspace),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = InputField::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = InputField::handle_event(
         &state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);

--- a/src/component/line_input/handle_event_tests.rs
+++ b/src/component/line_input/handle_event_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key, Modifiers};
 
 // ---- handle_event ----
 
@@ -40,7 +40,7 @@ fn test_handle_event_char() {
 #[test]
 fn test_handle_event_enter() {
     let state = LineInputState::new();
-    let event = Event::key(KeyCode::Enter);
+    let event = Event::key(Key::Enter);
     assert_eq!(
         LineInput::handle_event(&state, &event, &EventContext::new().focused(true)),
         Some(LineInputMessage::Submit)
@@ -50,7 +50,7 @@ fn test_handle_event_enter() {
 #[test]
 fn test_handle_event_backspace() {
     let state = LineInputState::new();
-    let event = Event::key(KeyCode::Backspace);
+    let event = Event::key(Key::Backspace);
     assert_eq!(
         LineInput::handle_event(&state, &event, &EventContext::new().focused(true)),
         Some(LineInputMessage::Backspace)
@@ -60,7 +60,7 @@ fn test_handle_event_backspace() {
 #[test]
 fn test_handle_event_delete() {
     let state = LineInputState::new();
-    let event = Event::key(KeyCode::Delete);
+    let event = Event::key(Key::Delete);
     assert_eq!(
         LineInput::handle_event(&state, &event, &EventContext::new().focused(true)),
         Some(LineInputMessage::Delete)
@@ -72,19 +72,19 @@ fn test_handle_event_arrows() {
     let state = LineInputState::new();
     let ctx = EventContext::new().focused(true);
     assert_eq!(
-        LineInput::handle_event(&state, &Event::key(KeyCode::Left), &ctx),
+        LineInput::handle_event(&state, &Event::key(Key::Left), &ctx),
         Some(LineInputMessage::Left)
     );
     assert_eq!(
-        LineInput::handle_event(&state, &Event::key(KeyCode::Right), &ctx),
+        LineInput::handle_event(&state, &Event::key(Key::Right), &ctx),
         Some(LineInputMessage::Right)
     );
     assert_eq!(
-        LineInput::handle_event(&state, &Event::key(KeyCode::Home), &ctx),
+        LineInput::handle_event(&state, &Event::key(Key::Home), &ctx),
         Some(LineInputMessage::Home)
     );
     assert_eq!(
-        LineInput::handle_event(&state, &Event::key(KeyCode::End), &ctx),
+        LineInput::handle_event(&state, &Event::key(Key::End), &ctx),
         Some(LineInputMessage::End)
     );
 }
@@ -124,35 +124,19 @@ fn test_handle_event_shift_arrows() {
     let state = LineInputState::new();
     let ctx = EventContext::new().focused(true);
     assert_eq!(
-        LineInput::handle_event(
-            &state,
-            &Event::key_with(KeyCode::Left, KeyModifiers::SHIFT),
-            &ctx
-        ),
+        LineInput::handle_event(&state, &Event::key_with(Key::Left, Modifiers::SHIFT), &ctx),
         Some(LineInputMessage::SelectLeft)
     );
     assert_eq!(
-        LineInput::handle_event(
-            &state,
-            &Event::key_with(KeyCode::Right, KeyModifiers::SHIFT),
-            &ctx
-        ),
+        LineInput::handle_event(&state, &Event::key_with(Key::Right, Modifiers::SHIFT), &ctx),
         Some(LineInputMessage::SelectRight)
     );
     assert_eq!(
-        LineInput::handle_event(
-            &state,
-            &Event::key_with(KeyCode::Home, KeyModifiers::SHIFT),
-            &ctx
-        ),
+        LineInput::handle_event(&state, &Event::key_with(Key::Home, Modifiers::SHIFT), &ctx),
         Some(LineInputMessage::SelectHome)
     );
     assert_eq!(
-        LineInput::handle_event(
-            &state,
-            &Event::key_with(KeyCode::End, KeyModifiers::SHIFT),
-            &ctx
-        ),
+        LineInput::handle_event(&state, &Event::key_with(Key::End, Modifiers::SHIFT), &ctx),
         Some(LineInputMessage::SelectEnd)
     );
 }
@@ -164,7 +148,7 @@ fn test_handle_event_ctrl_arrows() {
     assert_eq!(
         LineInput::handle_event(
             &state,
-            &Event::key_with(KeyCode::Left, KeyModifiers::CONTROL),
+            &Event::key_with(Key::Left, Modifiers::CONTROL),
             &ctx
         ),
         Some(LineInputMessage::WordLeft)
@@ -172,7 +156,7 @@ fn test_handle_event_ctrl_arrows() {
     assert_eq!(
         LineInput::handle_event(
             &state,
-            &Event::key_with(KeyCode::Right, KeyModifiers::CONTROL),
+            &Event::key_with(Key::Right, Modifiers::CONTROL),
             &ctx
         ),
         Some(LineInputMessage::WordRight)
@@ -183,13 +167,13 @@ fn test_handle_event_ctrl_arrows() {
 fn test_handle_event_ctrl_shift_arrows() {
     let state = LineInputState::new();
     let ctx = EventContext::new().focused(true);
-    let mods = KeyModifiers::CONTROL | KeyModifiers::SHIFT;
+    let mods = Modifiers::CONTROL | Modifiers::SHIFT;
     assert_eq!(
-        LineInput::handle_event(&state, &Event::key_with(KeyCode::Left, mods), &ctx),
+        LineInput::handle_event(&state, &Event::key_with(Key::Left, mods), &ctx),
         Some(LineInputMessage::SelectWordLeft)
     );
     assert_eq!(
-        LineInput::handle_event(&state, &Event::key_with(KeyCode::Right, mods), &ctx),
+        LineInput::handle_event(&state, &Event::key_with(Key::Right, mods), &ctx),
         Some(LineInputMessage::SelectWordRight)
     );
 }
@@ -201,7 +185,7 @@ fn test_handle_event_ctrl_backspace() {
     assert_eq!(
         LineInput::handle_event(
             &state,
-            &Event::key_with(KeyCode::Backspace, KeyModifiers::CONTROL),
+            &Event::key_with(Key::Backspace, Modifiers::CONTROL),
             &ctx
         ),
         Some(LineInputMessage::DeleteWordBack)
@@ -215,7 +199,7 @@ fn test_handle_event_ctrl_delete() {
     assert_eq!(
         LineInput::handle_event(
             &state,
-            &Event::key_with(KeyCode::Delete, KeyModifiers::CONTROL),
+            &Event::key_with(Key::Delete, Modifiers::CONTROL),
             &ctx
         ),
         Some(LineInputMessage::DeleteWordForward)
@@ -231,7 +215,7 @@ fn test_up_on_first_row_is_history_prev() {
     let ctx = EventContext::new().focused(true);
     // Single row -> cursor on row 0 -> Up = HistoryPrev
     assert_eq!(
-        LineInput::handle_event(&state, &Event::key(KeyCode::Up), &ctx),
+        LineInput::handle_event(&state, &Event::key(Key::Up), &ctx),
         Some(LineInputMessage::HistoryPrev)
     );
 }
@@ -243,7 +227,7 @@ fn test_up_on_second_row_is_visual_up() {
     let ctx = EventContext::new().focused(true);
     // "hello" | " worl" | "d!" -> cursor at end (row 2)
     assert_eq!(
-        LineInput::handle_event(&state, &Event::key(KeyCode::Up), &ctx),
+        LineInput::handle_event(&state, &Event::key(Key::Up), &ctx),
         Some(LineInputMessage::VisualUp)
     );
 }
@@ -255,7 +239,7 @@ fn test_down_on_last_row_is_history_next() {
     let ctx = EventContext::new().focused(true);
     // Single row -> cursor on last row -> Down = HistoryNext
     assert_eq!(
-        LineInput::handle_event(&state, &Event::key(KeyCode::Down), &ctx),
+        LineInput::handle_event(&state, &Event::key(Key::Down), &ctx),
         Some(LineInputMessage::HistoryNext)
     );
 }
@@ -268,7 +252,7 @@ fn test_down_on_first_row_is_visual_down() {
     let ctx = EventContext::new().focused(true);
     // cursor at row 0, multiple rows -> Down = VisualDown
     assert_eq!(
-        LineInput::handle_event(&state, &Event::key(KeyCode::Down), &ctx),
+        LineInput::handle_event(&state, &Event::key(Key::Down), &ctx),
         Some(LineInputMessage::VisualDown)
     );
 }

--- a/src/component/line_input/mod.rs
+++ b/src/component/line_input/mod.rs
@@ -37,7 +37,7 @@ mod property_tests;
 mod tests;
 
 use crate::component::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 use crate::undo::UndoStack;
 
 use chunking::{chunk_buffer, cursor_to_visual};
@@ -670,18 +670,18 @@ impl Component for LineInput {
         }
 
         let key = event.as_key()?;
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+        let ctrl = key.modifiers.ctrl();
+        let shift = key.modifiers.shift();
 
-        match key.code {
+        match key.key {
             // Undo/Redo
-            KeyCode::Char('z') if ctrl => Some(LineInputMessage::Undo),
-            KeyCode::Char('y') if ctrl => Some(LineInputMessage::Redo),
+            Key::Char('z') if ctrl => Some(LineInputMessage::Undo),
+            Key::Char('y') if ctrl => Some(LineInputMessage::Redo),
 
             // Clipboard
-            KeyCode::Char('c') if ctrl => Some(LineInputMessage::Copy),
-            KeyCode::Char('x') if ctrl => Some(LineInputMessage::Cut),
-            KeyCode::Char('v') if ctrl => {
+            Key::Char('c') if ctrl => Some(LineInputMessage::Copy),
+            Key::Char('x') if ctrl => Some(LineInputMessage::Cut),
+            Key::Char('v') if ctrl => {
                 // Use internal clipboard
                 if !state.clipboard.is_empty() {
                     Some(LineInputMessage::Paste(state.clipboard.clone()))
@@ -691,42 +691,42 @@ impl Component for LineInput {
             }
 
             // Select all
-            KeyCode::Char('a') if ctrl => Some(LineInputMessage::SelectAll),
+            Key::Char('a') if ctrl => Some(LineInputMessage::SelectAll),
 
             // Clear
-            KeyCode::Char('u') if ctrl => Some(LineInputMessage::Clear),
+            Key::Char('u') if ctrl => Some(LineInputMessage::Clear),
 
             // Regular character insertion
-            KeyCode::Char(c) if !ctrl => Some(LineInputMessage::Insert(c)),
+            Key::Char(_) if !ctrl => key.raw_char.map(LineInputMessage::Insert),
 
             // Selection with shift
-            KeyCode::Left if ctrl && shift => Some(LineInputMessage::SelectWordLeft),
-            KeyCode::Right if ctrl && shift => Some(LineInputMessage::SelectWordRight),
-            KeyCode::Left if shift => Some(LineInputMessage::SelectLeft),
-            KeyCode::Right if shift => Some(LineInputMessage::SelectRight),
-            KeyCode::Home if shift => Some(LineInputMessage::SelectHome),
-            KeyCode::End if shift => Some(LineInputMessage::SelectEnd),
+            Key::Left if ctrl && shift => Some(LineInputMessage::SelectWordLeft),
+            Key::Right if ctrl && shift => Some(LineInputMessage::SelectWordRight),
+            Key::Left if shift => Some(LineInputMessage::SelectLeft),
+            Key::Right if shift => Some(LineInputMessage::SelectRight),
+            Key::Home if shift => Some(LineInputMessage::SelectHome),
+            Key::End if shift => Some(LineInputMessage::SelectEnd),
 
             // Word deletion
-            KeyCode::Backspace if ctrl => Some(LineInputMessage::DeleteWordBack),
-            KeyCode::Delete if ctrl => Some(LineInputMessage::DeleteWordForward),
+            Key::Backspace if ctrl => Some(LineInputMessage::DeleteWordBack),
+            Key::Delete if ctrl => Some(LineInputMessage::DeleteWordForward),
 
             // Character deletion
-            KeyCode::Backspace => Some(LineInputMessage::Backspace),
-            KeyCode::Delete => Some(LineInputMessage::Delete),
+            Key::Backspace => Some(LineInputMessage::Backspace),
+            Key::Delete => Some(LineInputMessage::Delete),
 
             // Word navigation
-            KeyCode::Left if ctrl => Some(LineInputMessage::WordLeft),
-            KeyCode::Right if ctrl => Some(LineInputMessage::WordRight),
+            Key::Left if ctrl => Some(LineInputMessage::WordLeft),
+            Key::Right if ctrl => Some(LineInputMessage::WordRight),
 
             // Character navigation
-            KeyCode::Left => Some(LineInputMessage::Left),
-            KeyCode::Right => Some(LineInputMessage::Right),
-            KeyCode::Home => Some(LineInputMessage::Home),
-            KeyCode::End => Some(LineInputMessage::End),
+            Key::Left => Some(LineInputMessage::Left),
+            Key::Right => Some(LineInputMessage::Right),
+            Key::Home => Some(LineInputMessage::Home),
+            Key::End => Some(LineInputMessage::End),
 
             // Up/Down: context-dependent
-            KeyCode::Up => {
+            Key::Up => {
                 let (row, _) =
                     cursor_to_visual(&state.buffer, state.cursor, state.last_display_width);
                 if row == 0 {
@@ -735,7 +735,7 @@ impl Component for LineInput {
                     Some(LineInputMessage::VisualUp)
                 }
             }
-            KeyCode::Down => {
+            Key::Down => {
                 let (row, _) =
                     cursor_to_visual(&state.buffer, state.cursor, state.last_display_width);
                 let chunks = chunk_buffer(&state.buffer, state.last_display_width);
@@ -750,7 +750,7 @@ impl Component for LineInput {
             }
 
             // Submit
-            KeyCode::Enter => Some(LineInputMessage::Submit),
+            Key::Enter => Some(LineInputMessage::Submit),
 
             _ => None,
         }

--- a/src/component/loading_list/mod.rs
+++ b/src/component/loading_list/mod.rs
@@ -36,7 +36,7 @@
 //! ```
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 use crate::scroll::ScrollState;
 
 mod items;
@@ -739,10 +739,10 @@ impl<T: Clone> Component for LoadingList<T> {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Up | KeyCode::Char('k') => Some(LoadingListMessage::Up),
-                KeyCode::Down | KeyCode::Char('j') => Some(LoadingListMessage::Down),
-                KeyCode::Enter => Some(LoadingListMessage::Select),
+            match key.key {
+                Key::Up | Key::Char('k') => Some(LoadingListMessage::Up),
+                Key::Down | Key::Char('j') => Some(LoadingListMessage::Down),
+                Key::Enter => Some(LoadingListMessage::Select),
                 _ => None,
             }
         } else {

--- a/src/component/loading_list/tests/events.rs
+++ b/src/component/loading_list/tests/events.rs
@@ -11,7 +11,7 @@ fn test_handle_event_up() {
 
     let msg = LoadingList::<TestItem>::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(LoadingListMessage::Up));
@@ -24,7 +24,7 @@ fn test_handle_event_down() {
 
     let msg = LoadingList::<TestItem>::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(LoadingListMessage::Down));
@@ -37,7 +37,7 @@ fn test_handle_event_select() {
 
     let msg = LoadingList::<TestItem>::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(LoadingListMessage::Select));
@@ -72,7 +72,7 @@ fn test_handle_event_ignored_when_unfocused() {
     // Not focused by default
     let msg = LoadingList::<TestItem>::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::default(),
     );
     assert_eq!(msg, None);
@@ -90,7 +90,7 @@ fn test_dispatch_event() {
     // Down dispatches Down message, which selects the first item
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert!(matches!(
@@ -128,7 +128,7 @@ fn test_disabled_prevents_handle_event() {
     let state = LoadingListState::with_items(items, |i| i.name.clone());
     let msg = LoadingList::<TestItem>::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -179,14 +179,14 @@ fn test_handle_event_unrecognized_key() {
 
     let msg = LoadingList::<TestItem>::handle_event(
         &state,
-        &Event::key(KeyCode::Tab),
+        &Event::key(Key::Tab),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
 
     let msg = LoadingList::<TestItem>::handle_event(
         &state,
-        &Event::key(KeyCode::Esc),
+        &Event::key(Key::Esc),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
@@ -205,7 +205,7 @@ fn test_handle_event_all_keys_ignored_when_unfocused() {
     assert_eq!(
         LoadingList::<TestItem>::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::default()
         ),
         None
@@ -213,7 +213,7 @@ fn test_handle_event_all_keys_ignored_when_unfocused() {
     assert_eq!(
         LoadingList::<TestItem>::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::default()
         ),
         None
@@ -221,7 +221,7 @@ fn test_handle_event_all_keys_ignored_when_unfocused() {
     assert_eq!(
         LoadingList::<TestItem>::handle_event(
             &state,
-            &Event::key(KeyCode::Enter),
+            &Event::key(Key::Enter),
             &EventContext::default()
         ),
         None
@@ -294,21 +294,21 @@ fn test_dispatch_event_chained_navigation() {
     // Navigate down 3 times, wrapping around
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(LoadingListOutput::SelectionChanged(0)));
 
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(LoadingListOutput::SelectionChanged(1)));
 
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(LoadingListOutput::SelectionChanged(2)));
@@ -316,7 +316,7 @@ fn test_dispatch_event_chained_navigation() {
     // Wraps to top
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(LoadingListOutput::SelectionChanged(0)));
@@ -331,14 +331,14 @@ fn test_dispatch_event_up_navigation() {
 
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(LoadingListOutput::SelectionChanged(1)));
 
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(LoadingListOutput::SelectionChanged(0)));
@@ -346,7 +346,7 @@ fn test_dispatch_event_up_navigation() {
     // Wraps to bottom
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(LoadingListOutput::SelectionChanged(2)));
@@ -361,7 +361,7 @@ fn test_dispatch_event_enter_selects() {
 
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert!(matches!(

--- a/src/component/loading_list/tests/mod.rs
+++ b/src/component/loading_list/tests/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 #[derive(Clone, Debug, PartialEq)]
 struct TestItem {

--- a/src/component/log_correlation/mod.rs
+++ b/src/component/log_correlation/mod.rs
@@ -40,7 +40,7 @@ use std::marker::PhantomData;
 use ratatui::prelude::*;
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 use crate::scroll::ScrollState;
 
 /// Severity level for a correlation log entry.
@@ -736,20 +736,19 @@ impl Component for LogCorrelation {
 
         let key = event.as_key()?;
 
-        match key.code {
-            KeyCode::Up | KeyCode::Char('k') => Some(LogCorrelationMessage::ScrollUp),
-            KeyCode::Down | KeyCode::Char('j') => Some(LogCorrelationMessage::ScrollDown),
-            KeyCode::Home => Some(LogCorrelationMessage::ScrollToTop),
-            KeyCode::End => Some(LogCorrelationMessage::ScrollToBottom),
-            KeyCode::Tab => {
-                if key.modifiers.contains(KeyModifiers::SHIFT) {
+        match key.key {
+            Key::Up | Key::Char('k') => Some(LogCorrelationMessage::ScrollUp),
+            Key::Down | Key::Char('j') => Some(LogCorrelationMessage::ScrollDown),
+            Key::Home => Some(LogCorrelationMessage::ScrollToTop),
+            Key::End => Some(LogCorrelationMessage::ScrollToBottom),
+            Key::Tab => {
+                if key.modifiers.shift() {
                     Some(LogCorrelationMessage::FocusPrevStream)
                 } else {
                     Some(LogCorrelationMessage::FocusNextStream)
                 }
             }
-            KeyCode::BackTab => Some(LogCorrelationMessage::FocusPrevStream),
-            KeyCode::Char('s') => Some(LogCorrelationMessage::ToggleSyncScroll),
+            Key::Char('s') => Some(LogCorrelationMessage::ToggleSyncScroll),
             _ => None,
         }
     }

--- a/src/component/log_correlation/tests/events.rs
+++ b/src/component/log_correlation/tests/events.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::input::Modifiers;
 
 // =============================================================================
 // Sync scroll
@@ -215,7 +216,7 @@ fn test_disabled_ignores_events() {
     let state = focused_state();
     let msg = LogCorrelation::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -236,7 +237,7 @@ fn test_disabled_ignores_update() {
 fn test_unfocused_ignores_events() {
     let state = two_stream_state();
     let msg =
-        LogCorrelation::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
+        LogCorrelation::handle_event(&state, &Event::key(Key::Down), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -250,7 +251,7 @@ fn test_up_key() {
     assert_eq!(
         LogCorrelation::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true)
         ),
         Some(LogCorrelationMessage::ScrollUp)
@@ -271,7 +272,7 @@ fn test_down_key() {
     assert_eq!(
         LogCorrelation::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true)
         ),
         Some(LogCorrelationMessage::ScrollDown)
@@ -292,7 +293,7 @@ fn test_home_end_keys() {
     assert_eq!(
         LogCorrelation::handle_event(
             &state,
-            &Event::key(KeyCode::Home),
+            &Event::key(Key::Home),
             &EventContext::new().focused(true)
         ),
         Some(LogCorrelationMessage::ScrollToTop)
@@ -300,7 +301,7 @@ fn test_home_end_keys() {
     assert_eq!(
         LogCorrelation::handle_event(
             &state,
-            &Event::key(KeyCode::End),
+            &Event::key(Key::End),
             &EventContext::new().focused(true)
         ),
         Some(LogCorrelationMessage::ScrollToBottom)
@@ -313,7 +314,7 @@ fn test_tab_key() {
     assert_eq!(
         LogCorrelation::handle_event(
             &state,
-            &Event::key(KeyCode::Tab),
+            &Event::key(Key::Tab),
             &EventContext::new().focused(true)
         ),
         Some(LogCorrelationMessage::FocusNextStream)
@@ -326,7 +327,7 @@ fn test_backtab_key() {
     assert_eq!(
         LogCorrelation::handle_event(
             &state,
-            &Event::key(KeyCode::BackTab),
+            &Event::key_with(Key::Tab, Modifiers::SHIFT),
             &EventContext::new().focused(true)
         ),
         Some(LogCorrelationMessage::FocusPrevStream)
@@ -355,7 +356,7 @@ fn test_instance_handle_event() {
     let state = focused_state();
     let msg = LogCorrelation::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(LogCorrelationMessage::ScrollDown));
@@ -373,7 +374,7 @@ fn test_instance_dispatch_event() {
     let mut state = focused_state();
     LogCorrelation::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(state.scroll_offset(), 1);

--- a/src/component/log_viewer/enhancement_tests.rs
+++ b/src/component/log_viewer/enhancement_tests.rs
@@ -396,7 +396,7 @@ fn test_search_history_up_key_binding() {
     assert_eq!(
         LogViewer::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::SearchHistoryUp)
@@ -410,7 +410,7 @@ fn test_search_history_down_key_binding() {
     assert_eq!(
         LogViewer::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::SearchHistoryDown)

--- a/src/component/log_viewer/mod.rs
+++ b/src/component/log_viewer/mod.rs
@@ -46,7 +46,7 @@ use super::{
     Component, EventContext, InputFieldMessage, InputFieldState, RenderContext, StatusLogEntry,
     StatusLogLevel,
 };
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 
 pub use state::LogViewerState;
 
@@ -200,26 +200,26 @@ impl Component for LogViewer {
         let key = event.as_key()?;
 
         match state.focus {
-            Focus::Log => match key.code {
-                KeyCode::Up | KeyCode::Char('k') => Some(LogViewerMessage::ScrollUp),
-                KeyCode::Down | KeyCode::Char('j') => Some(LogViewerMessage::ScrollDown),
-                KeyCode::Home => Some(LogViewerMessage::ScrollToTop),
-                KeyCode::End => Some(LogViewerMessage::ScrollToBottom),
-                KeyCode::Char('/') => Some(LogViewerMessage::FocusSearch),
-                KeyCode::Char('f') => Some(LogViewerMessage::ToggleFollow),
-                KeyCode::Char('1') => Some(LogViewerMessage::ToggleInfo),
-                KeyCode::Char('2') => Some(LogViewerMessage::ToggleSuccess),
-                KeyCode::Char('3') => Some(LogViewerMessage::ToggleWarning),
-                KeyCode::Char('4') => Some(LogViewerMessage::ToggleError),
+            Focus::Log => match key.key {
+                Key::Up | Key::Char('k') => Some(LogViewerMessage::ScrollUp),
+                Key::Down | Key::Char('j') => Some(LogViewerMessage::ScrollDown),
+                Key::Home => Some(LogViewerMessage::ScrollToTop),
+                Key::End => Some(LogViewerMessage::ScrollToBottom),
+                Key::Char('/') => Some(LogViewerMessage::FocusSearch),
+                Key::Char('f') => Some(LogViewerMessage::ToggleFollow),
+                Key::Char('1') => Some(LogViewerMessage::ToggleInfo),
+                Key::Char('2') => Some(LogViewerMessage::ToggleSuccess),
+                Key::Char('3') => Some(LogViewerMessage::ToggleWarning),
+                Key::Char('4') => Some(LogViewerMessage::ToggleError),
                 _ => None,
             },
-            Focus::Search => match key.code {
-                KeyCode::Esc => Some(LogViewerMessage::ClearSearch),
-                KeyCode::Enter => Some(LogViewerMessage::ConfirmSearch),
-                KeyCode::Up => Some(LogViewerMessage::SearchHistoryUp),
-                KeyCode::Down => Some(LogViewerMessage::SearchHistoryDown),
-                KeyCode::Char(c) => {
-                    if key.modifiers.contains(KeyModifiers::CONTROL) {
+            Focus::Search => match key.key {
+                Key::Esc => Some(LogViewerMessage::ClearSearch),
+                Key::Enter => Some(LogViewerMessage::ConfirmSearch),
+                Key::Up => Some(LogViewerMessage::SearchHistoryUp),
+                Key::Down => Some(LogViewerMessage::SearchHistoryDown),
+                Key::Char(c) => {
+                    if key.modifiers.ctrl() {
                         match c {
                             'r' => Some(LogViewerMessage::ToggleRegex),
                             _ => None,
@@ -228,12 +228,12 @@ impl Component for LogViewer {
                         Some(LogViewerMessage::SearchInput(c))
                     }
                 }
-                KeyCode::Backspace => Some(LogViewerMessage::SearchBackspace),
-                KeyCode::Delete => Some(LogViewerMessage::SearchDelete),
-                KeyCode::Left => Some(LogViewerMessage::SearchLeft),
-                KeyCode::Right => Some(LogViewerMessage::SearchRight),
-                KeyCode::Home => Some(LogViewerMessage::SearchHome),
-                KeyCode::End => Some(LogViewerMessage::SearchEnd),
+                Key::Backspace => Some(LogViewerMessage::SearchBackspace),
+                Key::Delete => Some(LogViewerMessage::SearchDelete),
+                Key::Left => Some(LogViewerMessage::SearchLeft),
+                Key::Right => Some(LogViewerMessage::SearchRight),
+                Key::Home => Some(LogViewerMessage::SearchHome),
+                Key::End => Some(LogViewerMessage::SearchEnd),
                 _ => None,
             },
         }

--- a/src/component/log_viewer/tests/events.rs
+++ b/src/component/log_viewer/tests/events.rs
@@ -10,7 +10,7 @@ fn test_log_mode_up_key() {
     assert_eq!(
         LogViewer::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::ScrollUp)
@@ -31,7 +31,7 @@ fn test_log_mode_down_key() {
     assert_eq!(
         LogViewer::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::ScrollDown)
@@ -52,7 +52,7 @@ fn test_log_mode_home_end() {
     assert_eq!(
         LogViewer::handle_event(
             &state,
-            &Event::key(KeyCode::Home),
+            &Event::key(Key::Home),
             &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::ScrollToTop)
@@ -60,7 +60,7 @@ fn test_log_mode_home_end() {
     assert_eq!(
         LogViewer::handle_event(
             &state,
-            &Event::key(KeyCode::End),
+            &Event::key(Key::End),
             &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::ScrollToBottom)
@@ -142,7 +142,7 @@ fn test_search_mode_esc() {
     assert_eq!(
         LogViewer::handle_event(
             &state,
-            &Event::key(KeyCode::Esc),
+            &Event::key(Key::Esc),
             &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::ClearSearch)
@@ -156,7 +156,7 @@ fn test_search_mode_enter() {
     assert_eq!(
         LogViewer::handle_event(
             &state,
-            &Event::key(KeyCode::Enter),
+            &Event::key(Key::Enter),
             &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::ConfirmSearch)
@@ -170,7 +170,7 @@ fn test_search_mode_backspace() {
     assert_eq!(
         LogViewer::handle_event(
             &state,
-            &Event::key(KeyCode::Backspace),
+            &Event::key(Key::Backspace),
             &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::SearchBackspace)
@@ -184,7 +184,7 @@ fn test_search_mode_delete() {
     assert_eq!(
         LogViewer::handle_event(
             &state,
-            &Event::key(KeyCode::Delete),
+            &Event::key(Key::Delete),
             &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::SearchDelete)
@@ -198,7 +198,7 @@ fn test_search_mode_left_right() {
     assert_eq!(
         LogViewer::handle_event(
             &state,
-            &Event::key(KeyCode::Left),
+            &Event::key(Key::Left),
             &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::SearchLeft)
@@ -206,7 +206,7 @@ fn test_search_mode_left_right() {
     assert_eq!(
         LogViewer::handle_event(
             &state,
-            &Event::key(KeyCode::Right),
+            &Event::key(Key::Right),
             &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::SearchRight)
@@ -220,7 +220,7 @@ fn test_search_mode_home_end() {
     assert_eq!(
         LogViewer::handle_event(
             &state,
-            &Event::key(KeyCode::Home),
+            &Event::key(Key::Home),
             &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::SearchHome)
@@ -228,7 +228,7 @@ fn test_search_mode_home_end() {
     assert_eq!(
         LogViewer::handle_event(
             &state,
-            &Event::key(KeyCode::End),
+            &Event::key(Key::End),
             &EventContext::new().focused(true)
         ),
         Some(LogViewerMessage::SearchEnd)
@@ -244,7 +244,7 @@ fn test_instance_handle_event() {
     let state = focused_state();
     let msg = LogViewer::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(LogViewerMessage::ScrollDown));
@@ -262,7 +262,7 @@ fn test_instance_dispatch_event() {
     let mut state = focused_state();
     LogViewer::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(state.scroll_offset(), 1);

--- a/src/component/log_viewer/tests/update.rs
+++ b/src/component/log_viewer/tests/update.rs
@@ -155,7 +155,7 @@ fn test_disabled_ignores_events() {
     let state = focused_state();
     let msg = LogViewer::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -168,6 +168,6 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = sample_state();
-    let msg = LogViewer::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
+    let msg = LogViewer::handle_event(&state, &Event::key(Key::Down), &EventContext::default());
     assert_eq!(msg, None);
 }

--- a/src/component/markdown_renderer/mod.rs
+++ b/src/component/markdown_renderer/mod.rs
@@ -36,7 +36,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 use crate::scroll::ScrollState;
 
 /// Messages that can be sent to a [`MarkdownRenderer`].
@@ -326,23 +326,21 @@ impl Component for MarkdownRenderer {
         }
 
         let key = event.as_key()?;
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+        let ctrl = key.modifiers.ctrl();
+        let shift = key.modifiers.shift();
 
-        match key.code {
-            KeyCode::Up | KeyCode::Char('k') if !ctrl => Some(MarkdownRendererMessage::ScrollUp),
-            KeyCode::Down | KeyCode::Char('j') if !ctrl => {
-                Some(MarkdownRendererMessage::ScrollDown)
-            }
-            KeyCode::PageUp => Some(MarkdownRendererMessage::PageUp(10)),
-            KeyCode::PageDown => Some(MarkdownRendererMessage::PageDown(10)),
-            KeyCode::Char('u') if ctrl => Some(MarkdownRendererMessage::PageUp(10)),
-            KeyCode::Char('d') if ctrl => Some(MarkdownRendererMessage::PageDown(10)),
-            KeyCode::Home | KeyCode::Char('g') if !shift => Some(MarkdownRendererMessage::Home),
-            KeyCode::End | KeyCode::Char('G') if shift || key.code == KeyCode::End => {
+        match key.key {
+            Key::Up | Key::Char('k') if !ctrl => Some(MarkdownRendererMessage::ScrollUp),
+            Key::Down | Key::Char('j') if !ctrl => Some(MarkdownRendererMessage::ScrollDown),
+            Key::PageUp => Some(MarkdownRendererMessage::PageUp(10)),
+            Key::PageDown => Some(MarkdownRendererMessage::PageDown(10)),
+            Key::Char('u') if ctrl => Some(MarkdownRendererMessage::PageUp(10)),
+            Key::Char('d') if ctrl => Some(MarkdownRendererMessage::PageDown(10)),
+            Key::Home | Key::Char('g') if !shift => Some(MarkdownRendererMessage::Home),
+            Key::End | Key::Char('g') if key.modifiers.shift() || key.key == Key::End => {
                 Some(MarkdownRendererMessage::End)
             }
-            KeyCode::Char('s') if !ctrl && !shift => Some(MarkdownRendererMessage::ToggleSource),
+            Key::Char('s') if !ctrl && !shift => Some(MarkdownRendererMessage::ToggleSource),
             _ => None,
         }
     }

--- a/src/component/markdown_renderer/tests.rs
+++ b/src/component/markdown_renderer/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::component::test_utils;
+use crate::input::Modifiers;
 
 fn focused_state() -> MarkdownRendererState {
     MarkdownRendererState::new()
@@ -191,7 +192,7 @@ fn test_disabled_ignores_events() {
     let state = focused_state();
     let msg = MarkdownRenderer::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -201,7 +202,7 @@ fn test_disabled_ignores_events() {
 fn test_unfocused_ignores_events() {
     let state = MarkdownRendererState::new();
     let msg =
-        MarkdownRenderer::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default());
+        MarkdownRenderer::handle_event(&state, &Event::key(Key::Up), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -215,7 +216,7 @@ fn test_handle_event_up() {
     assert_eq!(
         MarkdownRenderer::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true)
         ),
         Some(MarkdownRendererMessage::ScrollUp)
@@ -228,7 +229,7 @@ fn test_handle_event_down() {
     assert_eq!(
         MarkdownRenderer::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true)
         ),
         Some(MarkdownRendererMessage::ScrollDown)
@@ -262,7 +263,7 @@ fn test_handle_event_page_up_down() {
     assert_eq!(
         MarkdownRenderer::handle_event(
             &state,
-            &Event::key(KeyCode::PageUp),
+            &Event::key(Key::PageUp),
             &EventContext::new().focused(true)
         ),
         Some(MarkdownRendererMessage::PageUp(10))
@@ -270,7 +271,7 @@ fn test_handle_event_page_up_down() {
     assert_eq!(
         MarkdownRenderer::handle_event(
             &state,
-            &Event::key(KeyCode::PageDown),
+            &Event::key(Key::PageDown),
             &EventContext::new().focused(true)
         ),
         Some(MarkdownRendererMessage::PageDown(10))
@@ -304,7 +305,7 @@ fn test_handle_event_home_end() {
     assert_eq!(
         MarkdownRenderer::handle_event(
             &state,
-            &Event::key(KeyCode::Home),
+            &Event::key(Key::Home),
             &EventContext::new().focused(true)
         ),
         Some(MarkdownRendererMessage::Home)
@@ -312,7 +313,7 @@ fn test_handle_event_home_end() {
     assert_eq!(
         MarkdownRenderer::handle_event(
             &state,
-            &Event::key(KeyCode::End),
+            &Event::key(Key::End),
             &EventContext::new().focused(true)
         ),
         Some(MarkdownRendererMessage::End)
@@ -334,7 +335,7 @@ fn test_handle_event_g_and_G() {
     assert_eq!(
         MarkdownRenderer::handle_event(
             &state,
-            &Event::key_with(KeyCode::Char('G'), KeyModifiers::SHIFT),
+            &Event::key_with(Key::Char('g'), Modifiers::SHIFT),
             &EventContext::new().focused(true)
         ),
         Some(MarkdownRendererMessage::End)

--- a/src/component/menu/mod.rs
+++ b/src/component/menu/mod.rs
@@ -26,7 +26,7 @@
 use ratatui::widgets::Paragraph;
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 /// A menu item.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -515,10 +515,10 @@ impl Component for Menu {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Left => Some(MenuMessage::Left),
-                KeyCode::Right => Some(MenuMessage::Right),
-                KeyCode::Enter => Some(MenuMessage::Select),
+            match key.key {
+                Key::Left => Some(MenuMessage::Left),
+                Key::Right => Some(MenuMessage::Right),
+                Key::Enter => Some(MenuMessage::Select),
                 _ => None,
             }
         } else {

--- a/src/component/menu/tests.rs
+++ b/src/component/menu/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 #[test]
 fn test_menu_item_new() {
@@ -432,7 +432,7 @@ fn test_handle_event_left_when_focused() {
 
     let msg = Menu::handle_event(
         &state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(MenuMessage::Left));
@@ -444,7 +444,7 @@ fn test_handle_event_right_when_focused() {
 
     let msg = Menu::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(MenuMessage::Right));
@@ -456,7 +456,7 @@ fn test_handle_event_select_when_focused() {
 
     let msg = Menu::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(MenuMessage::Select));
@@ -467,21 +467,13 @@ fn test_handle_event_ignored_when_unfocused() {
     let state = MenuState::new(vec![MenuItem::new("File"), MenuItem::new("Edit")]);
     // Not focused by default
 
-    let msg = Menu::handle_event(
-        &state,
-        &Event::key(KeyCode::Right),
-        &EventContext::default(),
-    );
+    let msg = Menu::handle_event(&state, &Event::key(Key::Right), &EventContext::default());
     assert_eq!(msg, None);
 
-    let msg = Menu::handle_event(
-        &state,
-        &Event::key(KeyCode::Enter),
-        &EventContext::default(),
-    );
+    let msg = Menu::handle_event(&state, &Event::key(Key::Enter), &EventContext::default());
     assert_eq!(msg, None);
 
-    let msg = Menu::handle_event(&state, &Event::key(KeyCode::Left), &EventContext::default());
+    let msg = Menu::handle_event(&state, &Event::key(Key::Left), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -494,7 +486,7 @@ fn test_dispatch_event() {
     // Dispatch Right: should move selection from 0 to 1
     let output = Menu::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(MenuOutput::SelectionChanged(1)));
@@ -503,7 +495,7 @@ fn test_dispatch_event() {
     // Dispatch Enter: should select the current item
     let output = Menu::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(MenuOutput::Selected(1)));
@@ -518,7 +510,7 @@ fn test_instance_methods() {
     // dispatch_event via associated function
     let output = Menu::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(MenuOutput::SelectionChanged(1)));
@@ -532,7 +524,7 @@ fn test_instance_methods() {
     // handle_event via associated function
     let msg = Menu::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(MenuMessage::Select));
@@ -570,21 +562,21 @@ fn test_handle_event_ignored_when_disabled() {
 
     let msg = Menu::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Menu::handle_event(
         &state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Menu::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -596,7 +588,7 @@ fn test_dispatch_event_ignored_when_disabled() {
 
     let output = Menu::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(output, None);

--- a/src/component/metrics_dashboard/mod.rs
+++ b/src/component/metrics_dashboard/mod.rs
@@ -36,7 +36,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Sparkline};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 use crate::theme::Theme;
 
 /// Messages that can be sent to a MetricsDashboard.
@@ -532,14 +532,14 @@ impl Component for MetricsDashboard {
 
         let key = event.as_key()?;
 
-        match key.code {
-            KeyCode::Left | KeyCode::Char('h') => Some(MetricsDashboardMessage::Left),
-            KeyCode::Right | KeyCode::Char('l') => Some(MetricsDashboardMessage::Right),
-            KeyCode::Up | KeyCode::Char('k') => Some(MetricsDashboardMessage::Up),
-            KeyCode::Down | KeyCode::Char('j') => Some(MetricsDashboardMessage::Down),
-            KeyCode::Home => Some(MetricsDashboardMessage::First),
-            KeyCode::End => Some(MetricsDashboardMessage::Last),
-            KeyCode::Enter => Some(MetricsDashboardMessage::Select),
+        match key.key {
+            Key::Left | Key::Char('h') => Some(MetricsDashboardMessage::Left),
+            Key::Right | Key::Char('l') => Some(MetricsDashboardMessage::Right),
+            Key::Up | Key::Char('k') => Some(MetricsDashboardMessage::Up),
+            Key::Down | Key::Char('j') => Some(MetricsDashboardMessage::Down),
+            Key::Home => Some(MetricsDashboardMessage::First),
+            Key::End => Some(MetricsDashboardMessage::Last),
+            Key::Enter => Some(MetricsDashboardMessage::Select),
             _ => None,
         }
     }

--- a/src/component/metrics_dashboard/tests.rs
+++ b/src/component/metrics_dashboard/tests.rs
@@ -349,7 +349,7 @@ fn test_disabled_ignores_events() {
     let state = focused_state();
     let msg = MetricsDashboard::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -362,11 +362,8 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = MetricsDashboardState::new(sample_widgets(), 3);
-    let msg = MetricsDashboard::handle_event(
-        &state,
-        &Event::key(KeyCode::Right),
-        &EventContext::default(),
-    );
+    let msg =
+        MetricsDashboard::handle_event(&state, &Event::key(Key::Right), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -380,7 +377,7 @@ fn test_key_maps() {
     assert_eq!(
         MetricsDashboard::handle_event(
             &state,
-            &Event::key(KeyCode::Left),
+            &Event::key(Key::Left),
             &EventContext::new().focused(true)
         ),
         Some(MetricsDashboardMessage::Left)
@@ -388,7 +385,7 @@ fn test_key_maps() {
     assert_eq!(
         MetricsDashboard::handle_event(
             &state,
-            &Event::key(KeyCode::Right),
+            &Event::key(Key::Right),
             &EventContext::new().focused(true)
         ),
         Some(MetricsDashboardMessage::Right)
@@ -396,7 +393,7 @@ fn test_key_maps() {
     assert_eq!(
         MetricsDashboard::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true)
         ),
         Some(MetricsDashboardMessage::Up)
@@ -404,7 +401,7 @@ fn test_key_maps() {
     assert_eq!(
         MetricsDashboard::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true)
         ),
         Some(MetricsDashboardMessage::Down)
@@ -412,7 +409,7 @@ fn test_key_maps() {
     assert_eq!(
         MetricsDashboard::handle_event(
             &state,
-            &Event::key(KeyCode::Home),
+            &Event::key(Key::Home),
             &EventContext::new().focused(true)
         ),
         Some(MetricsDashboardMessage::First)
@@ -420,7 +417,7 @@ fn test_key_maps() {
     assert_eq!(
         MetricsDashboard::handle_event(
             &state,
-            &Event::key(KeyCode::End),
+            &Event::key(Key::End),
             &EventContext::new().focused(true)
         ),
         Some(MetricsDashboardMessage::Last)
@@ -428,7 +425,7 @@ fn test_key_maps() {
     assert_eq!(
         MetricsDashboard::handle_event(
             &state,
-            &Event::key(KeyCode::Enter),
+            &Event::key(Key::Enter),
             &EventContext::new().focused(true)
         ),
         Some(MetricsDashboardMessage::Select)
@@ -527,7 +524,7 @@ fn test_instance_handle_event() {
     let state = focused_state();
     let msg = MetricsDashboard::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(MetricsDashboardMessage::Right));
@@ -545,7 +542,7 @@ fn test_instance_dispatch_event() {
     let mut state = focused_state();
     let output = MetricsDashboard::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(MetricsDashboardOutput::SelectionChanged(1)));

--- a/src/component/multi_progress/mod.rs
+++ b/src/component/multi_progress/mod.rs
@@ -35,7 +35,7 @@ pub use types::*;
 use ratatui::widgets::{Block, Borders, List, ListItem};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 /// State for the MultiProgress component.
 #[derive(Clone, Debug, PartialEq)]
@@ -706,10 +706,10 @@ impl Component for MultiProgress {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Up | KeyCode::Char('k') => Some(MultiProgressMessage::ScrollUp),
-                KeyCode::Down | KeyCode::Char('j') => Some(MultiProgressMessage::ScrollDown),
-                KeyCode::Enter => Some(MultiProgressMessage::Select),
+            match key.key {
+                Key::Up | Key::Char('k') => Some(MultiProgressMessage::ScrollUp),
+                Key::Down | Key::Char('j') => Some(MultiProgressMessage::ScrollDown),
+                Key::Enter => Some(MultiProgressMessage::Select),
                 _ => None,
             }
         } else {

--- a/src/component/multi_progress/tests/events.rs
+++ b/src/component/multi_progress/tests/events.rs
@@ -11,7 +11,7 @@ fn test_handle_event_scroll_up() {
     // Up arrow -> ScrollUp
     let msg = MultiProgress::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(MultiProgressMessage::ScrollUp));
@@ -32,7 +32,7 @@ fn test_handle_event_scroll_down() {
     // Down arrow -> ScrollDown
     let msg = MultiProgress::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(MultiProgressMessage::ScrollDown));
@@ -49,8 +49,7 @@ fn test_handle_event_scroll_down() {
 #[test]
 fn test_handle_event_ignored_when_unfocused() {
     let state = MultiProgressState::new();
-    let msg =
-        MultiProgress::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default());
+    let msg = MultiProgress::handle_event(&state, &Event::key(Key::Up), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -69,7 +68,7 @@ fn test_dispatch_event() {
     // Down arrow dispatches ScrollDown
     MultiProgress::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(state.selected(), Some(6));
@@ -90,7 +89,7 @@ fn test_instance_methods() {
     // handle_event via associated function
     let msg = MultiProgress::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(MultiProgressMessage::ScrollUp));
@@ -102,7 +101,7 @@ fn test_instance_methods() {
     // dispatch_event via associated function
     MultiProgress::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(state.selected(), Some(3));
@@ -118,14 +117,14 @@ fn test_handle_event_ignored_when_disabled() {
 
     let msg = MultiProgress::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = MultiProgress::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -155,7 +154,7 @@ fn test_dispatch_event_ignored_when_disabled() {
 
     MultiProgress::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(state.selected(), Some(5)); // Should not change
@@ -171,28 +170,28 @@ fn test_handle_event_unrecognized_key() {
 
     let msg = MultiProgress::handle_event(
         &state,
-        &Event::key(KeyCode::Tab),
+        &Event::key(Key::Tab),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
 
     let msg = MultiProgress::handle_event(
         &state,
-        &Event::key(KeyCode::Esc),
+        &Event::key(Key::Esc),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
 
     let msg = MultiProgress::handle_event(
         &state,
-        &Event::key(KeyCode::Home),
+        &Event::key(Key::Home),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
 
     let msg = MultiProgress::handle_event(
         &state,
-        &Event::key(KeyCode::End),
+        &Event::key(Key::End),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
@@ -230,7 +229,7 @@ fn test_handle_event_instance_unrecognized() {
 
     let msg = MultiProgress::handle_event(
         &state,
-        &Event::key(KeyCode::Tab),
+        &Event::key(Key::Tab),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
@@ -246,7 +245,7 @@ fn test_dispatch_event_unrecognized_returns_none() {
 
     let output = MultiProgress::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Tab),
+        &Event::key(Key::Tab),
         &EventContext::new().focused(true),
     );
     assert!(output.is_none());
@@ -257,11 +256,8 @@ fn test_dispatch_event_unfocused_returns_none() {
     let mut state = MultiProgressState::new();
     // Not focused
 
-    let output = MultiProgress::dispatch_event(
-        &mut state,
-        &Event::key(KeyCode::Up),
-        &EventContext::default(),
-    );
+    let output =
+        MultiProgress::dispatch_event(&mut state, &Event::key(Key::Up), &EventContext::default());
     assert!(output.is_none());
 }
 
@@ -279,7 +275,7 @@ fn test_dispatch_event_scroll_up() {
 
     MultiProgress::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(state.selected(), Some(4));
@@ -327,7 +323,7 @@ fn test_instance_dispatch_event_scroll_up() {
 
     MultiProgress::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(state.selected(), Some(4));
@@ -369,7 +365,7 @@ fn test_handle_event_enter_produces_select() {
 
     let msg = MultiProgress::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(MultiProgressMessage::Select));
@@ -426,7 +422,7 @@ fn test_dispatch_event_enter_selects_item() {
 
     let output = MultiProgress::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(MultiProgressOutput::Selected(1)));
@@ -438,7 +434,7 @@ fn test_instance_handle_event_enter() {
 
     let msg = MultiProgress::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(MultiProgressMessage::Select));
@@ -451,7 +447,7 @@ fn test_instance_dispatch_event_enter() {
 
     let output = MultiProgress::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(MultiProgressOutput::Selected(0)));

--- a/src/component/multi_progress/tests/mod.rs
+++ b/src/component/multi_progress/tests/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 mod component;
 mod events;

--- a/src/component/number_input/mod.rs
+++ b/src/component/number_input/mod.rs
@@ -34,7 +34,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 /// Messages that can be sent to a NumberInput.
 #[derive(Clone, Debug, PartialEq)]
@@ -540,21 +540,22 @@ impl Component for NumberInput {
         if let Some(key) = event.as_key() {
             if state.editing {
                 // Edit mode key handling
-                match key.code {
-                    KeyCode::Enter => Some(NumberInputMessage::ConfirmEdit),
-                    KeyCode::Esc => Some(NumberInputMessage::CancelEdit),
-                    KeyCode::Backspace => Some(NumberInputMessage::EditBackspace),
-                    KeyCode::Char(c) if is_valid_numeric_char(c, &state.edit_buffer) => {
-                        Some(NumberInputMessage::EditChar(c))
-                    }
+                match key.key {
+                    Key::Enter => Some(NumberInputMessage::ConfirmEdit),
+                    Key::Esc => Some(NumberInputMessage::CancelEdit),
+                    Key::Backspace => Some(NumberInputMessage::EditBackspace),
+                    Key::Char(_) => key
+                        .raw_char
+                        .filter(|c| is_valid_numeric_char(*c, &state.edit_buffer))
+                        .map(NumberInputMessage::EditChar),
                     _ => None,
                 }
             } else {
                 // Normal mode key handling
-                match key.code {
-                    KeyCode::Up | KeyCode::Char('k') => Some(NumberInputMessage::Increment),
-                    KeyCode::Down | KeyCode::Char('j') => Some(NumberInputMessage::Decrement),
-                    KeyCode::Enter => Some(NumberInputMessage::StartEdit),
+                match key.key {
+                    Key::Up | Key::Char('k') => Some(NumberInputMessage::Increment),
+                    Key::Down | Key::Char('j') => Some(NumberInputMessage::Decrement),
+                    Key::Enter => Some(NumberInputMessage::StartEdit),
                     _ => None,
                 }
             }

--- a/src/component/number_input/tests.rs
+++ b/src/component/number_input/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 // ========================================
 // Construction Tests
@@ -479,7 +479,7 @@ fn test_handle_event_up_increments() {
     let state = NumberInputState::new(0.0);
     let msg = NumberInput::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(NumberInputMessage::Increment));
@@ -490,7 +490,7 @@ fn test_handle_event_down_decrements() {
     let state = NumberInputState::new(0.0);
     let msg = NumberInput::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(NumberInputMessage::Decrement));
@@ -523,7 +523,7 @@ fn test_handle_event_enter_starts_edit() {
     let state = NumberInputState::new(0.0);
     let msg = NumberInput::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(NumberInputMessage::StartEdit));
@@ -589,7 +589,7 @@ fn test_handle_event_edit_mode_enter_confirms() {
     state.editing = true;
     let msg = NumberInput::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(NumberInputMessage::ConfirmEdit));
@@ -601,7 +601,7 @@ fn test_handle_event_edit_mode_escape_cancels() {
     state.editing = true;
     let msg = NumberInput::handle_event(
         &state,
-        &Event::key(KeyCode::Esc),
+        &Event::key(Key::Esc),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(NumberInputMessage::CancelEdit));
@@ -613,7 +613,7 @@ fn test_handle_event_edit_mode_backspace() {
     state.editing = true;
     let msg = NumberInput::handle_event(
         &state,
-        &Event::key(KeyCode::Backspace),
+        &Event::key(Key::Backspace),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(NumberInputMessage::EditBackspace));
@@ -665,7 +665,7 @@ fn test_handle_event_edit_mode_rejects_non_leading_minus() {
 #[test]
 fn test_handle_event_unfocused() {
     let state = NumberInputState::new(0.0);
-    let msg = NumberInput::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default());
+    let msg = NumberInput::handle_event(&state, &Event::key(Key::Up), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -674,7 +674,7 @@ fn test_handle_event_disabled() {
     let state = NumberInputState::new(0.0);
     let msg = NumberInput::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -701,7 +701,7 @@ fn test_dispatch_event_increment() {
     let mut state = NumberInputState::new(0.0);
     let output = NumberInput::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(NumberInputOutput::ValueChanged(1.0)));
@@ -711,11 +711,8 @@ fn test_dispatch_event_increment() {
 #[test]
 fn test_dispatch_event_unfocused() {
     let mut state = NumberInputState::new(0.0);
-    let output = NumberInput::dispatch_event(
-        &mut state,
-        &Event::key(KeyCode::Up),
-        &EventContext::default(),
-    );
+    let output =
+        NumberInput::dispatch_event(&mut state, &Event::key(Key::Up), &EventContext::default());
     assert_eq!(output, None);
     assert_eq!(state.value(), 0.0);
 }
@@ -727,7 +724,7 @@ fn test_dispatch_event_enter_then_type() {
     // Enter edit mode
     let output = NumberInput::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(NumberInputOutput::EditStarted));
@@ -752,7 +749,7 @@ fn test_instance_handle_event() {
     let state = NumberInputState::new(0.0);
     let msg = NumberInput::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(NumberInputMessage::Increment));
@@ -763,7 +760,7 @@ fn test_instance_dispatch_event() {
     let mut state = NumberInputState::new(0.0);
     let output = NumberInput::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(NumberInputOutput::ValueChanged(1.0)));

--- a/src/component/paginator/mod.rs
+++ b/src/component/paginator/mod.rs
@@ -40,7 +40,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 use crate::theme::Theme;
 
 /// Display style for the paginator.
@@ -491,11 +491,11 @@ impl Component for Paginator {
 
         let key = event.as_key()?;
 
-        match key.code {
-            KeyCode::Left | KeyCode::Char('h') => Some(PaginatorMessage::PrevPage),
-            KeyCode::Right | KeyCode::Char('l') => Some(PaginatorMessage::NextPage),
-            KeyCode::Home => Some(PaginatorMessage::FirstPage),
-            KeyCode::End => Some(PaginatorMessage::LastPage),
+        match key.key {
+            Key::Left | Key::Char('h') => Some(PaginatorMessage::PrevPage),
+            Key::Right | Key::Char('l') => Some(PaginatorMessage::NextPage),
+            Key::Home => Some(PaginatorMessage::FirstPage),
+            Key::End => Some(PaginatorMessage::LastPage),
             _ => None,
         }
     }

--- a/src/component/paginator/tests.rs
+++ b/src/component/paginator/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::component::test_utils;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 fn focused_state(total_pages: usize) -> PaginatorState {
     PaginatorState::new(total_pages)
@@ -321,7 +321,7 @@ fn test_handle_event_right_next() {
     let state = focused_state(5);
     let msg = Paginator::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(PaginatorMessage::NextPage));
@@ -343,7 +343,7 @@ fn test_handle_event_left_prev() {
     let state = focused_state(5);
     let msg = Paginator::handle_event(
         &state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(PaginatorMessage::PrevPage));
@@ -365,7 +365,7 @@ fn test_handle_event_home() {
     let state = focused_state(5);
     let msg = Paginator::handle_event(
         &state,
-        &Event::key(KeyCode::Home),
+        &Event::key(Key::Home),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(PaginatorMessage::FirstPage));
@@ -376,7 +376,7 @@ fn test_handle_event_end() {
     let state = focused_state(5);
     let msg = Paginator::handle_event(
         &state,
-        &Event::key(KeyCode::End),
+        &Event::key(Key::End),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(PaginatorMessage::LastPage));
@@ -396,11 +396,7 @@ fn test_handle_event_unrecognized() {
 #[test]
 fn test_handle_event_unfocused_ignores() {
     let state = PaginatorState::new(5);
-    let msg = Paginator::handle_event(
-        &state,
-        &Event::key(KeyCode::Right),
-        &EventContext::default(),
-    );
+    let msg = Paginator::handle_event(&state, &Event::key(Key::Right), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -409,7 +405,7 @@ fn test_handle_event_disabled_ignores() {
     let state = focused_state(5);
     let msg = Paginator::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -424,7 +420,7 @@ fn test_instance_handle_event() {
     let state = focused_state(5);
     let msg = Paginator::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(PaginatorMessage::NextPage));
@@ -435,7 +431,7 @@ fn test_instance_dispatch_event() {
     let mut state = focused_state(5);
     let output = Paginator::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(PaginatorOutput::PageChanged(1)));

--- a/src/component/pane_layout/mod.rs
+++ b/src/component/pane_layout/mod.rs
@@ -40,7 +40,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 
 /// The direction in which panes are arranged.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -803,14 +803,14 @@ impl Component for PaneLayout {
         }
 
         let key = event.as_key()?;
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let ctrl = key.modifiers.ctrl();
 
-        match key.code {
-            KeyCode::Tab if !ctrl => Some(PaneLayoutMessage::FocusNext),
-            KeyCode::BackTab => Some(PaneLayoutMessage::FocusPrev),
-            KeyCode::Right | KeyCode::Down if ctrl => Some(PaneLayoutMessage::GrowFocused),
-            KeyCode::Left | KeyCode::Up if ctrl => Some(PaneLayoutMessage::ShrinkFocused),
-            KeyCode::Char('0') if ctrl => Some(PaneLayoutMessage::ResetProportions),
+        match key.key {
+            Key::Tab if key.modifiers.shift() => Some(PaneLayoutMessage::FocusPrev),
+            Key::Tab if !ctrl => Some(PaneLayoutMessage::FocusNext),
+            Key::Right | Key::Down if ctrl => Some(PaneLayoutMessage::GrowFocused),
+            Key::Left | Key::Up if ctrl => Some(PaneLayoutMessage::ShrinkFocused),
+            Key::Char('0') if ctrl => Some(PaneLayoutMessage::ResetProportions),
             _ => None,
         }
     }

--- a/src/component/pane_layout/tests.rs
+++ b/src/component/pane_layout/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::component::Component;
 use crate::component::test_utils::setup_render;
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key, Modifiers};
 use ratatui::prelude::Rect;
 
 // ========== PaneConfig Tests ==========
@@ -499,7 +499,7 @@ fn test_handle_event_tab() {
     let state = PaneLayoutState::new(PaneDirection::Horizontal, panes);
     let msg = PaneLayout::handle_event(
         &state,
-        &Event::key(KeyCode::Tab),
+        &Event::key(Key::Tab),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(PaneLayoutMessage::FocusNext));
@@ -511,7 +511,7 @@ fn test_handle_event_backtab() {
     let state = PaneLayoutState::new(PaneDirection::Horizontal, panes);
     let msg = PaneLayout::handle_event(
         &state,
-        &Event::key(KeyCode::BackTab),
+        &Event::key_with(Key::Tab, Modifiers::SHIFT),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(PaneLayoutMessage::FocusPrev));
@@ -523,7 +523,7 @@ fn test_handle_event_ctrl_right() {
     let state = PaneLayoutState::new(PaneDirection::Horizontal, panes);
     let msg = PaneLayout::handle_event(
         &state,
-        &Event::key_with(KeyCode::Right, KeyModifiers::CONTROL),
+        &Event::key_with(Key::Right, Modifiers::CONTROL),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(PaneLayoutMessage::GrowFocused));
@@ -535,7 +535,7 @@ fn test_handle_event_ctrl_left() {
     let state = PaneLayoutState::new(PaneDirection::Horizontal, panes);
     let msg = PaneLayout::handle_event(
         &state,
-        &Event::key_with(KeyCode::Left, KeyModifiers::CONTROL),
+        &Event::key_with(Key::Left, Modifiers::CONTROL),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(PaneLayoutMessage::ShrinkFocused));
@@ -557,7 +557,7 @@ fn test_handle_event_ctrl_0() {
 fn test_handle_event_unfocused_ignored() {
     let panes = vec![PaneConfig::new("a")];
     let state = PaneLayoutState::new(PaneDirection::Horizontal, panes);
-    let msg = PaneLayout::handle_event(&state, &Event::key(KeyCode::Tab), &EventContext::default());
+    let msg = PaneLayout::handle_event(&state, &Event::key(Key::Tab), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -567,7 +567,7 @@ fn test_handle_event_disabled_ignored() {
     let state = PaneLayoutState::new(PaneDirection::Horizontal, panes);
     let msg = PaneLayout::handle_event(
         &state,
-        &Event::key(KeyCode::Tab),
+        &Event::key(Key::Tab),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -593,7 +593,7 @@ fn test_dispatch_event() {
     let mut state = PaneLayoutState::new(PaneDirection::Horizontal, panes);
     let output = PaneLayout::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Tab),
+        &Event::key(Key::Tab),
         &EventContext::new().focused(true),
     );
     assert!(matches!(

--- a/src/component/radio_group/mod.rs
+++ b/src/component/radio_group/mod.rs
@@ -31,7 +31,7 @@ use std::marker::PhantomData;
 use ratatui::widgets::{List, ListItem};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 /// Messages that can be sent to a RadioGroup.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -335,10 +335,10 @@ impl<T: Clone + std::fmt::Display + 'static> Component for RadioGroup<T> {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Up | KeyCode::Char('k') => Some(RadioGroupMessage::Up),
-                KeyCode::Down | KeyCode::Char('j') => Some(RadioGroupMessage::Down),
-                KeyCode::Enter => Some(RadioGroupMessage::Confirm),
+            match key.key {
+                Key::Up | Key::Char('k') => Some(RadioGroupMessage::Up),
+                Key::Down | Key::Char('j') => Some(RadioGroupMessage::Down),
+                Key::Enter => Some(RadioGroupMessage::Confirm),
                 _ => None,
             }
         } else {

--- a/src/component/radio_group/tests.rs
+++ b/src/component/radio_group/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 #[test]
 fn test_new() {
@@ -271,7 +271,7 @@ fn test_handle_event_up() {
     let state = RadioGroupState::new(vec!["A".to_string(), "B".to_string(), "C".to_string()]);
     let msg = RadioGroup::<String>::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(RadioGroupMessage::Up));
@@ -282,7 +282,7 @@ fn test_handle_event_down() {
     let state = RadioGroupState::new(vec!["A".to_string(), "B".to_string(), "C".to_string()]);
     let msg = RadioGroup::<String>::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(RadioGroupMessage::Down));
@@ -315,7 +315,7 @@ fn test_handle_event_enter() {
     let state = RadioGroupState::new(vec!["A".to_string(), "B".to_string(), "C".to_string()]);
     let msg = RadioGroup::<String>::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(RadioGroupMessage::Confirm));
@@ -324,11 +324,8 @@ fn test_handle_event_enter() {
 #[test]
 fn test_handle_event_ignored_when_unfocused() {
     let state = RadioGroupState::new(vec!["A".to_string(), "B".to_string(), "C".to_string()]);
-    let msg = RadioGroup::<String>::handle_event(
-        &state,
-        &Event::key(KeyCode::Up),
-        &EventContext::default(),
-    );
+    let msg =
+        RadioGroup::<String>::handle_event(&state, &Event::key(Key::Up), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -337,7 +334,7 @@ fn test_handle_event_ignored_when_disabled() {
     let state = RadioGroupState::new(vec!["A".to_string(), "B".to_string(), "C".to_string()]);
     let msg = RadioGroup::<String>::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -348,7 +345,7 @@ fn test_dispatch_event_radio() {
     let mut state = RadioGroupState::new(vec!["A".to_string(), "B".to_string(), "C".to_string()]);
     let output = RadioGroup::<String>::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(RadioGroupOutput::SelectionChanged(1)));

--- a/src/component/scroll_view/mod.rs
+++ b/src/component/scroll_view/mod.rs
@@ -33,7 +33,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 use crate::scroll::ScrollState;
 
 /// Messages that can be sent to a ScrollView.
@@ -452,18 +452,18 @@ impl Component for ScrollView {
         }
 
         let key = event.as_key()?;
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+        let ctrl = key.modifiers.ctrl();
+        let shift = key.modifiers.shift();
 
-        match key.code {
-            KeyCode::Up | KeyCode::Char('k') if !ctrl => Some(ScrollViewMessage::ScrollUp),
-            KeyCode::Down | KeyCode::Char('j') if !ctrl => Some(ScrollViewMessage::ScrollDown),
-            KeyCode::PageUp => Some(ScrollViewMessage::PageUp),
-            KeyCode::PageDown => Some(ScrollViewMessage::PageDown),
-            KeyCode::Char('u') if ctrl => Some(ScrollViewMessage::PageUp),
-            KeyCode::Char('d') if ctrl => Some(ScrollViewMessage::PageDown),
-            KeyCode::Home | KeyCode::Char('g') if !shift => Some(ScrollViewMessage::Home),
-            KeyCode::End | KeyCode::Char('G') if shift || key.code == KeyCode::End => {
+        match key.key {
+            Key::Up | Key::Char('k') if !ctrl => Some(ScrollViewMessage::ScrollUp),
+            Key::Down | Key::Char('j') if !ctrl => Some(ScrollViewMessage::ScrollDown),
+            Key::PageUp => Some(ScrollViewMessage::PageUp),
+            Key::PageDown => Some(ScrollViewMessage::PageDown),
+            Key::Char('u') if ctrl => Some(ScrollViewMessage::PageUp),
+            Key::Char('d') if ctrl => Some(ScrollViewMessage::PageDown),
+            Key::Home | Key::Char('g') if !shift => Some(ScrollViewMessage::Home),
+            Key::End | Key::Char('g') if key.modifiers.shift() || key.key == Key::End => {
                 Some(ScrollViewMessage::End)
             }
             _ => None,

--- a/src/component/scroll_view/tests.rs
+++ b/src/component/scroll_view/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::component::test_utils;
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key, Modifiers};
 
 fn focused_state() -> ScrollViewState {
     ScrollViewState::new()
@@ -313,7 +313,7 @@ fn test_handle_event_up() {
     assert_eq!(
         ScrollView::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true)
         ),
         Some(ScrollViewMessage::ScrollUp)
@@ -326,7 +326,7 @@ fn test_handle_event_down() {
     assert_eq!(
         ScrollView::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true)
         ),
         Some(ScrollViewMessage::ScrollDown)
@@ -360,7 +360,7 @@ fn test_handle_event_page_up_down() {
     assert_eq!(
         ScrollView::handle_event(
             &state,
-            &Event::key(KeyCode::PageUp),
+            &Event::key(Key::PageUp),
             &EventContext::new().focused(true)
         ),
         Some(ScrollViewMessage::PageUp)
@@ -368,7 +368,7 @@ fn test_handle_event_page_up_down() {
     assert_eq!(
         ScrollView::handle_event(
             &state,
-            &Event::key(KeyCode::PageDown),
+            &Event::key(Key::PageDown),
             &EventContext::new().focused(true)
         ),
         Some(ScrollViewMessage::PageDown)
@@ -402,7 +402,7 @@ fn test_handle_event_home_end() {
     assert_eq!(
         ScrollView::handle_event(
             &state,
-            &Event::key(KeyCode::Home),
+            &Event::key(Key::Home),
             &EventContext::new().focused(true)
         ),
         Some(ScrollViewMessage::Home)
@@ -410,7 +410,7 @@ fn test_handle_event_home_end() {
     assert_eq!(
         ScrollView::handle_event(
             &state,
-            &Event::key(KeyCode::End),
+            &Event::key(Key::End),
             &EventContext::new().focused(true)
         ),
         Some(ScrollViewMessage::End)
@@ -432,7 +432,7 @@ fn test_handle_event_g_and_G() {
     assert_eq!(
         ScrollView::handle_event(
             &state,
-            &Event::key_with(KeyCode::Char('G'), KeyModifiers::SHIFT),
+            &Event::key_with(Key::Char('g'), Modifiers::SHIFT),
             &EventContext::new().focused(true)
         ),
         Some(ScrollViewMessage::End)
@@ -456,11 +456,11 @@ fn test_handle_event_unrecognized() {
 fn test_handle_event_unfocused_ignores() {
     let state = ScrollViewState::new();
     assert_eq!(
-        ScrollView::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default()),
+        ScrollView::handle_event(&state, &Event::key(Key::Up), &EventContext::default()),
         None
     );
     assert_eq!(
-        ScrollView::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default()),
+        ScrollView::handle_event(&state, &Event::key(Key::Down), &EventContext::default()),
         None
     );
 }
@@ -471,7 +471,7 @@ fn test_handle_event_disabled_ignores() {
     assert_eq!(
         ScrollView::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true).disabled(true)
         ),
         None
@@ -482,7 +482,7 @@ fn test_dispatch_event_no_change() {
     let mut state = scrollable_state();
     let output = ScrollView::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, None);

--- a/src/component/scrollable_text/mod.rs
+++ b/src/component/scrollable_text/mod.rs
@@ -29,7 +29,7 @@
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 use crate::scroll::ScrollState;
 
 /// Messages that can be sent to a ScrollableText.
@@ -311,18 +311,18 @@ impl Component for ScrollableText {
         }
 
         let key = event.as_key()?;
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+        let ctrl = key.modifiers.ctrl();
+        let shift = key.modifiers.shift();
 
-        match key.code {
-            KeyCode::Up | KeyCode::Char('k') if !ctrl => Some(ScrollableTextMessage::ScrollUp),
-            KeyCode::Down | KeyCode::Char('j') if !ctrl => Some(ScrollableTextMessage::ScrollDown),
-            KeyCode::PageUp => Some(ScrollableTextMessage::PageUp(10)),
-            KeyCode::PageDown => Some(ScrollableTextMessage::PageDown(10)),
-            KeyCode::Char('u') if ctrl => Some(ScrollableTextMessage::PageUp(10)),
-            KeyCode::Char('d') if ctrl => Some(ScrollableTextMessage::PageDown(10)),
-            KeyCode::Home | KeyCode::Char('g') if !shift => Some(ScrollableTextMessage::Home),
-            KeyCode::End | KeyCode::Char('G') if shift || key.code == KeyCode::End => {
+        match key.key {
+            Key::Up | Key::Char('k') if !ctrl => Some(ScrollableTextMessage::ScrollUp),
+            Key::Down | Key::Char('j') if !ctrl => Some(ScrollableTextMessage::ScrollDown),
+            Key::PageUp => Some(ScrollableTextMessage::PageUp(10)),
+            Key::PageDown => Some(ScrollableTextMessage::PageDown(10)),
+            Key::Char('u') if ctrl => Some(ScrollableTextMessage::PageUp(10)),
+            Key::Char('d') if ctrl => Some(ScrollableTextMessage::PageDown(10)),
+            Key::Home | Key::Char('g') if !shift => Some(ScrollableTextMessage::Home),
+            Key::End | Key::Char('g') if key.modifiers.shift() || key.key == Key::End => {
                 Some(ScrollableTextMessage::End)
             }
             _ => None,

--- a/src/component/scrollable_text/tests.rs
+++ b/src/component/scrollable_text/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::component::test_utils;
+use crate::input::Modifiers;
 
 fn focused_state() -> ScrollableTextState {
     ScrollableTextState::new()
@@ -195,7 +196,7 @@ fn test_disabled_ignores_events() {
     let state = focused_state();
     let msg = ScrollableText::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -204,8 +205,7 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = ScrollableTextState::new();
-    let msg =
-        ScrollableText::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default());
+    let msg = ScrollableText::handle_event(&state, &Event::key(Key::Up), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -219,7 +219,7 @@ fn test_handle_event_up() {
     assert_eq!(
         ScrollableText::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true)
         ),
         Some(ScrollableTextMessage::ScrollUp)
@@ -232,7 +232,7 @@ fn test_handle_event_down() {
     assert_eq!(
         ScrollableText::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true)
         ),
         Some(ScrollableTextMessage::ScrollDown)
@@ -266,7 +266,7 @@ fn test_handle_event_page_up_down() {
     assert_eq!(
         ScrollableText::handle_event(
             &state,
-            &Event::key(KeyCode::PageUp),
+            &Event::key(Key::PageUp),
             &EventContext::new().focused(true)
         ),
         Some(ScrollableTextMessage::PageUp(10))
@@ -274,7 +274,7 @@ fn test_handle_event_page_up_down() {
     assert_eq!(
         ScrollableText::handle_event(
             &state,
-            &Event::key(KeyCode::PageDown),
+            &Event::key(Key::PageDown),
             &EventContext::new().focused(true)
         ),
         Some(ScrollableTextMessage::PageDown(10))
@@ -308,7 +308,7 @@ fn test_handle_event_home_end() {
     assert_eq!(
         ScrollableText::handle_event(
             &state,
-            &Event::key(KeyCode::Home),
+            &Event::key(Key::Home),
             &EventContext::new().focused(true)
         ),
         Some(ScrollableTextMessage::Home)
@@ -316,7 +316,7 @@ fn test_handle_event_home_end() {
     assert_eq!(
         ScrollableText::handle_event(
             &state,
-            &Event::key(KeyCode::End),
+            &Event::key(Key::End),
             &EventContext::new().focused(true)
         ),
         Some(ScrollableTextMessage::End)
@@ -338,7 +338,7 @@ fn test_handle_event_g_and_G() {
     assert_eq!(
         ScrollableText::handle_event(
             &state,
-            &Event::key_with(KeyCode::Char('G'), KeyModifiers::SHIFT),
+            &Event::key_with(Key::Char('g'), Modifiers::SHIFT),
             &EventContext::new().focused(true)
         ),
         Some(ScrollableTextMessage::End)

--- a/src/component/searchable_list/event_tests.rs
+++ b/src/component/searchable_list/event_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::KeyCode;
+use crate::input::{Key, Modifiers};
 
 fn sample_items() -> Vec<String> {
     vec![
@@ -20,7 +20,7 @@ fn test_tab_maps_to_toggle_focus() {
     let state = focused_state();
     let msg = SearchableList::handle_event(
         &state,
-        &Event::key(KeyCode::Tab),
+        &Event::key(Key::Tab),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::ToggleFocus));
@@ -31,7 +31,7 @@ fn test_backtab_maps_to_toggle_focus() {
     let state = focused_state();
     let msg = SearchableList::handle_event(
         &state,
-        &Event::key(KeyCode::BackTab),
+        &Event::key_with(Key::Tab, Modifiers::SHIFT),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::ToggleFocus));
@@ -42,7 +42,7 @@ fn test_esc_maps_to_filter_clear() {
     let state = focused_state();
     let msg = SearchableList::handle_event(
         &state,
-        &Event::key(KeyCode::Esc),
+        &Event::key(Key::Esc),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::FilterClear));
@@ -66,7 +66,7 @@ fn test_enter_in_filter_mode_maps_to_toggle_focus() {
     assert!(state.is_filter_focused());
     let msg = SearchableList::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::ToggleFocus));
@@ -77,7 +77,7 @@ fn test_backspace_in_filter_mode_maps_to_filter_backspace() {
     let state = focused_state();
     let msg = SearchableList::handle_event(
         &state,
-        &Event::key(KeyCode::Backspace),
+        &Event::key(Key::Backspace),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::FilterBackspace));
@@ -113,14 +113,14 @@ fn test_arrow_keys_in_list_mode() {
 
     let msg = SearchableList::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::Up));
 
     let msg = SearchableList::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::Down));
@@ -153,14 +153,14 @@ fn test_home_end_in_list_mode() {
 
     let msg = SearchableList::handle_event(
         &state,
-        &Event::key(KeyCode::Home),
+        &Event::key(Key::Home),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::First));
 
     let msg = SearchableList::handle_event(
         &state,
-        &Event::key(KeyCode::End),
+        &Event::key(Key::End),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::Last));
@@ -193,14 +193,14 @@ fn test_page_keys_in_list_mode() {
 
     let msg = SearchableList::handle_event(
         &state,
-        &Event::key(KeyCode::PageUp),
+        &Event::key(Key::PageUp),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::PageUp(10)));
 
     let msg = SearchableList::handle_event(
         &state,
-        &Event::key(KeyCode::PageDown),
+        &Event::key(Key::PageDown),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::PageDown(10)));
@@ -213,7 +213,7 @@ fn test_enter_in_list_mode_maps_to_select() {
 
     let msg = SearchableList::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SearchableListMessage::Select));

--- a/src/component/searchable_list/mod.rs
+++ b/src/component/searchable_list/mod.rs
@@ -41,7 +41,7 @@ use std::sync::Arc;
 use ratatui::widgets::ListState;
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 use crate::scroll::ScrollState;
 
 /// A matcher function that takes `(query, item_text)` and returns
@@ -726,51 +726,50 @@ impl<T: Clone + Display + 'static> Component for SearchableList<T> {
 
         if let Some(key) = event.as_key() {
             // Tab always toggles focus between filter and list
-            if key.code == KeyCode::Tab || key.code == KeyCode::BackTab {
+            if key.key == Key::Tab {
                 return Some(SearchableListMessage::ToggleFocus);
             }
 
             // Esc clears the filter
-            if key.code == KeyCode::Esc {
+            if key.key == Key::Esc {
                 return Some(SearchableListMessage::FilterClear);
             }
 
             match state.internal_focus {
                 Focus::Filter => {
-                    match key.code {
+                    match key.key {
                         // Navigation keys work from filter too
-                        KeyCode::Up | KeyCode::Char('k')
-                            if key.modifiers.contains(KeyModifiers::CONTROL) =>
-                        {
+                        Key::Up | Key::Char('k') if key.modifiers.ctrl() => {
                             Some(SearchableListMessage::Up)
                         }
-                        KeyCode::Down | KeyCode::Char('j')
-                            if key.modifiers.contains(KeyModifiers::CONTROL) =>
-                        {
+                        Key::Down | Key::Char('j') if key.modifiers.ctrl() => {
                             Some(SearchableListMessage::Down)
                         }
                         // Enter in filter moves focus to list
-                        KeyCode::Enter => Some(SearchableListMessage::ToggleFocus),
+                        Key::Enter => Some(SearchableListMessage::ToggleFocus),
                         // Backspace deletes from filter
-                        KeyCode::Backspace => Some(SearchableListMessage::FilterBackspace),
+                        Key::Backspace => Some(SearchableListMessage::FilterBackspace),
                         // Regular characters go to filter
-                        KeyCode::Char(c) => Some(SearchableListMessage::FilterChar(c)),
+                        Key::Char(_) => key.raw_char.map(SearchableListMessage::FilterChar),
                         _ => None,
                     }
                 }
                 Focus::List => {
-                    match key.code {
-                        KeyCode::Up | KeyCode::Char('k') => Some(SearchableListMessage::Up),
-                        KeyCode::Down | KeyCode::Char('j') => Some(SearchableListMessage::Down),
-                        KeyCode::Home | KeyCode::Char('g') => Some(SearchableListMessage::First),
-                        KeyCode::End | KeyCode::Char('G') => Some(SearchableListMessage::Last),
-                        KeyCode::PageUp => Some(SearchableListMessage::PageUp(10)),
-                        KeyCode::PageDown => Some(SearchableListMessage::PageDown(10)),
-                        KeyCode::Enter => Some(SearchableListMessage::Select),
+                    match key.key {
+                        Key::Up | Key::Char('k') => Some(SearchableListMessage::Up),
+                        Key::Down | Key::Char('j') => Some(SearchableListMessage::Down),
+                        Key::Char('g') if key.modifiers.shift() => {
+                            Some(SearchableListMessage::Last)
+                        }
+                        Key::Home | Key::Char('g') => Some(SearchableListMessage::First),
+                        Key::End => Some(SearchableListMessage::Last),
+                        Key::PageUp => Some(SearchableListMessage::PageUp(10)),
+                        Key::PageDown => Some(SearchableListMessage::PageDown(10)),
+                        Key::Enter => Some(SearchableListMessage::Select),
                         // In list mode, typing switches to filter
-                        KeyCode::Char(c) => {
+                        Key::Char(_) => {
                             // Let user type to start filtering from list view
-                            Some(SearchableListMessage::FilterChar(c))
+                            key.raw_char.map(SearchableListMessage::FilterChar)
                         }
                         _ => None,
                     }

--- a/src/component/select/mod.rs
+++ b/src/component/select/mod.rs
@@ -30,7 +30,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 /// Messages that can be sent to a Select.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -489,16 +489,16 @@ impl Component for Select {
         }
         if let Some(key) = event.as_key() {
             if state.is_open {
-                match key.code {
-                    KeyCode::Enter => Some(SelectMessage::Confirm),
-                    KeyCode::Esc => Some(SelectMessage::Close),
-                    KeyCode::Up | KeyCode::Char('k') => Some(SelectMessage::Up),
-                    KeyCode::Down | KeyCode::Char('j') => Some(SelectMessage::Down),
+                match key.key {
+                    Key::Enter => Some(SelectMessage::Confirm),
+                    Key::Esc => Some(SelectMessage::Close),
+                    Key::Up | Key::Char('k') => Some(SelectMessage::Up),
+                    Key::Down | Key::Char('j') => Some(SelectMessage::Down),
                     _ => None,
                 }
             } else {
-                match key.code {
-                    KeyCode::Enter | KeyCode::Char(' ') => Some(SelectMessage::Toggle),
+                match key.key {
+                    Key::Enter | Key::Char(' ') => Some(SelectMessage::Toggle),
                     _ => None,
                 }
             }

--- a/src/component/select/tests.rs
+++ b/src/component/select/tests.rs
@@ -262,7 +262,7 @@ fn test_large_select_navigation() {
 // handle_event Tests
 // ========================================
 
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 #[test]
 fn test_handle_event_toggle_when_closed() {
@@ -271,7 +271,7 @@ fn test_handle_event_toggle_when_closed() {
     // Enter when closed -> Toggle
     let msg = Select::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectMessage::Toggle));
@@ -292,7 +292,7 @@ fn test_handle_event_confirm_when_open() {
 
     let msg = Select::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectMessage::Confirm));
@@ -305,7 +305,7 @@ fn test_handle_event_close_when_open() {
 
     let msg = Select::handle_event(
         &state,
-        &Event::key(KeyCode::Esc),
+        &Event::key(Key::Esc),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectMessage::Close));
@@ -318,7 +318,7 @@ fn test_handle_event_up_when_open() {
 
     let msg = Select::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectMessage::Up));
@@ -339,7 +339,7 @@ fn test_handle_event_down_when_open() {
 
     let msg = Select::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectMessage::Down));
@@ -356,11 +356,7 @@ fn test_handle_event_down_when_open() {
 #[test]
 fn test_handle_event_ignored_when_unfocused() {
     let state = SelectState::new(vec!["A", "B", "C"]);
-    let msg = Select::handle_event(
-        &state,
-        &Event::key(KeyCode::Enter),
-        &EventContext::default(),
-    );
+    let msg = Select::handle_event(&state, &Event::key(Key::Enter), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -369,7 +365,7 @@ fn test_handle_event_ignored_when_disabled() {
     let state = SelectState::new(vec!["A", "B", "C"]);
     let msg = Select::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -388,7 +384,7 @@ fn test_dispatch_event() {
     // Enter when open dispatches Confirm, which selects the item
     let output = Select::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(SelectOutput::Selected("B".to_string())));
@@ -401,7 +397,7 @@ fn test_instance_methods() {
     // static handle_event
     let msg = Select::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectMessage::Toggle));
@@ -414,7 +410,7 @@ fn test_instance_methods() {
     // static dispatch_event
     let output = Select::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(SelectOutput::SelectionChanged(1)));

--- a/src/component/selectable_list/mod.rs
+++ b/src/component/selectable_list/mod.rs
@@ -29,7 +29,7 @@
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 use crate::scroll::ScrollState;
 
 /// Messages that can be sent to a SelectableList.
@@ -519,14 +519,15 @@ impl<T: Clone + std::fmt::Display + 'static> Component for SelectableList<T> {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Up | KeyCode::Char('k') => Some(SelectableListMessage::Up),
-                KeyCode::Down | KeyCode::Char('j') => Some(SelectableListMessage::Down),
-                KeyCode::Home | KeyCode::Char('g') => Some(SelectableListMessage::First),
-                KeyCode::End | KeyCode::Char('G') => Some(SelectableListMessage::Last),
-                KeyCode::Enter => Some(SelectableListMessage::Select),
-                KeyCode::PageUp => Some(SelectableListMessage::PageUp(10)),
-                KeyCode::PageDown => Some(SelectableListMessage::PageDown(10)),
+            match key.key {
+                Key::Up | Key::Char('k') => Some(SelectableListMessage::Up),
+                Key::Down | Key::Char('j') => Some(SelectableListMessage::Down),
+                Key::Char('g') if key.modifiers.shift() => Some(SelectableListMessage::Last),
+                Key::Home | Key::Char('g') => Some(SelectableListMessage::First),
+                Key::End => Some(SelectableListMessage::Last),
+                Key::Enter => Some(SelectableListMessage::Select),
+                Key::PageUp => Some(SelectableListMessage::PageUp(10)),
+                Key::PageDown => Some(SelectableListMessage::PageDown(10)),
                 _ => None,
             }
         } else {

--- a/src/component/selectable_list/tests.rs
+++ b/src/component/selectable_list/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 #[test]
 fn test_init_empty() {
@@ -338,7 +338,7 @@ fn test_handle_event_up() {
     let state = SelectableListState::new(vec!["one".to_string(), "two".to_string()]);
     let msg = SelectableList::<String>::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectableListMessage::Up));
@@ -349,7 +349,7 @@ fn test_handle_event_down() {
     let state = SelectableListState::new(vec!["one".to_string(), "two".to_string()]);
     let msg = SelectableList::<String>::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectableListMessage::Down));
@@ -360,7 +360,7 @@ fn test_handle_event_home() {
     let state = SelectableListState::new(vec!["one".to_string(), "two".to_string()]);
     let msg = SelectableList::<String>::handle_event(
         &state,
-        &Event::key(KeyCode::Home),
+        &Event::key(Key::Home),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectableListMessage::First));
@@ -371,7 +371,7 @@ fn test_handle_event_end() {
     let state = SelectableListState::new(vec!["one".to_string(), "two".to_string()]);
     let msg = SelectableList::<String>::handle_event(
         &state,
-        &Event::key(KeyCode::End),
+        &Event::key(Key::End),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectableListMessage::Last));
@@ -382,7 +382,7 @@ fn test_handle_event_enter() {
     let state = SelectableListState::new(vec!["one".to_string(), "two".to_string()]);
     let msg = SelectableList::<String>::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectableListMessage::Select));
@@ -393,7 +393,7 @@ fn test_handle_event_page_up() {
     let state = SelectableListState::new(vec!["one".to_string(), "two".to_string()]);
     let msg = SelectableList::<String>::handle_event(
         &state,
-        &Event::key(KeyCode::PageUp),
+        &Event::key(Key::PageUp),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectableListMessage::PageUp(10)));
@@ -404,7 +404,7 @@ fn test_handle_event_page_down() {
     let state = SelectableListState::new(vec!["one".to_string(), "two".to_string()]);
     let msg = SelectableList::<String>::handle_event(
         &state,
-        &Event::key(KeyCode::PageDown),
+        &Event::key(Key::PageDown),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SelectableListMessage::PageDown(10)));
@@ -459,7 +459,7 @@ fn test_handle_event_ignored_when_unfocused() {
     let state = SelectableListState::new(vec!["one".to_string(), "two".to_string()]);
     let msg = SelectableList::<String>::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::default(),
     );
     assert_eq!(msg, None);
@@ -470,7 +470,7 @@ fn test_dispatch_event_selectable_list() {
     let mut state = SelectableListState::new(vec!["one".to_string(), "two".to_string()]);
     let output = SelectableList::<String>::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(SelectableListOutput::SelectionChanged(1)));

--- a/src/component/slider/mod.rs
+++ b/src/component/slider/mod.rs
@@ -34,7 +34,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 use crate::theme::Theme;
 
 /// Orientation of the slider.
@@ -455,22 +455,22 @@ impl Component for Slider {
 
         if let Some(key) = event.as_key() {
             match state.orientation {
-                SliderOrientation::Horizontal => match key.code {
-                    KeyCode::Right | KeyCode::Char('l') => Some(SliderMessage::Increment),
-                    KeyCode::Left | KeyCode::Char('h') => Some(SliderMessage::Decrement),
-                    KeyCode::PageUp => Some(SliderMessage::IncrementPage),
-                    KeyCode::PageDown => Some(SliderMessage::DecrementPage),
-                    KeyCode::Home => Some(SliderMessage::SetMin),
-                    KeyCode::End => Some(SliderMessage::SetMax),
+                SliderOrientation::Horizontal => match key.key {
+                    Key::Right | Key::Char('l') => Some(SliderMessage::Increment),
+                    Key::Left | Key::Char('h') => Some(SliderMessage::Decrement),
+                    Key::PageUp => Some(SliderMessage::IncrementPage),
+                    Key::PageDown => Some(SliderMessage::DecrementPage),
+                    Key::Home => Some(SliderMessage::SetMin),
+                    Key::End => Some(SliderMessage::SetMax),
                     _ => None,
                 },
-                SliderOrientation::Vertical => match key.code {
-                    KeyCode::Up | KeyCode::Char('k') => Some(SliderMessage::Increment),
-                    KeyCode::Down | KeyCode::Char('j') => Some(SliderMessage::Decrement),
-                    KeyCode::PageUp => Some(SliderMessage::IncrementPage),
-                    KeyCode::PageDown => Some(SliderMessage::DecrementPage),
-                    KeyCode::Home => Some(SliderMessage::SetMin),
-                    KeyCode::End => Some(SliderMessage::SetMax),
+                SliderOrientation::Vertical => match key.key {
+                    Key::Up | Key::Char('k') => Some(SliderMessage::Increment),
+                    Key::Down | Key::Char('j') => Some(SliderMessage::Decrement),
+                    Key::PageUp => Some(SliderMessage::IncrementPage),
+                    Key::PageDown => Some(SliderMessage::DecrementPage),
+                    Key::Home => Some(SliderMessage::SetMin),
+                    Key::End => Some(SliderMessage::SetMax),
                     _ => None,
                 },
             }

--- a/src/component/slider/tests.rs
+++ b/src/component/slider/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 // ========================================
 // Construction Tests
@@ -305,7 +305,7 @@ fn test_handle_event_right_horizontal() {
     let state = SliderState::new(0.0, 100.0);
     let msg = Slider::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::Increment));
@@ -316,7 +316,7 @@ fn test_handle_event_left_horizontal() {
     let state = SliderState::new(0.0, 100.0);
     let msg = Slider::handle_event(
         &state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::Decrement));
@@ -349,7 +349,7 @@ fn test_handle_event_page_up() {
     let state = SliderState::new(0.0, 100.0);
     let msg = Slider::handle_event(
         &state,
-        &Event::key(KeyCode::PageUp),
+        &Event::key(Key::PageUp),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::IncrementPage));
@@ -360,7 +360,7 @@ fn test_handle_event_page_down() {
     let state = SliderState::new(0.0, 100.0);
     let msg = Slider::handle_event(
         &state,
-        &Event::key(KeyCode::PageDown),
+        &Event::key(Key::PageDown),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::DecrementPage));
@@ -371,7 +371,7 @@ fn test_handle_event_home() {
     let state = SliderState::new(0.0, 100.0);
     let msg = Slider::handle_event(
         &state,
-        &Event::key(KeyCode::Home),
+        &Event::key(Key::Home),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::SetMin));
@@ -382,7 +382,7 @@ fn test_handle_event_end() {
     let state = SliderState::new(0.0, 100.0);
     let msg = Slider::handle_event(
         &state,
-        &Event::key(KeyCode::End),
+        &Event::key(Key::End),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::SetMax));
@@ -397,7 +397,7 @@ fn test_handle_event_up_vertical() {
     let state = SliderState::new(0.0, 100.0).with_orientation(SliderOrientation::Vertical);
     let msg = Slider::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::Increment));
@@ -408,7 +408,7 @@ fn test_handle_event_down_vertical() {
     let state = SliderState::new(0.0, 100.0).with_orientation(SliderOrientation::Vertical);
     let msg = Slider::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::Decrement));
@@ -441,7 +441,7 @@ fn test_handle_event_page_up_vertical() {
     let state = SliderState::new(0.0, 100.0).with_orientation(SliderOrientation::Vertical);
     let msg = Slider::handle_event(
         &state,
-        &Event::key(KeyCode::PageUp),
+        &Event::key(Key::PageUp),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::IncrementPage));
@@ -452,7 +452,7 @@ fn test_handle_event_home_vertical() {
     let state = SliderState::new(0.0, 100.0).with_orientation(SliderOrientation::Vertical);
     let msg = Slider::handle_event(
         &state,
-        &Event::key(KeyCode::Home),
+        &Event::key(Key::Home),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::SetMin));
@@ -463,7 +463,7 @@ fn test_handle_event_end_vertical() {
     let state = SliderState::new(0.0, 100.0).with_orientation(SliderOrientation::Vertical);
     let msg = Slider::handle_event(
         &state,
-        &Event::key(KeyCode::End),
+        &Event::key(Key::End),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SliderMessage::SetMax));
@@ -476,11 +476,7 @@ fn test_handle_event_end_vertical() {
 #[test]
 fn test_handle_event_unfocused() {
     let state = SliderState::new(0.0, 100.0);
-    let msg = Slider::handle_event(
-        &state,
-        &Event::key(KeyCode::Right),
-        &EventContext::default(),
-    );
+    let msg = Slider::handle_event(&state, &Event::key(Key::Right), &EventContext::default());
     assert_eq!(msg, None);
 }
 #[test]
@@ -503,7 +499,7 @@ fn test_dispatch_event() {
     let mut state = SliderState::new(0.0, 100.0);
     let output = Slider::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(SliderOutput::ValueChanged(1.0)));
@@ -515,7 +511,7 @@ fn test_dispatch_event_unfocused() {
     let mut state = SliderState::new(0.0, 100.0);
     let output = Slider::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::default(),
     );
     assert_eq!(output, None);

--- a/src/component/span_tree/mod.rs
+++ b/src/component/span_tree/mod.rs
@@ -33,7 +33,7 @@
 use std::collections::HashSet;
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 use crate::scroll::ScrollState;
 
 mod render;
@@ -761,21 +761,19 @@ impl Component for SpanTree {
             return None;
         }
         if let Some(key) = event.as_key() {
-            let has_shift = key.modifiers.contains(KeyModifiers::SHIFT);
-            match key.code {
-                KeyCode::Up | KeyCode::Char('k') if !has_shift => Some(SpanTreeMessage::SelectUp),
-                KeyCode::Down | KeyCode::Char('j') if !has_shift => {
-                    Some(SpanTreeMessage::SelectDown)
-                }
-                KeyCode::Right | KeyCode::Char('l') if has_shift => Some(
-                    SpanTreeMessage::SetLabelWidth(state.label_width.saturating_add(2)),
-                ),
-                KeyCode::Left | KeyCode::Char('h') if has_shift => Some(
-                    SpanTreeMessage::SetLabelWidth(state.label_width.saturating_sub(2)),
-                ),
-                KeyCode::Right | KeyCode::Char('l') => Some(SpanTreeMessage::Expand),
-                KeyCode::Left | KeyCode::Char('h') => Some(SpanTreeMessage::Collapse),
-                KeyCode::Char(' ') | KeyCode::Enter => Some(SpanTreeMessage::Toggle),
+            let has_shift = key.modifiers.shift();
+            match key.key {
+                Key::Up | Key::Char('k') if !has_shift => Some(SpanTreeMessage::SelectUp),
+                Key::Down | Key::Char('j') if !has_shift => Some(SpanTreeMessage::SelectDown),
+                Key::Right | Key::Char('l') if has_shift => Some(SpanTreeMessage::SetLabelWidth(
+                    state.label_width.saturating_add(2),
+                )),
+                Key::Left | Key::Char('h') if has_shift => Some(SpanTreeMessage::SetLabelWidth(
+                    state.label_width.saturating_sub(2),
+                )),
+                Key::Right | Key::Char('l') => Some(SpanTreeMessage::Expand),
+                Key::Left | Key::Char('h') => Some(SpanTreeMessage::Collapse),
+                Key::Char(' ') | Key::Enter => Some(SpanTreeMessage::Toggle),
                 _ => None,
             }
         } else {

--- a/src/component/span_tree/tests.rs
+++ b/src/component/span_tree/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::component::Component;
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key, Modifiers};
 use ratatui::style::Color;
 
 // =============================================================================
@@ -506,7 +506,7 @@ fn test_set_label_width_clamped_high() {
 #[test]
 fn test_handle_event_not_focused() {
     let state = SpanTreeState::new(vec![SpanNode::new("r", "root", 0.0, 10.0)]);
-    let msg = SpanTree::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
+    let msg = SpanTree::handle_event(&state, &Event::key(Key::Down), &EventContext::default());
     assert_eq!(msg, None);
 }
 #[test]
@@ -515,7 +515,7 @@ fn test_handle_event_down() {
     assert_eq!(
         SpanTree::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true)
         ),
         Some(SpanTreeMessage::SelectDown)
@@ -536,7 +536,7 @@ fn test_handle_event_up() {
     assert_eq!(
         SpanTree::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true)
         ),
         Some(SpanTreeMessage::SelectUp)
@@ -557,7 +557,7 @@ fn test_handle_event_expand() {
     assert_eq!(
         SpanTree::handle_event(
             &state,
-            &Event::key(KeyCode::Right),
+            &Event::key(Key::Right),
             &EventContext::new().focused(true)
         ),
         Some(SpanTreeMessage::Expand)
@@ -578,7 +578,7 @@ fn test_handle_event_collapse() {
     assert_eq!(
         SpanTree::handle_event(
             &state,
-            &Event::key(KeyCode::Left),
+            &Event::key(Key::Left),
             &EventContext::new().focused(true)
         ),
         Some(SpanTreeMessage::Collapse)
@@ -607,7 +607,7 @@ fn test_handle_event_toggle() {
     assert_eq!(
         SpanTree::handle_event(
             &state,
-            &Event::key(KeyCode::Enter),
+            &Event::key(Key::Enter),
             &EventContext::new().focused(true)
         ),
         Some(SpanTreeMessage::Toggle)
@@ -619,7 +619,7 @@ fn test_handle_event_shift_right() {
     let state = SpanTreeState::new(vec![SpanNode::new("r", "root", 0.0, 10.0)]);
     let msg = SpanTree::handle_event(
         &state,
-        &Event::key_with(KeyCode::Right, KeyModifiers::SHIFT),
+        &Event::key_with(Key::Right, Modifiers::SHIFT),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SpanTreeMessage::SetLabelWidth(32)));
@@ -630,7 +630,7 @@ fn test_handle_event_shift_left() {
     let state = SpanTreeState::new(vec![SpanNode::new("r", "root", 0.0, 10.0)]);
     let msg = SpanTree::handle_event(
         &state,
-        &Event::key_with(KeyCode::Left, KeyModifiers::SHIFT),
+        &Event::key_with(Key::Left, Modifiers::SHIFT),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SpanTreeMessage::SetLabelWidth(28)));
@@ -648,7 +648,7 @@ fn test_dispatch_event() {
 
     let output = SpanTree::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(SpanTreeOutput::Selected("c".into())));

--- a/src/component/split_panel/mod.rs
+++ b/src/component/split_panel/mod.rs
@@ -35,7 +35,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 
 /// The orientation of a split panel.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -376,16 +376,16 @@ impl Component for SplitPanel {
 
         if let Some(key) = event.as_key() {
             // Tab toggles pane focus
-            if key.code == KeyCode::Tab || key.code == KeyCode::BackTab {
+            if key.key == Key::Tab {
                 return Some(SplitPanelMessage::FocusOther);
             }
 
             // Ctrl+arrow resizes
-            if key.modifiers.contains(KeyModifiers::CONTROL) {
-                match key.code {
-                    KeyCode::Left | KeyCode::Up => return Some(SplitPanelMessage::ShrinkFirst),
-                    KeyCode::Right | KeyCode::Down => return Some(SplitPanelMessage::GrowFirst),
-                    KeyCode::Char('0') => return Some(SplitPanelMessage::ResetRatio),
+            if key.modifiers.ctrl() {
+                match key.key {
+                    Key::Left | Key::Up => return Some(SplitPanelMessage::ShrinkFirst),
+                    Key::Right | Key::Down => return Some(SplitPanelMessage::GrowFirst),
+                    Key::Char('0') => return Some(SplitPanelMessage::ResetRatio),
                     _ => {}
                 }
             }

--- a/src/component/split_panel/tests.rs
+++ b/src/component/split_panel/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::component::test_utils;
+use crate::input::Modifiers;
 
 fn vertical_state() -> SplitPanelState {
     SplitPanelState::new(SplitOrientation::Vertical)
@@ -246,7 +247,7 @@ fn test_disabled_ignores_events() {
 
     let msg = SplitPanel::handle_event(
         &state,
-        &Event::key(KeyCode::Tab),
+        &Event::key(Key::Tab),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -259,7 +260,7 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = SplitPanelState::new(SplitOrientation::Vertical);
-    let msg = SplitPanel::handle_event(&state, &Event::key(KeyCode::Tab), &EventContext::default());
+    let msg = SplitPanel::handle_event(&state, &Event::key(Key::Tab), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -272,7 +273,7 @@ fn test_tab_maps_to_focus_other() {
     let state = vertical_state();
     let msg = SplitPanel::handle_event(
         &state,
-        &Event::key(KeyCode::Tab),
+        &Event::key(Key::Tab),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SplitPanelMessage::FocusOther));
@@ -283,7 +284,7 @@ fn test_backtab_maps_to_focus_other() {
     let state = vertical_state();
     let msg = SplitPanel::handle_event(
         &state,
-        &Event::key(KeyCode::BackTab),
+        &Event::key_with(Key::Tab, Modifiers::SHIFT),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SplitPanelMessage::FocusOther));
@@ -294,7 +295,7 @@ fn test_ctrl_right_maps_to_grow_first() {
     let state = vertical_state();
     let msg = SplitPanel::handle_event(
         &state,
-        &Event::key_with(KeyCode::Right, KeyModifiers::CONTROL),
+        &Event::key_with(Key::Right, Modifiers::CONTROL),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SplitPanelMessage::GrowFirst));
@@ -305,7 +306,7 @@ fn test_ctrl_left_maps_to_shrink_first() {
     let state = vertical_state();
     let msg = SplitPanel::handle_event(
         &state,
-        &Event::key_with(KeyCode::Left, KeyModifiers::CONTROL),
+        &Event::key_with(Key::Left, Modifiers::CONTROL),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SplitPanelMessage::ShrinkFirst));
@@ -316,7 +317,7 @@ fn test_ctrl_down_maps_to_grow_first() {
     let state = vertical_state();
     let msg = SplitPanel::handle_event(
         &state,
-        &Event::key_with(KeyCode::Down, KeyModifiers::CONTROL),
+        &Event::key_with(Key::Down, Modifiers::CONTROL),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SplitPanelMessage::GrowFirst));
@@ -327,7 +328,7 @@ fn test_ctrl_up_maps_to_shrink_first() {
     let state = vertical_state();
     let msg = SplitPanel::handle_event(
         &state,
-        &Event::key_with(KeyCode::Up, KeyModifiers::CONTROL),
+        &Event::key_with(Key::Up, Modifiers::CONTROL),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SplitPanelMessage::ShrinkFirst));
@@ -349,7 +350,7 @@ fn test_arrow_without_ctrl_ignored() {
     let state = vertical_state();
     let msg = SplitPanel::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
@@ -408,7 +409,7 @@ fn test_dispatch_event_resize() {
     let mut state = vertical_state();
     let output = SplitPanel::dispatch_event(
         &mut state,
-        &Event::key_with(KeyCode::Right, KeyModifiers::CONTROL),
+        &Event::key_with(Key::Right, Modifiers::CONTROL),
         &EventContext::new().focused(true),
     );
     assert!(matches!(output, Some(SplitPanelOutput::RatioChanged(_))));

--- a/src/component/status_log/mod.rs
+++ b/src/component/status_log/mod.rs
@@ -31,7 +31,7 @@ pub use entry::{StatusLogEntry, StatusLogLevel};
 use ratatui::widgets::{Block, Borders, List, ListItem};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 /// Messages that can be sent to a StatusLog component.
 #[derive(Clone, Debug, PartialEq)]
@@ -696,11 +696,11 @@ impl Component for StatusLog {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Up | KeyCode::Char('k') => Some(StatusLogMessage::ScrollUp),
-                KeyCode::Down | KeyCode::Char('j') => Some(StatusLogMessage::ScrollDown),
-                KeyCode::Home => Some(StatusLogMessage::ScrollToTop),
-                KeyCode::End => Some(StatusLogMessage::ScrollToBottom),
+            match key.key {
+                Key::Up | Key::Char('k') => Some(StatusLogMessage::ScrollUp),
+                Key::Down | Key::Char('j') => Some(StatusLogMessage::ScrollDown),
+                Key::Home => Some(StatusLogMessage::ScrollToTop),
+                Key::End => Some(StatusLogMessage::ScrollToBottom),
                 _ => None,
             }
         } else {

--- a/src/component/status_log/tests.rs
+++ b/src/component/status_log/tests.rs
@@ -588,7 +588,7 @@ fn test_view_unfocused() {
 // handle_event Tests
 // ========================================
 
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 #[test]
 fn test_handle_event_scroll_up() {
@@ -597,7 +597,7 @@ fn test_handle_event_scroll_up() {
     // Up arrow -> ScrollUp
     let msg = StatusLog::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StatusLogMessage::ScrollUp));
@@ -618,7 +618,7 @@ fn test_handle_event_scroll_down() {
     // Down arrow -> ScrollDown
     let msg = StatusLog::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StatusLogMessage::ScrollDown));
@@ -638,7 +638,7 @@ fn test_handle_event_scroll_to_top() {
 
     let msg = StatusLog::handle_event(
         &state,
-        &Event::key(KeyCode::Home),
+        &Event::key(Key::Home),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StatusLogMessage::ScrollToTop));
@@ -650,7 +650,7 @@ fn test_handle_event_scroll_to_bottom() {
 
     let msg = StatusLog::handle_event(
         &state,
-        &Event::key(KeyCode::End),
+        &Event::key(Key::End),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StatusLogMessage::ScrollToBottom));
@@ -659,7 +659,7 @@ fn test_handle_event_scroll_to_bottom() {
 #[test]
 fn test_handle_event_ignored_when_unfocused() {
     let state = StatusLogState::new();
-    let msg = StatusLog::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default());
+    let msg = StatusLog::handle_event(&state, &Event::key(Key::Up), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -678,7 +678,7 @@ fn test_dispatch_event() {
     // Down arrow dispatches ScrollDown
     StatusLog::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(state.scroll_offset(), 4);
@@ -694,7 +694,7 @@ fn test_instance_methods() {
     // static handle_event
     let msg = StatusLog::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StatusLogMessage::ScrollUp));
@@ -706,7 +706,7 @@ fn test_instance_methods() {
     // static dispatch_event
     StatusLog::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(state.scroll_offset(), 2);
@@ -722,14 +722,14 @@ fn test_handle_event_ignored_when_disabled() {
 
     let msg = StatusLog::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = StatusLog::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -743,14 +743,14 @@ fn test_handle_event_ignored_when_disabled() {
 
     let msg = StatusLog::handle_event(
         &state,
-        &Event::key(KeyCode::Home),
+        &Event::key(Key::Home),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = StatusLog::handle_event(
         &state,
-        &Event::key(KeyCode::End),
+        &Event::key(Key::End),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -766,7 +766,7 @@ fn test_dispatch_event_ignored_when_disabled() {
 
     let output = StatusLog::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(output, None);

--- a/src/component/step_indicator/mod.rs
+++ b/src/component/step_indicator/mod.rs
@@ -32,7 +32,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 use crate::theme::Theme;
 
 /// The status of a single step in a workflow.
@@ -729,12 +729,12 @@ impl Component for StepIndicator {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Left | KeyCode::Char('h') => Some(StepIndicatorMessage::FocusPrev),
-                KeyCode::Right | KeyCode::Char('l') => Some(StepIndicatorMessage::FocusNext),
-                KeyCode::Home => Some(StepIndicatorMessage::First),
-                KeyCode::End => Some(StepIndicatorMessage::Last),
-                KeyCode::Enter => Some(StepIndicatorMessage::Select),
+            match key.key {
+                Key::Left | Key::Char('h') => Some(StepIndicatorMessage::FocusPrev),
+                Key::Right | Key::Char('l') => Some(StepIndicatorMessage::FocusNext),
+                Key::Home => Some(StepIndicatorMessage::First),
+                Key::End => Some(StepIndicatorMessage::Last),
+                Key::Enter => Some(StepIndicatorMessage::Select),
                 _ => None,
             }
         } else {

--- a/src/component/step_indicator/tests.rs
+++ b/src/component/step_indicator/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::component::Component;
 use crate::component::test_utils::setup_render;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 // ========== Step Tests ==========
 
@@ -499,7 +499,7 @@ fn test_handle_event_right_arrow() {
     let state = StepIndicatorState::new(vec![Step::new("A"), Step::new("B")]);
     let msg = StepIndicator::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StepIndicatorMessage::FocusNext));
@@ -521,7 +521,7 @@ fn test_handle_event_left_arrow() {
     let state = StepIndicatorState::new(vec![Step::new("A"), Step::new("B")]);
     let msg = StepIndicator::handle_event(
         &state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StepIndicatorMessage::FocusPrev));
@@ -543,7 +543,7 @@ fn test_handle_event_home() {
     let state = StepIndicatorState::new(vec![Step::new("A"), Step::new("B")]);
     let msg = StepIndicator::handle_event(
         &state,
-        &Event::key(KeyCode::Home),
+        &Event::key(Key::Home),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StepIndicatorMessage::First));
@@ -554,7 +554,7 @@ fn test_handle_event_end() {
     let state = StepIndicatorState::new(vec![Step::new("A"), Step::new("B")]);
     let msg = StepIndicator::handle_event(
         &state,
-        &Event::key(KeyCode::End),
+        &Event::key(Key::End),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StepIndicatorMessage::Last));
@@ -565,7 +565,7 @@ fn test_handle_event_enter() {
     let state = StepIndicatorState::new(vec![Step::new("A"), Step::new("B")]);
     let msg = StepIndicator::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StepIndicatorMessage::Select));
@@ -574,11 +574,8 @@ fn test_handle_event_enter() {
 #[test]
 fn test_handle_event_unfocused_ignored() {
     let state = StepIndicatorState::new(vec![Step::new("A")]);
-    let msg = StepIndicator::handle_event(
-        &state,
-        &Event::key(KeyCode::Right),
-        &EventContext::default(),
-    );
+    let msg =
+        StepIndicator::handle_event(&state, &Event::key(Key::Right), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -587,7 +584,7 @@ fn test_handle_event_disabled_ignored() {
     let state = StepIndicatorState::new(vec![Step::new("A")]);
     let msg = StepIndicator::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -611,7 +608,7 @@ fn test_dispatch_event() {
     let mut state = StepIndicatorState::new(vec![Step::new("A"), Step::new("B")]);
     let output = StepIndicator::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(StepIndicatorOutput::FocusChanged(1)));

--- a/src/component/styled_text/mod.rs
+++ b/src/component/styled_text/mod.rs
@@ -40,7 +40,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 
 /// Messages that can be sent to a StyledText component.
 #[derive(Clone, Debug, PartialEq)]
@@ -380,18 +380,18 @@ impl Component for StyledText {
         }
 
         let key = event.as_key()?;
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+        let ctrl = key.modifiers.ctrl();
+        let shift = key.modifiers.shift();
 
-        match key.code {
-            KeyCode::Up | KeyCode::Char('k') if !ctrl => Some(StyledTextMessage::ScrollUp),
-            KeyCode::Down | KeyCode::Char('j') if !ctrl => Some(StyledTextMessage::ScrollDown),
-            KeyCode::PageUp => Some(StyledTextMessage::PageUp(10)),
-            KeyCode::PageDown => Some(StyledTextMessage::PageDown(10)),
-            KeyCode::Char('u') if ctrl => Some(StyledTextMessage::PageUp(10)),
-            KeyCode::Char('d') if ctrl => Some(StyledTextMessage::PageDown(10)),
-            KeyCode::Home | KeyCode::Char('g') if !shift => Some(StyledTextMessage::Home),
-            KeyCode::End | KeyCode::Char('G') if shift || key.code == KeyCode::End => {
+        match key.key {
+            Key::Up | Key::Char('k') if !ctrl => Some(StyledTextMessage::ScrollUp),
+            Key::Down | Key::Char('j') if !ctrl => Some(StyledTextMessage::ScrollDown),
+            Key::PageUp => Some(StyledTextMessage::PageUp(10)),
+            Key::PageDown => Some(StyledTextMessage::PageDown(10)),
+            Key::Char('u') if ctrl => Some(StyledTextMessage::PageUp(10)),
+            Key::Char('d') if ctrl => Some(StyledTextMessage::PageDown(10)),
+            Key::Home | Key::Char('g') if !shift => Some(StyledTextMessage::Home),
+            Key::End | Key::Char('g') if key.modifiers.shift() || key.key == Key::End => {
                 Some(StyledTextMessage::End)
             }
             _ => None,

--- a/src/component/styled_text/tests.rs
+++ b/src/component/styled_text/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::component::Component;
 use crate::component::test_utils::setup_render;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 // ========== StyledContent Builder Tests ==========
 
@@ -319,7 +319,7 @@ fn test_handle_event_up() {
     let state = StyledTextState::new();
     let msg = StyledText::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StyledTextMessage::ScrollUp));
@@ -341,7 +341,7 @@ fn test_handle_event_down() {
     let state = StyledTextState::new();
     let msg = StyledText::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StyledTextMessage::ScrollDown));
@@ -363,7 +363,7 @@ fn test_handle_event_page_up() {
     let state = StyledTextState::new();
     let msg = StyledText::handle_event(
         &state,
-        &Event::key(KeyCode::PageUp),
+        &Event::key(Key::PageUp),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StyledTextMessage::PageUp(10)));
@@ -374,7 +374,7 @@ fn test_handle_event_page_down() {
     let state = StyledTextState::new();
     let msg = StyledText::handle_event(
         &state,
-        &Event::key(KeyCode::PageDown),
+        &Event::key(Key::PageDown),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StyledTextMessage::PageDown(10)));
@@ -407,7 +407,7 @@ fn test_handle_event_home() {
     let state = StyledTextState::new();
     let msg = StyledText::handle_event(
         &state,
-        &Event::key(KeyCode::Home),
+        &Event::key(Key::Home),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StyledTextMessage::Home));
@@ -429,7 +429,7 @@ fn test_handle_event_end() {
     let state = StyledTextState::new();
     let msg = StyledText::handle_event(
         &state,
-        &Event::key(KeyCode::End),
+        &Event::key(Key::End),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(StyledTextMessage::End));
@@ -438,8 +438,7 @@ fn test_handle_event_end() {
 #[test]
 fn test_handle_event_unfocused_ignored() {
     let state = StyledTextState::new();
-    let msg =
-        StyledText::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
+    let msg = StyledText::handle_event(&state, &Event::key(Key::Down), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -448,7 +447,7 @@ fn test_handle_event_disabled_ignored() {
     let state = StyledTextState::new();
     let msg = StyledText::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -472,7 +471,7 @@ fn test_dispatch_event() {
     let mut state = StyledTextState::new();
     let output = StyledText::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(StyledTextOutput::ScrollChanged(1)));

--- a/src/component/switch/mod.rs
+++ b/src/component/switch/mod.rs
@@ -31,7 +31,7 @@
 use ratatui::widgets::Paragraph;
 
 use super::{Component, EventContext, RenderContext, Toggleable};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 /// Messages that can be sent to a Switch.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -331,8 +331,8 @@ impl Component for Switch {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Enter | KeyCode::Char(' ') => Some(SwitchMessage::Toggle),
+            match key.key {
+                Key::Enter | Key::Char(' ') => Some(SwitchMessage::Toggle),
                 _ => None,
             }
         } else {

--- a/src/component/switch/tests.rs
+++ b/src/component/switch/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 // ========================================
 // Construction Tests
@@ -184,7 +184,7 @@ fn test_handle_event_enter_when_focused() {
     let state = SwitchState::new();
     let msg = Switch::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(SwitchMessage::Toggle));
@@ -204,11 +204,7 @@ fn test_handle_event_space_when_focused() {
 #[test]
 fn test_handle_event_ignored_when_unfocused() {
     let state = SwitchState::new();
-    let msg = Switch::handle_event(
-        &state,
-        &Event::key(KeyCode::Enter),
-        &EventContext::default(),
-    );
+    let msg = Switch::handle_event(&state, &Event::key(Key::Enter), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -217,7 +213,7 @@ fn test_handle_event_ignored_when_disabled() {
     let state = SwitchState::new();
     let msg = Switch::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -239,7 +235,7 @@ fn test_dispatch_event() {
     let mut state = SwitchState::new();
     let output = Switch::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(SwitchOutput::On));
@@ -251,7 +247,7 @@ fn test_dispatch_event_unfocused() {
     let mut state = SwitchState::new();
     let output = Switch::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::default(),
     );
     assert_eq!(output, None);

--- a/src/component/tab_bar/mod.rs
+++ b/src/component/tab_bar/mod.rs
@@ -30,7 +30,7 @@
 //! ```
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 use crate::theme::Theme;
 
 mod render;
@@ -749,12 +749,12 @@ impl Component for TabBar {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Left | KeyCode::Char('h') => Some(TabBarMessage::PrevTab),
-                KeyCode::Right | KeyCode::Char('l') => Some(TabBarMessage::NextTab),
-                KeyCode::Home => Some(TabBarMessage::First),
-                KeyCode::End => Some(TabBarMessage::Last),
-                KeyCode::Char('w') => Some(TabBarMessage::CloseActiveTab),
+            match key.key {
+                Key::Left | Key::Char('h') => Some(TabBarMessage::PrevTab),
+                Key::Right | Key::Char('l') => Some(TabBarMessage::NextTab),
+                Key::Home => Some(TabBarMessage::First),
+                Key::End => Some(TabBarMessage::Last),
+                Key::Char('w') => Some(TabBarMessage::CloseActiveTab),
                 _ => None,
             }
         } else {

--- a/src/component/tab_bar/tests.rs
+++ b/src/component/tab_bar/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 use ratatui::layout::Rect;
 
 // ========== Tab Tests ==========
@@ -463,7 +463,7 @@ fn test_handle_event_navigation_keys() {
     assert_eq!(
         TabBar::handle_event(
             &state,
-            &Event::key(KeyCode::Right),
+            &Event::key(Key::Right),
             &EventContext::new().focused(true)
         ),
         Some(TabBarMessage::NextTab)
@@ -471,7 +471,7 @@ fn test_handle_event_navigation_keys() {
     assert_eq!(
         TabBar::handle_event(
             &state,
-            &Event::key(KeyCode::Left),
+            &Event::key(Key::Left),
             &EventContext::new().focused(true)
         ),
         Some(TabBarMessage::PrevTab)
@@ -479,7 +479,7 @@ fn test_handle_event_navigation_keys() {
     assert_eq!(
         TabBar::handle_event(
             &state,
-            &Event::key(KeyCode::Home),
+            &Event::key(Key::Home),
             &EventContext::new().focused(true)
         ),
         Some(TabBarMessage::First)
@@ -487,7 +487,7 @@ fn test_handle_event_navigation_keys() {
     assert_eq!(
         TabBar::handle_event(
             &state,
-            &Event::key(KeyCode::End),
+            &Event::key(Key::End),
             &EventContext::new().focused(true)
         ),
         Some(TabBarMessage::Last)
@@ -532,11 +532,7 @@ fn test_handle_event_close_key() {
 fn test_handle_event_unfocused() {
     let state = TabBarState::new(vec![Tab::new("a", "A")]);
     assert_eq!(
-        TabBar::handle_event(
-            &state,
-            &Event::key(KeyCode::Right),
-            &EventContext::default()
-        ),
+        TabBar::handle_event(&state, &Event::key(Key::Right), &EventContext::default()),
         None
     );
     assert_eq!(
@@ -564,7 +560,7 @@ fn test_dispatch_event_next() {
     let mut state = TabBarState::new(vec![Tab::new("a", "A"), Tab::new("b", "B")]);
     let output = TabBar::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(TabBarOutput::TabSelected(1)));
@@ -594,14 +590,14 @@ fn test_instance_methods() {
 
     let msg = TabBar::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TabBarMessage::NextTab));
 
     let output = TabBar::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(TabBarOutput::TabSelected(1)));

--- a/src/component/table/mod.rs
+++ b/src/component/table/mod.rs
@@ -67,7 +67,7 @@ use std::marker::PhantomData;
 use ratatui::prelude::*;
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 use crate::scroll::ScrollState;
 use crate::theme::Theme;
 
@@ -932,25 +932,25 @@ impl<T: TableRow + 'static> Component for Table<T> {
             return None;
         }
         if let Some(key) = event.as_key() {
-            let has_shift = key.modifiers.contains(KeyModifiers::SHIFT);
-            match key.code {
-                KeyCode::Up | KeyCode::Char('k') => Some(TableMessage::Up),
-                KeyCode::Down | KeyCode::Char('j') => Some(TableMessage::Down),
-                KeyCode::Home => Some(TableMessage::First),
-                KeyCode::End => Some(TableMessage::Last),
-                KeyCode::Enter if has_shift => {
+            let has_shift = key.modifiers.shift();
+            match key.key {
+                Key::Up | Key::Char('k') => Some(TableMessage::Up),
+                Key::Down | Key::Char('j') => Some(TableMessage::Down),
+                Key::Home => Some(TableMessage::First),
+                Key::End => Some(TableMessage::Last),
+                Key::Enter if has_shift => {
                     // Shift+Enter adds the current primary sort column to the sort stack
                     // This is a no-op if there's no selection context for a column
                     None
                 }
-                KeyCode::Enter => Some(TableMessage::Select),
-                KeyCode::Char('+') => {
+                Key::Enter => Some(TableMessage::Select),
+                Key::Char('+') => {
                     // Increase the width of the currently selected column
                     // Uses the primary sort column index, or column 0 if no sort
                     let col = state.sort_columns.first().map(|&(c, _)| c).unwrap_or(0);
                     Some(TableMessage::IncreaseColumnWidth(col))
                 }
-                KeyCode::Char('-') => {
+                Key::Char('-') => {
                     // Decrease the width of the currently selected column
                     let col = state.sort_columns.first().map(|&(c, _)| c).unwrap_or(0);
                     Some(TableMessage::DecreaseColumnWidth(col))

--- a/src/component/table/tests.rs
+++ b/src/component/table/tests.rs
@@ -743,17 +743,17 @@ fn test_unicode_cell_content() {
 
 mod handle_event_tests {
     use super::*;
-    use crate::input::{Event, KeyCode};
+    use crate::input::{Event, Key};
 
     #[test]
     fn test_key_bindings_when_focused() {
         let state = TableState::new(test_rows(), test_columns());
         let he = |e| Table::<TestRow>::handle_event(&state, &e, &EventContext::new().focused(true));
-        assert_eq!(he(Event::key(KeyCode::Up)), Some(TableMessage::Up));
-        assert_eq!(he(Event::key(KeyCode::Down)), Some(TableMessage::Down));
-        assert_eq!(he(Event::key(KeyCode::Home)), Some(TableMessage::First));
-        assert_eq!(he(Event::key(KeyCode::End)), Some(TableMessage::Last));
-        assert_eq!(he(Event::key(KeyCode::Enter)), Some(TableMessage::Select));
+        assert_eq!(he(Event::key(Key::Up)), Some(TableMessage::Up));
+        assert_eq!(he(Event::key(Key::Down)), Some(TableMessage::Down));
+        assert_eq!(he(Event::key(Key::Home)), Some(TableMessage::First));
+        assert_eq!(he(Event::key(Key::End)), Some(TableMessage::Last));
+        assert_eq!(he(Event::key(Key::Enter)), Some(TableMessage::Select));
         assert_eq!(he(Event::char('k')), Some(TableMessage::Up));
         assert_eq!(he(Event::char('j')), Some(TableMessage::Down));
     }
@@ -764,7 +764,7 @@ mod handle_event_tests {
         assert_eq!(
             Table::<TestRow>::handle_event(
                 &state,
-                &Event::key(KeyCode::Down),
+                &Event::key(Key::Down),
                 &EventContext::default()
             ),
             None
@@ -772,7 +772,7 @@ mod handle_event_tests {
         assert_eq!(
             Table::<TestRow>::handle_event(
                 &state,
-                &Event::key(KeyCode::Enter),
+                &Event::key(Key::Enter),
                 &EventContext::default()
             ),
             None
@@ -785,7 +785,7 @@ mod handle_event_tests {
         assert_eq!(
             Table::<TestRow>::handle_event(
                 &state,
-                &Event::key(KeyCode::Down),
+                &Event::key(Key::Down),
                 &EventContext::new().focused(true).disabled(true)
             ),
             None
@@ -797,7 +797,7 @@ mod handle_event_tests {
         let mut state = TableState::new(test_rows(), test_columns());
         let output = Table::<TestRow>::dispatch_event(
             &mut state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true),
         );
         assert_eq!(output, Some(TableOutput::SelectionChanged(1)));
@@ -810,7 +810,7 @@ mod handle_event_tests {
 
         let output = Table::<TestRow>::dispatch_event(
             &mut state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true),
         );
         assert_eq!(output, Some(TableOutput::SelectionChanged(1)));
@@ -820,7 +820,7 @@ mod handle_event_tests {
 
         let msg = Table::<TestRow>::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true),
         );
         assert_eq!(msg, Some(TableMessage::Up));

--- a/src/component/tabs/mod.rs
+++ b/src/component/tabs/mod.rs
@@ -30,7 +30,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 /// Messages that can be sent to a Tabs component.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -437,12 +437,12 @@ impl<T: Clone + Display + 'static> Component for Tabs<T> {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Left | KeyCode::Char('h') => Some(TabsMessage::Left),
-                KeyCode::Right | KeyCode::Char('l') => Some(TabsMessage::Right),
-                KeyCode::Home => Some(TabsMessage::First),
-                KeyCode::End => Some(TabsMessage::Last),
-                KeyCode::Enter => Some(TabsMessage::Confirm),
+            match key.key {
+                Key::Left | Key::Char('h') => Some(TabsMessage::Left),
+                Key::Right | Key::Char('l') => Some(TabsMessage::Right),
+                Key::Home => Some(TabsMessage::First),
+                Key::End => Some(TabsMessage::Last),
+                Key::Enter => Some(TabsMessage::Confirm),
                 _ => None,
             }
         } else {

--- a/src/component/tabs/tests.rs
+++ b/src/component/tabs/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 // State Tests
 
@@ -404,7 +404,7 @@ fn test_handle_event_left_when_focused() {
 
     let msg = Tabs::<&str>::handle_event(
         &state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TabsMessage::Left));
@@ -416,7 +416,7 @@ fn test_handle_event_right_when_focused() {
 
     let msg = Tabs::<&str>::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TabsMessage::Right));
@@ -428,7 +428,7 @@ fn test_handle_event_first_when_focused() {
 
     let msg = Tabs::<&str>::handle_event(
         &state,
-        &Event::key(KeyCode::Home),
+        &Event::key(Key::Home),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TabsMessage::First));
@@ -440,7 +440,7 @@ fn test_handle_event_last_when_focused() {
 
     let msg = Tabs::<&str>::handle_event(
         &state,
-        &Event::key(KeyCode::End),
+        &Event::key(Key::End),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TabsMessage::Last));
@@ -452,7 +452,7 @@ fn test_handle_event_confirm_when_focused() {
 
     let msg = Tabs::<&str>::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TabsMessage::Confirm));
@@ -482,18 +482,10 @@ fn test_handle_event_ignored_when_unfocused() {
     let state = TabsState::new(vec!["A", "B", "C"]);
     // focused is false by default
 
-    let msg = Tabs::<&str>::handle_event(
-        &state,
-        &Event::key(KeyCode::Right),
-        &EventContext::default(),
-    );
+    let msg = Tabs::<&str>::handle_event(&state, &Event::key(Key::Right), &EventContext::default());
     assert_eq!(msg, None);
 
-    let msg = Tabs::<&str>::handle_event(
-        &state,
-        &Event::key(KeyCode::Enter),
-        &EventContext::default(),
-    );
+    let msg = Tabs::<&str>::handle_event(&state, &Event::key(Key::Enter), &EventContext::default());
     assert_eq!(msg, None);
 
     let msg = Tabs::<&str>::handle_event(&state, &Event::char('l'), &EventContext::default());
@@ -506,14 +498,14 @@ fn test_handle_event_ignored_when_disabled() {
 
     let msg = Tabs::<&str>::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Tabs::<&str>::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -528,7 +520,7 @@ fn test_dispatch_event() {
     // Dispatch Right: should move selection from 0 to 1
     let output = Tabs::<&str>::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(TabsOutput::SelectionChanged(1)));
@@ -537,7 +529,7 @@ fn test_dispatch_event() {
     // Dispatch Enter: should confirm the current selection
     let output = Tabs::<&str>::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(TabsOutput::Confirmed("B")));
@@ -552,7 +544,7 @@ fn test_instance_methods() {
     // dispatch_event via static method
     let output = Tabs::<&str>::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(TabsOutput::SelectionChanged(1)));
@@ -566,7 +558,7 @@ fn test_instance_methods() {
     // handle_event via static method
     let msg = Tabs::<&str>::handle_event(
         &state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TabsMessage::Left));

--- a/src/component/terminal_output/mod.rs
+++ b/src/component/terminal_output/mod.rs
@@ -46,7 +46,7 @@ mod render;
 pub use ansi::{AnsiSegment, parse_ansi};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 use crate::scroll::ScrollState;
 
 /// Messages that can be sent to a TerminalOutput component.
@@ -706,22 +706,22 @@ impl Component for TerminalOutput {
         }
 
         let key = event.as_key()?;
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+        let ctrl = key.modifiers.ctrl();
+        let shift = key.modifiers.shift();
 
-        match key.code {
-            KeyCode::Up | KeyCode::Char('k') if !ctrl => Some(TerminalOutputMessage::ScrollUp),
-            KeyCode::Down | KeyCode::Char('j') if !ctrl => Some(TerminalOutputMessage::ScrollDown),
-            KeyCode::PageUp => Some(TerminalOutputMessage::PageUp(10)),
-            KeyCode::PageDown => Some(TerminalOutputMessage::PageDown(10)),
-            KeyCode::Char('u') if ctrl => Some(TerminalOutputMessage::PageUp(10)),
-            KeyCode::Char('d') if ctrl => Some(TerminalOutputMessage::PageDown(10)),
-            KeyCode::Home | KeyCode::Char('g') if !shift => Some(TerminalOutputMessage::Home),
-            KeyCode::End | KeyCode::Char('G') if shift || key.code == KeyCode::End => {
+        match key.key {
+            Key::Up | Key::Char('k') if !ctrl => Some(TerminalOutputMessage::ScrollUp),
+            Key::Down | Key::Char('j') if !ctrl => Some(TerminalOutputMessage::ScrollDown),
+            Key::PageUp => Some(TerminalOutputMessage::PageUp(10)),
+            Key::PageDown => Some(TerminalOutputMessage::PageDown(10)),
+            Key::Char('u') if ctrl => Some(TerminalOutputMessage::PageUp(10)),
+            Key::Char('d') if ctrl => Some(TerminalOutputMessage::PageDown(10)),
+            Key::Home | Key::Char('g') if !shift => Some(TerminalOutputMessage::Home),
+            Key::End | Key::Char('g') if key.modifiers.shift() || key.key == Key::End => {
                 Some(TerminalOutputMessage::End)
             }
-            KeyCode::Char('a') if !ctrl => Some(TerminalOutputMessage::ToggleAutoScroll),
-            KeyCode::Char('n') if !ctrl => Some(TerminalOutputMessage::ToggleLineNumbers),
+            Key::Char('a') if !ctrl => Some(TerminalOutputMessage::ToggleAutoScroll),
+            Key::Char('n') if !ctrl => Some(TerminalOutputMessage::ToggleLineNumbers),
             _ => None,
         }
     }

--- a/src/component/terminal_output/tests.rs
+++ b/src/component/terminal_output/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::component::test_utils;
-use crate::input::KeyModifiers;
+use crate::input::Modifiers;
 
 fn focused_state() -> TerminalOutputState {
     TerminalOutputState::new()
@@ -382,7 +382,7 @@ fn test_disabled_ignores_events() {
     let state = focused_state();
     let msg = TerminalOutput::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -391,8 +391,7 @@ fn test_disabled_ignores_events() {
 #[test]
 fn test_unfocused_ignores_events() {
     let state = TerminalOutputState::new();
-    let msg =
-        TerminalOutput::handle_event(&state, &Event::key(KeyCode::Up), &EventContext::default());
+    let msg = TerminalOutput::handle_event(&state, &Event::key(Key::Up), &EventContext::default());
     assert_eq!(msg, None);
 }
 
@@ -406,7 +405,7 @@ fn test_handle_event_up() {
     assert_eq!(
         TerminalOutput::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true)
         ),
         Some(TerminalOutputMessage::ScrollUp)
@@ -419,7 +418,7 @@ fn test_handle_event_down() {
     assert_eq!(
         TerminalOutput::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true)
         ),
         Some(TerminalOutputMessage::ScrollDown)
@@ -453,7 +452,7 @@ fn test_handle_event_page_up_down() {
     assert_eq!(
         TerminalOutput::handle_event(
             &state,
-            &Event::key(KeyCode::PageUp),
+            &Event::key(Key::PageUp),
             &EventContext::new().focused(true)
         ),
         Some(TerminalOutputMessage::PageUp(10))
@@ -461,7 +460,7 @@ fn test_handle_event_page_up_down() {
     assert_eq!(
         TerminalOutput::handle_event(
             &state,
-            &Event::key(KeyCode::PageDown),
+            &Event::key(Key::PageDown),
             &EventContext::new().focused(true)
         ),
         Some(TerminalOutputMessage::PageDown(10))
@@ -495,7 +494,7 @@ fn test_handle_event_home_end() {
     assert_eq!(
         TerminalOutput::handle_event(
             &state,
-            &Event::key(KeyCode::Home),
+            &Event::key(Key::Home),
             &EventContext::new().focused(true)
         ),
         Some(TerminalOutputMessage::Home)
@@ -503,7 +502,7 @@ fn test_handle_event_home_end() {
     assert_eq!(
         TerminalOutput::handle_event(
             &state,
-            &Event::key(KeyCode::End),
+            &Event::key(Key::End),
             &EventContext::new().focused(true)
         ),
         Some(TerminalOutputMessage::End)
@@ -525,7 +524,7 @@ fn test_handle_event_g_and_G() {
     assert_eq!(
         TerminalOutput::handle_event(
             &state,
-            &Event::key_with(KeyCode::Char('G'), KeyModifiers::SHIFT),
+            &Event::key_with(Key::Char('g'), Modifiers::SHIFT),
             &EventContext::new().focused(true),
         ),
         Some(TerminalOutputMessage::End)

--- a/src/component/text_area/mod.rs
+++ b/src/component/text_area/mod.rs
@@ -31,7 +31,7 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 use unicode_width::UnicodeWidthStr;
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key};
 use crate::undo::UndoStack;
 
 #[cfg(feature = "clipboard")]
@@ -663,16 +663,16 @@ impl Component for TextArea {
             return Some(TextAreaMessage::Paste(text.clone()));
         }
         if let Some(key) = event.as_key() {
-            let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-            let shift = key.modifiers.contains(KeyModifiers::SHIFT);
-            match key.code {
+            let ctrl = key.modifiers.ctrl();
+            let shift = key.modifiers.shift();
+            match key.key {
                 // Undo/redo
-                KeyCode::Char('z') if ctrl => Some(TextAreaMessage::Undo),
-                KeyCode::Char('y') if ctrl => Some(TextAreaMessage::Redo),
+                Key::Char('z') if ctrl => Some(TextAreaMessage::Undo),
+                Key::Char('y') if ctrl => Some(TextAreaMessage::Redo),
                 // Clipboard
-                KeyCode::Char('c') if ctrl => Some(TextAreaMessage::Copy),
-                KeyCode::Char('x') if ctrl => Some(TextAreaMessage::Cut),
-                KeyCode::Char('v') if ctrl => {
+                Key::Char('c') if ctrl => Some(TextAreaMessage::Copy),
+                Key::Char('x') if ctrl => Some(TextAreaMessage::Cut),
+                Key::Char('v') if ctrl => {
                     // Try system clipboard first, fall back to internal
                     #[cfg(feature = "clipboard")]
                     if let Some(text) = system_clipboard_get() {
@@ -684,35 +684,35 @@ impl Component for TextArea {
                         Some(TextAreaMessage::Paste(state.clipboard.clone()))
                     }
                 }
-                KeyCode::Char('a') if ctrl => Some(TextAreaMessage::SelectAll),
-                KeyCode::Char(c) if !ctrl => Some(TextAreaMessage::Insert(c)),
-                KeyCode::Enter => Some(TextAreaMessage::NewLine),
+                Key::Char('a') if ctrl => Some(TextAreaMessage::SelectAll),
+                Key::Char(_) if !ctrl => key.raw_char.map(TextAreaMessage::Insert),
+                Key::Enter => Some(TextAreaMessage::NewLine),
                 // Selection movement
-                KeyCode::Left if ctrl && shift => Some(TextAreaMessage::SelectWordLeft),
-                KeyCode::Right if ctrl && shift => Some(TextAreaMessage::SelectWordRight),
-                KeyCode::Left if shift => Some(TextAreaMessage::SelectLeft),
-                KeyCode::Right if shift => Some(TextAreaMessage::SelectRight),
-                KeyCode::Up if shift => Some(TextAreaMessage::SelectUp),
-                KeyCode::Down if shift => Some(TextAreaMessage::SelectDown),
-                KeyCode::Home if shift => Some(TextAreaMessage::SelectHome),
-                KeyCode::End if shift => Some(TextAreaMessage::SelectEnd),
+                Key::Left if ctrl && shift => Some(TextAreaMessage::SelectWordLeft),
+                Key::Right if ctrl && shift => Some(TextAreaMessage::SelectWordRight),
+                Key::Left if shift => Some(TextAreaMessage::SelectLeft),
+                Key::Right if shift => Some(TextAreaMessage::SelectRight),
+                Key::Up if shift => Some(TextAreaMessage::SelectUp),
+                Key::Down if shift => Some(TextAreaMessage::SelectDown),
+                Key::Home if shift => Some(TextAreaMessage::SelectHome),
+                Key::End if shift => Some(TextAreaMessage::SelectEnd),
                 // Deletion
-                KeyCode::Backspace if ctrl => Some(TextAreaMessage::DeleteLine),
-                KeyCode::Backspace => Some(TextAreaMessage::Backspace),
-                KeyCode::Delete => Some(TextAreaMessage::Delete),
+                Key::Backspace if ctrl => Some(TextAreaMessage::DeleteLine),
+                Key::Backspace => Some(TextAreaMessage::Backspace),
+                Key::Delete => Some(TextAreaMessage::Delete),
                 // Navigation
-                KeyCode::Left if ctrl => Some(TextAreaMessage::WordLeft),
-                KeyCode::Right if ctrl => Some(TextAreaMessage::WordRight),
-                KeyCode::Left => Some(TextAreaMessage::Left),
-                KeyCode::Right => Some(TextAreaMessage::Right),
-                KeyCode::Up => Some(TextAreaMessage::Up),
-                KeyCode::Down => Some(TextAreaMessage::Down),
-                KeyCode::Home if ctrl => Some(TextAreaMessage::TextStart),
-                KeyCode::End if ctrl => Some(TextAreaMessage::TextEnd),
-                KeyCode::Home => Some(TextAreaMessage::Home),
-                KeyCode::End => Some(TextAreaMessage::End),
-                KeyCode::Char('k') if ctrl => Some(TextAreaMessage::DeleteToEnd),
-                KeyCode::Char('u') if ctrl => Some(TextAreaMessage::DeleteToStart),
+                Key::Left if ctrl => Some(TextAreaMessage::WordLeft),
+                Key::Right if ctrl => Some(TextAreaMessage::WordRight),
+                Key::Left => Some(TextAreaMessage::Left),
+                Key::Right => Some(TextAreaMessage::Right),
+                Key::Up => Some(TextAreaMessage::Up),
+                Key::Down => Some(TextAreaMessage::Down),
+                Key::Home if ctrl => Some(TextAreaMessage::TextStart),
+                Key::End if ctrl => Some(TextAreaMessage::TextEnd),
+                Key::Home => Some(TextAreaMessage::Home),
+                Key::End => Some(TextAreaMessage::End),
+                Key::Char('k') if ctrl => Some(TextAreaMessage::DeleteToEnd),
+                Key::Char('u') if ctrl => Some(TextAreaMessage::DeleteToStart),
                 _ => None,
             }
         } else {

--- a/src/component/text_area/selection_tests.rs
+++ b/src/component/text_area/selection_tests.rs
@@ -296,7 +296,7 @@ fn test_shift_left_event() {
     let state = focused_state("hello");
     let msg = TextArea::handle_event(
         &state,
-        &Event::key_with(KeyCode::Left, KeyModifiers::SHIFT),
+        &Event::key_with(Key::Left, Modifiers::SHIFT),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::SelectLeft));
@@ -307,7 +307,7 @@ fn test_shift_right_event() {
     let state = focused_state("hello");
     let msg = TextArea::handle_event(
         &state,
-        &Event::key_with(KeyCode::Right, KeyModifiers::SHIFT),
+        &Event::key_with(Key::Right, Modifiers::SHIFT),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::SelectRight));
@@ -318,7 +318,7 @@ fn test_shift_up_event() {
     let state = focused_state("hello");
     let msg = TextArea::handle_event(
         &state,
-        &Event::key_with(KeyCode::Up, KeyModifiers::SHIFT),
+        &Event::key_with(Key::Up, Modifiers::SHIFT),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::SelectUp));
@@ -329,7 +329,7 @@ fn test_shift_down_event() {
     let state = focused_state("hello");
     let msg = TextArea::handle_event(
         &state,
-        &Event::key_with(KeyCode::Down, KeyModifiers::SHIFT),
+        &Event::key_with(Key::Down, Modifiers::SHIFT),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::SelectDown));

--- a/src/component/text_area/tests.rs
+++ b/src/component/text_area/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode, KeyModifiers};
+use crate::input::{Event, Key, Modifiers};
 
 #[path = "selection_tests.rs"]
 mod selection_tests;
@@ -803,7 +803,7 @@ fn test_handle_event_enter() {
     let state = TextArea::init();
     let msg = TextArea::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::NewLine));
@@ -814,7 +814,7 @@ fn test_handle_event_arrow_up() {
     let state = TextArea::init();
     let msg = TextArea::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::Up));
@@ -825,7 +825,7 @@ fn test_handle_event_arrow_down() {
     let state = TextArea::init();
     let msg = TextArea::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::Down));
@@ -836,7 +836,7 @@ fn test_handle_event_arrow_left() {
     let state = TextArea::init();
     let msg = TextArea::handle_event(
         &state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::Left));
@@ -847,7 +847,7 @@ fn test_handle_event_arrow_right() {
     let state = TextArea::init();
     let msg = TextArea::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::Right));
@@ -858,7 +858,7 @@ fn test_handle_event_ctrl_home() {
     let state = TextArea::init();
     let msg = TextArea::handle_event(
         &state,
-        &Event::key_with(KeyCode::Home, KeyModifiers::CONTROL),
+        &Event::key_with(Key::Home, Modifiers::CONTROL),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::TextStart));
@@ -869,7 +869,7 @@ fn test_handle_event_ctrl_end() {
     let state = TextArea::init();
     let msg = TextArea::handle_event(
         &state,
-        &Event::key_with(KeyCode::End, KeyModifiers::CONTROL),
+        &Event::key_with(Key::End, Modifiers::CONTROL),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TextAreaMessage::TextEnd));

--- a/src/component/timeline/mod.rs
+++ b/src/component/timeline/mod.rs
@@ -33,7 +33,7 @@ use std::marker::PhantomData;
 use ratatui::widgets::{Block, Borders};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 pub(crate) mod render;
 mod types;
@@ -634,15 +634,15 @@ impl Component for Timeline {
 
         let key = event.as_key()?;
 
-        match key.code {
-            KeyCode::Left | KeyCode::Char('h') => Some(TimelineMessage::PanLeft),
-            KeyCode::Right | KeyCode::Char('l') => Some(TimelineMessage::PanRight),
-            KeyCode::Char('+') | KeyCode::Char('=') => Some(TimelineMessage::ZoomIn),
-            KeyCode::Char('-') => Some(TimelineMessage::ZoomOut),
-            KeyCode::Up | KeyCode::Char('k') => Some(TimelineMessage::SelectPrev),
-            KeyCode::Down | KeyCode::Char('j') => Some(TimelineMessage::SelectNext),
-            KeyCode::Home => Some(TimelineMessage::FitAll),
-            KeyCode::Enter => {
+        match key.key {
+            Key::Left | Key::Char('h') => Some(TimelineMessage::PanLeft),
+            Key::Right | Key::Char('l') => Some(TimelineMessage::PanRight),
+            Key::Char('+') | Key::Char('=') => Some(TimelineMessage::ZoomIn),
+            Key::Char('-') => Some(TimelineMessage::ZoomOut),
+            Key::Up | Key::Char('k') => Some(TimelineMessage::SelectPrev),
+            Key::Down | Key::Char('j') => Some(TimelineMessage::SelectNext),
+            Key::Home => Some(TimelineMessage::FitAll),
+            Key::Enter => {
                 // On Enter, re-emit the current selection if any
                 if state.selected_index.is_some() {
                     // We handle this in update by returning the selection output

--- a/src/component/timeline/tests.rs
+++ b/src/component/timeline/tests.rs
@@ -506,7 +506,7 @@ fn test_left_maps_to_pan_left() {
     assert_eq!(
         Timeline::handle_event(
             &state,
-            &Event::key(KeyCode::Left),
+            &Event::key(Key::Left),
             &EventContext::new().focused(true)
         ),
         Some(TimelineMessage::PanLeft)
@@ -532,7 +532,7 @@ fn test_right_maps_to_pan_right() {
     assert_eq!(
         Timeline::handle_event(
             &state,
-            &Event::key(KeyCode::Right),
+            &Event::key(Key::Right),
             &EventContext::new().focused(true)
         ),
         Some(TimelineMessage::PanRight)
@@ -597,7 +597,7 @@ fn test_up_maps_to_select_prev() {
     assert_eq!(
         Timeline::handle_event(
             &state,
-            &Event::key(KeyCode::Up),
+            &Event::key(Key::Up),
             &EventContext::new().focused(true)
         ),
         Some(TimelineMessage::SelectPrev)
@@ -623,7 +623,7 @@ fn test_down_maps_to_select_next() {
     assert_eq!(
         Timeline::handle_event(
             &state,
-            &Event::key(KeyCode::Down),
+            &Event::key(Key::Down),
             &EventContext::new().focused(true)
         ),
         Some(TimelineMessage::SelectNext)
@@ -649,7 +649,7 @@ fn test_home_maps_to_fit_all() {
     assert_eq!(
         Timeline::handle_event(
             &state,
-            &Event::key(KeyCode::Home),
+            &Event::key(Key::Home),
             &EventContext::new().focused(true)
         ),
         Some(TimelineMessage::FitAll)
@@ -665,7 +665,7 @@ fn test_disabled_ignores_events() {
     let state = focused_timeline();
     let msg = Timeline::handle_event(
         &state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -676,7 +676,7 @@ fn test_unfocused_ignores_events() {
     let state = TimelineState::new()
         .with_events(sample_events())
         .with_spans(sample_spans());
-    let msg = Timeline::handle_event(&state, &Event::key(KeyCode::Left), &EventContext::default());
+    let msg = Timeline::handle_event(&state, &Event::key(Key::Left), &EventContext::default());
     assert_eq!(msg, None);
 }
 #[test]

--- a/src/component/tree/mod.rs
+++ b/src/component/tree/mod.rs
@@ -26,7 +26,7 @@
 //! ```
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 use crate::scroll::ScrollState;
 
 mod render;
@@ -920,13 +920,13 @@ impl<T: Clone + 'static> Component for Tree<T> {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.code {
-                KeyCode::Up | KeyCode::Char('k') => Some(TreeMessage::Up),
-                KeyCode::Down | KeyCode::Char('j') => Some(TreeMessage::Down),
-                KeyCode::Left | KeyCode::Char('h') => Some(TreeMessage::Collapse),
-                KeyCode::Right | KeyCode::Char('l') => Some(TreeMessage::Expand),
-                KeyCode::Char(' ') => Some(TreeMessage::Toggle),
-                KeyCode::Enter => Some(TreeMessage::Select),
+            match key.key {
+                Key::Up | Key::Char('k') => Some(TreeMessage::Up),
+                Key::Down | Key::Char('j') => Some(TreeMessage::Down),
+                Key::Left | Key::Char('h') => Some(TreeMessage::Collapse),
+                Key::Right | Key::Char('l') => Some(TreeMessage::Expand),
+                Key::Char(' ') => Some(TreeMessage::Toggle),
+                Key::Enter => Some(TreeMessage::Select),
                 _ => None,
             }
         } else {

--- a/src/component/tree/tests/edge_cases.rs
+++ b/src/component/tree/tests/edge_cases.rs
@@ -264,7 +264,7 @@ fn test_expand_leaf_via_dispatch_event() {
 
     let output = Tree::<()>::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, None);
@@ -276,7 +276,7 @@ fn test_collapse_leaf_via_dispatch_event() {
 
     let output = Tree::<()>::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, None);
@@ -302,7 +302,7 @@ fn test_handle_event_tab_key() {
 
     let msg = Tree::<()>::handle_event(
         &state,
-        &Event::key(KeyCode::Tab),
+        &Event::key(Key::Tab),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);
@@ -314,7 +314,7 @@ fn test_handle_event_escape_key() {
 
     let msg = Tree::<()>::handle_event(
         &state,
-        &Event::key(KeyCode::Esc),
+        &Event::key(Key::Esc),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, None);

--- a/src/component/tree/tests/events.rs
+++ b/src/component/tree/tests/events.rs
@@ -14,7 +14,7 @@ fn test_handle_event_up_when_focused() {
     let mut state = make_tree_state();
     state.selected_index = Some(1);
 
-    let event = Event::key(KeyCode::Up);
+    let event = Event::key(Key::Up);
     let msg = Tree::<&str>::handle_event(&state, &event, &EventContext::new().focused(true));
     assert_eq!(msg, Some(TreeMessage::Up));
 }
@@ -23,7 +23,7 @@ fn test_handle_event_up_when_focused() {
 fn test_handle_event_down_when_focused() {
     let state = make_tree_state();
 
-    let event = Event::key(KeyCode::Down);
+    let event = Event::key(Key::Down);
     let msg = Tree::<&str>::handle_event(&state, &event, &EventContext::new().focused(true));
     assert_eq!(msg, Some(TreeMessage::Down));
 }
@@ -32,7 +32,7 @@ fn test_handle_event_down_when_focused() {
 fn test_handle_event_expand_when_focused() {
     let state = make_tree_state();
 
-    let event = Event::key(KeyCode::Right);
+    let event = Event::key(Key::Right);
     let msg = Tree::<&str>::handle_event(&state, &event, &EventContext::new().focused(true));
     assert_eq!(msg, Some(TreeMessage::Expand));
 }
@@ -41,7 +41,7 @@ fn test_handle_event_expand_when_focused() {
 fn test_handle_event_collapse_when_focused() {
     let state = make_tree_state();
 
-    let event = Event::key(KeyCode::Left);
+    let event = Event::key(Key::Left);
     let msg = Tree::<&str>::handle_event(&state, &event, &EventContext::new().focused(true));
     assert_eq!(msg, Some(TreeMessage::Collapse));
 }
@@ -59,7 +59,7 @@ fn test_handle_event_toggle_when_focused() {
 fn test_handle_event_select_when_focused() {
     let state = make_tree_state();
 
-    let event = Event::key(KeyCode::Enter);
+    let event = Event::key(Key::Enter);
     let msg = Tree::<&str>::handle_event(&state, &event, &EventContext::new().focused(true));
     assert_eq!(msg, Some(TreeMessage::Select));
 }
@@ -102,15 +102,10 @@ fn test_handle_event_ignored_when_unfocused() {
     let state = make_tree_state();
     // focused is false by default
 
-    let msg =
-        Tree::<&str>::handle_event(&state, &Event::key(KeyCode::Down), &EventContext::default());
+    let msg = Tree::<&str>::handle_event(&state, &Event::key(Key::Down), &EventContext::default());
     assert_eq!(msg, None);
 
-    let msg = Tree::<&str>::handle_event(
-        &state,
-        &Event::key(KeyCode::Enter),
-        &EventContext::default(),
-    );
+    let msg = Tree::<&str>::handle_event(&state, &Event::key(Key::Enter), &EventContext::default());
     assert_eq!(msg, None);
 
     let msg = Tree::<&str>::handle_event(&state, &Event::char('j'), &EventContext::default());
@@ -126,7 +121,7 @@ fn test_dispatch_event() {
     // Dispatch Down: should move selection from 0 to 1
     let output = Tree::<&str>::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, None); // Down returns None but updates state
@@ -135,7 +130,7 @@ fn test_dispatch_event() {
     // Dispatch Enter: should select the current node
     let output = Tree::<&str>::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(TreeOutput::Selected(vec![0, 0])));
@@ -150,7 +145,7 @@ fn test_instance_methods() {
     // dispatch_event via static method
     let output = Tree::<&str>::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(output, None); // Down returns None but updates state
@@ -163,7 +158,7 @@ fn test_instance_methods() {
     // handle_event via static method
     let msg = Tree::<&str>::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TreeMessage::Up));
@@ -187,35 +182,35 @@ fn test_handle_event_ignored_when_disabled() {
 
     let msg = Tree::<&str>::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Tree::<&str>::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Tree::<&str>::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Tree::<&str>::handle_event(
         &state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
 
     let msg = Tree::<&str>::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -241,7 +236,7 @@ fn test_dispatch_event_ignored_when_disabled() {
 
     let output = Tree::<&str>::dispatch_event(
         &mut state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(output, None);

--- a/src/component/tree/tests/mod.rs
+++ b/src/component/tree/tests/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 mod component;
 mod edge_cases;

--- a/src/component/treemap/mod.rs
+++ b/src/component/treemap/mod.rs
@@ -31,7 +31,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders};
 
 use super::{Component, EventContext, RenderContext};
-use crate::input::{Event, KeyCode};
+use crate::input::{Event, Key};
 
 /// Layout algorithm module.
 pub mod layout;
@@ -667,14 +667,14 @@ impl Component for Treemap {
 
         let key = event.as_key()?;
 
-        match key.code {
-            KeyCode::Left | KeyCode::Char('h') => Some(TreemapMessage::SelectPrev),
-            KeyCode::Right | KeyCode::Char('l') => Some(TreemapMessage::SelectNext),
-            KeyCode::Down | KeyCode::Char('j') => Some(TreemapMessage::SelectChild),
-            KeyCode::Up | KeyCode::Char('k') => Some(TreemapMessage::SelectParent),
-            KeyCode::Enter => Some(TreemapMessage::ZoomIn),
-            KeyCode::Esc | KeyCode::Backspace => Some(TreemapMessage::ZoomOut),
-            KeyCode::Home => Some(TreemapMessage::ResetZoom),
+        match key.key {
+            Key::Left | Key::Char('h') => Some(TreemapMessage::SelectPrev),
+            Key::Right | Key::Char('l') => Some(TreemapMessage::SelectNext),
+            Key::Down | Key::Char('j') => Some(TreemapMessage::SelectChild),
+            Key::Up | Key::Char('k') => Some(TreemapMessage::SelectParent),
+            Key::Enter => Some(TreemapMessage::ZoomIn),
+            Key::Esc | Key::Backspace => Some(TreemapMessage::ZoomOut),
+            Key::Home => Some(TreemapMessage::ResetZoom),
             _ => None,
         }
     }

--- a/src/component/treemap/tests.rs
+++ b/src/component/treemap/tests.rs
@@ -548,7 +548,7 @@ fn test_right_maps_to_select_next() {
     let state = sample_state();
     let msg = Treemap::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TreemapMessage::SelectNext));
@@ -559,7 +559,7 @@ fn test_left_maps_to_select_prev() {
     let state = sample_state();
     let msg = Treemap::handle_event(
         &state,
-        &Event::key(KeyCode::Left),
+        &Event::key(Key::Left),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TreemapMessage::SelectPrev));
@@ -570,7 +570,7 @@ fn test_down_maps_to_select_child() {
     let state = sample_state();
     let msg = Treemap::handle_event(
         &state,
-        &Event::key(KeyCode::Down),
+        &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TreemapMessage::SelectChild));
@@ -581,7 +581,7 @@ fn test_up_maps_to_select_parent() {
     let state = sample_state();
     let msg = Treemap::handle_event(
         &state,
-        &Event::key(KeyCode::Up),
+        &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TreemapMessage::SelectParent));
@@ -592,7 +592,7 @@ fn test_enter_maps_to_zoom_in() {
     let state = sample_state();
     let msg = Treemap::handle_event(
         &state,
-        &Event::key(KeyCode::Enter),
+        &Event::key(Key::Enter),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TreemapMessage::ZoomIn));
@@ -603,7 +603,7 @@ fn test_esc_maps_to_zoom_out() {
     let state = sample_state();
     let msg = Treemap::handle_event(
         &state,
-        &Event::key(KeyCode::Esc),
+        &Event::key(Key::Esc),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TreemapMessage::ZoomOut));
@@ -614,7 +614,7 @@ fn test_backspace_maps_to_zoom_out() {
     let state = sample_state();
     let msg = Treemap::handle_event(
         &state,
-        &Event::key(KeyCode::Backspace),
+        &Event::key(Key::Backspace),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TreemapMessage::ZoomOut));
@@ -625,7 +625,7 @@ fn test_home_maps_to_reset_zoom() {
     let state = sample_state();
     let msg = Treemap::handle_event(
         &state,
-        &Event::key(KeyCode::Home),
+        &Event::key(Key::Home),
         &EventContext::new().focused(true),
     );
     assert_eq!(msg, Some(TreemapMessage::ResetZoom));
@@ -677,7 +677,7 @@ fn test_disabled_ignores_events() {
     let state = sample_state();
     let msg = Treemap::handle_event(
         &state,
-        &Event::key(KeyCode::Right),
+        &Event::key(Key::Right),
         &EventContext::new().focused(true).disabled(true),
     );
     assert_eq!(msg, None);
@@ -687,11 +687,7 @@ fn test_disabled_ignores_events() {
 fn test_unfocused_ignores_events() {
     let root = TreemapNode::new("root", 0.0).with_child(TreemapNode::new("a", 10.0));
     let state = TreemapState::new().with_root(root);
-    let msg = Treemap::handle_event(
-        &state,
-        &Event::key(KeyCode::Right),
-        &EventContext::default(),
-    );
+    let msg = Treemap::handle_event(&state, &Event::key(Key::Right), &EventContext::default());
     assert_eq!(msg, None);
 }
 #[test]

--- a/src/component/usage_display/tests.rs
+++ b/src/component/usage_display/tests.rs
@@ -653,7 +653,7 @@ fn test_view_zero_height() {
 #[test]
 fn test_handle_event_returns_none() {
     let state = UsageDisplayState::new().metric(UsageMetric::new("CPU", "45%"));
-    let event = crate::input::Event::key(crate::input::KeyCode::Char('q'));
+    let event = crate::input::Event::key(crate::input::Key::Char('q'));
     let msg = UsageDisplay::handle_event(&state, &event, &EventContext::default());
     assert!(msg.is_none());
 }
@@ -661,7 +661,7 @@ fn test_handle_event_returns_none() {
 #[test]
 fn test_dispatch_event_returns_none() {
     let mut state = UsageDisplayState::new().metric(UsageMetric::new("CPU", "45%"));
-    let event = crate::input::Event::key(crate::input::KeyCode::Enter);
+    let event = crate::input::Event::key(crate::input::Key::Enter);
     let output = UsageDisplay::dispatch_event(&mut state, &event, &EventContext::default());
     assert!(output.is_none());
 }

--- a/src/harness/app_harness/mod.rs
+++ b/src/harness/app_harness/mod.rs
@@ -369,7 +369,7 @@ impl<A: App> AppHarness<A> {
     /// use envision::harness::AppHarness;
     ///
     /// let mut harness = AppHarness::<MyApp>::new(80, 24)?;
-    /// harness.push_event(Event::key(KeyCode::Enter));
+    /// harness.push_event(Event::key(Key::Enter));
     /// harness.tick()?;
     /// # Ok::<(), envision::EnvisionError>(())
     /// ```

--- a/src/harness/test_harness/mod.rs
+++ b/src/harness/test_harness/mod.rs
@@ -175,10 +175,10 @@ impl TestHarness {
     ///
     /// ```rust
     /// use envision::harness::TestHarness;
-    /// use envision::input::{Event, KeyCode};
+    /// use envision::input::{Event, Key};
     ///
     /// let mut harness = TestHarness::new(80, 24);
-    /// harness.push_event(Event::key(KeyCode::Enter));
+    /// harness.push_event(Event::key(Key::Enter));
     /// let event = harness.pop_event();
     /// assert!(event.is_some());
     /// ```

--- a/src/input/convert.rs
+++ b/src/input/convert.rs
@@ -2,15 +2,32 @@
 //!
 //! These functions are `pub(crate)` so the runtime and subscription modules
 //! can call them, but they are not part of envision's public API.
-//!
-//! NOTE: These converters are unused until Task 3 (the atomic switch) wires
-//! the Event enum to use envision's owned types. The allow(dead_code) is
-//! intentional and will be removed in that commit.
 
-#![allow(dead_code)]
-
+use super::events::Event;
 use super::key::{Key, KeyEvent, KeyEventKind, Modifiers};
 use super::mouse::{MouseButton, MouseEvent, MouseEventKind};
+
+/// Converts a crossterm event to an envision event.
+///
+/// Returns `None` for key events that envision doesn't model (e.g. CapsLock)
+/// and for key release/repeat events (only presses are forwarded).
+pub(crate) fn from_crossterm_event(event: crossterm::event::Event) -> Option<Event> {
+    match event {
+        crossterm::event::Event::Key(key) => {
+            // Only handle key press events, not release or repeat
+            if key.kind == crossterm::event::KeyEventKind::Press {
+                from_crossterm_key(key).map(Event::Key)
+            } else {
+                None
+            }
+        }
+        crossterm::event::Event::Mouse(mouse) => Some(Event::Mouse(from_crossterm_mouse(mouse))),
+        crossterm::event::Event::Resize(w, h) => Some(Event::Resize(w, h)),
+        crossterm::event::Event::FocusGained => Some(Event::FocusGained),
+        crossterm::event::Event::FocusLost => Some(Event::FocusLost),
+        crossterm::event::Event::Paste(s) => Some(Event::Paste(s)),
+    }
+}
 
 /// Converts a crossterm key event to an envision key event.
 ///
@@ -406,5 +423,76 @@ mod tests {
         };
         let result = from_crossterm_mouse(ct_mouse);
         assert!(result.modifiers.ctrl());
+    }
+
+    // ========== Event-level conversion tests ==========
+
+    #[test]
+    fn test_event_key_press() {
+        let ct_event = ct::Event::Key(ct_key(ct::KeyCode::Enter));
+        let result = from_crossterm_event(ct_event).unwrap();
+        assert!(matches!(result, Event::Key(ke) if ke.key == Key::Enter));
+    }
+
+    #[test]
+    fn test_event_key_release_filtered() {
+        let mut key = ct_key(ct::KeyCode::Enter);
+        key.kind = ct::KeyEventKind::Release;
+        let ct_event = ct::Event::Key(key);
+        assert!(from_crossterm_event(ct_event).is_none());
+    }
+
+    #[test]
+    fn test_event_key_repeat_filtered() {
+        let mut key = ct_key(ct::KeyCode::Enter);
+        key.kind = ct::KeyEventKind::Repeat;
+        let ct_event = ct::Event::Key(key);
+        assert!(from_crossterm_event(ct_event).is_none());
+    }
+
+    #[test]
+    fn test_event_dropped_key_filtered() {
+        let ct_event = ct::Event::Key(ct_key(ct::KeyCode::Null));
+        assert!(from_crossterm_event(ct_event).is_none());
+    }
+
+    #[test]
+    fn test_event_mouse() {
+        let ct_event = ct::Event::Mouse(ct::MouseEvent {
+            kind: ct::MouseEventKind::Down(ct::MouseButton::Left),
+            column: 5,
+            row: 10,
+            modifiers: ct::KeyModifiers::empty(),
+        });
+        let result = from_crossterm_event(ct_event).unwrap();
+        assert!(matches!(result, Event::Mouse(_)));
+    }
+
+    #[test]
+    fn test_event_resize() {
+        let ct_event = ct::Event::Resize(80, 24);
+        let result = from_crossterm_event(ct_event).unwrap();
+        assert!(matches!(result, Event::Resize(80, 24)));
+    }
+
+    #[test]
+    fn test_event_focus_gained() {
+        let ct_event = ct::Event::FocusGained;
+        let result = from_crossterm_event(ct_event).unwrap();
+        assert!(matches!(result, Event::FocusGained));
+    }
+
+    #[test]
+    fn test_event_focus_lost() {
+        let ct_event = ct::Event::FocusLost;
+        let result = from_crossterm_event(ct_event).unwrap();
+        assert!(matches!(result, Event::FocusLost));
+    }
+
+    #[test]
+    fn test_event_paste() {
+        let ct_event = ct::Event::Paste("hello".to_string());
+        let result = from_crossterm_event(ct_event).unwrap();
+        assert!(matches!(result, Event::Paste(s) if s == "hello"));
     }
 }

--- a/src/input/convert.rs
+++ b/src/input/convert.rs
@@ -1,0 +1,410 @@
+//! Private converters from crossterm event types to envision event types.
+//!
+//! These functions are `pub(crate)` so the runtime and subscription modules
+//! can call them, but they are not part of envision's public API.
+//!
+//! NOTE: These converters are unused until Task 3 (the atomic switch) wires
+//! the Event enum to use envision's owned types. The allow(dead_code) is
+//! intentional and will be removed in that commit.
+
+#![allow(dead_code)]
+
+use super::key::{Key, KeyEvent, KeyEventKind, Modifiers};
+use super::mouse::{MouseButton, MouseEvent, MouseEventKind};
+
+/// Converts a crossterm key event to an envision key event.
+///
+/// Returns `None` for key codes that envision doesn't model.
+pub(crate) fn from_crossterm_key(key: crossterm::event::KeyEvent) -> Option<KeyEvent> {
+    let mut modifiers = from_crossterm_modifiers(key.modifiers);
+    let kind = from_crossterm_key_kind(key.kind);
+
+    let (envision_key, raw_char) = match key.code {
+        crossterm::event::KeyCode::Char(c) => {
+            // Normalize control characters (Ctrl+letter sends 0x01-0x1A)
+            if c.is_ascii_control() && c != '\t' && c != '\r' && c != '\n' {
+                let letter = (c as u8 + b'a' - 1) as char;
+                modifiers |= Modifiers::CONTROL;
+                (Key::Char(letter), Some(c))
+            }
+            // Normalize uppercase ASCII letters to lowercase
+            else if c.is_ascii_uppercase() {
+                (Key::Char(c.to_ascii_lowercase()), Some(c))
+            }
+            // Everything else passes through
+            else {
+                (Key::Char(c), Some(c))
+            }
+        }
+        crossterm::event::KeyCode::F(n) => (Key::F(n), None),
+        crossterm::event::KeyCode::Backspace => (Key::Backspace, None),
+        crossterm::event::KeyCode::Enter => (Key::Enter, None),
+        crossterm::event::KeyCode::Left => (Key::Left, None),
+        crossterm::event::KeyCode::Right => (Key::Right, None),
+        crossterm::event::KeyCode::Up => (Key::Up, None),
+        crossterm::event::KeyCode::Down => (Key::Down, None),
+        crossterm::event::KeyCode::Home => (Key::Home, None),
+        crossterm::event::KeyCode::End => (Key::End, None),
+        crossterm::event::KeyCode::PageUp => (Key::PageUp, None),
+        crossterm::event::KeyCode::PageDown => (Key::PageDown, None),
+        crossterm::event::KeyCode::Tab => (Key::Tab, None),
+        crossterm::event::KeyCode::BackTab => {
+            modifiers |= Modifiers::SHIFT;
+            (Key::Tab, None)
+        }
+        crossterm::event::KeyCode::Delete => (Key::Delete, None),
+        crossterm::event::KeyCode::Insert => (Key::Insert, None),
+        crossterm::event::KeyCode::Esc => (Key::Esc, None),
+        // Dropped variants: Null, CapsLock, ScrollLock, NumLock,
+        // PrintScreen, Pause, Menu, KeypadBegin, Media, Modifier
+        _ => return None,
+    };
+
+    Some(KeyEvent {
+        key: envision_key,
+        modifiers,
+        kind,
+        raw_char,
+    })
+}
+
+/// Converts a crossterm mouse event to an envision mouse event.
+pub(crate) fn from_crossterm_mouse(mouse: crossterm::event::MouseEvent) -> MouseEvent {
+    MouseEvent {
+        kind: from_crossterm_mouse_kind(mouse.kind),
+        column: mouse.column,
+        row: mouse.row,
+        modifiers: from_crossterm_modifiers(mouse.modifiers),
+    }
+}
+
+/// Converts crossterm key modifiers to envision modifiers.
+pub(crate) fn from_crossterm_modifiers(mods: crossterm::event::KeyModifiers) -> Modifiers {
+    let mut result = Modifiers::NONE;
+    if mods.contains(crossterm::event::KeyModifiers::SHIFT) {
+        result |= Modifiers::SHIFT;
+    }
+    if mods.contains(crossterm::event::KeyModifiers::CONTROL) {
+        result |= Modifiers::CONTROL;
+    }
+    if mods.contains(crossterm::event::KeyModifiers::ALT) {
+        result |= Modifiers::ALT;
+    }
+    if mods.contains(crossterm::event::KeyModifiers::SUPER) {
+        result |= Modifiers::SUPER;
+    }
+    result
+}
+
+pub(crate) fn from_crossterm_key_kind(kind: crossterm::event::KeyEventKind) -> KeyEventKind {
+    match kind {
+        crossterm::event::KeyEventKind::Press => KeyEventKind::Press,
+        crossterm::event::KeyEventKind::Release => KeyEventKind::Release,
+        crossterm::event::KeyEventKind::Repeat => KeyEventKind::Repeat,
+    }
+}
+
+pub(crate) fn from_crossterm_mouse_kind(kind: crossterm::event::MouseEventKind) -> MouseEventKind {
+    match kind {
+        crossterm::event::MouseEventKind::Down(b) => MouseEventKind::Down(from_crossterm_button(b)),
+        crossterm::event::MouseEventKind::Up(b) => MouseEventKind::Up(from_crossterm_button(b)),
+        crossterm::event::MouseEventKind::Drag(b) => MouseEventKind::Drag(from_crossterm_button(b)),
+        crossterm::event::MouseEventKind::Moved => MouseEventKind::Moved,
+        crossterm::event::MouseEventKind::ScrollDown => MouseEventKind::ScrollDown,
+        crossterm::event::MouseEventKind::ScrollUp => MouseEventKind::ScrollUp,
+        crossterm::event::MouseEventKind::ScrollLeft => MouseEventKind::ScrollLeft,
+        crossterm::event::MouseEventKind::ScrollRight => MouseEventKind::ScrollRight,
+    }
+}
+
+pub(crate) fn from_crossterm_button(button: crossterm::event::MouseButton) -> MouseButton {
+    match button {
+        crossterm::event::MouseButton::Left => MouseButton::Left,
+        crossterm::event::MouseButton::Right => MouseButton::Right,
+        crossterm::event::MouseButton::Middle => MouseButton::Middle,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event as ct;
+
+    fn ct_key(code: ct::KeyCode) -> ct::KeyEvent {
+        ct::KeyEvent::new(code, ct::KeyModifiers::empty())
+    }
+
+    fn ct_key_with_mods(code: ct::KeyCode, mods: ct::KeyModifiers) -> ct::KeyEvent {
+        ct::KeyEvent::new(code, mods)
+    }
+
+    // ========== Key normalization tests ==========
+
+    #[test]
+    fn test_lowercase_char() {
+        let result = from_crossterm_key(ct_key(ct::KeyCode::Char('a'))).unwrap();
+        assert_eq!(result.key, Key::Char('a'));
+        assert!(result.modifiers.is_none());
+        assert_eq!(result.raw_char, Some('a'));
+    }
+
+    #[test]
+    fn test_uppercase_with_shift_normalizes() {
+        let result = from_crossterm_key(ct_key_with_mods(
+            ct::KeyCode::Char('A'),
+            ct::KeyModifiers::SHIFT,
+        ))
+        .unwrap();
+        assert_eq!(result.key, Key::Char('a'));
+        assert!(result.modifiers.shift());
+        assert_eq!(result.raw_char, Some('A'));
+    }
+
+    #[test]
+    fn test_uppercase_without_shift_caps_lock() {
+        // Caps lock sends uppercase without SHIFT modifier
+        let result = from_crossterm_key(ct_key(ct::KeyCode::Char('A'))).unwrap();
+        assert_eq!(result.key, Key::Char('a'));
+        assert!(!result.modifiers.shift());
+        assert_eq!(result.raw_char, Some('A'));
+    }
+
+    #[test]
+    fn test_symbol_with_shift_preserved() {
+        let result = from_crossterm_key(ct_key_with_mods(
+            ct::KeyCode::Char('!'),
+            ct::KeyModifiers::SHIFT,
+        ))
+        .unwrap();
+        assert_eq!(result.key, Key::Char('!'));
+        assert!(result.modifiers.shift());
+        assert_eq!(result.raw_char, Some('!'));
+    }
+
+    #[test]
+    fn test_ctrl_c_from_modifier() {
+        let result = from_crossterm_key(ct_key_with_mods(
+            ct::KeyCode::Char('c'),
+            ct::KeyModifiers::CONTROL,
+        ))
+        .unwrap();
+        assert_eq!(result.key, Key::Char('c'));
+        assert!(result.modifiers.ctrl());
+        assert_eq!(result.raw_char, Some('c'));
+    }
+
+    #[test]
+    fn test_ctrl_c_from_raw_control_char() {
+        // Some terminals send '\x03' instead of 'c' + CONTROL
+        let result = from_crossterm_key(ct_key(ct::KeyCode::Char('\x03'))).unwrap();
+        assert_eq!(result.key, Key::Char('c'));
+        assert!(result.modifiers.ctrl());
+        assert_eq!(result.raw_char, Some('\x03'));
+    }
+
+    #[test]
+    fn test_backtab_becomes_tab_with_shift() {
+        let result = from_crossterm_key(ct_key(ct::KeyCode::BackTab)).unwrap();
+        assert_eq!(result.key, Key::Tab);
+        assert!(result.modifiers.shift());
+        assert!(result.raw_char.is_none());
+    }
+
+    #[test]
+    fn test_enter() {
+        let result = from_crossterm_key(ct_key(ct::KeyCode::Enter)).unwrap();
+        assert_eq!(result.key, Key::Enter);
+        assert!(result.modifiers.is_none());
+        assert!(result.raw_char.is_none());
+    }
+
+    #[test]
+    fn test_function_key() {
+        let result = from_crossterm_key(ct_key(ct::KeyCode::F(5))).unwrap();
+        assert_eq!(result.key, Key::F(5));
+        assert!(result.raw_char.is_none());
+    }
+
+    #[test]
+    fn test_arrows() {
+        assert_eq!(
+            from_crossterm_key(ct_key(ct::KeyCode::Left)).unwrap().key,
+            Key::Left
+        );
+        assert_eq!(
+            from_crossterm_key(ct_key(ct::KeyCode::Right)).unwrap().key,
+            Key::Right
+        );
+        assert_eq!(
+            from_crossterm_key(ct_key(ct::KeyCode::Up)).unwrap().key,
+            Key::Up
+        );
+        assert_eq!(
+            from_crossterm_key(ct_key(ct::KeyCode::Down)).unwrap().key,
+            Key::Down
+        );
+    }
+
+    #[test]
+    fn test_navigation_keys() {
+        assert_eq!(
+            from_crossterm_key(ct_key(ct::KeyCode::Home)).unwrap().key,
+            Key::Home
+        );
+        assert_eq!(
+            from_crossterm_key(ct_key(ct::KeyCode::End)).unwrap().key,
+            Key::End
+        );
+        assert_eq!(
+            from_crossterm_key(ct_key(ct::KeyCode::PageUp)).unwrap().key,
+            Key::PageUp
+        );
+        assert_eq!(
+            from_crossterm_key(ct_key(ct::KeyCode::PageDown))
+                .unwrap()
+                .key,
+            Key::PageDown
+        );
+    }
+
+    #[test]
+    fn test_editing_keys() {
+        assert_eq!(
+            from_crossterm_key(ct_key(ct::KeyCode::Backspace))
+                .unwrap()
+                .key,
+            Key::Backspace
+        );
+        assert_eq!(
+            from_crossterm_key(ct_key(ct::KeyCode::Delete)).unwrap().key,
+            Key::Delete
+        );
+        assert_eq!(
+            from_crossterm_key(ct_key(ct::KeyCode::Insert)).unwrap().key,
+            Key::Insert
+        );
+        assert_eq!(
+            from_crossterm_key(ct_key(ct::KeyCode::Tab)).unwrap().key,
+            Key::Tab
+        );
+        assert_eq!(
+            from_crossterm_key(ct_key(ct::KeyCode::Esc)).unwrap().key,
+            Key::Esc
+        );
+    }
+
+    #[test]
+    fn test_dropped_keys_return_none() {
+        assert!(from_crossterm_key(ct_key(ct::KeyCode::Null)).is_none());
+        assert!(from_crossterm_key(ct_key(ct::KeyCode::CapsLock)).is_none());
+        assert!(from_crossterm_key(ct_key(ct::KeyCode::NumLock)).is_none());
+        assert!(from_crossterm_key(ct_key(ct::KeyCode::ScrollLock)).is_none());
+        assert!(from_crossterm_key(ct_key(ct::KeyCode::PrintScreen)).is_none());
+        assert!(from_crossterm_key(ct_key(ct::KeyCode::Pause)).is_none());
+        assert!(from_crossterm_key(ct_key(ct::KeyCode::Menu)).is_none());
+        assert!(from_crossterm_key(ct_key(ct::KeyCode::KeypadBegin)).is_none());
+    }
+
+    #[test]
+    fn test_key_event_kind_mapping() {
+        let press = ct::KeyEvent {
+            kind: ct::KeyEventKind::Press,
+            ..ct_key(ct::KeyCode::Enter)
+        };
+        assert_eq!(from_crossterm_key(press).unwrap().kind, KeyEventKind::Press);
+
+        let release = ct::KeyEvent {
+            kind: ct::KeyEventKind::Release,
+            ..ct_key(ct::KeyCode::Enter)
+        };
+        assert_eq!(
+            from_crossterm_key(release).unwrap().kind,
+            KeyEventKind::Release
+        );
+
+        let repeat = ct::KeyEvent {
+            kind: ct::KeyEventKind::Repeat,
+            ..ct_key(ct::KeyCode::Enter)
+        };
+        assert_eq!(
+            from_crossterm_key(repeat).unwrap().kind,
+            KeyEventKind::Repeat
+        );
+    }
+
+    // ========== Modifier conversion tests ==========
+
+    #[test]
+    fn test_modifier_mapping() {
+        let shift = from_crossterm_modifiers(ct::KeyModifiers::SHIFT);
+        assert!(shift.shift());
+        assert!(!shift.ctrl());
+
+        let ctrl = from_crossterm_modifiers(ct::KeyModifiers::CONTROL);
+        assert!(ctrl.ctrl());
+        assert!(!ctrl.shift());
+
+        let alt = from_crossterm_modifiers(ct::KeyModifiers::ALT);
+        assert!(alt.alt());
+
+        let sup = from_crossterm_modifiers(ct::KeyModifiers::SUPER);
+        assert!(sup.super_key());
+    }
+
+    #[test]
+    fn test_combined_modifiers() {
+        let mods = from_crossterm_modifiers(ct::KeyModifiers::SHIFT | ct::KeyModifiers::CONTROL);
+        assert!(mods.shift());
+        assert!(mods.ctrl());
+        assert!(!mods.alt());
+    }
+
+    #[test]
+    fn test_empty_modifiers() {
+        let mods = from_crossterm_modifiers(ct::KeyModifiers::empty());
+        assert!(mods.is_none());
+    }
+
+    // ========== Mouse conversion tests ==========
+
+    #[test]
+    fn test_mouse_button_mapping() {
+        let ct_mouse = ct::MouseEvent {
+            kind: ct::MouseEventKind::Down(ct::MouseButton::Left),
+            column: 10,
+            row: 5,
+            modifiers: ct::KeyModifiers::empty(),
+        };
+        let result = from_crossterm_mouse(ct_mouse);
+        assert_eq!(result.kind, MouseEventKind::Down(MouseButton::Left));
+        assert_eq!(result.column, 10);
+        assert_eq!(result.row, 5);
+        assert!(result.modifiers.is_none());
+    }
+
+    #[test]
+    fn test_mouse_scroll() {
+        let ct_mouse = ct::MouseEvent {
+            kind: ct::MouseEventKind::ScrollUp,
+            column: 0,
+            row: 0,
+            modifiers: ct::KeyModifiers::empty(),
+        };
+        assert_eq!(
+            from_crossterm_mouse(ct_mouse).kind,
+            MouseEventKind::ScrollUp
+        );
+    }
+
+    #[test]
+    fn test_mouse_with_modifiers() {
+        let ct_mouse = ct::MouseEvent {
+            kind: ct::MouseEventKind::Down(ct::MouseButton::Left),
+            column: 0,
+            row: 0,
+            modifiers: ct::KeyModifiers::CONTROL,
+        };
+        let result = from_crossterm_mouse(ct_mouse);
+        assert!(result.modifiers.ctrl());
+    }
+}

--- a/src/input/events/mod.rs
+++ b/src/input/events/mod.rs
@@ -1,15 +1,13 @@
 //! Event types for terminal input.
 
-use crossterm::event::{
-    KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton, MouseEvent,
-    MouseEventKind,
-};
+use super::key::{Key, KeyEvent, Modifiers};
+use super::mouse::{MouseButton, MouseEvent, MouseEventKind};
 
 /// A terminal input event.
 ///
-/// This wraps crossterm's event types to provide a unified interface
-/// for handling input events. The same type is used whether events come
-/// from a real terminal or are injected programmatically.
+/// This provides a unified interface for handling input events. The same
+/// type is used whether events come from a real terminal or are injected
+/// programmatically.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Event {
     /// A keyboard event
@@ -43,12 +41,14 @@ impl Event {
     /// assert!(event.is_key());
     /// ```
     pub fn char(c: char) -> Self {
-        Self::Key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE))
+        Self::Key(KeyEvent::char(c))
     }
 
     /// Creates a key press event for a character with modifiers.
-    pub fn char_with(c: char, modifiers: KeyModifiers) -> Self {
-        Self::Key(KeyEvent::new(KeyCode::Char(c), modifiers))
+    pub fn char_with(c: char, modifiers: Modifiers) -> Self {
+        let mut ke = KeyEvent::char(c);
+        ke.modifiers |= modifiers;
+        Self::Key(ke)
     }
 
     /// Creates a key press event for a special key.
@@ -56,13 +56,13 @@ impl Event {
     /// # Example
     ///
     /// ```rust
-    /// use envision::input::{Event, KeyCode};
+    /// use envision::input::{Event, Key};
     ///
-    /// let event = Event::key(KeyCode::Enter);
+    /// let event = Event::key(Key::Enter);
     /// assert!(event.is_key());
     /// ```
-    pub fn key(code: KeyCode) -> Self {
-        Self::Key(KeyEvent::new(code, KeyModifiers::NONE))
+    pub fn key(key: Key) -> Self {
+        Self::Key(KeyEvent::new(key))
     }
 
     /// Creates a key press event with modifiers.
@@ -70,13 +70,21 @@ impl Event {
     /// # Example
     ///
     /// ```rust
-    /// use envision::input::{Event, KeyCode, KeyModifiers};
+    /// use envision::input::{Event, Key, Modifiers};
     ///
-    /// let event = Event::key_with(KeyCode::Char('s'), KeyModifiers::CONTROL);
+    /// let event = Event::key_with(Key::Char('s'), Modifiers::CONTROL);
     /// assert!(event.is_key());
     /// ```
-    pub fn key_with(code: KeyCode, modifiers: KeyModifiers) -> Self {
-        Self::Key(KeyEvent::new(code, modifiers))
+    pub fn key_with(key: Key, modifiers: Modifiers) -> Self {
+        Self::Key(KeyEvent {
+            key,
+            modifiers,
+            kind: super::key::KeyEventKind::Press,
+            raw_char: match key {
+                Key::Char(c) => Some(c),
+                _ => None,
+            },
+        })
     }
 
     /// Creates a Ctrl+key event.
@@ -90,7 +98,7 @@ impl Event {
     /// assert!(event.is_key());
     /// ```
     pub fn ctrl(c: char) -> Self {
-        Self::Key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL))
+        Self::Key(KeyEvent::ctrl(c))
     }
 
     /// Creates an Alt+key event.
@@ -104,7 +112,12 @@ impl Event {
     /// assert!(event.is_key());
     /// ```
     pub fn alt(c: char) -> Self {
-        Self::Key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::ALT))
+        Self::Key(KeyEvent {
+            key: Key::Char(c.to_ascii_lowercase()),
+            modifiers: Modifiers::ALT,
+            kind: super::key::KeyEventKind::Press,
+            raw_char: Some(c),
+        })
     }
 
     /// Creates a mouse click event at the specified position.
@@ -122,7 +135,7 @@ impl Event {
             kind: MouseEventKind::Down(MouseButton::Left),
             column: x,
             row: y,
-            modifiers: KeyModifiers::NONE,
+            modifiers: Modifiers::NONE,
         })
     }
 
@@ -132,7 +145,7 @@ impl Event {
             kind: MouseEventKind::Down(button),
             column: x,
             row: y,
-            modifiers: KeyModifiers::NONE,
+            modifiers: Modifiers::NONE,
         })
     }
 
@@ -142,7 +155,7 @@ impl Event {
             kind: MouseEventKind::Up(MouseButton::Left),
             column: x,
             row: y,
-            modifiers: KeyModifiers::NONE,
+            modifiers: Modifiers::NONE,
         })
     }
 
@@ -152,7 +165,7 @@ impl Event {
             kind: MouseEventKind::Moved,
             column: x,
             row: y,
-            modifiers: KeyModifiers::NONE,
+            modifiers: Modifiers::NONE,
         })
     }
 
@@ -162,7 +175,7 @@ impl Event {
             kind: MouseEventKind::Drag(button),
             column: x,
             row: y,
-            modifiers: KeyModifiers::NONE,
+            modifiers: Modifiers::NONE,
         })
     }
 
@@ -172,7 +185,7 @@ impl Event {
             kind: MouseEventKind::ScrollUp,
             column: x,
             row: y,
-            modifiers: KeyModifiers::NONE,
+            modifiers: Modifiers::NONE,
         })
     }
 
@@ -182,7 +195,7 @@ impl Event {
             kind: MouseEventKind::ScrollDown,
             column: x,
             row: y,
-            modifiers: KeyModifiers::NONE,
+            modifiers: Modifiers::NONE,
         })
     }
 
@@ -219,9 +232,9 @@ impl Event {
     /// # Example
     ///
     /// ```rust
-    /// use envision::input::{Event, KeyCode};
+    /// use envision::input::{Event, Key};
     ///
-    /// let event = Event::key(KeyCode::Enter);
+    /// let event = Event::key(Key::Enter);
     /// assert!(event.as_key().is_some());
     /// assert!(Event::click(0, 0).as_key().is_none());
     /// ```
@@ -258,7 +271,7 @@ impl Event {
     /// # Example
     ///
     /// ```rust
-    /// use envision::input::{Event, KeyCode};
+    /// use envision::input::{Event, Key};
     ///
     /// assert_eq!(Event::char('a').kind_name(), "Key");
     /// assert_eq!(Event::click(0, 0).kind_name(), "Mouse");
@@ -290,48 +303,20 @@ impl From<MouseEvent> for Event {
     }
 }
 
-impl From<crossterm::event::Event> for Event {
-    fn from(event: crossterm::event::Event) -> Self {
-        match event {
-            crossterm::event::Event::Key(e) => Event::Key(e),
-            crossterm::event::Event::Mouse(e) => Event::Mouse(e),
-            crossterm::event::Event::Resize(w, h) => Event::Resize(w, h),
-            crossterm::event::Event::FocusGained => Event::FocusGained,
-            crossterm::event::Event::FocusLost => Event::FocusLost,
-            crossterm::event::Event::Paste(s) => Event::Paste(s),
-        }
-    }
-}
-
-impl From<Event> for crossterm::event::Event {
-    fn from(event: Event) -> Self {
-        match event {
-            Event::Key(e) => crossterm::event::Event::Key(e),
-            Event::Mouse(e) => crossterm::event::Event::Mouse(e),
-            Event::Resize(w, h) => crossterm::event::Event::Resize(w, h),
-            Event::FocusGained => crossterm::event::Event::FocusGained,
-            Event::FocusLost => crossterm::event::Event::FocusLost,
-            Event::Paste(s) => crossterm::event::Event::Paste(s),
-        }
-    }
-}
-
 /// Builder for creating key events with specific properties.
 #[derive(Clone, Debug)]
 pub struct KeyEventBuilder {
-    code: Option<KeyCode>,
-    modifiers: KeyModifiers,
-    kind: KeyEventKind,
-    state: KeyEventState,
+    key: Option<Key>,
+    modifiers: Modifiers,
+    kind: super::key::KeyEventKind,
 }
 
 impl Default for KeyEventBuilder {
     fn default() -> Self {
         Self {
-            code: None,
-            modifiers: KeyModifiers::NONE,
-            kind: KeyEventKind::Press,
-            state: KeyEventState::NONE,
+            key: None,
+            modifiers: Modifiers::NONE,
+            kind: super::key::KeyEventKind::Press,
         }
     }
 }
@@ -342,55 +327,59 @@ impl KeyEventBuilder {
         Self::default()
     }
 
-    /// Sets the key code.
-    pub fn code(mut self, code: KeyCode) -> Self {
-        self.code = Some(code);
+    /// Sets the key.
+    pub fn code(mut self, key: Key) -> Self {
+        self.key = Some(key);
         self
     }
 
     /// Sets the key to a character.
     pub fn char(mut self, c: char) -> Self {
-        self.code = Some(KeyCode::Char(c));
+        self.key = Some(Key::Char(c));
         self
     }
 
     /// Adds the Control modifier.
     pub fn ctrl(mut self) -> Self {
-        self.modifiers |= KeyModifiers::CONTROL;
+        self.modifiers |= Modifiers::CONTROL;
         self
     }
 
     /// Adds the Alt modifier.
     pub fn alt(mut self) -> Self {
-        self.modifiers |= KeyModifiers::ALT;
+        self.modifiers |= Modifiers::ALT;
         self
     }
 
     /// Adds the Shift modifier.
     pub fn shift(mut self) -> Self {
-        self.modifiers |= KeyModifiers::SHIFT;
+        self.modifiers |= Modifiers::SHIFT;
         self
     }
 
     /// Sets the modifiers directly.
-    pub fn modifiers(mut self, modifiers: KeyModifiers) -> Self {
+    pub fn modifiers(mut self, modifiers: Modifiers) -> Self {
         self.modifiers = modifiers;
         self
     }
 
     /// Sets the event kind (Press, Release, Repeat).
-    pub fn kind(mut self, kind: KeyEventKind) -> Self {
+    pub fn kind(mut self, kind: super::key::KeyEventKind) -> Self {
         self.kind = kind;
         self
     }
 
     /// Builds the key event.
     pub fn build(self) -> KeyEvent {
+        let key = self.key.unwrap_or(Key::Esc);
         KeyEvent {
-            code: self.code.unwrap_or(KeyCode::Null),
+            key,
             modifiers: self.modifiers,
             kind: self.kind,
-            state: self.state,
+            raw_char: match key {
+                Key::Char(c) => Some(c),
+                _ => None,
+            },
         }
     }
 
@@ -406,7 +395,7 @@ pub struct MouseEventBuilder {
     kind: MouseEventKind,
     column: u16,
     row: u16,
-    modifiers: KeyModifiers,
+    modifiers: Modifiers,
 }
 
 impl MouseEventBuilder {
@@ -416,7 +405,7 @@ impl MouseEventBuilder {
             kind: MouseEventKind::Moved,
             column: 0,
             row: 0,
-            modifiers: KeyModifiers::NONE,
+            modifiers: Modifiers::NONE,
         }
     }
 
@@ -471,19 +460,19 @@ impl MouseEventBuilder {
 
     /// Adds the Control modifier.
     pub fn ctrl(mut self) -> Self {
-        self.modifiers |= KeyModifiers::CONTROL;
+        self.modifiers |= Modifiers::CONTROL;
         self
     }
 
     /// Adds the Alt modifier.
     pub fn alt(mut self) -> Self {
-        self.modifiers |= KeyModifiers::ALT;
+        self.modifiers |= Modifiers::ALT;
         self
     }
 
     /// Adds the Shift modifier.
     pub fn shift(mut self) -> Self {
-        self.modifiers |= KeyModifiers::SHIFT;
+        self.modifiers |= Modifiers::SHIFT;
         self
     }
 

--- a/src/input/events/tests.rs
+++ b/src/input/events/tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::input::key::{Key, KeyEvent, KeyEventKind, Modifiers};
+use crate::input::mouse::{MouseButton, MouseEvent, MouseEventKind};
 
 // -------------------------------------------------------------------------
 // Event constructors
@@ -9,48 +11,51 @@ fn test_simulated_event_char() {
     let event = Event::char('a');
     assert!(event.is_key());
     let key = event.as_key().unwrap();
-    assert_eq!(key.code, KeyCode::Char('a'));
-    assert_eq!(key.modifiers, KeyModifiers::NONE);
+    assert_eq!(key.key, Key::Char('a'));
+    assert!(key.modifiers.is_none());
+    assert_eq!(key.raw_char, Some('a'));
 }
 
 #[test]
 fn test_simulated_event_char_with() {
-    let event = Event::char_with('A', KeyModifiers::SHIFT);
+    let event = Event::char_with('A', Modifiers::SHIFT);
     let key = event.as_key().unwrap();
-    assert_eq!(key.code, KeyCode::Char('A'));
-    assert!(key.modifiers.contains(KeyModifiers::SHIFT));
+    // KeyEvent::char('A') normalizes to lowercase
+    assert_eq!(key.key, Key::Char('a'));
+    assert!(key.modifiers.shift());
+    assert_eq!(key.raw_char, Some('A'));
 }
 
 #[test]
 fn test_simulated_event_key() {
-    let event = Event::key(KeyCode::Enter);
+    let event = Event::key(Key::Enter);
     let key = event.as_key().unwrap();
-    assert_eq!(key.code, KeyCode::Enter);
-    assert_eq!(key.modifiers, KeyModifiers::NONE);
+    assert_eq!(key.key, Key::Enter);
+    assert!(key.modifiers.is_none());
 }
 
 #[test]
 fn test_simulated_event_key_with() {
-    let event = Event::key_with(KeyCode::Tab, KeyModifiers::SHIFT);
+    let event = Event::key_with(Key::Tab, Modifiers::SHIFT);
     let key = event.as_key().unwrap();
-    assert_eq!(key.code, KeyCode::Tab);
-    assert!(key.modifiers.contains(KeyModifiers::SHIFT));
+    assert_eq!(key.key, Key::Tab);
+    assert!(key.modifiers.shift());
 }
 
 #[test]
 fn test_simulated_event_ctrl() {
     let event = Event::ctrl('c');
     let key = event.as_key().unwrap();
-    assert_eq!(key.code, KeyCode::Char('c'));
-    assert!(key.modifiers.contains(KeyModifiers::CONTROL));
+    assert_eq!(key.key, Key::Char('c'));
+    assert!(key.modifiers.ctrl());
 }
 
 #[test]
 fn test_simulated_event_alt() {
     let event = Event::alt('x');
     let key = event.as_key().unwrap();
-    assert_eq!(key.code, KeyCode::Char('x'));
-    assert!(key.modifiers.contains(KeyModifiers::ALT));
+    assert_eq!(key.key, Key::Char('x'));
+    assert!(key.modifiers.alt());
 }
 
 #[test]
@@ -148,7 +153,7 @@ fn test_simulated_event_as_mouse_none() {
 
 #[test]
 fn test_from_key_event() {
-    let key = KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE);
+    let key = KeyEvent::new(Key::Char('z'));
     let event: Event = key.into();
     assert!(event.is_key());
 }
@@ -159,55 +164,10 @@ fn test_from_mouse_event() {
         kind: MouseEventKind::Moved,
         column: 0,
         row: 0,
-        modifiers: KeyModifiers::NONE,
+        modifiers: Modifiers::NONE,
     };
     let event: Event = mouse.into();
     assert!(event.is_mouse());
-}
-
-#[test]
-fn test_crossterm_conversion() {
-    let simulated = Event::key(KeyCode::Enter);
-    let crossterm: crossterm::event::Event = simulated.clone().into();
-    let back: Event = crossterm.into();
-    assert_eq!(simulated, back);
-}
-
-#[test]
-fn test_crossterm_conversion_resize() {
-    let event = crossterm::event::Event::Resize(80, 24);
-    let simulated: Event = event.into();
-    assert!(matches!(simulated, Event::Resize(80, 24)));
-
-    let back: crossterm::event::Event = simulated.into();
-    assert!(matches!(back, crossterm::event::Event::Resize(80, 24)));
-}
-
-#[test]
-fn test_crossterm_conversion_focus() {
-    let gained = crossterm::event::Event::FocusGained;
-    let simulated: Event = gained.into();
-    assert!(matches!(simulated, Event::FocusGained));
-
-    let back: crossterm::event::Event = simulated.into();
-    assert!(matches!(back, crossterm::event::Event::FocusGained));
-
-    let lost = crossterm::event::Event::FocusLost;
-    let simulated: Event = lost.into();
-    assert!(matches!(simulated, Event::FocusLost));
-
-    let back: crossterm::event::Event = simulated.into();
-    assert!(matches!(back, crossterm::event::Event::FocusLost));
-}
-
-#[test]
-fn test_crossterm_conversion_paste() {
-    let event = crossterm::event::Event::Paste("hello".to_string());
-    let simulated: Event = event.into();
-    assert!(matches!(simulated, Event::Paste(ref s) if s == "hello"));
-
-    let back: crossterm::event::Event = simulated.into();
-    assert!(matches!(back, crossterm::event::Event::Paste(ref s) if s == "hello"));
 }
 
 // -------------------------------------------------------------------------
@@ -218,31 +178,33 @@ fn test_crossterm_conversion_paste() {
 fn test_key_event_builder() {
     let event = KeyEventBuilder::new().char('x').ctrl().shift().build();
 
-    assert_eq!(event.code, KeyCode::Char('x'));
-    assert!(event.modifiers.contains(KeyModifiers::CONTROL));
-    assert!(event.modifiers.contains(KeyModifiers::SHIFT));
+    assert_eq!(event.key, Key::Char('x'));
+    assert!(event.modifiers.ctrl());
+    assert!(event.modifiers.shift());
 }
 
 #[test]
 fn test_key_event_builder_code() {
-    let event = KeyEventBuilder::new().code(KeyCode::F(1)).build();
+    let event = KeyEventBuilder::new().code(Key::F(1)).build();
 
-    assert_eq!(event.code, KeyCode::F(1));
+    assert_eq!(event.key, Key::F(1));
 }
 
 #[test]
 fn test_key_event_builder_alt() {
     let event = KeyEventBuilder::new().char('a').alt().build();
 
-    assert!(event.modifiers.contains(KeyModifiers::ALT));
+    assert!(event.modifiers.alt());
 }
 
 #[test]
 fn test_key_event_builder_modifiers() {
-    let mods = KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT;
+    let mods = Modifiers::CONTROL | Modifiers::ALT | Modifiers::SHIFT;
     let event = KeyEventBuilder::new().char('a').modifiers(mods).build();
 
-    assert_eq!(event.modifiers, mods);
+    assert!(event.modifiers.ctrl());
+    assert!(event.modifiers.alt());
+    assert!(event.modifiers.shift());
 }
 
 #[test]
@@ -260,14 +222,14 @@ fn test_key_event_builder_into_event() {
     let event = KeyEventBuilder::new().char('b').into_event();
 
     assert!(event.is_key());
-    assert_eq!(event.as_key().unwrap().code, KeyCode::Char('b'));
+    assert_eq!(event.as_key().unwrap().key, Key::Char('b'));
 }
 
 #[test]
 fn test_key_event_builder_default_code() {
-    // When no code is set, should use KeyCode::Null
+    // When no key is set, should use Key::Esc
     let event = KeyEventBuilder::new().build();
-    assert_eq!(event.code, KeyCode::Null);
+    assert_eq!(event.key, Key::Esc);
 }
 
 // -------------------------------------------------------------------------
@@ -288,7 +250,7 @@ fn test_mouse_event_builder() {
         event.kind,
         MouseEventKind::Down(MouseButton::Right)
     ));
-    assert!(event.modifiers.contains(KeyModifiers::CONTROL));
+    assert!(event.modifiers.ctrl());
 }
 
 #[test]
@@ -346,14 +308,14 @@ fn test_mouse_event_builder_scroll_down() {
 fn test_mouse_event_builder_alt() {
     let event = MouseEventBuilder::new().alt().build();
 
-    assert!(event.modifiers.contains(KeyModifiers::ALT));
+    assert!(event.modifiers.alt());
 }
 
 #[test]
 fn test_mouse_event_builder_shift() {
     let event = MouseEventBuilder::new().shift().build();
 
-    assert!(event.modifiers.contains(KeyModifiers::SHIFT));
+    assert!(event.modifiers.shift());
 }
 
 #[test]
@@ -382,7 +344,7 @@ fn test_mouse_event_builder_default() {
 #[test]
 fn test_kind_name_key() {
     assert_eq!(Event::char('a').kind_name(), "Key");
-    assert_eq!(Event::key(KeyCode::Enter).kind_name(), "Key");
+    assert_eq!(Event::key(Key::Enter).kind_name(), "Key");
     assert_eq!(Event::ctrl('c').kind_name(), "Key");
 }
 

--- a/src/input/key.rs
+++ b/src/input/key.rs
@@ -1,0 +1,379 @@
+//! Envision-owned keyboard input types.
+//!
+//! These types replace the crossterm re-exports that envision previously
+//! used for keyboard events. Letter keys are normalized to lowercase;
+//! use [`KeyEvent::raw_char`] for the actual terminal character.
+
+use std::ops::{BitAnd, BitOr, BitOrAssign};
+
+/// A keyboard key, normalized.
+///
+/// For ASCII letters, the `Char` variant always contains the lowercase
+/// form regardless of shift or caps lock state. Check
+/// [`KeyEvent::modifiers`] for shift state, and [`KeyEvent::raw_char`]
+/// for the character the terminal actually sent.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::input::key::Key;
+///
+/// // Pattern-match on normalized keys for keybindings
+/// let key = Key::Char('q');
+/// assert!(matches!(key, Key::Char('q')));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Key {
+    /// A character key. Always lowercase for ASCII letters.
+    Char(char),
+    /// A function key (F1 through F24).
+    F(u8),
+    /// The backspace key.
+    Backspace,
+    /// The enter/return key.
+    Enter,
+    /// The left arrow key.
+    Left,
+    /// The right arrow key.
+    Right,
+    /// The up arrow key.
+    Up,
+    /// The down arrow key.
+    Down,
+    /// The home key.
+    Home,
+    /// The end key.
+    End,
+    /// The page up key.
+    PageUp,
+    /// The page down key.
+    PageDown,
+    /// The tab key.
+    Tab,
+    /// The delete key.
+    Delete,
+    /// The insert key.
+    Insert,
+    /// The escape key.
+    Esc,
+}
+
+/// A keyboard event with normalization and raw character preservation.
+///
+/// # Two views of the same keypress
+///
+/// - **`key`**: normalized for keybindings. ASCII letters are always
+///   lowercase. Use this for `match` arms in `handle_event`.
+/// - **`raw_char`**: the character the terminal actually sent. Preserves
+///   case (uppercase for Shift or Caps Lock). Use this for text input.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::input::key::{Key, KeyEvent, Modifiers};
+///
+/// // Constructors normalize automatically
+/// let event = KeyEvent::char('A');
+/// assert_eq!(event.key, Key::Char('a'));        // normalized
+/// assert!(event.modifiers.shift());             // shift inferred
+/// assert_eq!(event.raw_char, Some('A'));         // original preserved
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeyEvent {
+    /// The key, normalized. ASCII letters are always lowercase.
+    pub key: Key,
+    /// Modifier keys held during the event.
+    pub modifiers: Modifiers,
+    /// Whether this is a press, release, or repeat.
+    pub kind: KeyEventKind,
+    /// The character the terminal actually sent, if this was a
+    /// character key. `None` for non-character keys.
+    pub raw_char: Option<char>,
+}
+
+impl KeyEvent {
+    /// Creates a key press event with no modifiers.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::key::{Key, KeyEvent};
+    ///
+    /// let event = KeyEvent::new(Key::Enter);
+    /// assert_eq!(event.key, Key::Enter);
+    /// assert!(event.modifiers.is_none());
+    /// assert!(event.raw_char.is_none());
+    /// ```
+    pub fn new(key: Key) -> Self {
+        Self {
+            key,
+            modifiers: Modifiers::NONE,
+            kind: KeyEventKind::Press,
+            raw_char: None,
+        }
+    }
+
+    /// Creates a normalized character key press.
+    ///
+    /// Uppercase letters are normalized: `char('A')` produces
+    /// `key=Char('a')`, `modifiers=SHIFT`, `raw_char=Some('A')`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::key::{Key, KeyEvent, Modifiers};
+    ///
+    /// let lower = KeyEvent::char('a');
+    /// assert_eq!(lower.key, Key::Char('a'));
+    /// assert!(lower.modifiers.is_none());
+    /// assert_eq!(lower.raw_char, Some('a'));
+    ///
+    /// let upper = KeyEvent::char('A');
+    /// assert_eq!(upper.key, Key::Char('a'));
+    /// assert!(upper.modifiers.shift());
+    /// assert_eq!(upper.raw_char, Some('A'));
+    /// ```
+    pub fn char(c: char) -> Self {
+        if c.is_ascii_uppercase() {
+            Self {
+                key: Key::Char(c.to_ascii_lowercase()),
+                modifiers: Modifiers::SHIFT,
+                kind: KeyEventKind::Press,
+                raw_char: Some(c),
+            }
+        } else {
+            Self {
+                key: Key::Char(c),
+                modifiers: Modifiers::NONE,
+                kind: KeyEventKind::Press,
+                raw_char: Some(c),
+            }
+        }
+    }
+
+    /// Creates a Ctrl+character key press.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::input::key::{Key, KeyEvent, Modifiers};
+    ///
+    /// let event = KeyEvent::ctrl('c');
+    /// assert_eq!(event.key, Key::Char('c'));
+    /// assert!(event.modifiers.ctrl());
+    /// ```
+    pub fn ctrl(c: char) -> Self {
+        Self {
+            key: Key::Char(c.to_ascii_lowercase()),
+            modifiers: Modifiers::CONTROL,
+            kind: KeyEventKind::Press,
+            raw_char: Some(c),
+        }
+    }
+
+    /// Returns true if this is a press event.
+    pub fn is_press(&self) -> bool {
+        self.kind == KeyEventKind::Press
+    }
+
+    /// Returns true if this is a release event.
+    pub fn is_release(&self) -> bool {
+        self.kind == KeyEventKind::Release
+    }
+}
+
+/// The kind of key event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum KeyEventKind {
+    /// A key was pressed.
+    Press,
+    /// A key was released (not supported by all terminals).
+    Release,
+    /// A key is being held and is repeating.
+    Repeat,
+}
+
+/// Modifier keys held during an input event.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::input::key::Modifiers;
+///
+/// let mods = Modifiers::CONTROL | Modifiers::SHIFT;
+/// assert!(mods.ctrl());
+/// assert!(mods.shift());
+/// assert!(!mods.alt());
+/// ```
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct Modifiers(u8);
+
+impl Modifiers {
+    /// No modifier keys held.
+    pub const NONE: Self = Self(0);
+    /// Shift key held.
+    pub const SHIFT: Self = Self(1 << 0);
+    /// Control key held.
+    pub const CONTROL: Self = Self(1 << 1);
+    /// Alt/Option key held.
+    pub const ALT: Self = Self(1 << 2);
+    /// Super/Cmd/Win key held.
+    pub const SUPER: Self = Self(1 << 3);
+
+    /// Returns true if the shift key is held.
+    pub fn shift(self) -> bool {
+        self.0 & Self::SHIFT.0 != 0
+    }
+
+    /// Returns true if the control key is held.
+    pub fn ctrl(self) -> bool {
+        self.0 & Self::CONTROL.0 != 0
+    }
+
+    /// Returns true if the alt/option key is held.
+    pub fn alt(self) -> bool {
+        self.0 & Self::ALT.0 != 0
+    }
+
+    /// Returns true if the super/cmd/win key is held.
+    pub fn super_key(self) -> bool {
+        self.0 & Self::SUPER.0 != 0
+    }
+
+    /// Returns true if no modifier keys are held.
+    pub fn is_none(self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl BitOr for Modifiers {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl BitOrAssign for Modifiers {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+impl BitAnd for Modifiers {
+    type Output = Self;
+    fn bitand(self, rhs: Self) -> Self {
+        Self(self.0 & rhs.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_key_equality() {
+        assert_eq!(Key::Char('a'), Key::Char('a'));
+        assert_ne!(Key::Char('a'), Key::Char('b'));
+        assert_ne!(Key::Char('a'), Key::Enter);
+        assert_eq!(Key::F(5), Key::F(5));
+        assert_ne!(Key::F(5), Key::F(6));
+    }
+
+    #[test]
+    fn test_key_event_new() {
+        let event = KeyEvent::new(Key::Enter);
+        assert_eq!(event.key, Key::Enter);
+        assert!(event.modifiers.is_none());
+        assert_eq!(event.kind, KeyEventKind::Press);
+        assert!(event.raw_char.is_none());
+    }
+
+    #[test]
+    fn test_key_event_char_lowercase() {
+        let event = KeyEvent::char('a');
+        assert_eq!(event.key, Key::Char('a'));
+        assert!(event.modifiers.is_none());
+        assert_eq!(event.raw_char, Some('a'));
+    }
+
+    #[test]
+    fn test_key_event_char_uppercase_normalizes() {
+        let event = KeyEvent::char('A');
+        assert_eq!(event.key, Key::Char('a'));
+        assert!(event.modifiers.shift());
+        assert_eq!(event.raw_char, Some('A'));
+    }
+
+    #[test]
+    fn test_key_event_ctrl() {
+        let event = KeyEvent::ctrl('c');
+        assert_eq!(event.key, Key::Char('c'));
+        assert!(event.modifiers.ctrl());
+        assert!(!event.modifiers.shift());
+        assert_eq!(event.raw_char, Some('c'));
+    }
+
+    #[test]
+    fn test_key_event_is_press_release() {
+        let press = KeyEvent::new(Key::Enter);
+        assert!(press.is_press());
+        assert!(!press.is_release());
+
+        let release = KeyEvent {
+            kind: KeyEventKind::Release,
+            ..KeyEvent::new(Key::Enter)
+        };
+        assert!(!release.is_press());
+        assert!(release.is_release());
+    }
+
+    #[test]
+    fn test_modifiers_default() {
+        let m = Modifiers::default();
+        assert!(m.is_none());
+        assert!(!m.shift());
+        assert!(!m.ctrl());
+        assert!(!m.alt());
+        assert!(!m.super_key());
+    }
+
+    #[test]
+    fn test_modifiers_individual() {
+        assert!(Modifiers::SHIFT.shift());
+        assert!(!Modifiers::SHIFT.ctrl());
+        assert!(Modifiers::CONTROL.ctrl());
+        assert!(!Modifiers::CONTROL.shift());
+        assert!(Modifiers::ALT.alt());
+        assert!(Modifiers::SUPER.super_key());
+    }
+
+    #[test]
+    fn test_modifiers_bitor() {
+        let mods = Modifiers::CONTROL | Modifiers::SHIFT;
+        assert!(mods.ctrl());
+        assert!(mods.shift());
+        assert!(!mods.alt());
+    }
+
+    #[test]
+    fn test_modifiers_bitor_assign() {
+        let mut mods = Modifiers::NONE;
+        mods |= Modifiers::ALT;
+        assert!(mods.alt());
+        assert!(!mods.ctrl());
+    }
+
+    #[test]
+    fn test_modifiers_bitand() {
+        let mods = Modifiers::CONTROL | Modifiers::SHIFT;
+        let masked = mods & Modifiers::CONTROL;
+        assert!(masked.ctrl());
+        assert!(!masked.shift());
+    }
+
+    #[test]
+    fn test_key_event_kind_equality() {
+        assert_eq!(KeyEventKind::Press, KeyEventKind::Press);
+        assert_ne!(KeyEventKind::Press, KeyEventKind::Release);
+    }
+}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -23,6 +23,8 @@
 //! ```
 
 mod events;
+pub mod key;
+pub mod mouse;
 mod queue;
 
 pub use events::{Event, KeyEventBuilder, MouseEventBuilder};

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -7,14 +7,13 @@
 //! # Example
 //!
 //! ```rust
-//! use envision::input::{EventQueue, Event};
-//! use crossterm::event::{KeyCode, KeyModifiers};
+//! use envision::input::{EventQueue, Event, Key};
 //!
 //! let mut queue = EventQueue::new();
 //!
 //! // Type "hello" then press Enter
 //! queue.type_str("hello");
-//! queue.key(KeyCode::Enter);
+//! queue.key(Key::Enter);
 //!
 //! // Process events
 //! while let Some(event) = queue.pop() {
@@ -29,10 +28,6 @@ pub mod mouse;
 mod queue;
 
 pub use events::{Event, KeyEventBuilder, MouseEventBuilder};
+pub use key::{Key, KeyEvent, KeyEventKind, Modifiers};
+pub use mouse::{MouseButton, MouseEvent, MouseEventKind};
 pub use queue::EventQueue;
-
-// Re-export crossterm event types for convenience
-pub use crossterm::event::{
-    KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton, MouseEvent,
-    MouseEventKind,
-};

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -22,6 +22,7 @@
 //! }
 //! ```
 
+pub(crate) mod convert;
 mod events;
 pub mod key;
 pub mod mouse;

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -1,0 +1,115 @@
+//! Envision-owned mouse input types.
+
+use super::key::Modifiers;
+
+/// A mouse event.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::input::mouse::{MouseEvent, MouseEventKind, MouseButton};
+/// use envision::input::key::Modifiers;
+///
+/// let event = MouseEvent {
+///     kind: MouseEventKind::Down(MouseButton::Left),
+///     column: 10,
+///     row: 5,
+///     modifiers: Modifiers::NONE,
+/// };
+/// assert_eq!(event.column, 10);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MouseEvent {
+    /// The kind of mouse event.
+    pub kind: MouseEventKind,
+    /// The column (x coordinate).
+    pub column: u16,
+    /// The row (y coordinate).
+    pub row: u16,
+    /// Modifier keys held during the event.
+    pub modifiers: Modifiers,
+}
+
+/// The kind of mouse event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MouseEventKind {
+    /// A button was pressed.
+    Down(MouseButton),
+    /// A button was released.
+    Up(MouseButton),
+    /// The mouse was dragged while a button was held.
+    Drag(MouseButton),
+    /// The mouse was moved (no button held).
+    Moved,
+    /// Scroll wheel up.
+    ScrollUp,
+    /// Scroll wheel down.
+    ScrollDown,
+    /// Scroll wheel left.
+    ScrollLeft,
+    /// Scroll wheel right.
+    ScrollRight,
+}
+
+/// A mouse button.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MouseButton {
+    /// The left mouse button.
+    Left,
+    /// The right mouse button.
+    Right,
+    /// The middle mouse button.
+    Middle,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mouse_event_construction() {
+        let event = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 10,
+            row: 5,
+            modifiers: Modifiers::NONE,
+        };
+        assert_eq!(event.column, 10);
+        assert_eq!(event.row, 5);
+        assert!(event.modifiers.is_none());
+    }
+
+    #[test]
+    fn test_mouse_event_kind_equality() {
+        assert_eq!(
+            MouseEventKind::Down(MouseButton::Left),
+            MouseEventKind::Down(MouseButton::Left),
+        );
+        assert_ne!(
+            MouseEventKind::Down(MouseButton::Left),
+            MouseEventKind::Down(MouseButton::Right),
+        );
+        assert_ne!(
+            MouseEventKind::Down(MouseButton::Left),
+            MouseEventKind::Up(MouseButton::Left),
+        );
+    }
+
+    #[test]
+    fn test_mouse_button_equality() {
+        assert_eq!(MouseButton::Left, MouseButton::Left);
+        assert_ne!(MouseButton::Left, MouseButton::Right);
+    }
+
+    #[test]
+    fn test_mouse_with_modifiers() {
+        let event = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 0,
+            row: 0,
+            modifiers: Modifiers::CONTROL | Modifiers::SHIFT,
+        };
+        assert!(event.modifiers.ctrl());
+        assert!(event.modifiers.shift());
+    }
+}

--- a/src/input/queue/mod.rs
+++ b/src/input/queue/mod.rs
@@ -3,9 +3,9 @@
 use std::collections::VecDeque;
 use std::time::Duration;
 
-use crossterm::event::KeyCode;
-
 use super::events::Event;
+use super::key::Key;
+use super::mouse::MouseButton;
 
 /// A queue of simulated input events.
 ///
@@ -15,13 +15,13 @@ use super::events::Event;
 /// # Example
 ///
 /// ```rust
-/// use envision::input::{EventQueue, KeyCode};
+/// use envision::input::{EventQueue, Key};
 ///
 /// let mut queue = EventQueue::new();
 ///
 /// // Type "hello" then press Enter
 /// queue.type_str("hello");
-/// queue.key(KeyCode::Enter);
+/// queue.key(Key::Enter);
 ///
 /// // Process events
 /// assert_eq!(queue.len(), 6); // 5 chars + Enter
@@ -51,11 +51,11 @@ impl EventQueue {
     /// # Example
     ///
     /// ```rust
-    /// use envision::input::{Event, EventQueue, KeyCode};
+    /// use envision::input::{Event, EventQueue, Key};
     ///
     /// let queue = EventQueue::with_events(vec![
     ///     Event::char('a'),
-    ///     Event::key(KeyCode::Enter),
+    ///     Event::key(Key::Enter),
     /// ]);
     /// assert_eq!(queue.len(), 2);
     /// ```
@@ -111,8 +111,8 @@ impl EventQueue {
     }
 
     /// Adds a key event for a special key.
-    pub fn key(&mut self, code: KeyCode) {
-        self.push(Event::key(code));
+    pub fn key(&mut self, key: Key) {
+        self.push(Event::key(key));
     }
 
     /// Adds a character key event.
@@ -149,72 +149,72 @@ impl EventQueue {
 
     /// Adds an Enter key event.
     pub fn enter(&mut self) {
-        self.key(KeyCode::Enter);
+        self.key(Key::Enter);
     }
 
     /// Adds an Escape key event.
     pub fn escape(&mut self) {
-        self.key(KeyCode::Esc);
+        self.key(Key::Esc);
     }
 
     /// Adds a Tab key event.
     pub fn tab(&mut self) {
-        self.key(KeyCode::Tab);
+        self.key(Key::Tab);
     }
 
     /// Adds a Backspace key event.
     pub fn backspace(&mut self) {
-        self.key(KeyCode::Backspace);
+        self.key(Key::Backspace);
     }
 
     /// Adds a Delete key event.
     pub fn delete(&mut self) {
-        self.key(KeyCode::Delete);
+        self.key(Key::Delete);
     }
 
     /// Adds an Up arrow key event.
     pub fn up(&mut self) {
-        self.key(KeyCode::Up);
+        self.key(Key::Up);
     }
 
     /// Adds a Down arrow key event.
     pub fn down(&mut self) {
-        self.key(KeyCode::Down);
+        self.key(Key::Down);
     }
 
     /// Adds a Left arrow key event.
     pub fn left(&mut self) {
-        self.key(KeyCode::Left);
+        self.key(Key::Left);
     }
 
     /// Adds a Right arrow key event.
     pub fn right(&mut self) {
-        self.key(KeyCode::Right);
+        self.key(Key::Right);
     }
 
     /// Adds a Home key event.
     pub fn home(&mut self) {
-        self.key(KeyCode::Home);
+        self.key(Key::Home);
     }
 
     /// Adds an End key event.
     pub fn end(&mut self) {
-        self.key(KeyCode::End);
+        self.key(Key::End);
     }
 
     /// Adds a Page Up key event.
     pub fn page_up(&mut self) {
-        self.key(KeyCode::PageUp);
+        self.key(Key::PageUp);
     }
 
     /// Adds a Page Down key event.
     pub fn page_down(&mut self) {
-        self.key(KeyCode::PageDown);
+        self.key(Key::PageDown);
     }
 
     /// Adds a function key event (F1-F12).
     pub fn function(&mut self, n: u8) {
-        self.key(KeyCode::F(n));
+        self.key(Key::F(n));
     }
 
     /// Adds a mouse click event.
@@ -233,11 +233,7 @@ impl EventQueue {
     /// Adds mouse events to simulate a drag from one position to another.
     pub fn drag(&mut self, from: (u16, u16), to: (u16, u16)) {
         self.push(Event::click(from.0, from.1));
-        self.push(Event::mouse_drag(
-            to.0,
-            to.1,
-            crossterm::event::MouseButton::Left,
-        ));
+        self.push(Event::mouse_drag(to.0, to.1, MouseButton::Left));
         self.push(Event::mouse_up(to.0, to.1));
     }
 

--- a/src/input/queue/tests.rs
+++ b/src/input/queue/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::input::key::Key;
 
 #[test]
 fn test_new_queue_is_empty() {
@@ -43,10 +44,10 @@ fn test_convenience_methods() {
     queue.backspace();
 
     assert_eq!(queue.len(), 4);
-    assert_eq!(queue.pop(), Some(Event::key(KeyCode::Enter)));
-    assert_eq!(queue.pop(), Some(Event::key(KeyCode::Esc)));
-    assert_eq!(queue.pop(), Some(Event::key(KeyCode::Tab)));
-    assert_eq!(queue.pop(), Some(Event::key(KeyCode::Backspace)));
+    assert_eq!(queue.pop(), Some(Event::key(Key::Enter)));
+    assert_eq!(queue.pop(), Some(Event::key(Key::Esc)));
+    assert_eq!(queue.pop(), Some(Event::key(Key::Tab)));
+    assert_eq!(queue.pop(), Some(Event::key(Key::Backspace)));
 }
 
 #[test]
@@ -58,10 +59,10 @@ fn test_arrow_keys() {
     queue.right();
 
     assert_eq!(queue.len(), 4);
-    assert_eq!(queue.pop(), Some(Event::key(KeyCode::Up)));
-    assert_eq!(queue.pop(), Some(Event::key(KeyCode::Down)));
-    assert_eq!(queue.pop(), Some(Event::key(KeyCode::Left)));
-    assert_eq!(queue.pop(), Some(Event::key(KeyCode::Right)));
+    assert_eq!(queue.pop(), Some(Event::key(Key::Up)));
+    assert_eq!(queue.pop(), Some(Event::key(Key::Down)));
+    assert_eq!(queue.pop(), Some(Event::key(Key::Left)));
+    assert_eq!(queue.pop(), Some(Event::key(Key::Right)));
 }
 
 #[test]
@@ -106,7 +107,7 @@ fn test_peek() {
 
 #[test]
 fn test_with_events() {
-    let events = vec![Event::char('a'), Event::key(KeyCode::Enter)];
+    let events = vec![Event::char('a'), Event::key(Key::Enter)];
 
     let queue = EventQueue::with_events(events);
     assert_eq!(queue.len(), 2);
@@ -163,7 +164,7 @@ fn test_delete() {
     queue.delete();
 
     assert_eq!(queue.len(), 1);
-    assert_eq!(queue.pop(), Some(Event::key(KeyCode::Delete)));
+    assert_eq!(queue.pop(), Some(Event::key(Key::Delete)));
 }
 
 #[test]
@@ -173,8 +174,8 @@ fn test_home_end() {
     queue.end();
 
     assert_eq!(queue.len(), 2);
-    assert_eq!(queue.pop(), Some(Event::key(KeyCode::Home)));
-    assert_eq!(queue.pop(), Some(Event::key(KeyCode::End)));
+    assert_eq!(queue.pop(), Some(Event::key(Key::Home)));
+    assert_eq!(queue.pop(), Some(Event::key(Key::End)));
 }
 
 #[test]
@@ -184,8 +185,8 @@ fn test_page_up_down() {
     queue.page_down();
 
     assert_eq!(queue.len(), 2);
-    assert_eq!(queue.pop(), Some(Event::key(KeyCode::PageUp)));
-    assert_eq!(queue.pop(), Some(Event::key(KeyCode::PageDown)));
+    assert_eq!(queue.pop(), Some(Event::key(Key::PageUp)));
+    assert_eq!(queue.pop(), Some(Event::key(Key::PageDown)));
 }
 
 #[test]
@@ -195,8 +196,8 @@ fn test_function_keys() {
     queue.function(12);
 
     assert_eq!(queue.len(), 2);
-    assert_eq!(queue.pop(), Some(Event::key(KeyCode::F(1))));
-    assert_eq!(queue.pop(), Some(Event::key(KeyCode::F(12))));
+    assert_eq!(queue.pop(), Some(Event::key(Key::F(1))));
+    assert_eq!(queue.pop(), Some(Event::key(Key::F(12))));
 }
 
 #[test]
@@ -318,7 +319,7 @@ fn test_queue_default() {
 #[test]
 fn test_key_method() {
     let mut queue = EventQueue::new();
-    queue.key(KeyCode::Insert);
+    queue.key(Key::Insert);
 
-    assert_eq!(queue.pop(), Some(Event::key(KeyCode::Insert)));
+    assert_eq!(queue.pop(), Some(Event::key(Key::Insert)));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@
 //! let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
 //!
 //! // Inject events programmatically
-//! vt.send(Event::key(KeyCode::Char('j')));
+//! vt.send(Event::char('j'));
 //! vt.tick()?;
 //!
 //! // Inspect the display
@@ -271,7 +271,7 @@ pub use component::{MarkdownRenderer, MarkdownRendererMessage, MarkdownRendererS
 
 pub use error::{BoxedError, EnvisionError, Result};
 pub use harness::{AppHarness, Assertion, Snapshot, TestHarness};
-pub use input::{Event, EventQueue};
+pub use input::{Event, EventQueue, Key, KeyEvent, Modifiers, MouseButton, MouseEvent};
 pub use overlay::{Overlay, OverlayAction, OverlayStack};
 pub use scroll::{ScrollState, render_scrollbar, render_scrollbar_inside_border};
 pub use theme::Theme;
@@ -298,7 +298,7 @@ pub mod prelude {
     };
 
     // Input
-    pub use crate::input::{Event, EventQueue, KeyCode, KeyModifiers};
+    pub use crate::input::{Event, EventQueue, Key, Modifiers};
 
     // Overlay
     pub use crate::overlay::{Overlay, OverlayAction, OverlayStack};

--- a/src/overlay/stack/tests.rs
+++ b/src/overlay/stack/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crossterm::event::KeyCode;
+use crate::input::Key;
 
 struct ConsumeOverlay;
 
@@ -145,7 +145,7 @@ fn test_stack_handle_event_dismiss() {
     impl Overlay<i32> for DismissOverlay {
         fn handle_event(&mut self, event: &Event) -> OverlayAction<i32> {
             if let Some(key) = event.as_key() {
-                if key.code == KeyCode::Esc {
+                if key.key == Key::Esc {
                     return OverlayAction::Dismiss;
                 }
             }
@@ -157,7 +157,7 @@ fn test_stack_handle_event_dismiss() {
     let mut stack: OverlayStack<i32> = OverlayStack::new();
     stack.push(Box::new(DismissOverlay));
 
-    let event = Event::key(KeyCode::Esc);
+    let event = Event::key(Key::Esc);
     let action = stack.handle_event(&event);
     assert!(matches!(action, OverlayAction::Dismiss));
 }

--- a/src/overlay/traits.rs
+++ b/src/overlay/traits.rs
@@ -18,9 +18,8 @@ use super::OverlayAction;
 ///
 /// ```rust
 /// use envision::overlay::{Overlay, OverlayAction};
-/// use envision::input::Event;
+/// use envision::input::{Event, Key};
 /// use envision::theme::Theme;
-/// use crossterm::event::KeyCode;
 /// use ratatui::layout::Rect;
 /// use ratatui::Frame;
 ///
@@ -31,9 +30,9 @@ use super::OverlayAction;
 /// impl Overlay<String> for ConfirmDialog {
 ///     fn handle_event(&mut self, event: &Event) -> OverlayAction<String> {
 ///         if let Some(key) = event.as_key() {
-///             match key.code {
-///                 KeyCode::Char('y') => OverlayAction::DismissWithMessage("confirmed".into()),
-///                 KeyCode::Char('n') | KeyCode::Esc => OverlayAction::Dismiss,
+///             match key.key {
+///                 Key::Char('y') => OverlayAction::DismissWithMessage("confirmed".into()),
+///                 Key::Char('n') | Key::Esc => OverlayAction::Dismiss,
 ///                 _ => OverlayAction::Consumed,
 ///             }
 ///         } else {
@@ -59,7 +58,7 @@ pub trait Overlay<M>: Send {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crossterm::event::KeyCode;
+    use crate::input::Key;
 
     struct TestOverlay {
         consumed_count: u32,
@@ -68,9 +67,9 @@ mod tests {
     impl Overlay<String> for TestOverlay {
         fn handle_event(&mut self, event: &Event) -> OverlayAction<String> {
             if let Some(key) = event.as_key() {
-                match key.code {
-                    KeyCode::Esc => OverlayAction::Dismiss,
-                    KeyCode::Enter => OverlayAction::DismissWithMessage("confirmed".to_string()),
+                match key.key {
+                    Key::Esc => OverlayAction::Dismiss,
+                    Key::Enter => OverlayAction::DismissWithMessage("confirmed".to_string()),
                     _ => {
                         self.consumed_count += 1;
                         OverlayAction::Consumed
@@ -99,7 +98,7 @@ mod tests {
     #[test]
     fn test_overlay_handle_event_dismiss() {
         let mut overlay = TestOverlay { consumed_count: 0 };
-        let event = Event::key(KeyCode::Esc);
+        let event = Event::key(Key::Esc);
 
         let action = overlay.handle_event(&event);
         assert!(matches!(action, OverlayAction::Dismiss));
@@ -108,7 +107,7 @@ mod tests {
     #[test]
     fn test_overlay_handle_event_dismiss_with_message() {
         let mut overlay = TestOverlay { consumed_count: 0 };
-        let event = Event::key(KeyCode::Enter);
+        let event = Event::key(Key::Enter);
 
         let action = overlay.handle_event(&event);
         assert!(matches!(action, OverlayAction::DismissWithMessage(ref s) if s == "confirmed"));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -359,7 +359,7 @@ fn test_form_workflow_with_focus_manager() {
     // Verify Checkbox is no longer focused and Button is
 
     // Press Enter on Button via dispatch_event
-    let enter_event = Event::key(crossterm::event::KeyCode::Enter);
+    let enter_event = Event::key(envision::input::Key::Enter);
     let output = Button::dispatch_event(
         &mut button,
         &enter_event,
@@ -385,7 +385,7 @@ fn test_selectable_list_stress_10000_items() {
     assert_eq!(state.selected_index(), Some(0));
 
     // Send 100 Down events via dispatch_event
-    let down_event = Event::key(crossterm::event::KeyCode::Down);
+    let down_event = Event::key(envision::input::Key::Down);
     for _ in 0..100 {
         SelectableList::<String>::dispatch_event(
             &mut state,

--- a/tests/integration_new_components_2.rs
+++ b/tests/integration_new_components_2.rs
@@ -709,23 +709,23 @@ fn test_slider_dispatch_event_keyboard() {
     let mut state = SliderState::new(0.0, 100.0).with_step(5.0);
 
     // Right arrow should increment
-    let event = envision::input::Event::key(crossterm::event::KeyCode::Right);
+    let event = envision::input::Event::key(envision::input::Key::Right);
     Slider::dispatch_event(&mut state, &event, &EventContext::new().focused(true));
     assert_eq!(state.value(), 5.0);
 
     // Left arrow should decrement
-    let event = envision::input::Event::key(crossterm::event::KeyCode::Left);
+    let event = envision::input::Event::key(envision::input::Key::Left);
     Slider::dispatch_event(&mut state, &event, &EventContext::new().focused(true));
     assert_eq!(state.value(), 0.0);
 
     // Home should go to min
     Slider::update(&mut state, SliderMessage::SetValue(50.0));
-    let event = envision::input::Event::key(crossterm::event::KeyCode::Home);
+    let event = envision::input::Event::key(envision::input::Key::Home);
     Slider::dispatch_event(&mut state, &event, &EventContext::new().focused(true));
     assert_eq!(state.value(), 0.0);
 
     // End should go to max
-    let event = envision::input::Event::key(crossterm::event::KeyCode::End);
+    let event = envision::input::Event::key(envision::input::Key::End);
     Slider::dispatch_event(&mut state, &event, &EventContext::new().focused(true));
     assert_eq!(state.value(), 100.0);
 }

--- a/tests/integration_stress.rs
+++ b/tests/integration_stress.rs
@@ -343,8 +343,8 @@ fn test_rapid_input_10000_events() {
     let mut state = SelectableListState::new(items);
 
     // Send 10,000 alternating Down/Up events via dispatch_event
-    let down = envision::Event::key(crossterm::event::KeyCode::Down);
-    let up = envision::Event::key(crossterm::event::KeyCode::Up);
+    let down = envision::Event::key(envision::input::Key::Down);
+    let up = envision::Event::key(envision::input::Key::Up);
 
     let ctx = envision::EventContext::new().focused(true);
     for i in 0..10_000 {


### PR DESCRIPTION
## Summary

**Breaking change for 0.14.0.** Replaces crossterm re-exports with envision-owned input types, decoupling the public API from crossterm entirely.

**Key changes:**
- \`KeyCode\` → \`Key\` (16-variant enum, ASCII letters always normalized to lowercase)
- \`KeyModifiers\` → \`Modifiers\` (plain struct with \`shift()\`/\`ctrl()\`/\`alt()\`/\`super_key()\` methods)
- \`KeyEvent\` — envision-owned, with \`raw_char: Option<char>\` preserving the terminal's original character for text input
- \`MouseEvent\` / \`MouseEventKind\` / \`MouseButton\` — envision-owned, mirroring crossterm's shape
- \`BackTab\` → \`Key::Tab\` with \`modifiers.shift()\`
- Niche keys (Media, Modifier-only, lock keys) silently dropped
- All crossterm types removed from public API
- \`TerminalEventSubscription\` handler now receives \`Event\` not \`crossterm::event::Event\`
- Text input components use \`raw_char\` for character insertion

Design spec: \`docs/superpowers/specs/2026-04-11-envision-owned-input-types-design.md\`

## Why

The investigation found envision re-exported 8 crossterm types as its public API. Every downstream user writing \`KeyCode::Char('q')\` depended on crossterm even though they imported from envision. Crossterm's key handling also has ambiguities (Shift+A normalization, BackTab as separate variant) that a framework should resolve.

Envision-owned types enable:
1. A clean, crossterm-free public API
2. Normalized key events for unambiguous keybindings
3. \`raw_char\` for correct text input regardless of shift/caps state
4. Foundation for future backend abstraction (termion/termwiz in 0.15.0+)

## Test plan

- [x] 7204 unit/integration tests pass
- [x] 1985 doc tests pass
- [x] All 89 examples compile
- [x] 25+ normalization tests covering: uppercase→lowercase, caps lock, Ctrl+C, BackTab, symbols, dropped keys
- [x] Zero \`KeyCode\` references outside convert.rs
- [x] Zero \`pub use crossterm\` in public re-exports
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] Zero \`#[allow(unused_imports)]\` or \`#[allow(dead_code)]\` added

## Migration

See MIGRATION.md for before/after examples:
1. Keybindings: \`KeyCode::Enter\` → \`Key::Enter\`
2. Character matching: \`KeyCode::Char('q')\` → \`Key::Char('q')\`
3. BackTab: \`KeyCode::BackTab\` → \`Key::Tab if modifiers.shift()\`
4. Text input: \`KeyCode::Char(c) => insert(c)\` → \`Key::Char(_) => insert(raw_char)\`
5. Modifiers: \`contains(KeyModifiers::SHIFT)\` → \`modifiers.shift()\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)