### PR TITLE
Add envision::terminal::restore() and docs/CHOOSING.md

### DIFF
--- a/docs/CHOOSING.md
+++ b/docs/CHOOSING.md
@@ -1,0 +1,121 @@
+# Choosing the Right Component
+
+Envision has 73 components. This guide helps you find the right one.
+
+## I want to show a list of things
+
+| Use case | Component | Why |
+|----------|-----------|-----|
+| Simple scrollable list with selection | [`SelectableList`] | Basic list with vim/arrow navigation |
+| List with search/filter | [`SearchableList`] | Combines a text filter with `SelectableList` |
+| List with per-item loading/error states | [`LoadingList`] | Each item has Pending/Ready/Error state |
+| Hierarchical/nested items | [`Tree`] | Expand/collapse with indentation |
+| Tabular data with columns | [`Table`] | Sortable columns, row selection |
+| Editable tabular data | [`DataGrid`] | Cell-level editing and navigation |
+| Fuzzy-searchable action picker | [`CommandPalette`] | Overlay-style, like VS Code's Ctrl+P |
+
+## I want text input
+
+| Use case | Component | Why |
+|----------|-----------|-----|
+| Single-line text | [`LineInput`] | History, clipboard, selection |
+| Single-line with field label | [`InputField`] | `LineInput` + border + label |
+| Multi-line text editing | [`TextArea`] | Undo/redo, line numbers, selection |
+| Number with min/max/step | [`NumberInput`] | Validates numeric input with range |
+| Dropdown with search | [`Dropdown`] | Type to filter, then select |
+| Dropdown without search | [`Select`] | Simple pick-one-from-list |
+
+## I want to show data visualization
+
+| Use case | Component | Why |
+|----------|-----------|-----|
+| Line, bar, area, or scatter chart | [`Chart`] | Multi-series, annotations, error bars |
+| Distribution/histogram | [`Histogram`] | Adaptive binning (Sturges/Scott/Freedman-Diaconis) |
+| Heatmap / 2D grid | [`Heatmap`] | Color scales (Viridis, Inferno, diverging) |
+| Box-and-whisker plots | [`BoxPlot`] | Statistical summaries with outliers |
+| Inline trend line | [`Sparkline`] | Compact, fits in a status bar |
+| Flame graph | [`FlameGraph`] | Hierarchical profiling data |
+| Dependency graph | [`DependencyGraph`] | Node-edge relationships |
+| Treemap | [`Treemap`] | Proportional area visualization |
+| Timeline / Gantt | [`Timeline`] | Events and spans on a time axis |
+| Span/trace tree | [`SpanTree`] | Distributed tracing hierarchies |
+
+## I want navigation / layout
+
+| Use case | Component | Why |
+|----------|-----------|-----|
+| Tab switching (simple) | [`Tabs`] | Horizontal tabs, generic type |
+| Tab switching (rich — closable, icons) | [`TabBar`] | Editor-style with overflow scrolling |
+| Menu with keyboard shortcuts | [`Menu`] | Nested items with enabled/disabled |
+| Breadcrumb path | [`Breadcrumb`] | Navigate hierarchical paths |
+| Step/wizard progress | [`StepIndicator`] | Pipeline visualization with per-step styles |
+| Multi-screen routing | [`Router`] | Navigation with history stack |
+| Page indicators | [`Paginator`] | Dots/numbers/compact styles |
+| Resizable split pane | [`SplitPanel`] | Two panels with draggable divider |
+| Resizable multi-pane | [`PaneLayout`] | N panes with proportional sizing |
+| Accordion panels | [`Accordion`] | Expand/collapse sections |
+
+## I want to show status / progress
+
+| Use case | Component | Why |
+|----------|-----------|-----|
+| Progress bar | [`ProgressBar`] | With ETA, rate, label |
+| Multiple progress bars | [`MultiProgress`] | Track concurrent tasks |
+| Gauge / meter | [`Gauge`] | Ratio display with thresholds |
+| Spinner | [`Spinner`] | Multiple animation styles |
+| Status bar | [`StatusBar`] | Bottom bar with left/center/right sections |
+| Status log | [`StatusLog`] | Timestamped messages |
+| Toast notifications | [`Toast`] | Timed popups with levels |
+
+## I want to display content
+
+| Use case | Component | Why |
+|----------|-----------|-----|
+| Scrollable text | [`ScrollableText`] | Read-only, scrollable |
+| Rich/styled text | [`StyledText`] | Inline styles and colors |
+| Markdown | [`MarkdownRenderer`] | Headings, bold, code, lists (requires `markdown` feature) |
+| Code with syntax hints | [`CodeBlock`] | Line numbers, highlight lines |
+| Diff view | [`DiffViewer`] | Side-by-side or unified |
+| Large block text | [`BigText`] | Block-character rendering |
+| Title with subtitle | [`TitleCard`] | Decorative header |
+| AI conversation | [`ConversationView`] | Role colors, code blocks, streaming |
+| Terminal output | [`TerminalOutput`] | ANSI-capable output display |
+| Resource usage | [`UsageDisplay`] | CPU/memory/disk metrics |
+
+## I want overlays / dialogs
+
+| Use case | Component | Why |
+|----------|-----------|-----|
+| Yes/No confirmation | [`ConfirmDialog`] | Preset buttons |
+| Custom dialog | [`Dialog`] | Custom buttons and content |
+| Tooltip | [`Tooltip`] | Positioned, auto-dismiss |
+| Command palette | [`CommandPalette`] | Fuzzy search overlay |
+| Help panel | [`HelpPanel`] | Keyboard shortcut reference |
+
+## I want logs / events
+
+| Use case | Component | Why |
+|----------|-----------|-----|
+| Filterable log viewer | [`LogViewer`] | Search, regex, follow mode |
+| Real-time event stream | [`EventStream`] | Levels, timestamps, source |
+| Multi-stream correlation | [`LogCorrelation`] | Synchronized scroll across streams |
+| Alert dashboard | [`AlertPanel`] | Metrics with thresholds and sparklines |
+| Metrics dashboard | [`MetricsDashboard`] | Charts, counters, gauges in a grid |
+
+## I want to manage focus
+
+| Component | Purpose |
+|-----------|---------|
+| [`FocusManager`] | Coordinates Tab/Shift+Tab focus cycling across components |
+
+Pass `focused: true/false` via `RenderContext` and `EventContext` to
+each component. `FocusManager` tracks which component is focused;
+your `view()` reads the focus state and passes it through.
+
+## Still not sure?
+
+- **`SelectableList` vs `SearchableList`**: If users need to filter by typing, use `SearchableList`. Otherwise `SelectableList`.
+- **`Select` vs `Dropdown`**: `Select` is a basic pick-list. `Dropdown` adds type-to-filter.
+- **`Tabs` vs `TabBar`**: `Tabs` is minimal (label + selection). `TabBar` adds close buttons, icons, modified indicators, overflow scrolling.
+- **`Table` vs `DataGrid`**: `Table` is read-only with sorting. `DataGrid` adds cell-level editing.
+- **`ConversationView` vs `ScrollableText`**: Use `ConversationView` for multi-role chat with structured message blocks. Use `ScrollableText` for simple read-only text.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -117,6 +117,7 @@ pub use command::{BoxedError, Command, CommandHandler};
 pub use model::App;
 #[cfg(feature = "serialization")]
 pub use persistence::load_state;
