### PR TITLE
Fix customer sharp edges: theme bug, README, g/G pattern, cross-ref docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,59 +194,102 @@ Envision provides a comprehensive library of 73 reusable UI components, all foll
 | `Breadcrumb` | Navigation breadcrumb trail |
 | `Menu` | Keyboard-navigable menu with shortcuts |
 | `Router` | Multi-screen navigation with history |
+| `StepIndicator` | Pipeline/workflow visualization with per-step styles |
 | `Tabs` | Horizontal tab navigation |
-| `Tree` | Hierarchical tree view with expand/collapse |
+| `TabBar` | Tab bar with closeable tabs and overflow |
 
 ### Data Components
 
 | Component | Description |
 |-----------|-------------|
-| `Table` | Data table with sorting and selection |
-| `SelectableList` | Scrollable list with keyboard navigation |
 | `LoadingList` | List with per-item loading and error states |
+| `SelectableList` | Scrollable list with keyboard navigation |
+| `Table` | Data table with sorting and selection |
+| `Tree` | Hierarchical tree view with expand/collapse |
+
+### Display Components
+
+| Component | Description |
+|-----------|-------------|
+| `BigText` | Large block-character text rendering |
+| `Calendar` | Month calendar with event markers |
+| `Canvas` | General-purpose drawing surface with shape primitives |
+| `CodeBlock` | Syntax-highlighted code display |
+| `Collapsible` | Expandable/collapsible content panel |
+| `Divider` | Horizontal or vertical separator |
+| `Gauge` | Ratio and measurement display with thresholds |
+| `HelpPanel` | Keyboard shortcut reference panel |
+| `KeyHints` | Contextual keyboard shortcut bar |
+| `MultiProgress` | Multiple concurrent progress trackers |
+| `Paginator` | Page navigation indicators |
+| `ProgressBar` | Progress display with ETA and rate |
+| `ScrollView` | Scrollable container for arbitrary content |
+| `ScrollableText` | Scrollable multi-line text display |
+| `Sparkline` | Inline trend visualization |
+| `Spinner` | Animated loading indicator (multiple styles) |
+| `StatusBar` | Application status bar with sections |
+| `StatusLog` | Timestamped status message log |
+| `StyledText` | Rich text display with styled content |
+| `TerminalOutput` | ANSI-capable terminal output display |
+| `TitleCard` | Styled title with optional subtitle |
+| `Toast` | Timed notification messages |
+| `UsageDisplay` | Resource usage metrics display |
 
 ### Overlay Components
 
 | Component | Description |
 |-----------|-------------|
 | `ConfirmDialog` | Preset confirmation dialog with Yes/No buttons |
-| `Dialog` | Modal dialog overlay with buttons |
+| `Dialog` | Modal dialog overlay with custom buttons |
+| `Tooltip` | Positioned tooltip with auto-dismiss |
 
 ### Compound Components
 
 | Component | Description |
 |-----------|-------------|
-| `ChatView` | Chat interface with message history and markdown rendering |
-| `Chart` | Data visualization with line and bar charts |
+| `AlertPanel` | Alert metrics dashboard with sparklines |
+| `BoxPlot` | Statistical box-and-whisker plots |
+| `Chart` | Line, bar, area, and scatter charts with annotations |
+| `CommandPalette` | Fuzzy-searchable command palette overlay |
+| `ConversationView` | AI conversation display with role colors and markdown |
 | `DataGrid` | Editable data table with cell navigation |
+| `DependencyGraph` | Node-edge dependency visualization |
+| `DiffViewer` | Side-by-side and unified diff display |
+| `EventStream` | Real-time event log with levels and timestamps |
 | `FileBrowser` | File system browser with pluggable backend |
+| `FlameGraph` | Hierarchical flame graph visualization |
 | `Form` | Multi-field form with validation |
+| `Heatmap` | 2D color-mapped data visualization |
+| `Histogram` | Distribution visualization with adaptive binning |
+| `LogCorrelation` | Multi-stream synchronized log viewer |
 | `LogViewer` | Filterable log display with search |
+| `MarkdownRenderer` | Markdown text rendering (headings, bold, code, lists) |
 | `MetricsDashboard` | Dashboard with charts, counters, and gauges |
-| `PaneLayout` | Resizable split-pane layouts with configurable proportions |
+| `PaneLayout` | Resizable split-pane layouts |
 | `SearchableList` | Filterable list with search input |
+| `SpanTree` | Hierarchical span/trace tree |
 | `SplitPanel` | Resizable dual-panel layout |
