### PR TITLE
Fix Event::key_with() normalization (0.14.1)

### DIFF
--- a/src/input/events/mod.rs
+++ b/src/input/events/mod.rs
@@ -76,15 +76,9 @@ impl Event {
     /// assert!(event.is_key());
     /// ```
     pub fn key_with(key: Key, modifiers: Modifiers) -> Self {
-        Self::Key(KeyEvent {
-            code: key,
-            modifiers,
-            kind: super::key::KeyEventKind::Press,
-            raw_char: match key {
-                Key::Char(c) => Some(c),
-                _ => None,
-            },
-        })
+        let mut ev = KeyEvent::new(key);
+        ev.modifiers |= modifiers;
+        Self::Key(ev)
     }
 
     /// Creates a Ctrl+key event.


### PR DESCRIPTION
Last constructor that could produce un-normalized \`Key::Char\`. Now routes through \`KeyEvent::new(key)\` then ORs in the modifiers.

Found by customer's adversarial verifier during the 0.14 migration. No callers in envision, but the public API contract was violated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)