### PR TITLE
Re-export MouseEventKind/KeyEventKind, document worker changes, improve guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ConversationView::view_from` signature changed** to take
   `(source, state, ctx: &mut RenderContext<'_, '_>)`.
 
+### Breaking (Worker module)
+
+- **`ProgressSender` is now generic**: `ProgressSender<P>` where `P` is
+  any `Send + 'static` type. The old `send_percentage()` and
+  `send_status()` convenience methods are removed. Use
+  `sender.send(WorkerProgress::new(0.5, None))` for percentage+string,
+  or define your own progress enum for richer updates.
+
 ### Added
 
+- `Command::subscribe(BoxedSubscription<M>)` for registering
+  subscriptions dynamically from within `update()`. This unblocks the
+  worker module for on-demand background tasks — return
+  `Command::subscribe(sub)` from `update()` and the runtime registers
+  the subscription on the next command processing cycle.
+- `ProgressSender::new(tx)` public constructor for creating a
+  `ProgressSender` outside of `WorkerBuilder` (testing, channel
+  bridging).
+- `ProgressSender::try_send()` for non-blocking fire-and-forget
+  progress updates. Use for high-frequency ticks where dropping one is
+  better than applying backpressure.
 - `RenderContext<'frame, 'buf>` type in `envision::component`
   that bundles `frame`, `area`, `theme`, `focused`, and `disabled`.
   Provides builder methods (`focused`, `disabled`), sub-area reborrow

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -231,12 +231,23 @@ for a shorter lifetime, reborrows the theme, and preserves `focused` and
 `disabled`. When the child context goes out of scope, the parent `ctx` is
 usable again.
 
-If a child needs different focus/disabled state, mutate the fields on the
-returned context:
+If a child needs different focus/disabled state, you can chain the
+builder methods directly on the returned context:
+
+```rust
+// Chaining pattern (preferred for simple cases)
+Header::view(
+    &state.header,
+    &mut ctx.with_area(chunks[0]).focused(state.current_focus == FocusTarget::Header),
+);
+```
+
+Or mutate the fields explicitly for more complex logic:
 
 ```rust
 let mut child_ctx = ctx.with_area(chunks[0]);
 child_ctx.focused = state.current_focus == FocusTarget::Header;
+child_ctx.disabled = !state.header_enabled;
 Header::view(&state.header, &mut child_ctx);
 ```
 
@@ -305,6 +316,45 @@ migrated to `&mut RenderContext<'_, '_>`:
 
 Call sites need the same `&mut RenderContext::new(...)` treatment as
 `Component::view` call sites.
+
+### 8. Worker module: `ProgressSender<P>` and `Command::subscribe`
+
+`ProgressSender` is now generic over your progress type:
+
+```rust
+// Before (0.13.x)
+progress_sender.send_percentage(0.5).await?;
+progress_sender.send_status(0.3, "downloading").await?;
+
+// After (0.14.0)
+// Use any type — an enum, struct, or the built-in WorkerProgress
+progress_sender.send(WorkerProgress::new(0.5, None)).await?;
+progress_sender.send(MyProgress::ChapterCount(12)).await?;
+
+// Non-blocking for high-frequency updates
+progress_sender.try_send(MyProgress::Tick(0.5)).ok();
+```
+
+Workers can now be spawned on-demand from `update()` using
+`Command::subscribe` to register the progress subscription:
+
+```rust
+fn update(state: &mut State, msg: Msg) -> Command<Msg> {
+    match msg {
+        Msg::StartWork => {
+            let (cmd, subscription, handle) = WorkerBuilder::new("task")
+                .spawn(
+                    |sender, cancel| async move { /* ... */ },
+                    Msg::Progress,
+                    |result| Msg::Done(result),
+                );
+            state.handle = Some(handle);
+            Command::combine(vec![cmd, Command::subscribe(subscription)])
+        }
+        // ...
+    }
+}
+```
 
 ## v0.6.0 to v0.7.0
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,7 +271,10 @@ pub use component::{MarkdownRenderer, MarkdownRendererMessage, MarkdownRendererS
 
 pub use error::{BoxedError, EnvisionError, Result};
 pub use harness::{AppHarness, Assertion, Snapshot, TestHarness};
-pub use input::{Event, EventQueue, Key, KeyEvent, Modifiers, MouseButton, MouseEvent};
+pub use input::{
+    Event, EventQueue, Key, KeyEvent, KeyEventKind, Modifiers, MouseButton, MouseEvent,
+    MouseEventKind,
+};
 pub use overlay::{Overlay, OverlayAction, OverlayStack};
 pub use scroll::{ScrollState, render_scrollbar, render_scrollbar_inside_border};
 pub use theme::Theme;
@@ -298,7 +301,10 @@ pub mod prelude {
     };
 
     // Input
-    pub use crate::input::{Event, EventQueue, Key, Modifiers};
+    pub use crate::input::{
+        Event, EventQueue, Key, KeyEvent, KeyEventKind, Modifiers, MouseButton, MouseEvent,
+        MouseEventKind,
+    };
 
     // Overlay
     pub use crate::overlay::{Overlay, OverlayAction, OverlayStack};


### PR DESCRIPTION
## Summary

Customer feedback fixes (Group B — docs and re-exports):

1. **Re-export `MouseEventKind` and `KeyEventKind`** at crate root and prelude. Previously only accessible via `envision::input::mouse::MouseEventKind`.

2. **CHANGELOG entries for `ProgressSender<P>`** (#409) and **`Command::subscribe`** (#410) — both were missing from the 0.14.0 changelog.

3. **MIGRATION.md section 8** — covers the worker module changes (generic ProgressSender, Command::subscribe, try_send, on-demand worker pattern).

4. **`with_area().focused()` chaining** shown in MIGRATION.md as the preferred pattern for sub-area rendering with different focus state.

## Test plan

- [x] `cargo check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt` — no diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)