+| `Timeline` | Time-based event and span visualization |
+| `Treemap` | Proportional area-based data visualization |
 
 ### Utility
 
 | Component | Description |
 |-----------|-------------|
 | `FocusManager` | Keyboard focus coordination |
+| `AppShell` | Consistent header/content/footer layout splits |
 
 ### Component Example
 
 ```rust
-use envision::component::{Button, ButtonMessage, ButtonState, Component, Focusable};
+use envision::component::{Button, ButtonMessage, ButtonOutput, ButtonState, Component};
 
 // Initialize state
 let mut state = ButtonState::new("Submit");
 
 // Handle messages
-Button::update(&mut state, ButtonMessage::Press);
-
-// Focus management
-Button::set_focused(&mut state, true);
-assert!(Button::is_focused(&state));
+let output = Button::update(&mut state, ButtonMessage::Press);
+assert_eq!(output, Some(ButtonOutput::Pressed));
 ```
 
 ## Architecture

--- a/src/component/code_block/mod.rs
+++ b/src/component/code_block/mod.rs
@@ -554,7 +554,6 @@ impl Component for CodeBlock {
 
         let key = event.as_key()?;
         let ctrl = key.modifiers.ctrl();
-        let shift = key.modifiers.shift();
 
         match key.code {
             Key::Up | Key::Char('k') if !ctrl => Some(CodeBlockMessage::ScrollUp),
@@ -565,10 +564,9 @@ impl Component for CodeBlock {
             Key::PageDown => Some(CodeBlockMessage::PageDown(10)),
             Key::Char('u') if ctrl => Some(CodeBlockMessage::PageUp(10)),
             Key::Char('d') if ctrl => Some(CodeBlockMessage::PageDown(10)),
-            Key::Home | Key::Char('g') if !shift => Some(CodeBlockMessage::Home),
-            Key::End | Key::Char('g') if key.modifiers.shift() || key.code == Key::End => {
-                Some(CodeBlockMessage::End)
-            }
+            Key::Char('g') if key.modifiers.shift() => Some(CodeBlockMessage::End),
+            Key::Home | Key::Char('g') => Some(CodeBlockMessage::Home),
+            Key::End => Some(CodeBlockMessage::End),
             Key::Char('n') if !ctrl => Some(CodeBlockMessage::ToggleLineNumbers),
             _ => None,
         }

--- a/src/component/command_palette/mod.rs
+++ b/src/component/command_palette/mod.rs
@@ -7,6 +7,9 @@
 //!
 //! Implements [`Toggleable`].
 //!
+//! See also [`SearchableList`](super::SearchableList) for an inline
+//! (non-overlay) searchable list.
+//!
 //! # Example
 //!
 //! ```rust

--- a/src/component/conversation_view/mod.rs
+++ b/src/component/conversation_view/mod.rs
@@ -250,6 +250,10 @@ impl ConversationViewState {
     /// When enabled and the `markdown` feature is active, text blocks are
     /// rendered as markdown (headings, bold, italic, code, lists, etc.)
     /// instead of plain text.
+    ///
+    /// **Note:** This has no effect unless the `markdown` Cargo feature is
+    /// enabled. Add `envision = { features = ["markdown"] }` to your
+    /// `Cargo.toml`, or use the `full` feature (included in defaults).
     pub fn with_markdown(mut self, enabled: bool) -> Self {
         self.markdown_enabled = enabled;
         self

--- a/src/component/conversation_view/render.rs
+++ b/src/component/conversation_view/render.rs
@@ -145,7 +145,7 @@ pub(super) fn build_display_lines<'a>(
     messages: &[ConversationMessage],
     state: &ConversationViewState,
     width: usize,
-    _theme: &Theme,
+    theme: &Theme,
 ) -> Vec<Line<'a>> {
     let mut lines = Vec::new();
 
@@ -153,7 +153,7 @@ pub(super) fn build_display_lines<'a>(
         if i > 0 {
             lines.push(Line::from(""));
         }
-        format_message(msg, state, width, &mut lines);
+        format_message(msg, state, width, theme, &mut lines);
     }
 
     lines
@@ -163,6 +163,7 @@ fn format_message<'a>(
     msg: &ConversationMessage,
     state: &ConversationViewState,
     width: usize,
+    theme: &Theme,
     lines: &mut Vec<Line<'a>>,
 ) {
     let role = msg.role();
@@ -202,7 +203,7 @@ fn format_message<'a>(
 
     let indent = if state.show_role_labels { "  " } else { "" };
     for block in msg.blocks() {
-        format_block(block, state, width, indent, role_style, lines);
+        format_block(block, state, width, indent, role_style, theme, lines);
     }
 }
 
@@ -212,6 +213,7 @@ fn format_block<'a>(
     width: usize,
     indent: &str,
     role_style: Style,
+    theme: &Theme,
     lines: &mut Vec<Line<'a>>,
 ) {
     match block {
@@ -222,6 +224,7 @@ fn format_block<'a>(
                 indent,
                 role_style,
                 state.markdown_enabled,
+                theme,
                 lines,
             );
         }
