### PR TITLE
Remove Clone bound from Message and Output types (BREAKING, 0.15.0)

### DIFF
--- a/src/app/command/mod.rs
+++ b/src/app/command/mod.rs
@@ -557,7 +557,7 @@ impl<M> Command<M> {
     /// ```
     pub fn subscribe(subscription: BoxedSubscription<M>) -> Self
     where
-        M: Send + Clone + 'static,
+        M: Send + 'static,
     {
         Self {
             actions: vec![CommandAction::Subscribe(subscription)],

--- a/src/app/model/mod.rs
+++ b/src/app/model/mod.rs
@@ -192,7 +192,7 @@ pub trait App: Sized {
     /// The message type representing all possible events.
     ///
     /// This should be an enum covering all ways the state can change.
-    type Message: Clone + Send + 'static;
+    type Message: Send + 'static;
 
     /// Initializes the application state and optional startup commands.
     ///

--- a/src/app/worker/mod.rs
+++ b/src/app/worker/mod.rs
@@ -370,7 +370,7 @@ impl WorkerBuilder {
         on_complete: C,
     ) -> (Command<M>, BoxedSubscription<M>, WorkerHandle)
     where
-        M: Send + Clone + 'static,
+        M: Send + 'static,
         P: Send + 'static,
         T: Send + 'static,
         E: Send + 'static,

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -523,13 +523,13 @@ pub trait Component: Sized {
     /// Messages this component can receive.
     ///
     /// These typically come from user input or parent components.
-    type Message: Clone;
+    type Message;
 
     /// Messages this component can emit to its parent.
     ///
     /// Use `()` if the component doesn't need to communicate upward.
     /// This enables child-to-parent communication without tight coupling.
-    type Output: Clone;
+    type Output;
 
     /// Initialize the component state.
     ///


### PR DESCRIPTION
## Summary

Drops the `Clone` requirement from `Component::Message`, `Component::Output`, `App::Message`, `Command::subscribe`, and `WorkerBuilder::spawn`.

**The bound was a phantom** — declared but never exercised. Investigation found zero `.clone()` calls on message values in production code. The entire architecture is move-based: messages flow through channels and update functions by value, never duplicated.

## What changed

5 lines — `Clone +` deleted from type bounds in:
- `App::Message: Clone + Send + 'static` → `Send + 'static`
- `Component::Message: Clone` → `Message` (no bound)
- `Component::Output: Clone` → `Output` (no bound)
- `Command::subscribe` where clause
- `WorkerBuilder::spawn` where clause

## Impact on downstream

**Backward-compatible in practice.** Existing code with `#[derive(Clone)]` keeps compiling (extra derives are harmless). Users with non-Clone payloads (file handles, mpsc::Sender, large buffers) are unblocked.

Customer feedback: "Dropping the bound is breaking but mechanical for callers (remove #[derive(Clone)], done). Worth the 0.15 slot."

## Test plan

- [x] 7211 tests pass
- [x] 1995 doc tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)