### PR TITLE
Gate with_markdown/set_markdown_enabled on markdown feature (BREAKING, 0.15.0)

### DIFF
--- a/src/component/conversation_view/mod.rs
+++ b/src/component/conversation_view/mod.rs
@@ -247,19 +247,8 @@ impl ConversationViewState {
 
     /// Enables or disables markdown rendering for text blocks (builder pattern).
     ///
-    /// When enabled and the `markdown` feature is active, text blocks are
-    /// rendered as markdown (headings, bold, italic, code, lists, etc.)
-    /// instead of plain text.
-    ///
-    /// **Note:** This has no effect unless the `markdown` Cargo feature is
-    /// enabled. Add `envision = { features = ["markdown"] }` to your
-    /// `Cargo.toml`, or use the `full` feature (included in defaults).
-    pub fn with_markdown(mut self, enabled: bool) -> Self {
-        self.markdown_enabled = enabled;
-        self
-    }
-
-    /// Returns whether markdown rendering is enabled.
+    /// When enabled, text blocks are rendered as markdown (headings, bold,
+    /// italic, code, lists, etc.) instead of plain text.
     ///
     /// # Example
     ///
@@ -269,6 +258,16 @@ impl ConversationViewState {
     /// let state = ConversationViewState::new().with_markdown(true);
     /// assert!(state.markdown_enabled());
     /// ```
+    #[cfg(feature = "markdown")]
+    pub fn with_markdown(mut self, enabled: bool) -> Self {
+        self.markdown_enabled = enabled;
+        self
+    }
+
+    /// Returns whether markdown rendering is enabled.
+    ///
+    /// Always returns `false` when the `markdown` Cargo feature is not
+    /// enabled (since the setter methods are not available).
     pub fn markdown_enabled(&self) -> bool {
         self.markdown_enabled
     }
@@ -284,6 +283,7 @@ impl ConversationViewState {
     /// state.set_markdown_enabled(true);
     /// assert!(state.markdown_enabled());
     /// ```
+    #[cfg(feature = "markdown")]
     pub fn set_markdown_enabled(&mut self, enabled: bool) {
         self.markdown_enabled = enabled;
     }

--- a/src/component/conversation_view/render.rs
+++ b/src/component/conversation_view/render.rs
@@ -314,6 +314,10 @@ fn format_text_block<'a>(
     theme: &Theme,
     lines: &mut Vec<Line<'a>>,
 ) {
+    // theme is used by the markdown rendering path below; suppress
+    // the unused-variable warning when the markdown feature is off.
+    let _ = &theme;
+
     if text.is_empty() {
         lines.push(Line::from(Span::styled(indent.to_string(), style)));
         return;


### PR DESCRIPTION
## Summary

Calling `with_markdown(true)` or `set_markdown_enabled(true)` without the `markdown` Cargo feature is now a **compile error** instead of a silent no-op.

Sharp edge #4 from the 0.11 review — three rounds. Finally closed.

- `with_markdown()` → `#[cfg(feature = "markdown")]`
- `set_markdown_enabled()` → `#[cfg(feature = "markdown")]`
- `markdown_enabled()` getter stays available everywhere (returns false by default)
- Field stays on struct (can never be set to true without the feature)

Customer: "Loudest possible failure, no runtime cost, no tracing dep."

## Test plan

- [x] Clippy clean with `--all-features`
- [x] Clippy clean without `markdown` feature
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)