### PR TITLE
Rename KeyEvent.key to .code, fix new() normalization, align g/G pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are normalized to lowercase; use `raw_char` for text input.
   `BackTab` is replaced by `Tab` with `modifiers.shift()`.
   See MIGRATION.md for the upgrade path.
+- **`KeyEvent` field `key` renamed to `code`** for readability.
+  `key.key` becomes `key.code` in all match expressions. The type
+  is still `Key`.
 - **`TerminalEventSubscription` handler now receives `Event`**
   instead of `crossterm::event::Event`. The subscription converts
   crossterm events internally before invoking the handler.
@@ -81,6 +84,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `KeyEvent::new(Key::Char('G'))` now normalizes uppercase letters
+  to lowercase with SHIFT modifier, matching the behavior of
+  `KeyEvent::char()` and `from_crossterm_key`. Previously, test code
+  using `Event::key(Key::Char('G'))` produced events that could never
+  occur from real terminal input.
 - `ConversationView` markdown rendering also recolors spans with
   `fg: None` (in addition to spans with the theme default foreground),
   defending against future markdown renderer changes.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -11,7 +11,7 @@ key changes:
 |---|---|
 | `KeyCode` | `Key` |
 | `KeyModifiers` | `Modifiers` |
-| `key.code` | `key.key` |
+| `key.code` (crossterm) | `key.code` (envision) |
 | `KeyCode::Char('a')` | `Key::Char('a')` |
 | `KeyCode::BackTab` | `Key::Tab` with `key.modifiers.shift()` |
 | `key.modifiers.contains(KeyModifiers::SHIFT)` | `key.modifiers.shift()` |
@@ -42,7 +42,7 @@ match key.code {
 }
 
 // After