+pub use runtime::terminal::restore_terminal;
 pub use runtime::{
     Runtime, RuntimeBuilder, RuntimeConfig, TerminalHook, TerminalRuntime, VirtualRuntime,
 };

--- a/src/app/runtime/mod.rs
+++ b/src/app/runtime/mod.rs
@@ -66,7 +66,7 @@
 
 mod builder;
 mod config;
-mod terminal;
+pub(crate) mod terminal;
 mod virtual_terminal;
 pub use builder::RuntimeBuilder;
 pub use config::{RuntimeConfig, TerminalHook};

--- a/src/app/runtime/terminal.rs
+++ b/src/app/runtime/terminal.rs
@@ -18,6 +18,41 @@ use super::Runtime;
 use super::config::RuntimeConfig;
 use crate::app::command::Command;
 use crate::app::model::App;
+
+/// Restores the terminal to its normal state.
+///
+/// Disables raw mode, leaves the alternate screen, disables mouse capture,
+/// and shows the cursor. Call this in panic handlers or cleanup code to
+/// ensure the terminal is left in a usable state.
+///
+/// This is a standalone function that does not require a [`Runtime`]
+/// instance — use it when you need terminal cleanup outside the normal
+/// runtime lifecycle (e.g., in a `std::panic::set_hook` handler).
+///
+/// # Errors
+///
+/// Returns an error if any of the terminal cleanup operations fail.
+/// Errors are generally non-fatal — the terminal may already be in the
+/// correct state.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// // Install a panic hook that restores the terminal
+/// let original_hook = std::panic::take_hook();
+/// std::panic::set_hook(Box::new(move |info| {
+///     let _ = envision::terminal::restore();
+///     original_hook(info);
+/// }));
+/// ```
+pub fn restore_terminal() -> crate::error::Result<()> {
+    disable_raw_mode()?;
+    io::stdout().execute(LeaveAlternateScreen)?;
+    io::stdout().execute(DisableMouseCapture)?;
+    // Show cursor using crossterm directly (no Terminal instance needed)
+    crossterm::execute!(io::stdout(), crossterm::cursor::Show)?;
+    Ok(())
+}
 use crate::overlay::OverlayAction;
 
 // =============================================================================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,14 @@ pub mod theme;
 pub(crate) mod undo;
 pub mod util;
 
+/// Terminal lifecycle utilities.
+///
+/// Provides `restore()` for cleaning up terminal state in panic
+/// handlers or other non-runtime cleanup paths.
+pub mod terminal {
+    pub use crate::app::restore_terminal as restore;
+}
+
 // Re-export commonly used types
 pub use adapter::{DualBackend, DualBackendBuilder};
 pub use annotation::{


### PR DESCRIPTION
## Summary

Two customer asks:

1. **`envision::terminal::restore()`** — standalone function for cleaning up terminal state without a Runtime instance. For panic handlers and cleanup code. Completes the crossterm encapsulation — downstreams can drop the direct crossterm dep.

```rust
std::panic::set_hook(Box::new(move |info| {
    let _ = envision::terminal::restore();
    original_hook(info);
}));
```

2. **`docs/CHOOSING.md`** — component decision tree organized by use case ("I want to show a list", "I want text input", etc.) with comparison tables for confusing pairs. Customer hand-rolled CommandPalette for months because it wasn't discoverable.

## Test plan

- [x] Compiles clean
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)