### PR TITLE
Make ProgressSender generic over progress type (BREAKING, 0.14.0)

### DIFF
--- a/src/app/worker/mod.rs
+++ b/src/app/worker/mod.rs
@@ -1,40 +1,57 @@
 //! Background task abstraction for TEA applications.
 //!
 //! The `Worker` module bridges async tasks to the TEA message loop with
-//! progress reporting and cancellation support. It provides a high-level
+//! typed progress reporting and cancellation support. It provides a high-level
 //! API for spawning background work that integrates naturally with the
 //! [`Command`] and [`Subscription`](crate::app::subscription::Subscription)
 //! system.
 //!
+//! # Progress Reporting
+//!
+//! Workers report progress via a [`ProgressSender<P>`] where `P` is your
+//! own progress type — an enum, struct, or any `Send + 'static` type.
+//! Use [`send`](ProgressSender::send) for important lifecycle events and
+//! [`try_send`](ProgressSender::try_send) for high-frequency updates where
+//! dropping one is acceptable.
+//!
 //! # Example
 //!
 //! ```rust
-//! use envision::app::worker::{WorkerBuilder, WorkerProgress};
+//! use envision::app::worker::WorkerBuilder;
 //! use envision::app::Command;
-//! use std::time::Duration;
+//!
+//! #[derive(Clone)]
+//! enum Progress {
+//!     ChapterCount(usize),
+//!     Encoding { percent: f32 },
+//!     FileSize(u64),
+//! }
 //!
 //! #[derive(Clone)]
 //! enum Msg {
-//!     Progress(WorkerProgress),
+//!     Update(Progress),
 //!     Done(String),
 //!     Failed(String),
 //! }
 //!
-//! // Spawn a simple worker (no progress reporting)
-//! let (cmd, handle) = WorkerBuilder::new("download")
-//!     .spawn_simple(
-//!         |_cancel| async move {
-//!             Ok::<_, String>("data".to_string())
+//! let (cmd, sub, handle) = WorkerBuilder::new("transcode")
+//!     .with_channel_capacity(128)
+//!     .spawn(
+//!         |sender, _cancel| async move {
+//!             sender.send(Progress::ChapterCount(12)).await.ok();
+//!             // High-frequency updates: try_send drops if channel full
+//!             sender.try_send(Progress::Encoding { percent: 0.5 }).ok();
+//!             Ok::<_, String>("output.m4b".to_string())
 //!         },
+//!         Msg::Update,
 //!         |result: Result<String, String>| match result {
-//!             Ok(data) => Msg::Done(data),
+//!             Ok(path) => Msg::Done(path),
 //!             Err(e) => Msg::Failed(e),
 //!         },
 //!     );
 //!
 //! // Cancel if needed
 //! handle.cancel();
-//! assert!(handle.is_cancelled());
 //! ```
 
 use std::future::Future;
@@ -45,7 +62,21 @@ use tokio_util::sync::CancellationToken;
 use super::command::Command;
 use super::subscription::{BoxedSubscription, ChannelSubscription, MappedSubscription};
 