-match key.key {
+match key.code {
     Key::Enter => Some(Msg::Submit),
     Key::Char('q') => Some(Msg::Quit),
     Key::Tab if key.modifiers.shift() => Some(Msg::FocusPrev),
@@ -64,7 +64,7 @@ let shift = key.modifiers.shift();
 
 #### Text input (Insert(c) patterns)
 
-ASCII letter keys are normalized to lowercase in `key.key`. For text
+ASCII letter keys are normalized to lowercase in `key.code`. For text
 input, use `key.raw_char` which preserves the original character:
 
 ```rust
@@ -109,7 +109,7 @@ let sub = terminal_events(|event| {
 use envision::input::{Event, Key};
 let sub = terminal_events(|event| {
     if let Some(key) = event.as_key() {
-        if key.key == Key::Char('q') { return Some(Msg::Quit); }
+        if key.code == Key::Char('q') { return Some(Msg::Quit); }
     }
     None
 });

--- a/examples/accordion.rs
+++ b/examples/accordion.rs
@@ -103,7 +103,7 @@ impl App for AccordionApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/alert_panel.rs
+++ b/examples/alert_panel.rs
@@ -91,7 +91,7 @@ impl App for AlertPanelApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/beautiful_dashboard.rs
+++ b/examples/beautiful_dashboard.rs
@@ -340,7 +340,7 @@ impl App for DashboardApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 Key::Tab if key.modifiers.shift() => Some(Msg::FocusPrev),
 

--- a/examples/big_text.rs
+++ b/examples/big_text.rs
@@ -107,7 +107,7 @@ impl App for BigTextApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }

--- a/examples/box_plot.rs
+++ b/examples/box_plot.rs
@@ -67,7 +67,7 @@ impl App for BoxPlotApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }

--- a/examples/breadcrumb.rs
+++ b/examples/breadcrumb.rs
@@ -107,7 +107,7 @@ impl App for BreadcrumbApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -139,7 +139,7 @@ impl App for ButtonApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => return Some(Msg::Quit),
                 Key::Tab if key.modifiers.shift() => return Some(Msg::FocusPrev),
                 Key::Tab => return Some(Msg::FocusNext),

--- a/examples/calendar.rs
+++ b/examples/calendar.rs
@@ -79,7 +79,7 @@ impl App for CalendarApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -101,7 +101,7 @@ impl App for CanvasApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -78,7 +78,7 @@ impl App for ChartApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }

--- a/examples/chart_enhanced.rs
+++ b/examples/chart_enhanced.rs
@@ -90,7 +90,7 @@ impl App for ChartEnhancedApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }

--- a/examples/chat_client.rs
+++ b/examples/chat_client.rs
@@ -381,7 +381,7 @@ impl App for ChatClient {
         }
 
         // Global shortcuts
-        match key.key {
+        match key.code {
             Key::Char('q') if ctrl => return Some(Msg::Quit),
             Key::Char('p') if ctrl => return Some(Msg::TogglePalette),
             Key::Char('n') if ctrl => return Some(Msg::NewTab),
@@ -399,7 +399,7 @@ impl App for ChatClient {
 
         // Input-focused: Ctrl+Enter submits, other keys go to TextArea
         if state.focus.is_focused(&Focus::Input) {
-            if ctrl && key.key == Key::Enter {
+            if ctrl && key.code == Key::Enter {
                 return Some(Msg::SubmitInput);
             }
             return TextArea::handle_event(&state.input, event, &EventContext::default())

--- a/examples/checkbox.rs
+++ b/examples/checkbox.rs
@@ -136,7 +136,7 @@ impl App for CheckboxApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => return Some(Msg::Quit),
                 Key::Tab if key.modifiers.shift() => return Some(Msg::FocusPrev),
 

--- a/examples/code_block.rs
+++ b/examples/code_block.rs
@@ -112,7 +112,7 @@ fn main() {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/collapsible.rs
+++ b/examples/collapsible.rs
@@ -90,7 +90,7 @@ impl App for CollapsibleApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/command_palette.rs
+++ b/examples/command_palette.rs
@@ -154,10 +154,10 @@ impl App for CommandPaletteApp {
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         // Global key bindings
         if let Some(key) = event.as_key() {
-            if key.key == Key::Esc && !state.palette.is_visible() {
+            if key.code == Key::Esc && !state.palette.is_visible() {
                 return Some(Msg::Quit);
             }
-            if key.key == Key::Char('p') && key.modifiers.ctrl() && !state.palette.is_visible() {
+            if key.code == Key::Char('p') && key.modifiers.ctrl() && !state.palette.is_visible() {
                 return Some(Msg::TogglePalette);
             }
         }

--- a/examples/component_showcase.rs
+++ b/examples/component_showcase.rs
@@ -568,7 +568,7 @@ impl App for ShowcaseApp {
         use envision::input::Key;
 
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 Key::Tab if key.modifiers.shift() => Some(Msg::FocusPrev),
 

--- a/examples/confirm_dialog.rs
+++ b/examples/confirm_dialog.rs
@@ -138,7 +138,7 @@ impl App for ConfirmDialogApp {
         }
 
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 Key::Char('d') => Some(Msg::ShowDeleteDialog),
                 Key::Char('s') => Some(Msg::ShowSaveDialog),

--- a/examples/conversation_view.rs
+++ b/examples/conversation_view.rs
@@ -155,7 +155,7 @@ impl App for ConversationApp {
 
     fn handle_event_with_state(state: &Self::State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Esc) {
+            if matches!(key.code, Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/counter_app.rs
+++ b/examples/counter_app.rs
@@ -152,7 +152,7 @@ impl App for CounterApp {
         use envision::input::Key;
 
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('+') | Key::Up => Some(Msg::Increment),
                 Key::Char('-') | Key::Down => Some(Msg::Decrement),
                 Key::Char('r') => Some(Msg::Reset),

--- a/examples/dashboard_builder.rs
+++ b/examples/dashboard_builder.rs
@@ -310,7 +310,7 @@ impl App for Dashboard {
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         let key = event.as_key()?;
 
-        match key.key {
+        match key.code {
             Key::Char('q') | Key::Esc => Some(Msg::Quit),
             Key::Left | Key::Char('h') => Some(Msg::Tab(TabsMessage::Left)),
             Key::Right | Key::Char('l') => Some(Msg::Tab(TabsMessage::Right)),

--- a/examples/dashboard_demo.rs
+++ b/examples/dashboard_demo.rs
@@ -376,10 +376,10 @@ impl App for DashboardApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if key.key == Key::Char('t') && key.modifiers.ctrl() {
+            if key.code == Key::Char('t') && key.modifiers.ctrl() {
                 return Some(Msg::CycleTheme);
             }
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => return Some(Msg::Quit),
                 Key::Char(' ') => return Some(Msg::StartBuild),
                 Key::Char('1') => return Some(Msg::AddToast(ToastLevel::Info)),

--- a/examples/data_grid.rs
+++ b/examples/data_grid.rs
@@ -110,7 +110,7 @@ impl App for DataGridApp {
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if !state.grid.is_editing() {
             if let Some(key) = event.as_key() {
-                if matches!(key.key, Key::Char('q') | Key::Esc) {
+                if matches!(key.code, Key::Char('q') | Key::Esc) {
                     return Some(Msg::Quit);
                 }
             }

--- a/examples/dependency_graph.rs
+++ b/examples/dependency_graph.rs
@@ -132,7 +132,7 @@ impl App for DependencyGraphApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q')) {
+            if matches!(key.code, Key::Char('q')) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/dialog.rs
+++ b/examples/dialog.rs
@@ -100,7 +100,7 @@ impl App for DialogApp {
                 .map(Msg::Dialog);
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 Key::Char('d') => Some(Msg::ShowDialog),
                 _ => None,

--- a/examples/diff_viewer.rs
+++ b/examples/diff_viewer.rs
@@ -101,7 +101,7 @@ fn main() {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/divider.rs
+++ b/examples/divider.rs
@@ -90,7 +90,7 @@ impl App for DividerApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }

--- a/examples/dropdown.rs
+++ b/examples/dropdown.rs
@@ -75,7 +75,7 @@ impl App for DropdownApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if key.key == Key::Esc && !state.language.is_open() {
+            if key.code == Key::Esc && !state.language.is_open() {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/event_stream.rs
+++ b/examples/event_stream.rs
@@ -183,7 +183,7 @@ impl App for EventStreamApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if key.key == Key::Char('q') && !state.stream.is_search_focused() {
+            if key.code == Key::Char('q') && !state.stream.is_search_focused() {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/file_browser.rs
+++ b/examples/file_browser.rs
@@ -102,7 +102,7 @@ impl App for FileBrowserApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc)
+            if matches!(key.code, Key::Char('q') | Key::Esc)
                 && state.browser.filter_text().is_empty()
             {
                 return Some(Msg::Quit);

--- a/examples/file_manager.rs
+++ b/examples/file_manager.rs
@@ -314,7 +314,7 @@ impl App for FileManager {
         }
 
         // Global shortcuts
-        match key.key {
+        match key.code {
             Key::Char('q') if ctrl => return Some(Msg::Quit),
             Key::Char('p') if ctrl => return Some(Msg::TogglePalette),
             Key::Char('h') if ctrl => {

--- a/examples/flame_graph.rs
+++ b/examples/flame_graph.rs
@@ -109,7 +109,7 @@ impl App for FlameGraphApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q')) {
+            if matches!(key.code, Key::Char('q')) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/focus_manager.rs
+++ b/examples/focus_manager.rs
@@ -165,7 +165,7 @@ impl App for FocusManagerApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => return Some(Msg::Quit),
                 Key::Tab if key.modifiers.shift() => return Some(Msg::FocusPrev),
 

--- a/examples/form.rs
+++ b/examples/form.rs
@@ -104,7 +104,7 @@ impl App for FormApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if key.key == Key::Esc {
+            if key.code == Key::Esc {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -111,7 +111,7 @@ impl App for GaugeApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }

--- a/examples/heatmap.rs
+++ b/examples/heatmap.rs
@@ -69,7 +69,7 @@ impl App for HeatmapApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => return Some(Msg::Quit),
                 _ => {}
             }

--- a/examples/help_panel.rs
+++ b/examples/help_panel.rs
@@ -109,7 +109,7 @@ impl App for HelpPanelApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/histogram.rs
+++ b/examples/histogram.rs
@@ -62,7 +62,7 @@ impl App for HistogramApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }

--- a/examples/input_field.rs
+++ b/examples/input_field.rs
@@ -103,7 +103,7 @@ impl App for InputFieldApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if key.key == Key::Esc {
+            if key.code == Key::Esc {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/key_hints.rs
+++ b/examples/key_hints.rs
@@ -106,7 +106,7 @@ impl App for KeyHintsApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') => Some(Msg::Quit),
                 Key::Char('e') => Some(Msg::SwitchToEdit),
                 Key::Esc => Some(Msg::SwitchToNormal),

--- a/examples/line_input.rs
+++ b/examples/line_input.rs
@@ -91,7 +91,7 @@ impl App for LineInputApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Esc) {
+            if matches!(key.code, Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/loading_list.rs
+++ b/examples/loading_list.rs
@@ -91,7 +91,7 @@ impl App for LoadingListApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/log_correlation.rs
+++ b/examples/log_correlation.rs
@@ -156,7 +156,7 @@ impl App for LogCorrelationApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if key.key == Key::Char('q') {
+            if key.code == Key::Char('q') {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/log_explorer.rs
+++ b/examples/log_explorer.rs
@@ -343,7 +343,7 @@ impl App for LogExplorer {
 
         // Global shortcuts (always active)
         let ctrl = key.modifiers.ctrl();
-        match key.key {
+        match key.code {
             Key::Char('q') | Key::Esc => return Some(Msg::Quit),
             Key::Tab => return Some(Msg::FocusNext),
             Key::Char('p') if ctrl => return Some(Msg::TogglePalette),
@@ -376,7 +376,7 @@ impl App for LogExplorer {
         // SplitPanel resize (Shift+Left/Right)
         let shift = key.modifiers.shift();
         if shift {
-            match key.key {
+            match key.code {
                 Key::Left => return Some(Msg::Split(SplitPanelMessage::ShrinkFirst)),
                 Key::Right => return Some(Msg::Split(SplitPanelMessage::GrowFirst)),
                 _ => {}

--- a/examples/log_viewer.rs
+++ b/examples/log_viewer.rs
@@ -94,7 +94,7 @@ impl App for LogViewerApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if key.key == Key::Char('q') && !state.viewer.is_search_focused() {
+            if key.code == Key::Char('q') && !state.viewer.is_search_focused() {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/markdown_renderer.rs
+++ b/examples/markdown_renderer.rs
@@ -124,7 +124,7 @@ impl App for MarkdownRendererApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -91,7 +91,7 @@ impl App for MenuApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/metrics_dashboard.rs
+++ b/examples/metrics_dashboard.rs
@@ -78,7 +78,7 @@ impl App for MetricsDashboardApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/multi_progress.rs
+++ b/examples/multi_progress.rs
@@ -74,7 +74,7 @@ impl App for MultiProgressApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/number_input.rs
+++ b/examples/number_input.rs
@@ -131,7 +131,7 @@ impl App for NumberInputApp {
 
         if let Some(key) = event.as_key() {
             if !any_editing {
-                match key.key {
+                match key.code {
                     Key::Char('q') | Key::Esc => return Some(Msg::Quit),
                     Key::Tab if key.modifiers.shift() => return Some(Msg::FocusPrev),
 

--- a/examples/paginator.rs
+++ b/examples/paginator.rs
@@ -127,7 +127,7 @@ impl App for PaginatorApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 Key::Right | Key::Char('l') => Some(Msg::Next),
                 Key::Left | Key::Char('h') => Some(Msg::Prev),

--- a/examples/pane_layout.rs
+++ b/examples/pane_layout.rs
@@ -109,7 +109,7 @@ impl App for PaneLayoutApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => return Some(Msg::Quit),
                 Key::Char('r') => {
                     return Some(Msg::Layout(PaneLayoutMessage::ResetProportions));

--- a/examples/production_app.rs
+++ b/examples/production_app.rs
@@ -252,7 +252,7 @@ impl App for ProcessorApp {
 
     fn handle_event_with_state(state: &Self::State, event: &Event) -> Option<Self::Message> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => {
                     return Some(ProcessorMsg::Quit);
                 }

--- a/examples/progress_bar.rs
+++ b/examples/progress_bar.rs
@@ -84,7 +84,7 @@ impl App for ProgressBarApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }

--- a/examples/radio_group.rs
+++ b/examples/radio_group.rs
@@ -86,7 +86,7 @@ impl App for RadioGroupApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/router.rs
+++ b/examples/router.rs
@@ -120,7 +120,7 @@ impl App for RouterApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 Key::Char('s') => Some(Msg::Navigate(Screen::Settings)),
                 Key::Char('p') => Some(Msg::Navigate(Screen::Profile)),

--- a/examples/scroll_view.rs
+++ b/examples/scroll_view.rs
@@ -91,7 +91,7 @@ impl App for ScrollViewApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/scrollable_text.rs
+++ b/examples/scrollable_text.rs
@@ -77,7 +77,7 @@ impl App for ScrollableTextApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/searchable_list.rs
+++ b/examples/searchable_list.rs
@@ -112,7 +112,7 @@ impl App for SearchableListApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if key.key == Key::Esc {
+            if key.code == Key::Esc {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -121,7 +121,7 @@ impl App for SelectApp {
             // Only allow quit/tab when dropdown is closed
             let any_open = state.color.is_open() || state.size.is_open();
             if !any_open {
-                match key.key {
+                match key.code {
                     Key::Char('q') | Key::Esc => return Some(Msg::Quit),
                     Key::Tab if key.modifiers.shift() => return Some(Msg::FocusPrev),
 

--- a/examples/selectable_list.rs
+++ b/examples/selectable_list.rs
@@ -79,7 +79,7 @@ impl App for SelectableListApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/slider.rs
+++ b/examples/slider.rs
@@ -139,7 +139,7 @@ impl App for SliderApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => return Some(Msg::Quit),
                 Key::Tab if key.modifiers.shift() => return Some(Msg::FocusPrev),
 

--- a/examples/span_tree.rs
+++ b/examples/span_tree.rs
@@ -100,7 +100,7 @@ impl App for SpanTreeApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/sparkline.rs
+++ b/examples/sparkline.rs
@@ -83,7 +83,7 @@ impl App for SparklineApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }

--- a/examples/spinner.rs
+++ b/examples/spinner.rs
@@ -90,7 +90,7 @@ impl App for SpinnerApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }

--- a/examples/split_panel.rs
+++ b/examples/split_panel.rs
@@ -100,7 +100,7 @@ impl App for SplitPanelApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/status_bar.rs
+++ b/examples/status_bar.rs
@@ -117,7 +117,7 @@ impl App for StatusBarApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') => Some(Msg::Quit),
                 Key::Char('i') => Some(Msg::SwitchToInsert),
                 Key::Esc => Some(Msg::SwitchToNormal),

--- a/examples/status_log.rs
+++ b/examples/status_log.rs
@@ -70,7 +70,7 @@ impl App for StatusLogApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/step_indicator.rs
+++ b/examples/step_indicator.rs
@@ -127,7 +127,7 @@ impl App for StepIndicatorApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => return Some(Msg::Quit),
                 Key::Char('c') => return Some(Msg::Step(StepIndicatorMessage::CompleteActive)),
                 Key::Char('n') => return Some(Msg::Step(StepIndicatorMessage::ActivateNext)),

--- a/examples/styled_text.rs
+++ b/examples/styled_text.rs
@@ -149,7 +149,7 @@ impl App for StyledTextApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/styling_showcase.rs
+++ b/examples/styling_showcase.rs
@@ -313,10 +313,10 @@ impl App for StylingShowcaseApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if key.key == Key::Char('t') && key.modifiers.ctrl() {
+            if key.code == Key::Char('t') && key.modifiers.ctrl() {
                 return Some(Msg::CycleTheme);
             }
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => return Some(Msg::Quit),
                 Key::Tab => return Some(Msg::TogglePanel),
                 _ => {}

--- a/examples/switch.rs
+++ b/examples/switch.rs
@@ -169,7 +169,7 @@ impl App for SwitchApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => return Some(Msg::Quit),
                 Key::Tab if key.modifiers.shift() => return Some(Msg::FocusPrev),
 

--- a/examples/tab_bar.rs
+++ b/examples/tab_bar.rs
@@ -114,10 +114,10 @@ impl App for TabBarApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
-            if matches!(key.key, Key::Char('n')) {
+            if matches!(key.code, Key::Char('n')) {
                 return Some(Msg::AddNewTab);
             }
         }

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -118,7 +118,7 @@ impl App for TableApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => return Some(Msg::Quit),
                 Key::Char('s') => return Some(Msg::Table(TableMessage::SortBy(0))),
                 _ => {}

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -91,7 +91,7 @@ impl App for TabsApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/terminal_output.rs
+++ b/examples/terminal_output.rs
@@ -92,7 +92,7 @@ impl App for TerminalOutputApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/text_area.rs
+++ b/examples/text_area.rs
@@ -65,7 +65,7 @@ impl App for TextAreaApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if key.key == Key::Esc {
+            if key.code == Key::Esc {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/themed_app.rs
+++ b/examples/themed_app.rs
@@ -263,7 +263,7 @@ impl App for ThemedApp {
         use envision::input::Key;
 
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('t') => Some(Msg::ToggleTheme),
                 Key::Char(' ') => Some(Msg::CheckboxToggled),
                 Key::Char('+') | Key::Char('=') => Some(Msg::IncreaseProgress),

--- a/examples/timeline.rs
+++ b/examples/timeline.rs
@@ -86,7 +86,7 @@ impl App for TimelineApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }

--- a/examples/title_card.rs
+++ b/examples/title_card.rs
@@ -104,7 +104,7 @@ impl App for TitleCardApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 _ => None,
             }

--- a/examples/toast.rs
+++ b/examples/toast.rs
@@ -79,7 +79,7 @@ impl App for ToastApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 Key::Char('s') => Some(Msg::AddSuccess),
                 Key::Char('w') => Some(Msg::AddWarning),

--- a/examples/tooltip.rs
+++ b/examples/tooltip.rs
@@ -114,7 +114,7 @@ impl App for TooltipApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') | Key::Esc => Some(Msg::Quit),
                 Key::Char('h') => Some(Msg::ShowHelp),
                 Key::Char('w') => Some(Msg::ShowWarning),

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -87,7 +87,7 @@ impl App for TreeApp {
 
     fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if matches!(key.key, Key::Char('q') | Key::Esc) {
+            if matches!(key.code, Key::Char('q') | Key::Esc) {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/treemap.rs
+++ b/examples/treemap.rs
@@ -89,7 +89,7 @@ impl App for TreemapApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            if let Key::Char('q') = key.key {
+            if let Key::Char('q') = key.code {
                 return Some(Msg::Quit);
             }
         }

--- a/examples/usage_display.rs
+++ b/examples/usage_display.rs
@@ -104,7 +104,7 @@ impl App for UsageDisplayApp {
 
     fn handle_event(event: &Event) -> Option<Msg> {
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char('q') => Some(Msg::Quit),
                 _ => None,
             }

--- a/src/app/model/tests.rs
+++ b/src/app/model/tests.rs
@@ -148,7 +148,7 @@ impl App for CustomApp {
 
     fn handle_event(event: &Event) -> Option<Self::Message> {
         if let Some(key) = event.as_key() {
-            if let Key::Char(c) = key.key {
+            if let Key::Char(c) = key.code {
                 if c == 'q' {
                     return Some(CustomMsg::Quit);
                 }

--- a/src/app/runtime/tests/mod.rs
+++ b/src/app/runtime/tests/mod.rs
@@ -373,7 +373,7 @@ impl App for EventApp {
     fn handle_event(event: &crate::input::Event) -> Option<Self::Message> {
         use crate::input::Key;
         if let Some(key) = event.as_key() {
-            if let Key::Char(c) = key.key {
+            if let Key::Char(c) = key.code {
                 if c == 'q' {
                     return Some(EventMsg::Quit);
                 }
@@ -673,7 +673,7 @@ mod overlay_tests {
     impl Overlay<EventMsg> for DialogOverlay {
         fn handle_event(&mut self, event: &Event) -> OverlayAction<EventMsg> {
             if let Some(key) = event.as_key() {
-                match key.key {
+                match key.code {
                     Key::Esc => OverlayAction::Dismiss,
                     Key::Enter => OverlayAction::DismissWithMessage(EventMsg::KeyPressed('!')),
                     _ => OverlayAction::Consumed,

--- a/src/app/runtime_core/tests.rs
+++ b/src/app/runtime_core/tests.rs
@@ -53,7 +53,7 @@ impl App for TestApp {
 
     fn handle_event(event: &Event) -> Option<Self::Message> {
         if let Some(key) = event.as_key() {
-            if let Key::Char(c) = key.key {
+            if let Key::Char(c) = key.code {
                 return Some(TestMsg::Set(c.to_string()));
             }
         }

--- a/src/app/subscription/terminal.rs
+++ b/src/app/subscription/terminal.rs
@@ -20,10 +20,10 @@ use crate::input::Event;
 ///
 /// let sub = TerminalEventSubscription::new(|event| {
 ///     match &event {
-///         Event::Key(key) if key.key == Key::Char('q') => {
+///         Event::Key(key) if key.code == Key::Char('q') => {
 ///             Some("quit".to_string())
 ///         }
-///         Event::Key(key) if key.key == Key::Up => {
+///         Event::Key(key) if key.code == Key::Up => {
 ///             Some("up".to_string())
 ///         }
 ///         _ => None,
@@ -101,7 +101,7 @@ where
 ///
 /// let sub = terminal_events(|event| {
 ///     if let Event::Key(key) = &event {
-///         if key.key == Key::Char('q') {
+///         if key.code == Key::Char('q') {
 ///             return Some("quit".to_string());
 ///         }
 ///     }

--- a/src/app/subscription/tests/terminal_events.rs
+++ b/src/app/subscription/tests/terminal_events.rs
@@ -6,7 +6,7 @@ fn test_terminal_event_subscription_creation() {
     // Test that we can create a TerminalEventSubscription
     let _sub = TerminalEventSubscription::new(|event: Event| {
         if let Some(key) = event.as_key() {
-            if key.key == Key::Char('q') {
+            if key.code == Key::Char('q') {
                 return Some(TestMsg::Quit);
             }
         }
@@ -16,7 +16,7 @@ fn test_terminal_event_subscription_creation() {
     // Test the convenience function
     let _sub2 = terminal_events(|event: Event| {
         if let Some(key) = event.as_key() {
-            if key.key == Key::Enter {
+            if key.code == Key::Enter {
                 return Some(TestMsg::Tick);
             }
         }
@@ -29,7 +29,7 @@ fn test_terminal_event_handler_filters_events() {
     // Create handler that only responds to 'q'
     let handler = |event: Event| -> Option<TestMsg> {
         if let Some(key) = event.as_key() {
-            if key.key == Key::Char('q') {
+            if key.code == Key::Char('q') {
                 return Some(TestMsg::Quit);
             }
         }
@@ -51,7 +51,7 @@ fn test_terminal_event_handler_with_modifiers() {
     // Create handler that responds to Ctrl+C
     let handler = |event: Event| -> Option<TestMsg> {
         if let Some(key) = event.as_key() {
-            if key.key == Key::Char('c') && key.modifiers.ctrl() {
+            if key.code == Key::Char('c') && key.modifiers.ctrl() {
                 return Some(TestMsg::Quit);
             }
         }
@@ -102,7 +102,7 @@ enum TestMsgWithQuit {
 fn test_terminal_events_convenience_function() {
     let sub = terminal_events(|event: Event| -> Option<TestMsgWithQuit> {
         if let Some(key) = event.as_key() {
-            if key.key == Key::Char('q') {
+            if key.code == Key::Char('q') {
                 return Some(TestMsgWithQuit::Quit);
             }
             if let Some(c) = key.raw_char {

--- a/src/component/accordion/mod.rs
+++ b/src/component/accordion/mod.rs
@@ -739,7 +739,7 @@ impl Component for Accordion {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Up | Key::Char('k') => Some(AccordionMessage::Up),
                 Key::Down | Key::Char('j') => Some(AccordionMessage::Down),
                 Key::Enter | Key::Char(' ') => Some(AccordionMessage::Toggle),

--- a/src/component/alert_panel/mod.rs
+++ b/src/component/alert_panel/mod.rs
@@ -695,7 +695,7 @@ impl Component for AlertPanel {
 
         let key = event.as_key()?;
 
-        match key.key {
+        match key.code {
             Key::Left | Key::Char('h') => Some(AlertPanelMessage::SelectPrev),
             Key::Right | Key::Char('l') => Some(AlertPanelMessage::SelectNext),
             Key::Up | Key::Char('k') => Some(AlertPanelMessage::SelectUp),

--- a/src/component/box_plot/mod.rs
+++ b/src/component/box_plot/mod.rs
@@ -838,7 +838,7 @@ impl Component for BoxPlot {
 
         let key = event.as_key()?;
 
-        match key.key {
+        match key.code {
             Key::Right | Key::Char('l') => Some(BoxPlotMessage::NextDataset),
             Key::Left | Key::Char('h') => Some(BoxPlotMessage::PrevDataset),
             Key::Char('o') => Some(BoxPlotMessage::ToggleOutliers),

--- a/src/component/breadcrumb/mod.rs
+++ b/src/component/breadcrumb/mod.rs
@@ -648,7 +648,7 @@ impl Component for Breadcrumb {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Left | Key::Char('h') => Some(BreadcrumbMessage::Left),
                 Key::Right | Key::Char('l') => Some(BreadcrumbMessage::Right),
                 Key::Home => Some(BreadcrumbMessage::First),

--- a/src/component/button/mod.rs
+++ b/src/component/button/mod.rs
@@ -183,7 +183,7 @@ impl Component for Button {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Enter | Key::Char(' ') => Some(ButtonMessage::Press),
                 _ => None,
             }

--- a/src/component/calendar/mod.rs
+++ b/src/component/calendar/mod.rs
@@ -684,7 +684,7 @@ impl Component for Calendar {
         }
 
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Left | Key::Char('h') => Some(CalendarMessage::SelectPrevDay),
                 Key::Right | Key::Char('l') => Some(CalendarMessage::SelectNextDay),
                 Key::Up | Key::Char('k') => Some(CalendarMessage::SelectPrevWeek),

--- a/src/component/chart/mod.rs
+++ b/src/component/chart/mod.rs
@@ -741,7 +741,7 @@ impl Component for Chart {
 
         let key = event.as_key()?;
 
-        match key.key {
+        match key.code {
             Key::Tab if key.modifiers.shift() => Some(ChartMessage::PrevSeries),
             Key::Tab => Some(ChartMessage::NextSeries),
             Key::Left | Key::Char('h') => Some(ChartMessage::CursorLeft),

--- a/src/component/checkbox/mod.rs
+++ b/src/component/checkbox/mod.rs
@@ -250,7 +250,7 @@ impl Component for Checkbox {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Enter | Key::Char(' ') => Some(CheckboxMessage::Toggle),
                 _ => None,
             }

--- a/src/component/code_block/mod.rs
+++ b/src/component/code_block/mod.rs
@@ -556,7 +556,7 @@ impl Component for CodeBlock {
         let ctrl = key.modifiers.ctrl();
         let shift = key.modifiers.shift();
 
-        match key.key {
+        match key.code {
             Key::Up | Key::Char('k') if !ctrl => Some(CodeBlockMessage::ScrollUp),
             Key::Down | Key::Char('j') if !ctrl => Some(CodeBlockMessage::ScrollDown),
             Key::Left | Key::Char('h') if !ctrl => Some(CodeBlockMessage::ScrollLeft),
@@ -566,7 +566,7 @@ impl Component for CodeBlock {
             Key::Char('u') if ctrl => Some(CodeBlockMessage::PageUp(10)),
             Key::Char('d') if ctrl => Some(CodeBlockMessage::PageDown(10)),
             Key::Home | Key::Char('g') if !shift => Some(CodeBlockMessage::Home),
-            Key::End | Key::Char('g') if key.modifiers.shift() || key.key == Key::End => {
+            Key::End | Key::Char('g') if key.modifiers.shift() || key.code == Key::End => {
                 Some(CodeBlockMessage::End)
             }
             Key::Char('n') if !ctrl => Some(CodeBlockMessage::ToggleLineNumbers),

--- a/src/component/collapsible/mod.rs
+++ b/src/component/collapsible/mod.rs
@@ -424,7 +424,7 @@ impl Component for Collapsible {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Char(' ') | Key::Enter => Some(CollapsibleMessage::Toggle),
                 Key::Right => Some(CollapsibleMessage::Expand),
                 Key::Left => Some(CollapsibleMessage::Collapse),

--- a/src/component/command_palette/mod.rs
+++ b/src/component/command_palette/mod.rs
@@ -626,7 +626,7 @@ impl Component for CommandPalette {
         }
 
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Esc => Some(CommandPaletteMessage::Dismiss),
                 Key::Enter => Some(CommandPaletteMessage::Confirm),
                 Key::Backspace => Some(CommandPaletteMessage::Backspace),

--- a/src/component/confirm_dialog/mod.rs
+++ b/src/component/confirm_dialog/mod.rs
@@ -574,7 +574,7 @@ impl Component for ConfirmDialog {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Tab if key.modifiers.shift() => Some(ConfirmDialogMessage::FocusPrev),
                 Key::Tab => Some(ConfirmDialogMessage::FocusNext),
                 Key::Enter => Some(ConfirmDialogMessage::Press),

--- a/src/component/conversation_view/mod.rs
+++ b/src/component/conversation_view/mod.rs
@@ -815,7 +815,7 @@ impl Component for ConversationView {
 
         let key = event.as_key()?;
 
-        match key.key {
+        match key.code {
             Key::Up | Key::Char('k') => Some(ConversationViewMessage::ScrollUp),
             Key::Down | Key::Char('j') => Some(ConversationViewMessage::ScrollDown),
             Key::Char('g') if key.modifiers.shift() => {

--- a/src/component/data_grid/mod.rs
+++ b/src/component/data_grid/mod.rs
@@ -633,7 +633,7 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
         if let Some(key) = event.as_key() {
             if state.editing {
                 // Editing mode key bindings
-                match key.key {
+                match key.code {
                     Key::Enter => Some(DataGridMessage::Enter),
                     Key::Esc => Some(DataGridMessage::Cancel),
                     Key::Char(_) => key.raw_char.map(DataGridMessage::Input),
@@ -645,7 +645,7 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
                 }
             } else {
                 // Navigation mode key bindings
-                match key.key {
+                match key.code {
                     Key::Up | Key::Char('k') => Some(DataGridMessage::Up),
                     Key::Down | Key::Char('j') => Some(DataGridMessage::Down),
                     Key::Left | Key::Char('h') => Some(DataGridMessage::Left),

--- a/src/component/dependency_graph/mod.rs
+++ b/src/component/dependency_graph/mod.rs
@@ -797,7 +797,7 @@ impl Component for DependencyGraph {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Tab if key.modifiers.shift() => Some(DependencyGraphMessage::SelectPrev),
                 Key::Down | Key::Char('j') | Key::Tab => Some(DependencyGraphMessage::SelectNext),
                 Key::Up | Key::Char('k') => Some(DependencyGraphMessage::SelectPrev),

--- a/src/component/dialog/mod.rs
+++ b/src/component/dialog/mod.rs
@@ -663,7 +663,7 @@ impl Component for Dialog {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Tab if key.modifiers.shift() => Some(DialogMessage::FocusPrev),
                 Key::Tab => Some(DialogMessage::FocusNext),
                 Key::Enter => Some(DialogMessage::Press),

--- a/src/component/diff_viewer/mod.rs
+++ b/src/component/diff_viewer/mod.rs
@@ -759,7 +759,7 @@ impl Component for DiffViewer {
         let ctrl = key.modifiers.ctrl();
         let shift = key.modifiers.shift();
 
-        match key.key {
+        match key.code {
             Key::Up | Key::Char('k') if !ctrl => Some(DiffViewerMessage::ScrollUp),
             Key::Down | Key::Char('j') if !ctrl => Some(DiffViewerMessage::ScrollDown),
             Key::Char('n') if !shift && !ctrl => Some(DiffViewerMessage::NextHunk),
@@ -770,7 +770,7 @@ impl Component for DiffViewer {
             Key::Char('u') if ctrl => Some(DiffViewerMessage::PageUp(10)),
             Key::Char('d') if ctrl => Some(DiffViewerMessage::PageDown(10)),
             Key::Home | Key::Char('g') if !shift => Some(DiffViewerMessage::Home),
-            Key::End | Key::Char('g') if key.modifiers.shift() || key.key == Key::End => {
+            Key::End | Key::Char('g') if key.modifiers.shift() || key.code == Key::End => {
                 Some(DiffViewerMessage::End)
             }
             Key::Char('m') if !ctrl => Some(DiffViewerMessage::ToggleMode),

--- a/src/component/dropdown/mod.rs
+++ b/src/component/dropdown/mod.rs
@@ -655,7 +655,7 @@ impl Component for Dropdown {
         }
         if let Some(key) = event.as_key() {
             if state.is_open {
-                match key.key {
+                match key.code {
                     Key::Enter => Some(DropdownMessage::Confirm),
                     Key::Esc => Some(DropdownMessage::Close),
                     Key::Up => Some(DropdownMessage::Up),
@@ -665,7 +665,7 @@ impl Component for Dropdown {
                     _ => None,
                 }
             } else {
-                match key.key {
+                match key.code {
                     Key::Enter => Some(DropdownMessage::Toggle),
                     _ => None,
                 }

--- a/src/component/event_stream/mod.rs
+++ b/src/component/event_stream/mod.rs
@@ -174,7 +174,7 @@ impl Component for EventStream {
         let key = event.as_key()?;
 
         match state.focus {
-            Focus::List => match key.key {
+            Focus::List => match key.code {
                 Key::Up | Key::Char('k') => Some(EventStreamMessage::ScrollUp),
                 Key::Down | Key::Char('j') => Some(EventStreamMessage::ScrollDown),
                 Key::Char('g') if key.modifiers.shift() => Some(EventStreamMessage::ScrollToBottom),
@@ -189,7 +189,7 @@ impl Component for EventStream {
                 Key::Char('f') => Some(EventStreamMessage::ToggleAutoScroll),
                 _ => None,
             },
-            Focus::Search => match key.key {
+            Focus::Search => match key.code {
                 Key::Esc => Some(EventStreamMessage::ClearSearch),
                 Key::Enter => Some(EventStreamMessage::FocusList),
                 Key::Char(c) => {

--- a/src/component/file_browser/mod.rs
+++ b/src/component/file_browser/mod.rs
@@ -655,11 +655,11 @@ impl Component for FileBrowser {
         let shift = key.modifiers.shift();
 
         match state.internal_focus {
-            FileBrowserFocus::FileList => match key.key {
+            FileBrowserFocus::FileList => match key.code {
                 Key::Up | Key::Char('k') if !ctrl => Some(FileBrowserMessage::Up),
                 Key::Down | Key::Char('j') if !ctrl => Some(FileBrowserMessage::Down),
                 Key::Home | Key::Char('g') if !shift => Some(FileBrowserMessage::First),
-                Key::End | Key::Char('g') if key.modifiers.shift() || key.key == Key::End => {
+                Key::End | Key::Char('g') if key.modifiers.shift() || key.code == Key::End => {
                     Some(FileBrowserMessage::Last)
                 }
                 Key::PageUp => Some(FileBrowserMessage::PageUp(10)),
@@ -677,11 +677,11 @@ impl Component for FileBrowser {
                     .map(FileBrowserMessage::FilterChar),
                 _ => None,
             },
-            FileBrowserFocus::PathBar => match key.key {
+            FileBrowserFocus::PathBar => match key.code {
                 Key::Tab => Some(FileBrowserMessage::CycleFocus),
                 _ => None,
             },
-            FileBrowserFocus::Filter => match key.key {
+            FileBrowserFocus::Filter => match key.code {
                 Key::Tab => Some(FileBrowserMessage::CycleFocus),
                 Key::Backspace => Some(FileBrowserMessage::FilterBackspace),
                 Key::Esc => Some(FileBrowserMessage::FilterClear),

--- a/src/component/flame_graph/mod.rs
+++ b/src/component/flame_graph/mod.rs
@@ -864,7 +864,7 @@ impl Component for FlameGraph {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Up | Key::Char('k') => Some(FlameGraphMessage::SelectUp),
                 Key::Down | Key::Char('j') => Some(FlameGraphMessage::SelectDown),
                 Key::Left | Key::Char('h') => Some(FlameGraphMessage::SelectLeft),

--- a/src/component/form/mod.rs
+++ b/src/component/form/mod.rs
@@ -460,21 +460,21 @@ impl Component for Form {
 
         if let Some(key) = event.as_key() {
             // Global keys (regardless of field type)
-            if key.key == Key::Tab && key.modifiers.shift() {
+            if key.code == Key::Tab && key.modifiers.shift() {
                 return Some(FormMessage::FocusPrev);
             }
-            if key.key == Key::Tab {
+            if key.code == Key::Tab {
                 return Some(FormMessage::FocusNext);
             }
 
             // Ctrl+Enter submits the form
-            if key.key == Key::Enter && key.modifiers.ctrl() {
+            if key.code == Key::Enter && key.modifiers.ctrl() {
                 return Some(FormMessage::Submit);
             }
 
             // Field-specific keys
             match &state.states.get(state.focused_index)? {
-                FieldState::Text(_) => match key.key {
+                FieldState::Text(_) => match key.code {
                     Key::Char(c) => Some(FormMessage::Input(c)),
                     Key::Backspace => Some(FormMessage::Backspace),
                     Key::Delete => Some(FormMessage::Delete),
@@ -484,13 +484,13 @@ impl Component for Form {
                     Key::End => Some(FormMessage::End),
                     _ => None,
                 },
-                FieldState::Checkbox(_) => match key.key {
+                FieldState::Checkbox(_) => match key.code {
                     Key::Char(' ') | Key::Enter => Some(FormMessage::Toggle),
                     _ => None,
                 },
                 FieldState::Select(s) => {
                     if s.is_open() {
-                        match key.key {
+                        match key.code {
                             Key::Up | Key::Char('k') => Some(FormMessage::SelectUp),
                             Key::Down | Key::Char('j') => Some(FormMessage::SelectDown),
                             Key::Enter => Some(FormMessage::SelectConfirm),
@@ -498,7 +498,7 @@ impl Component for Form {
                             _ => None,
                         }
                     } else {
-                        match key.key {
+                        match key.code {
                             Key::Enter | Key::Char(' ') => Some(FormMessage::Toggle),
                             _ => None,
                         }

--- a/src/component/heatmap/mod.rs
+++ b/src/component/heatmap/mod.rs
@@ -625,7 +625,7 @@ impl Component for Heatmap {
 
         let key = event.as_key()?;
 
-        match key.key {
+        match key.code {
             Key::Up | Key::Char('k') => Some(HeatmapMessage::SelectUp),
             Key::Down | Key::Char('j') => Some(HeatmapMessage::SelectDown),
             Key::Left | Key::Char('h') => Some(HeatmapMessage::SelectLeft),

--- a/src/component/help_panel/mod.rs
+++ b/src/component/help_panel/mod.rs
@@ -635,7 +635,7 @@ impl Component for HelpPanel {
         let ctrl = key.modifiers.ctrl();
         let shift = key.modifiers.shift();
 
-        match key.key {
+        match key.code {
             Key::Up | Key::Char('k') if !ctrl => Some(HelpPanelMessage::ScrollUp),
             Key::Down | Key::Char('j') if !ctrl => Some(HelpPanelMessage::ScrollDown),
             Key::PageUp => Some(HelpPanelMessage::PageUp(10)),
@@ -643,7 +643,7 @@ impl Component for HelpPanel {
             Key::Char('u') if ctrl => Some(HelpPanelMessage::PageUp(10)),
             Key::Char('d') if ctrl => Some(HelpPanelMessage::PageDown(10)),
             Key::Home | Key::Char('g') if !shift => Some(HelpPanelMessage::Home),
-            Key::End | Key::Char('g') if key.modifiers.shift() || key.key == Key::End => {
+            Key::End | Key::Char('g') if key.modifiers.shift() || key.code == Key::End => {
                 Some(HelpPanelMessage::End)
             }
             _ => None,

--- a/src/component/input_field/mod.rs
+++ b/src/component/input_field/mod.rs
@@ -790,7 +790,7 @@ impl Component for InputField {
         if let Some(key) = event.as_key() {
             let ctrl = key.modifiers.ctrl();
             let shift = key.modifiers.shift();
-            match key.key {
+            match key.code {
                 // Undo/redo
                 Key::Char('z') if ctrl => Some(InputFieldMessage::Undo),
                 Key::Char('y') if ctrl => Some(InputFieldMessage::Redo),

--- a/src/component/line_input/mod.rs
+++ b/src/component/line_input/mod.rs
@@ -673,7 +673,7 @@ impl Component for LineInput {
         let ctrl = key.modifiers.ctrl();
         let shift = key.modifiers.shift();
 
-        match key.key {
+        match key.code {
             // Undo/Redo
             Key::Char('z') if ctrl => Some(LineInputMessage::Undo),
             Key::Char('y') if ctrl => Some(LineInputMessage::Redo),

--- a/src/component/loading_list/mod.rs
+++ b/src/component/loading_list/mod.rs
@@ -739,7 +739,7 @@ impl<T: Clone> Component for LoadingList<T> {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Up | Key::Char('k') => Some(LoadingListMessage::Up),
                 Key::Down | Key::Char('j') => Some(LoadingListMessage::Down),
                 Key::Enter => Some(LoadingListMessage::Select),

--- a/src/component/log_correlation/mod.rs
+++ b/src/component/log_correlation/mod.rs
@@ -736,7 +736,7 @@ impl Component for LogCorrelation {
 
         let key = event.as_key()?;
 
-        match key.key {
+        match key.code {
             Key::Up | Key::Char('k') => Some(LogCorrelationMessage::ScrollUp),
             Key::Down | Key::Char('j') => Some(LogCorrelationMessage::ScrollDown),
             Key::Home => Some(LogCorrelationMessage::ScrollToTop),

--- a/src/component/log_viewer/mod.rs
+++ b/src/component/log_viewer/mod.rs
@@ -200,7 +200,7 @@ impl Component for LogViewer {
         let key = event.as_key()?;
 
         match state.focus {
-            Focus::Log => match key.key {
+            Focus::Log => match key.code {
                 Key::Up | Key::Char('k') => Some(LogViewerMessage::ScrollUp),
                 Key::Down | Key::Char('j') => Some(LogViewerMessage::ScrollDown),
                 Key::Home => Some(LogViewerMessage::ScrollToTop),
@@ -213,7 +213,7 @@ impl Component for LogViewer {
                 Key::Char('4') => Some(LogViewerMessage::ToggleError),
                 _ => None,
             },
-            Focus::Search => match key.key {
+            Focus::Search => match key.code {
                 Key::Esc => Some(LogViewerMessage::ClearSearch),
                 Key::Enter => Some(LogViewerMessage::ConfirmSearch),
                 Key::Up => Some(LogViewerMessage::SearchHistoryUp),

--- a/src/component/markdown_renderer/mod.rs
+++ b/src/component/markdown_renderer/mod.rs
@@ -329,7 +329,7 @@ impl Component for MarkdownRenderer {
         let ctrl = key.modifiers.ctrl();
         let shift = key.modifiers.shift();
 
-        match key.key {
+        match key.code {
             Key::Up | Key::Char('k') if !ctrl => Some(MarkdownRendererMessage::ScrollUp),
             Key::Down | Key::Char('j') if !ctrl => Some(MarkdownRendererMessage::ScrollDown),
             Key::PageUp => Some(MarkdownRendererMessage::PageUp(10)),
@@ -337,7 +337,7 @@ impl Component for MarkdownRenderer {
             Key::Char('u') if ctrl => Some(MarkdownRendererMessage::PageUp(10)),
             Key::Char('d') if ctrl => Some(MarkdownRendererMessage::PageDown(10)),
             Key::Home | Key::Char('g') if !shift => Some(MarkdownRendererMessage::Home),
-            Key::End | Key::Char('g') if key.modifiers.shift() || key.key == Key::End => {
+            Key::End | Key::Char('g') if key.modifiers.shift() || key.code == Key::End => {
                 Some(MarkdownRendererMessage::End)
             }
             Key::Char('s') if !ctrl && !shift => Some(MarkdownRendererMessage::ToggleSource),

--- a/src/component/menu/mod.rs
+++ b/src/component/menu/mod.rs
@@ -515,7 +515,7 @@ impl Component for Menu {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Left => Some(MenuMessage::Left),
                 Key::Right => Some(MenuMessage::Right),
                 Key::Enter => Some(MenuMessage::Select),

--- a/src/component/metrics_dashboard/mod.rs
+++ b/src/component/metrics_dashboard/mod.rs
@@ -532,7 +532,7 @@ impl Component for MetricsDashboard {
 
         let key = event.as_key()?;
 
-        match key.key {
+        match key.code {
             Key::Left | Key::Char('h') => Some(MetricsDashboardMessage::Left),
             Key::Right | Key::Char('l') => Some(MetricsDashboardMessage::Right),
             Key::Up | Key::Char('k') => Some(MetricsDashboardMessage::Up),

--- a/src/component/multi_progress/mod.rs
+++ b/src/component/multi_progress/mod.rs
@@ -706,7 +706,7 @@ impl Component for MultiProgress {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Up | Key::Char('k') => Some(MultiProgressMessage::ScrollUp),
                 Key::Down | Key::Char('j') => Some(MultiProgressMessage::ScrollDown),
                 Key::Enter => Some(MultiProgressMessage::Select),

--- a/src/component/number_input/mod.rs
+++ b/src/component/number_input/mod.rs
@@ -540,7 +540,7 @@ impl Component for NumberInput {
         if let Some(key) = event.as_key() {
             if state.editing {
                 // Edit mode key handling
-                match key.key {
+                match key.code {
                     Key::Enter => Some(NumberInputMessage::ConfirmEdit),
                     Key::Esc => Some(NumberInputMessage::CancelEdit),
                     Key::Backspace => Some(NumberInputMessage::EditBackspace),
@@ -552,7 +552,7 @@ impl Component for NumberInput {
                 }
             } else {
                 // Normal mode key handling
-                match key.key {
+                match key.code {
                     Key::Up | Key::Char('k') => Some(NumberInputMessage::Increment),
                     Key::Down | Key::Char('j') => Some(NumberInputMessage::Decrement),
                     Key::Enter => Some(NumberInputMessage::StartEdit),

--- a/src/component/paginator/mod.rs
+++ b/src/component/paginator/mod.rs
@@ -491,7 +491,7 @@ impl Component for Paginator {
 
         let key = event.as_key()?;
 
-        match key.key {
+        match key.code {
             Key::Left | Key::Char('h') => Some(PaginatorMessage::PrevPage),
             Key::Right | Key::Char('l') => Some(PaginatorMessage::NextPage),
             Key::Home => Some(PaginatorMessage::FirstPage),

--- a/src/component/pane_layout/mod.rs
+++ b/src/component/pane_layout/mod.rs
@@ -805,7 +805,7 @@ impl Component for PaneLayout {
         let key = event.as_key()?;
         let ctrl = key.modifiers.ctrl();
 
-        match key.key {
+        match key.code {
             Key::Tab if key.modifiers.shift() => Some(PaneLayoutMessage::FocusPrev),
             Key::Tab if !ctrl => Some(PaneLayoutMessage::FocusNext),
             Key::Right | Key::Down if ctrl => Some(PaneLayoutMessage::GrowFocused),

--- a/src/component/radio_group/mod.rs
+++ b/src/component/radio_group/mod.rs
@@ -335,7 +335,7 @@ impl<T: Clone + std::fmt::Display + 'static> Component for RadioGroup<T> {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Up | Key::Char('k') => Some(RadioGroupMessage::Up),
                 Key::Down | Key::Char('j') => Some(RadioGroupMessage::Down),
                 Key::Enter => Some(RadioGroupMessage::Confirm),

--- a/src/component/scroll_view/mod.rs
+++ b/src/component/scroll_view/mod.rs
@@ -455,7 +455,7 @@ impl Component for ScrollView {
         let ctrl = key.modifiers.ctrl();
         let shift = key.modifiers.shift();
 
-        match key.key {
+        match key.code {
             Key::Up | Key::Char('k') if !ctrl => Some(ScrollViewMessage::ScrollUp),
             Key::Down | Key::Char('j') if !ctrl => Some(ScrollViewMessage::ScrollDown),
             Key::PageUp => Some(ScrollViewMessage::PageUp),
@@ -463,7 +463,7 @@ impl Component for ScrollView {
             Key::Char('u') if ctrl => Some(ScrollViewMessage::PageUp),
             Key::Char('d') if ctrl => Some(ScrollViewMessage::PageDown),
             Key::Home | Key::Char('g') if !shift => Some(ScrollViewMessage::Home),
-            Key::End | Key::Char('g') if key.modifiers.shift() || key.key == Key::End => {
+            Key::End | Key::Char('g') if key.modifiers.shift() || key.code == Key::End => {
                 Some(ScrollViewMessage::End)
             }
             _ => None,

--- a/src/component/scrollable_text/mod.rs
+++ b/src/component/scrollable_text/mod.rs
@@ -314,7 +314,7 @@ impl Component for ScrollableText {
         let ctrl = key.modifiers.ctrl();
         let shift = key.modifiers.shift();
 
-        match key.key {
+        match key.code {
             Key::Up | Key::Char('k') if !ctrl => Some(ScrollableTextMessage::ScrollUp),
             Key::Down | Key::Char('j') if !ctrl => Some(ScrollableTextMessage::ScrollDown),
             Key::PageUp => Some(ScrollableTextMessage::PageUp(10)),
@@ -322,7 +322,7 @@ impl Component for ScrollableText {
             Key::Char('u') if ctrl => Some(ScrollableTextMessage::PageUp(10)),
             Key::Char('d') if ctrl => Some(ScrollableTextMessage::PageDown(10)),
             Key::Home | Key::Char('g') if !shift => Some(ScrollableTextMessage::Home),
-            Key::End | Key::Char('g') if key.modifiers.shift() || key.key == Key::End => {
+            Key::End | Key::Char('g') if key.modifiers.shift() || key.code == Key::End => {
                 Some(ScrollableTextMessage::End)
             }
             _ => None,

--- a/src/component/searchable_list/mod.rs
+++ b/src/component/searchable_list/mod.rs
@@ -726,18 +726,18 @@ impl<T: Clone + Display + 'static> Component for SearchableList<T> {
 
         if let Some(key) = event.as_key() {
             // Tab always toggles focus between filter and list
-            if key.key == Key::Tab {
+            if key.code == Key::Tab {
                 return Some(SearchableListMessage::ToggleFocus);
             }
 
             // Esc clears the filter
-            if key.key == Key::Esc {
+            if key.code == Key::Esc {
                 return Some(SearchableListMessage::FilterClear);
             }
 
             match state.internal_focus {
                 Focus::Filter => {
-                    match key.key {
+                    match key.code {
                         // Navigation keys work from filter too
                         Key::Up | Key::Char('k') if key.modifiers.ctrl() => {
                             Some(SearchableListMessage::Up)
@@ -755,7 +755,7 @@ impl<T: Clone + Display + 'static> Component for SearchableList<T> {
                     }
                 }
                 Focus::List => {
-                    match key.key {
+                    match key.code {
                         Key::Up | Key::Char('k') => Some(SearchableListMessage::Up),
                         Key::Down | Key::Char('j') => Some(SearchableListMessage::Down),
                         Key::Char('g') if key.modifiers.shift() => {

--- a/src/component/select/mod.rs
+++ b/src/component/select/mod.rs
@@ -489,7 +489,7 @@ impl Component for Select {
         }
         if let Some(key) = event.as_key() {
             if state.is_open {
-                match key.key {
+                match key.code {
                     Key::Enter => Some(SelectMessage::Confirm),
                     Key::Esc => Some(SelectMessage::Close),
                     Key::Up | Key::Char('k') => Some(SelectMessage::Up),
@@ -497,7 +497,7 @@ impl Component for Select {
                     _ => None,
                 }
             } else {
-                match key.key {
+                match key.code {
                     Key::Enter | Key::Char(' ') => Some(SelectMessage::Toggle),
                     _ => None,
                 }

--- a/src/component/selectable_list/mod.rs
+++ b/src/component/selectable_list/mod.rs
@@ -519,7 +519,7 @@ impl<T: Clone + std::fmt::Display + 'static> Component for SelectableList<T> {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Up | Key::Char('k') => Some(SelectableListMessage::Up),
                 Key::Down | Key::Char('j') => Some(SelectableListMessage::Down),
                 Key::Char('g') if key.modifiers.shift() => Some(SelectableListMessage::Last),

--- a/src/component/slider/mod.rs
+++ b/src/component/slider/mod.rs
@@ -455,7 +455,7 @@ impl Component for Slider {
 
         if let Some(key) = event.as_key() {
             match state.orientation {
-                SliderOrientation::Horizontal => match key.key {
+                SliderOrientation::Horizontal => match key.code {
                     Key::Right | Key::Char('l') => Some(SliderMessage::Increment),
                     Key::Left | Key::Char('h') => Some(SliderMessage::Decrement),
                     Key::PageUp => Some(SliderMessage::IncrementPage),
@@ -464,7 +464,7 @@ impl Component for Slider {
                     Key::End => Some(SliderMessage::SetMax),
                     _ => None,
                 },
-                SliderOrientation::Vertical => match key.key {
+                SliderOrientation::Vertical => match key.code {
                     Key::Up | Key::Char('k') => Some(SliderMessage::Increment),
                     Key::Down | Key::Char('j') => Some(SliderMessage::Decrement),
                     Key::PageUp => Some(SliderMessage::IncrementPage),

--- a/src/component/span_tree/mod.rs
+++ b/src/component/span_tree/mod.rs
@@ -762,7 +762,7 @@ impl Component for SpanTree {
         }
         if let Some(key) = event.as_key() {
             let has_shift = key.modifiers.shift();
-            match key.key {
+            match key.code {
                 Key::Up | Key::Char('k') if !has_shift => Some(SpanTreeMessage::SelectUp),
                 Key::Down | Key::Char('j') if !has_shift => Some(SpanTreeMessage::SelectDown),
                 Key::Right | Key::Char('l') if has_shift => Some(SpanTreeMessage::SetLabelWidth(

--- a/src/component/split_panel/mod.rs
+++ b/src/component/split_panel/mod.rs
@@ -376,13 +376,13 @@ impl Component for SplitPanel {
 
         if let Some(key) = event.as_key() {
             // Tab toggles pane focus
-            if key.key == Key::Tab {
+            if key.code == Key::Tab {
                 return Some(SplitPanelMessage::FocusOther);
             }
 
             // Ctrl+arrow resizes
             if key.modifiers.ctrl() {
-                match key.key {
+                match key.code {
                     Key::Left | Key::Up => return Some(SplitPanelMessage::ShrinkFirst),
                     Key::Right | Key::Down => return Some(SplitPanelMessage::GrowFirst),
                     Key::Char('0') => return Some(SplitPanelMessage::ResetRatio),

--- a/src/component/status_log/mod.rs
+++ b/src/component/status_log/mod.rs
@@ -696,7 +696,7 @@ impl Component for StatusLog {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Up | Key::Char('k') => Some(StatusLogMessage::ScrollUp),
                 Key::Down | Key::Char('j') => Some(StatusLogMessage::ScrollDown),
                 Key::Home => Some(StatusLogMessage::ScrollToTop),

--- a/src/component/step_indicator/mod.rs
+++ b/src/component/step_indicator/mod.rs
@@ -729,7 +729,7 @@ impl Component for StepIndicator {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Left | Key::Char('h') => Some(StepIndicatorMessage::FocusPrev),
                 Key::Right | Key::Char('l') => Some(StepIndicatorMessage::FocusNext),
                 Key::Home => Some(StepIndicatorMessage::First),

--- a/src/component/styled_text/mod.rs
+++ b/src/component/styled_text/mod.rs
@@ -383,7 +383,7 @@ impl Component for StyledText {
         let ctrl = key.modifiers.ctrl();
         let shift = key.modifiers.shift();
 
-        match key.key {
+        match key.code {
             Key::Up | Key::Char('k') if !ctrl => Some(StyledTextMessage::ScrollUp),
             Key::Down | Key::Char('j') if !ctrl => Some(StyledTextMessage::ScrollDown),
             Key::PageUp => Some(StyledTextMessage::PageUp(10)),
@@ -391,7 +391,7 @@ impl Component for StyledText {
             Key::Char('u') if ctrl => Some(StyledTextMessage::PageUp(10)),
             Key::Char('d') if ctrl => Some(StyledTextMessage::PageDown(10)),
             Key::Home | Key::Char('g') if !shift => Some(StyledTextMessage::Home),
-            Key::End | Key::Char('g') if key.modifiers.shift() || key.key == Key::End => {
+            Key::End | Key::Char('g') if key.modifiers.shift() || key.code == Key::End => {
                 Some(StyledTextMessage::End)
             }
             _ => None,

--- a/src/component/switch/mod.rs
+++ b/src/component/switch/mod.rs
@@ -331,7 +331,7 @@ impl Component for Switch {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Enter | Key::Char(' ') => Some(SwitchMessage::Toggle),
                 _ => None,
             }

--- a/src/component/tab_bar/mod.rs
+++ b/src/component/tab_bar/mod.rs
@@ -749,7 +749,7 @@ impl Component for TabBar {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Left | Key::Char('h') => Some(TabBarMessage::PrevTab),
                 Key::Right | Key::Char('l') => Some(TabBarMessage::NextTab),
                 Key::Home => Some(TabBarMessage::First),

--- a/src/component/table/mod.rs
+++ b/src/component/table/mod.rs
@@ -933,7 +933,7 @@ impl<T: TableRow + 'static> Component for Table<T> {
         }
         if let Some(key) = event.as_key() {
             let has_shift = key.modifiers.shift();
-            match key.key {
+            match key.code {
                 Key::Up | Key::Char('k') => Some(TableMessage::Up),
                 Key::Down | Key::Char('j') => Some(TableMessage::Down),
                 Key::Home => Some(TableMessage::First),

--- a/src/component/tabs/mod.rs
+++ b/src/component/tabs/mod.rs
@@ -437,7 +437,7 @@ impl<T: Clone + Display + 'static> Component for Tabs<T> {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Left | Key::Char('h') => Some(TabsMessage::Left),
                 Key::Right | Key::Char('l') => Some(TabsMessage::Right),
                 Key::Home => Some(TabsMessage::First),

--- a/src/component/terminal_output/mod.rs
+++ b/src/component/terminal_output/mod.rs
@@ -709,7 +709,7 @@ impl Component for TerminalOutput {
         let ctrl = key.modifiers.ctrl();
         let shift = key.modifiers.shift();
 
-        match key.key {
+        match key.code {
             Key::Up | Key::Char('k') if !ctrl => Some(TerminalOutputMessage::ScrollUp),
             Key::Down | Key::Char('j') if !ctrl => Some(TerminalOutputMessage::ScrollDown),
             Key::PageUp => Some(TerminalOutputMessage::PageUp(10)),
@@ -717,7 +717,7 @@ impl Component for TerminalOutput {
             Key::Char('u') if ctrl => Some(TerminalOutputMessage::PageUp(10)),
             Key::Char('d') if ctrl => Some(TerminalOutputMessage::PageDown(10)),
             Key::Home | Key::Char('g') if !shift => Some(TerminalOutputMessage::Home),
-            Key::End | Key::Char('g') if key.modifiers.shift() || key.key == Key::End => {
+            Key::End | Key::Char('g') if key.modifiers.shift() || key.code == Key::End => {
                 Some(TerminalOutputMessage::End)
             }
             Key::Char('a') if !ctrl => Some(TerminalOutputMessage::ToggleAutoScroll),

--- a/src/component/text_area/mod.rs
+++ b/src/component/text_area/mod.rs
@@ -665,7 +665,7 @@ impl Component for TextArea {
         if let Some(key) = event.as_key() {
             let ctrl = key.modifiers.ctrl();
             let shift = key.modifiers.shift();
-            match key.key {
+            match key.code {
                 // Undo/redo
                 Key::Char('z') if ctrl => Some(TextAreaMessage::Undo),
                 Key::Char('y') if ctrl => Some(TextAreaMessage::Redo),

--- a/src/component/timeline/mod.rs
+++ b/src/component/timeline/mod.rs
@@ -634,7 +634,7 @@ impl Component for Timeline {
 
         let key = event.as_key()?;
 
-        match key.key {
+        match key.code {
             Key::Left | Key::Char('h') => Some(TimelineMessage::PanLeft),
             Key::Right | Key::Char('l') => Some(TimelineMessage::PanRight),
             Key::Char('+') | Key::Char('=') => Some(TimelineMessage::ZoomIn),

--- a/src/component/tree/mod.rs
+++ b/src/component/tree/mod.rs
@@ -920,7 +920,7 @@ impl<T: Clone + 'static> Component for Tree<T> {
             return None;
         }
         if let Some(key) = event.as_key() {
-            match key.key {
+            match key.code {
                 Key::Up | Key::Char('k') => Some(TreeMessage::Up),
                 Key::Down | Key::Char('j') => Some(TreeMessage::Down),
                 Key::Left | Key::Char('h') => Some(TreeMessage::Collapse),

--- a/src/component/treemap/mod.rs
+++ b/src/component/treemap/mod.rs
@@ -667,7 +667,7 @@ impl Component for Treemap {
 
         let key = event.as_key()?;
 
-        match key.key {
+        match key.code {
             Key::Left | Key::Char('h') => Some(TreemapMessage::SelectPrev),
             Key::Right | Key::Char('l') => Some(TreemapMessage::SelectNext),
             Key::Down | Key::Char('j') => Some(TreemapMessage::SelectChild),

--- a/src/input/convert.rs
+++ b/src/input/convert.rs
@@ -78,7 +78,7 @@ pub(crate) fn from_crossterm_key(key: crossterm::event::KeyEvent) -> Option<KeyE
     };
 
     Some(KeyEvent {
-        key: envision_key,
+        code: envision_key,
         modifiers,
         kind,
         raw_char,
@@ -160,7 +160,7 @@ mod tests {
     #[test]
     fn test_lowercase_char() {
         let result = from_crossterm_key(ct_key(ct::KeyCode::Char('a'))).unwrap();
-        assert_eq!(result.key, Key::Char('a'));
+        assert_eq!(result.code, Key::Char('a'));
         assert!(result.modifiers.is_none());
         assert_eq!(result.raw_char, Some('a'));
     }
@@ -172,7 +172,7 @@ mod tests {
             ct::KeyModifiers::SHIFT,
         ))
         .unwrap();
-        assert_eq!(result.key, Key::Char('a'));
+        assert_eq!(result.code, Key::Char('a'));
         assert!(result.modifiers.shift());
         assert_eq!(result.raw_char, Some('A'));
     }
@@ -181,7 +181,7 @@ mod tests {
     fn test_uppercase_without_shift_caps_lock() {
         // Caps lock sends uppercase without SHIFT modifier
         let result = from_crossterm_key(ct_key(ct::KeyCode::Char('A'))).unwrap();
-        assert_eq!(result.key, Key::Char('a'));
+        assert_eq!(result.code, Key::Char('a'));
         assert!(!result.modifiers.shift());
         assert_eq!(result.raw_char, Some('A'));
     }
@@ -193,7 +193,7 @@ mod tests {
             ct::KeyModifiers::SHIFT,
         ))
         .unwrap();
-        assert_eq!(result.key, Key::Char('!'));
+        assert_eq!(result.code, Key::Char('!'));
         assert!(result.modifiers.shift());
         assert_eq!(result.raw_char, Some('!'));
     }
@@ -205,7 +205,7 @@ mod tests {
             ct::KeyModifiers::CONTROL,
         ))
         .unwrap();
-        assert_eq!(result.key, Key::Char('c'));
+        assert_eq!(result.code, Key::Char('c'));
         assert!(result.modifiers.ctrl());
         assert_eq!(result.raw_char, Some('c'));
     }
@@ -214,7 +214,7 @@ mod tests {
     fn test_ctrl_c_from_raw_control_char() {
         // Some terminals send '\x03' instead of 'c' + CONTROL
         let result = from_crossterm_key(ct_key(ct::KeyCode::Char('\x03'))).unwrap();
-        assert_eq!(result.key, Key::Char('c'));
+        assert_eq!(result.code, Key::Char('c'));
         assert!(result.modifiers.ctrl());
         assert_eq!(result.raw_char, Some('\x03'));
     }
@@ -222,7 +222,7 @@ mod tests {
     #[test]
     fn test_backtab_becomes_tab_with_shift() {
         let result = from_crossterm_key(ct_key(ct::KeyCode::BackTab)).unwrap();
-        assert_eq!(result.key, Key::Tab);
+        assert_eq!(result.code, Key::Tab);
         assert!(result.modifiers.shift());
         assert!(result.raw_char.is_none());
     }
@@ -230,7 +230,7 @@ mod tests {
     #[test]
     fn test_enter() {
         let result = from_crossterm_key(ct_key(ct::KeyCode::Enter)).unwrap();
-        assert_eq!(result.key, Key::Enter);
+        assert_eq!(result.code, Key::Enter);
         assert!(result.modifiers.is_none());
         assert!(result.raw_char.is_none());
     }
@@ -238,26 +238,26 @@ mod tests {
     #[test]
     fn test_function_key() {
         let result = from_crossterm_key(ct_key(ct::KeyCode::F(5))).unwrap();
-        assert_eq!(result.key, Key::F(5));
+        assert_eq!(result.code, Key::F(5));
         assert!(result.raw_char.is_none());
     }
 
     #[test]
     fn test_arrows() {
         assert_eq!(
-            from_crossterm_key(ct_key(ct::KeyCode::Left)).unwrap().key,
+            from_crossterm_key(ct_key(ct::KeyCode::Left)).unwrap().code,
             Key::Left
         );
         assert_eq!(
-            from_crossterm_key(ct_key(ct::KeyCode::Right)).unwrap().key,
+            from_crossterm_key(ct_key(ct::KeyCode::Right)).unwrap().code,
             Key::Right
         );
         assert_eq!(
-            from_crossterm_key(ct_key(ct::KeyCode::Up)).unwrap().key,
+            from_crossterm_key(ct_key(ct::KeyCode::Up)).unwrap().code,
             Key::Up
         );
         assert_eq!(
-            from_crossterm_key(ct_key(ct::KeyCode::Down)).unwrap().key,
+            from_crossterm_key(ct_key(ct::KeyCode::Down)).unwrap().code,
             Key::Down
         );
     }
@@ -265,21 +265,23 @@ mod tests {
     #[test]
     fn test_navigation_keys() {
         assert_eq!(
-            from_crossterm_key(ct_key(ct::KeyCode::Home)).unwrap().key,
+            from_crossterm_key(ct_key(ct::KeyCode::Home)).unwrap().code,
             Key::Home
         );
         assert_eq!(
-            from_crossterm_key(ct_key(ct::KeyCode::End)).unwrap().key,
+            from_crossterm_key(ct_key(ct::KeyCode::End)).unwrap().code,
             Key::End
         );
         assert_eq!(
-            from_crossterm_key(ct_key(ct::KeyCode::PageUp)).unwrap().key,
+            from_crossterm_key(ct_key(ct::KeyCode::PageUp))
+                .unwrap()
+                .code,
             Key::PageUp
         );
         assert_eq!(
             from_crossterm_key(ct_key(ct::KeyCode::PageDown))
                 .unwrap()
-                .key,
+                .code,
             Key::PageDown
         );
     }
@@ -289,23 +291,27 @@ mod tests {
         assert_eq!(
             from_crossterm_key(ct_key(ct::KeyCode::Backspace))
                 .unwrap()
-                .key,
+                .code,
             Key::Backspace
         );
         assert_eq!(
-            from_crossterm_key(ct_key(ct::KeyCode::Delete)).unwrap().key,
+            from_crossterm_key(ct_key(ct::KeyCode::Delete))
+                .unwrap()
+                .code,
             Key::Delete
         );
         assert_eq!(
-            from_crossterm_key(ct_key(ct::KeyCode::Insert)).unwrap().key,
+            from_crossterm_key(ct_key(ct::KeyCode::Insert))
+                .unwrap()
+                .code,
             Key::Insert
         );
         assert_eq!(
-            from_crossterm_key(ct_key(ct::KeyCode::Tab)).unwrap().key,
+            from_crossterm_key(ct_key(ct::KeyCode::Tab)).unwrap().code,
             Key::Tab
         );
         assert_eq!(
-            from_crossterm_key(ct_key(ct::KeyCode::Esc)).unwrap().key,
+            from_crossterm_key(ct_key(ct::KeyCode::Esc)).unwrap().code,
             Key::Esc
         );
     }
@@ -431,7 +437,7 @@ mod tests {
     fn test_event_key_press() {
         let ct_event = ct::Event::Key(ct_key(ct::KeyCode::Enter));
         let result = from_crossterm_event(ct_event).unwrap();
-        assert!(matches!(result, Event::Key(ke) if ke.key == Key::Enter));
+        assert!(matches!(result, Event::Key(ke) if ke.code == Key::Enter));
     }
 
     #[test]

--- a/src/input/events/mod.rs
+++ b/src/input/events/mod.rs
@@ -77,7 +77,7 @@ impl Event {
     /// ```
     pub fn key_with(key: Key, modifiers: Modifiers) -> Self {
         Self::Key(KeyEvent {
-            key,
+            code: key,
             modifiers,
             kind: super::key::KeyEventKind::Press,
             raw_char: match key {
@@ -113,7 +113,7 @@ impl Event {
     /// ```
     pub fn alt(c: char) -> Self {
         Self::Key(KeyEvent {
-            key: Key::Char(c.to_ascii_lowercase()),
+            code: Key::Char(c.to_ascii_lowercase()),
             modifiers: Modifiers::ALT,
             kind: super::key::KeyEventKind::Press,
             raw_char: Some(c),
@@ -373,7 +373,7 @@ impl KeyEventBuilder {
     pub fn build(self) -> KeyEvent {
         let key = self.key.unwrap_or(Key::Esc);
         KeyEvent {
-            key,
+            code: key,
             modifiers: self.modifiers,
             kind: self.kind,
             raw_char: match key {

--- a/src/input/events/tests.rs
+++ b/src/input/events/tests.rs
@@ -11,7 +11,7 @@ fn test_simulated_event_char() {
     let event = Event::char('a');
     assert!(event.is_key());
     let key = event.as_key().unwrap();
-    assert_eq!(key.key, Key::Char('a'));
+    assert_eq!(key.code, Key::Char('a'));
     assert!(key.modifiers.is_none());
     assert_eq!(key.raw_char, Some('a'));
 }
@@ -21,7 +21,7 @@ fn test_simulated_event_char_with() {
     let event = Event::char_with('A', Modifiers::SHIFT);
     let key = event.as_key().unwrap();
     // KeyEvent::char('A') normalizes to lowercase
-    assert_eq!(key.key, Key::Char('a'));
+    assert_eq!(key.code, Key::Char('a'));
     assert!(key.modifiers.shift());
     assert_eq!(key.raw_char, Some('A'));
 }
@@ -30,7 +30,7 @@ fn test_simulated_event_char_with() {
 fn test_simulated_event_key() {
     let event = Event::key(Key::Enter);
     let key = event.as_key().unwrap();
-    assert_eq!(key.key, Key::Enter);
+    assert_eq!(key.code, Key::Enter);
     assert!(key.modifiers.is_none());
 }
 
@@ -38,7 +38,7 @@ fn test_simulated_event_key() {
 fn test_simulated_event_key_with() {
     let event = Event::key_with(Key::Tab, Modifiers::SHIFT);
     let key = event.as_key().unwrap();
-    assert_eq!(key.key, Key::Tab);
+    assert_eq!(key.code, Key::Tab);
     assert!(key.modifiers.shift());
 }
 
@@ -46,7 +46,7 @@ fn test_simulated_event_key_with() {
 fn test_simulated_event_ctrl() {
     let event = Event::ctrl('c');
     let key = event.as_key().unwrap();
-    assert_eq!(key.key, Key::Char('c'));
+    assert_eq!(key.code, Key::Char('c'));
     assert!(key.modifiers.ctrl());
 }
 
@@ -54,7 +54,7 @@ fn test_simulated_event_ctrl() {
 fn test_simulated_event_alt() {
     let event = Event::alt('x');
     let key = event.as_key().unwrap();
-    assert_eq!(key.key, Key::Char('x'));
+    assert_eq!(key.code, Key::Char('x'));
     assert!(key.modifiers.alt());
 }
 
@@ -178,7 +178,7 @@ fn test_from_mouse_event() {
 fn test_key_event_builder() {
     let event = KeyEventBuilder::new().char('x').ctrl().shift().build();
 
-    assert_eq!(event.key, Key::Char('x'));
+    assert_eq!(event.code, Key::Char('x'));
     assert!(event.modifiers.ctrl());
     assert!(event.modifiers.shift());
 }
@@ -187,7 +187,7 @@ fn test_key_event_builder() {
 fn test_key_event_builder_code() {
     let event = KeyEventBuilder::new().code(Key::F(1)).build();
 
-    assert_eq!(event.key, Key::F(1));
+    assert_eq!(event.code, Key::F(1));
 }
 
 #[test]
@@ -222,14 +222,14 @@ fn test_key_event_builder_into_event() {
     let event = KeyEventBuilder::new().char('b').into_event();
 
     assert!(event.is_key());
-    assert_eq!(event.as_key().unwrap().key, Key::Char('b'));
+    assert_eq!(event.as_key().unwrap().code, Key::Char('b'));
 }
 
 #[test]
 fn test_key_event_builder_default_code() {
     // When no key is set, should use Key::Esc
     let event = KeyEventBuilder::new().build();
-    assert_eq!(event.key, Key::Esc);
+    assert_eq!(event.code, Key::Esc);
 }
 
 // -------------------------------------------------------------------------

--- a/src/input/key.rs
+++ b/src/input/key.rs
@@ -62,7 +62,7 @@ pub enum Key {
 ///
 /// # Two views of the same keypress
 ///
-/// - **`key`**: normalized for keybindings. ASCII letters are always
+/// - **`code`**: normalized for keybindings. ASCII letters are always
 ///   lowercase. Use this for `match` arms in `handle_event`.
 /// - **`raw_char`**: the character the terminal actually sent. Preserves
 ///   case (uppercase for Shift or Caps Lock). Use this for text input.
@@ -74,14 +74,14 @@ pub enum Key {
 ///
 /// // Constructors normalize automatically
 /// let event = KeyEvent::char('A');
-/// assert_eq!(event.key, Key::Char('a'));        // normalized
-/// assert!(event.modifiers.shift());             // shift inferred
-/// assert_eq!(event.raw_char, Some('A'));         // original preserved
+/// assert_eq!(event.code, Key::Char('a'));        // normalized
+/// assert!(event.modifiers.shift());              // shift inferred
+/// assert_eq!(event.raw_char, Some('A'));          // original preserved
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct KeyEvent {
     /// The key, normalized. ASCII letters are always lowercase.
-    pub key: Key,
+    pub code: Key,
     /// Modifier keys held during the event.
     pub modifiers: Modifiers,
     /// Whether this is a press, release, or repeat.
@@ -94,22 +94,52 @@ pub struct KeyEvent {
 impl KeyEvent {
     /// Creates a key press event with no modifiers.
     ///
+    /// For `Key::Char` variants, uppercase ASCII letters are normalized
+    /// to lowercase with SHIFT added, matching the behavior of
+    /// [`KeyEvent::char`] and the crossterm converter. Non-character keys
+    /// have `raw_char = None`.
+    ///
     /// # Example
     ///
     /// ```rust
     /// use envision::input::key::{Key, KeyEvent};
     ///
     /// let event = KeyEvent::new(Key::Enter);
-    /// assert_eq!(event.key, Key::Enter);
+    /// assert_eq!(event.code, Key::Enter);
     /// assert!(event.modifiers.is_none());
     /// assert!(event.raw_char.is_none());
+    ///
+    /// // Char keys set raw_char
+    /// let event = KeyEvent::new(Key::Char('a'));
+    /// assert_eq!(event.code, Key::Char('a'));
+    /// assert_eq!(event.raw_char, Some('a'));
+    ///
+    /// // Uppercase is normalized
+    /// let event = KeyEvent::new(Key::Char('G'));
+    /// assert_eq!(event.code, Key::Char('g'));
+    /// assert!(event.modifiers.shift());
+    /// assert_eq!(event.raw_char, Some('G'));
     /// ```
     pub fn new(key: Key) -> Self {
-        Self {
-            key,
-            modifiers: Modifiers::NONE,
-            kind: KeyEventKind::Press,
-            raw_char: None,
+        match key {
+            Key::Char(c) if c.is_ascii_uppercase() => Self {
+                code: Key::Char(c.to_ascii_lowercase()),
+                modifiers: Modifiers::SHIFT,
+                kind: KeyEventKind::Press,
+                raw_char: Some(c),
+            },
+            Key::Char(c) => Self {
+                code: Key::Char(c),
+                modifiers: Modifiers::NONE,
+                kind: KeyEventKind::Press,
+                raw_char: Some(c),
+            },
+            _ => Self {
+                code: key,
+                modifiers: Modifiers::NONE,
+                kind: KeyEventKind::Press,
+                raw_char: None,
+            },
         }
     }
 
@@ -124,26 +154,26 @@ impl KeyEvent {
     /// use envision::input::key::{Key, KeyEvent, Modifiers};
     ///
     /// let lower = KeyEvent::char('a');
-    /// assert_eq!(lower.key, Key::Char('a'));
+    /// assert_eq!(lower.code, Key::Char('a'));
     /// assert!(lower.modifiers.is_none());
     /// assert_eq!(lower.raw_char, Some('a'));
     ///
     /// let upper = KeyEvent::char('A');
-    /// assert_eq!(upper.key, Key::Char('a'));
+    /// assert_eq!(upper.code, Key::Char('a'));
     /// assert!(upper.modifiers.shift());
     /// assert_eq!(upper.raw_char, Some('A'));
     /// ```
     pub fn char(c: char) -> Self {
         if c.is_ascii_uppercase() {
             Self {
-                key: Key::Char(c.to_ascii_lowercase()),
+                code: Key::Char(c.to_ascii_lowercase()),
                 modifiers: Modifiers::SHIFT,
                 kind: KeyEventKind::Press,
                 raw_char: Some(c),
             }
         } else {
             Self {
-                key: Key::Char(c),
+                code: Key::Char(c),
                 modifiers: Modifiers::NONE,
                 kind: KeyEventKind::Press,
                 raw_char: Some(c),
@@ -159,12 +189,12 @@ impl KeyEvent {
     /// use envision::input::key::{Key, KeyEvent, Modifiers};
     ///
     /// let event = KeyEvent::ctrl('c');
-    /// assert_eq!(event.key, Key::Char('c'));
+    /// assert_eq!(event.code, Key::Char('c'));
     /// assert!(event.modifiers.ctrl());
     /// ```
     pub fn ctrl(c: char) -> Self {
         Self {
-            key: Key::Char(c.to_ascii_lowercase()),
+            code: Key::Char(c.to_ascii_lowercase()),
             modifiers: Modifiers::CONTROL,
             kind: KeyEventKind::Press,
             raw_char: Some(c),
@@ -280,18 +310,42 @@ mod tests {
     }
 
     #[test]
-    fn test_key_event_new() {
+    fn test_key_event_new_non_char() {
         let event = KeyEvent::new(Key::Enter);
-        assert_eq!(event.key, Key::Enter);
+        assert_eq!(event.code, Key::Enter);
         assert!(event.modifiers.is_none());
         assert_eq!(event.kind, KeyEventKind::Press);
         assert!(event.raw_char.is_none());
     }
 
     #[test]
+    fn test_key_event_new_lowercase_char() {
+        let event = KeyEvent::new(Key::Char('a'));
+        assert_eq!(event.code, Key::Char('a'));
+        assert!(event.modifiers.is_none());
+        assert_eq!(event.raw_char, Some('a'));
+    }
+
+    #[test]
+    fn test_key_event_new_uppercase_normalizes() {
+        let event = KeyEvent::new(Key::Char('G'));
+        assert_eq!(event.code, Key::Char('g'));
+        assert!(event.modifiers.shift());
+        assert_eq!(event.raw_char, Some('G'));
+    }
+
+    #[test]
+    fn test_key_event_new_non_letter_char() {
+        let event = KeyEvent::new(Key::Char('!'));
+        assert_eq!(event.code, Key::Char('!'));
+        assert!(event.modifiers.is_none());
+        assert_eq!(event.raw_char, Some('!'));
+    }
+
+    #[test]
     fn test_key_event_char_lowercase() {
         let event = KeyEvent::char('a');
-        assert_eq!(event.key, Key::Char('a'));
+        assert_eq!(event.code, Key::Char('a'));
         assert!(event.modifiers.is_none());
         assert_eq!(event.raw_char, Some('a'));
     }
@@ -299,7 +353,7 @@ mod tests {
     #[test]
     fn test_key_event_char_uppercase_normalizes() {
         let event = KeyEvent::char('A');
-        assert_eq!(event.key, Key::Char('a'));
+        assert_eq!(event.code, Key::Char('a'));
         assert!(event.modifiers.shift());
         assert_eq!(event.raw_char, Some('A'));
     }
@@ -307,7 +361,7 @@ mod tests {
     #[test]
     fn test_key_event_ctrl() {
         let event = KeyEvent::ctrl('c');
-        assert_eq!(event.key, Key::Char('c'));
+        assert_eq!(event.code, Key::Char('c'));
         assert!(event.modifiers.ctrl());
         assert!(!event.modifiers.shift());
         assert_eq!(event.raw_char, Some('c'));

--- a/src/overlay/stack/tests.rs
+++ b/src/overlay/stack/tests.rs
@@ -145,7 +145,7 @@ fn test_stack_handle_event_dismiss() {
     impl Overlay<i32> for DismissOverlay {
         fn handle_event(&mut self, event: &Event) -> OverlayAction<i32> {
             if let Some(key) = event.as_key() {
-                if key.key == Key::Esc {
+                if key.code == Key::Esc {
                     return OverlayAction::Dismiss;
                 }
             }

--- a/src/overlay/traits.rs
+++ b/src/overlay/traits.rs
@@ -30,7 +30,7 @@ use super::OverlayAction;
 /// impl Overlay<String> for ConfirmDialog {
 ///     fn handle_event(&mut self, event: &Event) -> OverlayAction<String> {
 ///         if let Some(key) = event.as_key() {
-///             match key.key {
+///             match key.code {
 ///                 Key::Char('y') => OverlayAction::DismissWithMessage("confirmed".into()),
 ///                 Key::Char('n') | Key::Esc => OverlayAction::Dismiss,
 ///                 _ => OverlayAction::Consumed,
@@ -67,7 +67,7 @@ mod tests {
     impl Overlay<String> for TestOverlay {
         fn handle_event(&mut self, event: &Event) -> OverlayAction<String> {
             if let Some(key) = event.as_key() {
-                match key.key {
+                match key.code {
                     Key::Esc => OverlayAction::Dismiss,
                     Key::Enter => OverlayAction::DismissWithMessage("confirmed".to_string()),
                     _ => {


### PR DESCRIPTION
## Summary

Three customer feedback fixes for the 0.14.0 input types:

1. **KeyEvent::new() normalization** — `KeyEvent::new(Key::Char('G'))` now normalizes to `code=Char('g'), modifiers=SHIFT, raw_char=Some('G')`, matching `KeyEvent::char()` and the crossterm converter. Fixes silent test/prod divergence.

2. **KeyEvent.key → KeyEvent.code** — `key.key` reads poorly; `key.code` matches crossterm convention and existing muscle memory. Cascade through all components, tests, examples, docs.

3. **g/G/End guard pattern** — consistent across all scrollable components, matches MIGRATION.md.

155 files changed (mostly mechanical `key.key` → `key.code` substitution).

## Test plan

- [x] 7210 tests pass
- [x] 1990 doc tests pass
- [x] All examples compile
- [x] Clippy clean
- [x] Zero `key.key` references remaining
- [x] CHANGELOG and MIGRATION updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)