@@ -308,6 +311,7 @@ fn format_text_block<'a>(
     indent: &str,
     style: Style,
     markdown_enabled: bool,
+    theme: &Theme,
     lines: &mut Vec<Line<'a>>,
 ) {
     if text.is_empty() {
@@ -317,13 +321,12 @@ fn format_text_block<'a>(
 
     #[cfg(feature = "markdown")]
     if markdown_enabled {
-        let theme = crate::theme::Theme::default();
         let indent_display_width = UnicodeWidthStr::width(indent);
         let available_width = width.saturating_sub(indent_display_width);
         let md_lines = crate::component::markdown_renderer::render::render_markdown(
             text,
             available_width as u16,
-            &theme,
+            theme,
         );
         for mut md_line in md_lines {
             for span in md_line.spans.iter_mut() {

--- a/src/component/diff_viewer/mod.rs
+++ b/src/component/diff_viewer/mod.rs
@@ -769,10 +769,9 @@ impl Component for DiffViewer {
             Key::PageDown => Some(DiffViewerMessage::PageDown(10)),
             Key::Char('u') if ctrl => Some(DiffViewerMessage::PageUp(10)),
             Key::Char('d') if ctrl => Some(DiffViewerMessage::PageDown(10)),
-            Key::Home | Key::Char('g') if !shift => Some(DiffViewerMessage::Home),
-            Key::End | Key::Char('g') if key.modifiers.shift() || key.code == Key::End => {
-                Some(DiffViewerMessage::End)
-            }
+            Key::Char('g') if key.modifiers.shift() => Some(DiffViewerMessage::End),
+            Key::Home | Key::Char('g') => Some(DiffViewerMessage::Home),
+            Key::End => Some(DiffViewerMessage::End),
             Key::Char('m') if !ctrl => Some(DiffViewerMessage::ToggleMode),
             _ => None,
         }

--- a/src/component/file_browser/mod.rs
+++ b/src/component/file_browser/mod.rs
@@ -652,16 +652,14 @@ impl Component for FileBrowser {
 
         let key = event.as_key()?;
         let ctrl = key.modifiers.ctrl();
-        let shift = key.modifiers.shift();
 
         match state.internal_focus {
             FileBrowserFocus::FileList => match key.code {
                 Key::Up | Key::Char('k') if !ctrl => Some(FileBrowserMessage::Up),
                 Key::Down | Key::Char('j') if !ctrl => Some(FileBrowserMessage::Down),
-                Key::Home | Key::Char('g') if !shift => Some(FileBrowserMessage::First),
-                Key::End | Key::Char('g') if key.modifiers.shift() || key.code == Key::End => {
-                    Some(FileBrowserMessage::Last)
-                }
+                Key::Char('g') if key.modifiers.shift() => Some(FileBrowserMessage::Last),
+                Key::Home | Key::Char('g') => Some(FileBrowserMessage::First),
+                Key::End => Some(FileBrowserMessage::Last),
                 Key::PageUp => Some(FileBrowserMessage::PageUp(10)),
                 Key::PageDown => Some(FileBrowserMessage::PageDown(10)),
                 Key::Enter => Some(FileBrowserMessage::Enter),

--- a/src/component/help_panel/mod.rs
+++ b/src/component/help_panel/mod.rs
@@ -633,7 +633,6 @@ impl Component for HelpPanel {
 
         let key = event.as_key()?;
         let ctrl = key.modifiers.ctrl();
-        let shift = key.modifiers.shift();
 
         match key.code {
             Key::Up | Key::Char('k') if !ctrl => Some(HelpPanelMessage::ScrollUp),
@@ -642,10 +641,9 @@ impl Component for HelpPanel {
             Key::PageDown => Some(HelpPanelMessage::PageDown(10)),
             Key::Char('u') if ctrl => Some(HelpPanelMessage::PageUp(10)),
             Key::Char('d') if ctrl => Some(HelpPanelMessage::PageDown(10)),
-            Key::Home | Key::Char('g') if !shift => Some(HelpPanelMessage::Home),
-            Key::End | Key::Char('g') if key.modifiers.shift() || key.code == Key::End => {
-                Some(HelpPanelMessage::End)
-            }
+            Key::Char('g') if key.modifiers.shift() => Some(HelpPanelMessage::End),
+            Key::Home | Key::Char('g') => Some(HelpPanelMessage::Home),
+            Key::End => Some(HelpPanelMessage::End),
             _ => None,
         }
     }

--- a/src/component/markdown_renderer/mod.rs
+++ b/src/component/markdown_renderer/mod.rs
@@ -336,10 +336,9 @@ impl Component for MarkdownRenderer {
             Key::PageDown => Some(MarkdownRendererMessage::PageDown(10)),
             Key::Char('u') if ctrl => Some(MarkdownRendererMessage::PageUp(10)),
             Key::Char('d') if ctrl => Some(MarkdownRendererMessage::PageDown(10)),
-            Key::Home | Key::Char('g') if !shift => Some(MarkdownRendererMessage::Home),
-            Key::End | Key::Char('g') if key.modifiers.shift() || key.code == Key::End => {
-                Some(MarkdownRendererMessage::End)
-            }
+            Key::Char('g') if key.modifiers.shift() => Some(MarkdownRendererMessage::End),
+            Key::Home | Key::Char('g') => Some(MarkdownRendererMessage::Home),
+            Key::End => Some(MarkdownRendererMessage::End),
             Key::Char('s') if !ctrl && !shift => Some(MarkdownRendererMessage::ToggleSource),
             _ => None,
         }

--- a/src/component/scroll_view/mod.rs
+++ b/src/component/scroll_view/mod.rs
@@ -453,7 +453,6 @@ impl Component for ScrollView {
 
         let key = event.as_key()?;
         let ctrl = key.modifiers.ctrl();
-        let shift = key.modifiers.shift();
 
         match key.code {
             Key::Up | Key::Char('k') if !ctrl => Some(ScrollViewMessage::ScrollUp),
@@ -462,10 +461,9 @@ impl Component for ScrollView {
             Key::PageDown => Some(ScrollViewMessage::PageDown),
             Key::Char('u') if ctrl => Some(ScrollViewMessage::PageUp),
             Key::Char('d') if ctrl => Some(ScrollViewMessage::PageDown),
-            Key::Home | Key::Char('g') if !shift => Some(ScrollViewMessage::Home),
-            Key::End | Key::Char('g') if key.modifiers.shift() || key.code == Key::End => {
-                Some(ScrollViewMessage::End)
-            }
+            Key::Char('g') if key.modifiers.shift() => Some(ScrollViewMessage::End),
+            Key::Home | Key::Char('g') => Some(ScrollViewMessage::Home),
+            Key::End => Some(ScrollViewMessage::End),
             _ => None,
         }
     }

--- a/src/component/scrollable_text/mod.rs
+++ b/src/component/scrollable_text/mod.rs
@@ -312,7 +312,6 @@ impl Component for ScrollableText {
 
         let key = event.as_key()?;
         let ctrl = key.modifiers.ctrl();
-        let shift = key.modifiers.shift();
 
         match key.code {
             Key::Up | Key::Char('k') if !ctrl => Some(ScrollableTextMessage::ScrollUp),
@@ -321,10 +320,9 @@ impl Component for ScrollableText {
             Key::PageDown => Some(ScrollableTextMessage::PageDown(10)),
             Key::Char('u') if ctrl => Some(ScrollableTextMessage::PageUp(10)),
             Key::Char('d') if ctrl => Some(ScrollableTextMessage::PageDown(10)),
-            Key::Home | Key::Char('g') if !shift => Some(ScrollableTextMessage::Home),
-            Key::End | Key::Char('g') if key.modifiers.shift() || key.code == Key::End => {
-                Some(ScrollableTextMessage::End)
-            }
+            Key::Char('g') if key.modifiers.shift() => Some(ScrollableTextMessage::End),
+            Key::Home | Key::Char('g') => Some(ScrollableTextMessage::Home),
+            Key::End => Some(ScrollableTextMessage::End),
             _ => None,
         }
     }

--- a/src/component/styled_text/mod.rs
+++ b/src/component/styled_text/mod.rs
@@ -381,7 +381,6 @@ impl Component for StyledText {
 
         let key = event.as_key()?;
         let ctrl = key.modifiers.ctrl();
-        let shift = key.modifiers.shift();
 
         match key.code {
             Key::Up | Key::Char('k') if !ctrl => Some(StyledTextMessage::ScrollUp),
@@ -390,10 +389,9 @@ impl Component for StyledText {
             Key::PageDown => Some(StyledTextMessage::PageDown(10)),
             Key::Char('u') if ctrl => Some(StyledTextMessage::PageUp(10)),
             Key::Char('d') if ctrl => Some(StyledTextMessage::PageDown(10)),
-            Key::Home | Key::Char('g') if !shift => Some(StyledTextMessage::Home),
-            Key::End | Key::Char('g') if key.modifiers.shift() || key.code == Key::End => {
-                Some(StyledTextMessage::End)
-            }
+            Key::Char('g') if key.modifiers.shift() => Some(StyledTextMessage::End),
+            Key::Home | Key::Char('g') => Some(StyledTextMessage::Home),
+            Key::End => Some(StyledTextMessage::End),
             _ => None,
         }
     }

--- a/src/component/tab_bar/mod.rs
+++ b/src/component/tab_bar/mod.rs
@@ -5,6 +5,8 @@
 //! and horizontal scrolling for overflow. State is stored in [`TabBarState`],
 //! updated via [`TabBarMessage`], and produces [`TabBarOutput`].
 //!
+//! See also [`Tabs`](super::Tabs) for a simpler tab component without
+//! closable tabs or overflow scrolling.
 //!
 //! # Example
 //!

--- a/src/component/tabs/mod.rs
+++ b/src/component/tabs/mod.rs
@@ -5,6 +5,8 @@
 //! State is stored in [`TabsState<T>`], updated via [`TabsMessage`], and produces
 //! [`TabsOutput`].
 //!
+//! See also [`TabBar`](super::TabBar) for a richer variant with closable tabs,
+//! modified indicators, and horizontal scrolling.
 //!
 //! # Example
 //!

--- a/src/component/terminal_output/mod.rs
+++ b/src/component/terminal_output/mod.rs
@@ -707,7 +707,6 @@ impl Component for TerminalOutput {
 
         let key = event.as_key()?;
         let ctrl = key.modifiers.ctrl();
-        let shift = key.modifiers.shift();
 
         match key.code {
             Key::Up | Key::Char('k') if !ctrl => Some(TerminalOutputMessage::ScrollUp),
@@ -716,10 +715,9 @@ impl Component for TerminalOutput {
             Key::PageDown => Some(TerminalOutputMessage::PageDown(10)),
             Key::Char('u') if ctrl => Some(TerminalOutputMessage::PageUp(10)),
             Key::Char('d') if ctrl => Some(TerminalOutputMessage::PageDown(10)),
-            Key::Home | Key::Char('g') if !shift => Some(TerminalOutputMessage::Home),
-            Key::End | Key::Char('g') if key.modifiers.shift() || key.code == Key::End => {
-                Some(TerminalOutputMessage::End)
-            }
+            Key::Char('g') if key.modifiers.shift() => Some(TerminalOutputMessage::End),
+            Key::Home | Key::Char('g') => Some(TerminalOutputMessage::Home),
+            Key::End => Some(TerminalOutputMessage::End),
             Key::Char('a') if !ctrl => Some(TerminalOutputMessage::ToggleAutoScroll),
             Key::Char('n') if !ctrl => Some(TerminalOutputMessage::ToggleLineNumbers),
             _ => None,


### PR DESCRIPTION
## Summary

Five fixes from customer feedback batch 3:

1. **SE2 (bug): markdown rendering ignores custom themes** — `conversation_view/render.rs:320` constructed `Theme::default()` instead of using the caller's theme. Custom themes got default-colored markdown. Fixed by threading the theme parameter through the call chain.

2. **SE1: README component list stale** — listed deleted `ChatView`, omitted `ConversationView`, `CommandPalette`, and 31 other components. Customer hand-rolled a command palette because they didn't know it existed. Full rewrite with all 73 components.

3. **B3: g/G/End pattern aligned with MIGRATION.md** — 9 components now use the three-arm form. Removed 7 unused `let shift` bindings.

4. **SE3: `with_markdown(true)` silent no-op documented** — added doc note explaining it requires the `markdown` feature.

5. **SE4: cross-reference docs** — Tabs↔TabBar, CommandPalette→SearchableList.

## Test plan

- [x] 7211 tests pass
- [x] 1993 doc tests pass
- [x] Clippy clean
- [x] `Theme::default()` removed from render path

🤖 Generated with [Claude Code](https://claude.com/claude-code)