-/// Progress information from a background worker.
+/// A convenience progress type providing percentage and status string.
+///
+/// This is one possible type for `ProgressSender<P>`. Use it when your
+/// worker only needs to report a completion percentage and an optional
+/// status message. For richer progress reporting, define your own type.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::app::worker::WorkerProgress;
+///
+/// let progress = WorkerProgress::new(0.5, Some("Downloading...".to_string()));
+/// assert_eq!(progress.percentage(), 0.5);
+/// assert_eq!(progress.status(), Some("Downloading..."));
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 pub struct WorkerProgress {
     /// Progress percentage (0.0 to 1.0, clamped).
@@ -64,9 +95,13 @@ impl WorkerProgress {
     /// ```rust
     /// use envision::app::worker::WorkerProgress;
     ///
-    /// let progress = WorkerProgress::new(0.5, Some("Downloading...".to_string()));
-    /// assert_eq!(progress.percentage(), 0.5);
-    /// assert_eq!(progress.status(), Some("Downloading..."));
+    /// let progress = WorkerProgress::new(0.75, Some("Processing...".to_string()));
+    /// assert_eq!(progress.percentage(), 0.75);
+    /// assert_eq!(progress.status(), Some("Processing..."));
+    ///
+    /// // Clamping
+    /// let clamped = WorkerProgress::new(1.5, None);
+    /// assert_eq!(clamped.percentage(), 1.0);
     /// ```
     pub fn new(percentage: f32, status: Option<String>) -> Self {
         Self {
@@ -86,53 +121,81 @@ impl WorkerProgress {
     }
 }
 
-/// A sender for reporting progress from within a worker task.
+/// A sender for reporting typed progress from within a worker task.
 ///
-/// This is passed to the worker's task function to allow it to
-/// send progress updates back to the application's message loop.
+/// Generic over `P` — the progress message type. Use any `Send + 'static`
+/// type: an enum with domain-specific variants, a struct, or the built-in
+/// [`WorkerProgress`] for simple percentage+string reporting.
+///
+/// # Backpressure vs fire-and-forget
+///
+/// - [`send`](Self::send): async, applies backpressure. Use for important
+///   lifecycle events (started, completed, failed) that must not be dropped.
+/// - [`try_send`](Self::try_send): non-blocking, drops the message if the
+///   channel is full. Use for high-frequency informational updates (per-frame
+///   progress ticks, per-segment completions) where dropping one is better
+///   than blocking the worker pipeline.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::app::worker::{WorkerBuilder, ProgressSender};
+///
+/// #[derive(Clone)]
+/// enum Update {
+///     Started,
+///     Tick(f32),
+///     Finished,
+/// }
+///
+/// #[derive(Clone)]
+/// enum Msg { Update(Update), Done(()) }
+///
+/// let (cmd, sub, handle) = WorkerBuilder::new("work")
+///     .spawn(
+///         |sender: ProgressSender<Update>, _cancel| async move {
+///             sender.send(Update::Started).await.ok();
+///             for i in 0..100 {
+///                 // Non-blocking: ok to drop if channel is full
+///                 sender.try_send(Update::Tick(i as f32 / 100.0)).ok();
+///             }
+///             sender.send(Update::Finished).await.ok();
+///             Ok::<_, ()>(())
+///         },
+///         Msg::Update,
+///         |_| Msg::Done(()),
+///     );
+/// ```
 #[derive(Clone)]
-pub struct ProgressSender {
-    tx: mpsc::Sender<WorkerProgress>,
+pub struct ProgressSender<P> {
+    tx: mpsc::Sender<P>,
 }
 
-impl ProgressSender {
-    /// Sends a progress update.
+impl<P: Send + 'static> ProgressSender<P> {
+    /// Sends a progress update, waiting if the channel is full.
     ///
-    /// Returns `Ok(())` if the message was sent, or `Err` if the
-    /// channel is closed (e.g., the worker was cancelled).
-    pub async fn send(
-        &self,
-        progress: WorkerProgress,
-    ) -> Result<(), mpsc::error::SendError<WorkerProgress>> {
+    /// Use this for important messages that must not be dropped (lifecycle
+    /// transitions, final results, error reports).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the progress channel is closed, which occurs when the
+    /// worker has been cancelled or the runtime has shut down.
+    pub async fn send(&self, progress: P) -> Result<(), mpsc::error::SendError<P>> {
         self.tx.send(progress).await
     }
 
-    /// Sends a progress update with just a percentage.
+    /// Attempts to send a progress update without blocking.
+    ///
+    /// Use this for high-frequency informational updates where dropping one
+    /// is acceptable (progress ticks, per-segment completions, metrics).
+    /// If the channel is full, the message is returned in the error.
     ///
     /// # Errors
     ///
-    /// Returns `Err` if the progress channel is closed, which occurs when the
-    /// worker has been cancelled or the runtime has shut down.
-    pub async fn send_percentage(
-        &self,
-        percentage: f32,
-    ) -> Result<(), mpsc::error::SendError<WorkerProgress>> {
-        self.send(WorkerProgress::new(percentage, None)).await
-    }
-
-    /// Sends a progress update with a percentage and status message.
-    ///
-    /// # Errors
-    ///
-    /// Returns `Err` if the progress channel is closed, which occurs when the
-    /// worker has been cancelled or the runtime has shut down.
-    pub async fn send_status(
-        &self,
-        percentage: f32,
-        status: impl Into<String>,
-    ) -> Result<(), mpsc::error::SendError<WorkerProgress>> {
-        self.send(WorkerProgress::new(percentage, Some(status.into())))
-            .await
+    /// Returns `Err` if the channel is full or closed.
+    pub fn try_send(&self, progress: P) -> Result<(), mpsc::error::TrySendError<P>> {
+        self.tx.try_send(progress)
     }
 }
 
@@ -145,7 +208,7 @@ impl ProgressSender {
 /// ```rust
 /// use envision::app::worker::WorkerHandle;
 ///
-/// // Handles are returned from Worker::spawn and Worker::spawn_simple
+/// // Handles are returned from WorkerBuilder::spawn and spawn_simple
 /// // Cancellation is automatic on drop, or explicit via cancel()
 /// ```
 pub struct WorkerHandle {
@@ -182,6 +245,30 @@ const DEFAULT_CHANNEL_CAPACITY: usize = 32;
 /// Builder for creating and spawning workers.
 ///
 /// Created via [`WorkerBuilder::new`].
+///
+/// # Example
+///
+/// ```rust
+/// use envision::app::worker::WorkerBuilder;
+/// use envision::app::Command;
+///
+/// #[derive(Clone)]
+/// enum Msg {
+///     Done(Vec<u8>),
+///     Failed(String),
+/// }
+///
+/// let (cmd, handle) = WorkerBuilder::new("fetch")
+///     .spawn_simple(
+///         |_cancel| async move {
+///             Ok::<_, String>(vec![1, 2, 3])
+///         },
+///         |result: Result<Vec<u8>, String>| match result {
+///             Ok(data) => Msg::Done(data),
+///             Err(e) => Msg::Failed(e),
+///         },
+///     );
+/// ```
 pub struct WorkerBuilder {
     id: String,
     channel_capacity: usize,
@@ -191,46 +278,29 @@ impl WorkerBuilder {
     /// Creates a new worker builder with the given identifier.
     ///
     /// The identifier is used for tracking and debugging purposes.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::app::worker::{WorkerBuilder, WorkerProgress};
-    /// use envision::app::Command;
-    ///
-    /// #[derive(Clone)]
-    /// enum Msg {
-    ///     Done(Vec<u8>),
-    ///     Failed(String),
-    /// }
-    ///
-    /// let (cmd, handle) = WorkerBuilder::new("fetch")
-    ///     .spawn_simple(
-    ///         |cancel| async move {
-    ///             Ok::<_, String>(vec![1, 2, 3])
-    ///         },
-    ///         |result: Result<Vec<u8>, String>| match result {
-    ///             Ok(data) => Msg::Done(data),
-    ///             Err(e) => Msg::Failed(e),
-    ///         },
-    ///     );
-    /// ```
     pub fn new(id: impl Into<String>) -> Self {
         Self {
             id: id.into(),
             channel_capacity: DEFAULT_CHANNEL_CAPACITY,
         }
     }
+
     /// Sets the channel capacity for progress updates.
     ///
     /// Default is 32. Higher values prevent the worker from blocking
     /// when the application is slow to process progress messages.
+    /// For high-frequency producers using [`try_send`](ProgressSender::try_send),
+    /// 128 is a good starting point.
     pub fn with_channel_capacity(mut self, capacity: usize) -> Self {
         self.channel_capacity = capacity;
         self
     }
 
-    /// Spawns a worker with progress reporting.
+    /// Spawns a worker with typed progress reporting.
+    ///
+    /// The worker receives a [`ProgressSender<P>`] for sending progress
+    /// updates of any user-defined type back to the application's message
+    /// loop.
     ///
     /// Returns:
     /// - A [`Command`] that executes the async task
@@ -239,25 +309,55 @@ impl WorkerBuilder {
     ///
     /// # Type Parameters
     ///
+    /// - `P`: The progress type — any `Send + 'static` type (your enum, struct, etc.)
     /// - `T`: The success type of the task
     /// - `E`: The error type of the task
     /// - `Fut`: The future returned by `task_fn`
-    /// - `F`: The task function, receiving a `ProgressSender` and `CancellationToken`
-    /// - `P`: Progress message mapper
-    /// - `C`: Completion message mapper
-    pub fn spawn<M, T, E, Fut, F, P, C>(
+    /// - `F`: The task function, receiving a `ProgressSender<P>` and `CancellationToken`
+    /// - `Pm`: Progress message mapper (`P -> M`)
+    /// - `C`: Completion message mapper (`Result<T, E> -> M`)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::app::worker::{WorkerBuilder, ProgressSender};
+    /// use envision::app::Command;
+    ///
+    /// #[derive(Clone)]
+    /// enum Progress { Started, Percent(f32), Done }
+    ///
+    /// #[derive(Clone)]
+    /// enum Msg { Progress(Progress), Complete(String) }
+    ///
+    /// let (cmd, sub, handle) = WorkerBuilder::new("process")
+    ///     .spawn(
+    ///         |sender: ProgressSender<Progress>, _cancel| async move {
+    ///             sender.send(Progress::Started).await.ok();
+    ///             sender.try_send(Progress::Percent(0.5)).ok();
+    ///             sender.send(Progress::Done).await.ok();
+    ///             Ok::<_, String>("result".to_string())
+    ///         },
+    ///         Msg::Progress,
+    ///         |result: Result<String, String>| match result {
+    ///             Ok(s) => Msg::Complete(s),
+    ///             Err(_) => Msg::Complete("failed".into()),
+    ///         },
+    ///     );
+    /// ```
+    pub fn spawn<M, P, T, E, Fut, F, Pm, C>(
         self,
         task_fn: F,
-        on_progress: P,
+        on_progress: Pm,
         on_complete: C,
     ) -> (Command<M>, BoxedSubscription<M>, WorkerHandle)
     where
         M: Send + Clone + 'static,
+        P: Send + 'static,
         T: Send + 'static,
         E: Send + 'static,
         Fut: Future<Output = Result<T, E>> + Send + 'static,
-        F: FnOnce(ProgressSender, CancellationToken) -> Fut + Send + 'static,
-        P: Fn(WorkerProgress) -> M + Send + 'static,
+        F: FnOnce(ProgressSender<P>, CancellationToken) -> Fut + Send + 'static,
+        Pm: Fn(P) -> M + Send + 'static,
         C: FnOnce(Result<T, E>) -> M + Send + 'static,
     {
         let cancel = CancellationToken::new();
@@ -293,13 +393,26 @@ impl WorkerBuilder {
     /// - A [`Command`] that executes the async task
     /// - A [`WorkerHandle`] for cancellation
     ///
-    /// # Type Parameters
+    /// # Example
     ///
-    /// - `T`: The success type of the task
-    /// - `E`: The error type of the task
-    /// - `Fut`: The future returned by `task_fn`
-    /// - `F`: The task function, receiving a `CancellationToken`
-    /// - `C`: Completion message mapper
+    /// ```rust
+    /// use envision::app::worker::WorkerBuilder;
+    /// use envision::app::Command;
+    ///
+    /// #[derive(Clone)]
+    /// enum Msg { Done(String), Failed(String) }
+    ///
+    /// let (cmd, handle) = WorkerBuilder::new("fetch")
+    ///     .spawn_simple(
+    ///         |_cancel| async move {
+    ///             Ok::<_, String>("data".to_string())
+    ///         },
+    ///         |result: Result<String, String>| match result {
+    ///             Ok(data) => Msg::Done(data),
+    ///             Err(e) => Msg::Failed(e),
+    ///         },
+    ///     );
+    /// ```
     pub fn spawn_simple<M, T, E, Fut, F, C>(
         self,
         task_fn: F,

--- a/src/app/worker/tests.rs
+++ b/src/app/worker/tests.rs
@@ -201,6 +201,7 @@ async fn test_spawn_with_progress() {
 #[tokio::test]
 async fn test_spawn_with_custom_progress_type() {
     #[derive(Clone, Debug)]
+    #[allow(dead_code)]
     enum Progress {
         ChapterFound(String),
         Encoding { percent: f32 },

--- a/src/app/worker/tests.rs
+++ b/src/app/worker/tests.rs
@@ -84,7 +84,7 @@ fn test_worker_builder_custom_capacity() {
 #[tokio::test]
 async fn test_progress_sender_send() {
     let (tx, mut rx) = mpsc::channel(8);
-    let sender = ProgressSender { tx };
+    let sender: ProgressSender<WorkerProgress> = ProgressSender { tx };
 
     sender
         .send(WorkerProgress::new(0.5, Some("halfway".to_string())))
@@ -97,27 +97,57 @@ async fn test_progress_sender_send() {
 }
 
 #[tokio::test]
-async fn test_progress_sender_send_percentage() {
+async fn test_progress_sender_custom_type() {
+    #[derive(Debug, PartialEq)]
+    enum MyProgress {
+        Started,
+        ChapterCount(usize),
+        Finished,
+    }
+
     let (tx, mut rx) = mpsc::channel(8);
-    let sender = ProgressSender { tx };
+    let sender: ProgressSender<MyProgress> = ProgressSender { tx };
 
-    sender.send_percentage(0.75).await.unwrap();
+    sender.send(MyProgress::Started).await.unwrap();
+    sender.send(MyProgress::ChapterCount(12)).await.unwrap();
+    sender.send(MyProgress::Finished).await.unwrap();
 
-    let received = rx.recv().await.unwrap();
-    assert_eq!(received.percentage(), 0.75);
-    assert!(received.status().is_none());
+    assert_eq!(rx.recv().await.unwrap(), MyProgress::Started);
+    assert_eq!(rx.recv().await.unwrap(), MyProgress::ChapterCount(12));
+    assert_eq!(rx.recv().await.unwrap(), MyProgress::Finished);
 }
 
 #[tokio::test]
-async fn test_progress_sender_send_status() {
+async fn test_progress_sender_try_send_succeeds() {
     let (tx, mut rx) = mpsc::channel(8);
-    let sender = ProgressSender { tx };
+    let sender: ProgressSender<u32> = ProgressSender { tx };
 
-    sender.send_status(0.3, "processing").await.unwrap();
+    sender.try_send(42).unwrap();
+    sender.try_send(43).unwrap();
 
-    let received = rx.recv().await.unwrap();
-    assert_eq!(received.percentage(), 0.3);
-    assert_eq!(received.status(), Some("processing"));
+    assert_eq!(rx.recv().await.unwrap(), 42);
+    assert_eq!(rx.recv().await.unwrap(), 43);
+}
+
+#[tokio::test]
+async fn test_progress_sender_try_send_full_channel() {
+    // Channel capacity 1 — second try_send should fail
+    let (tx, _rx) = mpsc::channel(1);
+    let sender: ProgressSender<u32> = ProgressSender { tx };
+
+    sender.try_send(1).unwrap(); // fills the channel
+    let result = sender.try_send(2);
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_progress_sender_try_send_closed_channel() {
+    let (tx, rx) = mpsc::channel(8);
+    let sender: ProgressSender<u32> = ProgressSender { tx };
+    drop(rx);
+
+    let result = sender.try_send(1);
+    assert!(result.is_err());
 }
 
 #[tokio::test]
@@ -152,8 +182,8 @@ async fn test_spawn_with_progress() {
     }
 
     let (cmd, _subscription, handle) = WorkerBuilder::new("download").spawn(
-        |progress_sender, _cancel| async move {
-            progress_sender.send_percentage(0.5).await.ok();
+        |sender: ProgressSender<WorkerProgress>, _cancel| async move {
+            sender.send(WorkerProgress::new(0.5, None)).await.ok();
             Ok::<_, String>("done".to_string())
         },
         Msg::Progress,
@@ -166,6 +196,40 @@ async fn test_spawn_with_progress() {
     assert!(!cmd.is_none());
     assert!(!handle.is_cancelled());
     assert_eq!(handle.id(), "download");
+}
+
+#[tokio::test]
+async fn test_spawn_with_custom_progress_type() {
+    #[derive(Clone, Debug)]
+    enum Progress {
+        ChapterFound(String),
+        Encoding { percent: f32 },
+    }
+
+    #[derive(Clone, Debug)]
+    #[allow(dead_code)]
+    enum Msg {
+        Update(Progress),
+        Done(String),
+    }
+
+    let (cmd, _sub, handle) = WorkerBuilder::new("transcode")
+        .with_channel_capacity(128)
+        .spawn(
+            |sender: ProgressSender<Progress>, _cancel| async move {
+                sender
+                    .send(Progress::ChapterFound("Chapter 1".into()))
+                    .await
+                    .ok();
+                sender.try_send(Progress::Encoding { percent: 0.5 }).ok();
+                Ok::<_, String>("output.m4b".to_string())
+            },
+            Msg::Update,
+            |result: Result<String, String>| Msg::Done(result.unwrap_or_default()),
+        );
+
+    assert!(!cmd.is_none());
+    assert_eq!(handle.id(), "transcode");
 }
 
 #[tokio::test]
@@ -190,11 +254,11 @@ async fn test_spawn_simple_error_handling() {
 #[tokio::test]
 async fn test_progress_sender_clone() {
     let (tx, mut rx) = mpsc::channel(8);
-    let sender = ProgressSender { tx };
+    let sender: ProgressSender<WorkerProgress> = ProgressSender { tx };
     let sender2 = sender.clone();
 
-    sender.send_percentage(0.25).await.unwrap();
-    sender2.send_percentage(0.50).await.unwrap();
+    sender.send(WorkerProgress::new(0.25, None)).await.unwrap();
+    sender2.send(WorkerProgress::new(0.50, None)).await.unwrap();
 
     let p1 = rx.recv().await.unwrap();
     let p2 = rx.recv().await.unwrap();
@@ -205,10 +269,10 @@ async fn test_progress_sender_clone() {
 #[tokio::test]
 async fn test_progress_sender_fails_when_receiver_dropped() {
     let (tx, rx) = mpsc::channel(8);
-    let sender = ProgressSender { tx };
+    let sender: ProgressSender<WorkerProgress> = ProgressSender { tx };
     drop(rx);
 
-    let result = sender.send_percentage(0.5).await;
+    let result = sender.send(WorkerProgress::new(0.5, None)).await;
     assert!(result.is_err());
 }
 


### PR DESCRIPTION
## Summary

**Breaking change for 0.14.0.** `ProgressSender` is now generic over the user's progress message type: `ProgressSender<P>`.

**Before:**
```rust
// Forced to use WorkerProgress (percentage + string)
sender.send_percentage(0.5).await?;
sender.send_status(0.3, "downloading").await?;
```

**After:**
```rust
// Use any type you want
sender.send(Progress::ChapterCount(12)).await?;
sender.try_send(Progress::Encoding { percent: 0.5 }).ok();
```

## Changes

- `ProgressSender<P>` is generic — any `Send + 'static` type works
- Removed `send_percentage()` and `send_status()` from core type (use `sender.send(WorkerProgress::new(...))` if you want percentage+string)
- Added `try_send()` for non-blocking fire-and-forget progress (drops message if channel full)
- `WorkerBuilder::spawn` now takes a generic `P` type parameter for progress
- `WorkerProgress` stays as a convenience type for the simple case
- `spawn_simple` unchanged (no progress channel)

## Why

Customer feedback: Claudio's coordinator sends rich structured updates (17+ variants — chapter counts, segment info, file sizes, durations). Forcing everything through percentage+string lost type safety.

## Test plan

- [x] 22 worker tests pass (including new tests for custom types, try_send full/closed)
- [x] Doc tests pass
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)