### PR TITLE
Delete old constructors, complete CHANGELOG/MIGRATION for 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
-- **API consistency sweep:** aligned builder/setter/getter naming across
-  components.
+- **Message `Clone` bound removed** from `Component::Message`,
+  `Component::Output`, `App::Message`, `Command::subscribe`, and
+  `WorkerBuilder::spawn`. The bound was never exercised — removal is
+  backward-compatible for users who keep `#[derive(Clone)]`. (#420)
+- **`ConversationView::view_from()` removed** along with the public
+  `MessageSource` trait. The API was unused by its target customer. (#423)
+- **`with_markdown()` and `set_markdown_enabled()` gated on `markdown`
+  feature.** Calling them without the feature is now a compile error
+  instead of a silent no-op. (#424)
+- **12 old `Runtime` constructors deleted.** `new_terminal()`,
+  `terminal_with_config()`, `new_terminal_with_state()`,
+  `terminal_with_state_and_config()`, `virtual_terminal()`,
+  `virtual_terminal_with_config()`, `virtual_terminal_with_state()`,
+  `virtual_terminal_with_state_and_config()`, `with_backend()`,
+  `with_backend_and_config()`, `with_backend_and_state()`, and
+  `with_backend_state_and_config()` (now `pub(crate)`) are removed.
+  Use `Runtime::builder()`, `Runtime::terminal_builder()`, or
+  `Runtime::virtual_builder()` instead.
+- **API consistency sweep — 11 renames:** (#425)
   - `CollapsibleState::expanded()` removed; use `is_expanded()` instead
     (matches accordion/tree/span_tree pattern).
   - `TabBarState::with_active()` renamed to `with_selected()`,
@@ -37,13 +54,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `RuntimeBuilder<A, B>` builder pattern for constructing `Runtime` instances.
-  Three entry points: `Runtime::builder(backend)` for any backend,
-  `Runtime::terminal_builder()` for real terminals, and
+- `RuntimeBuilder<A, B>` builder pattern for constructing `Runtime`
+  instances. Three entry points: `Runtime::builder(backend)` for any
+  backend, `Runtime::terminal_builder()` for real terminals, and
   `Runtime::virtual_builder(w, h)` for virtual terminals. Supports
   `.state()`, `.config()`, `.tick_rate()`, `.frame_rate()`,
-  `.max_messages()`, and `.channel_capacity()` builder methods.
-  Existing constructors are preserved for backward compatibility.
+  `.max_messages()`, and `.channel_capacity()` builder methods. (#421)
+- `envision::terminal::restore()` standalone function for terminal
+  cleanup in panic handlers. (#422)
+- `docs/CHOOSING.md` component decision tree. (#422)
+- `InputMode::{Desktop, Readline}` for `LineInput` keybinding mode.
+  Desktop mode (default) uses standard keybindings; Readline mode adds
+  Emacs-style shortcuts (Ctrl-A, Ctrl-E, Ctrl-K, etc.). (#426)
+- `LineInputMessage::DeleteToEnd` for readline Ctrl-K. (#426)
+- `StepIndicatorState::with_step_style(index, style)` per-step-index
+  style overrides. (#417)
+- `StepIndicatorState::with_status_style(status, style)` per-status
+  style overrides (renamed from `with_step_style`). (#417)
 
 ## [0.14.1] - 2026-04-12
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,78 @@
 # Migration Guide
 
+## v0.14.x to v0.15.0
+
+### Message `Clone` bound removed
+
+`Component::Message`, `Component::Output`, and `App::Message` no longer require `Clone`. Existing code with `#[derive(Clone)]` keeps compiling — the derive is now optional, not required.
+
+If you relied on the implied `Clone` bound in generic code (e.g., `fn foo<A: App>() where A::Message: Clone`), remove the bound or add it explicitly.
+
+### Runtime constructors replaced by builder
+
+The 12 `Runtime::new_terminal()` / `virtual_terminal()` / `with_backend()` constructors are removed. Use the builder instead:
+
+```rust
+// Before
+let rt = Runtime::<MyApp, _>::new_terminal()?;
+
+// After
+let rt = Runtime::<MyApp, _>::terminal_builder()?.build()?;
+```
+
+```rust
+// Before
+let rt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+
+// After
+let rt = Runtime::<MyApp, _>::virtual_builder(80, 24).build()?;
+```
+
+```rust
+// Before
+let rt = Runtime::<MyApp, _>::with_backend_state_and_config(
+    backend, state, cmd, config,
+)?;
+
+// After
+let rt = Runtime::<MyApp, _>::builder(backend)
+    .state(state, cmd)
+    .config(config)
+    .build()?;
+```
+
+### `ConversationView::view_from()` removed
+
+`view_from` and the public `MessageSource` trait are removed. Use the standard `ConversationView::view()` with messages stored in `ConversationViewState`.
+
+### `with_markdown()` requires the `markdown` feature
+
+Calling `with_markdown(true)` or `set_markdown_enabled(true)` without the `markdown` Cargo feature is now a compile error. Add `features = ["markdown"]` to your Cargo.toml or use the `full` feature (included in defaults).
+
+### API consistency renames
+
+| Before | After |
+|--------|-------|
+| `CollapsibleState::expanded()` | `is_expanded()` |
+| `TabBarState::active()` / `active_index()` / `set_active()` / `with_active()` | `selected()` / `selected_index()` / `set_selected()` / `with_selected()` |
+| `with_regex()` (log_viewer) | `with_use_regex()` |
+| `with_percentages()` (multi_progress) | `with_show_percentages()` |
+| `with_auto_remove()` (multi_progress) | `with_auto_remove_completed()` |
+| `with_show_line_numbers()` (diff_viewer) | `with_line_numbers()` |
+| `with_legend()` (chart) | `with_show_legend()` |
+| `with_timestamps()` (conversation_view, status_log, log_viewer) | `with_show_timestamps()` |
+| `with_role_labels()` (conversation_view) | `with_show_role_labels()` |
+
+### New features
+
+- `RuntimeBuilder` — `Runtime::terminal_builder()?.theme(t).tick_rate(d).build()?`
+- `envision::terminal::restore()` — standalone terminal cleanup for panic hooks
+- `InputMode::{Desktop, Readline}` on `LineInput` — `state.with_input_mode(InputMode::Readline)`
+- `StepIndicator` per-step-index styles — `state.with_step_style(0, Style::default().fg(Color::Cyan))`
+- `docs/CHOOSING.md` — component decision tree
+
+---
+
 ## v0.13.x to v0.14.0
 
 ### Envision-owned input types

--- a/benches/runtime.rs
+++ b/benches/runtime.rs
@@ -69,7 +69,9 @@ fn bench_runtime_creation(c: &mut Criterion) {
             |b, &(w, h)| {
                 b.iter(|| {
                     let runtime: Runtime<BenchApp, _> =
-                        Runtime::virtual_terminal(black_box(w), black_box(h)).unwrap();
+                        Runtime::virtual_builder(black_box(w), black_box(h))
+                            .build()
+                            .unwrap();
                     runtime
                 });
             },
@@ -81,12 +83,11 @@ fn bench_runtime_creation(c: &mut Criterion) {
             |b, &(w, h)| {
                 let config = RuntimeConfig::new().with_history(10);
                 b.iter(|| {
-                    let runtime: Runtime<BenchApp, _> = Runtime::virtual_terminal_with_config(
-                        black_box(w),
-                        black_box(h),
-                        config.clone(),
-                    )
-                    .unwrap();
+                    let runtime: Runtime<BenchApp, _> =
+                        Runtime::virtual_builder(black_box(w), black_box(h))
+                            .config(config.clone())
+                            .build()
+                            .unwrap();
                     runtime
                 });
             },
@@ -101,14 +102,14 @@ fn bench_runtime_dispatch(c: &mut Criterion) {
     let mut group = c.benchmark_group("runtime_dispatch");
 
     group.bench_function("single_message", |b| {
-        let mut runtime: Runtime<BenchApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+        let mut runtime: Runtime<BenchApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
         b.iter(|| {
             runtime.dispatch(black_box(BenchMsg::Increment));
         });
     });
 
     group.bench_function("batch_10", |b| {
-        let mut runtime: Runtime<BenchApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+        let mut runtime: Runtime<BenchApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
         let messages: Vec<_> = (0..10).map(|_| BenchMsg::Increment).collect();
         b.iter(|| {
             runtime.dispatch_all(black_box(messages.clone()));
@@ -116,7 +117,7 @@ fn bench_runtime_dispatch(c: &mut Criterion) {
     });
 
     group.bench_function("batch_100", |b| {
-        let mut runtime: Runtime<BenchApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+        let mut runtime: Runtime<BenchApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
         let messages: Vec<_> = (0..100).map(|_| BenchMsg::Increment).collect();
         b.iter(|| {
             runtime.dispatch_all(black_box(messages.clone()));
@@ -135,7 +136,8 @@ fn bench_runtime_tick(c: &mut Criterion) {
             BenchmarkId::new("tick", format!("{}x{}", width, height)),
             &(width, height),
             |b, &(w, h)| {
-                let mut runtime: Runtime<BenchApp, _> = Runtime::virtual_terminal(w, h).unwrap();
+                let mut runtime: Runtime<BenchApp, _> =
+                    Runtime::virtual_builder(w, h).build().unwrap();
                 b.iter(|| {
                     runtime.tick().unwrap();
                 });
@@ -146,7 +148,8 @@ fn bench_runtime_tick(c: &mut Criterion) {
             BenchmarkId::new("render_only", format!("{}x{}", width, height)),
             &(width, height),
             |b, &(w, h)| {
-                let mut runtime: Runtime<BenchApp, _> = Runtime::virtual_terminal(w, h).unwrap();
+                let mut runtime: Runtime<BenchApp, _> =
+                    Runtime::virtual_builder(w, h).build().unwrap();
                 b.iter(|| {
                     runtime.render().unwrap();
                 });

--- a/examples/accordion.rs
+++ b/examples/accordion.rs
@@ -113,7 +113,7 @@ impl App for AccordionApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<AccordionApp, _>::virtual_terminal(60, 20)?;
+    let mut vt = Runtime::<AccordionApp, _>::virtual_builder(60, 20).build()?;
 
     println!("=== Accordion Example ===\n");
 

--- a/examples/alert_panel.rs
+++ b/examples/alert_panel.rs
@@ -101,7 +101,7 @@ impl App for AlertPanelApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<AlertPanelApp, _>::virtual_terminal(80, 20)?;
+    let mut vt = Runtime::<AlertPanelApp, _>::virtual_builder(80, 20).build()?;
 
     println!("=== AlertPanel Example ===\n");
 

--- a/examples/async_counter.rs
+++ b/examples/async_counter.rs
@@ -184,7 +184,7 @@ impl App for AsyncCounterApp {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create the runtime
-    let mut runtime = Runtime::<AsyncCounterApp, _>::virtual_terminal(60, 20)?;
+    let mut runtime = Runtime::<AsyncCounterApp, _>::virtual_builder(60, 20).build()?;
 
     // Add tick subscription manually (since subscriptions aren't part of App trait)
     runtime.subscribe(tick(Duration::from_millis(500)).with_message(|| Msg::Tick));

--- a/examples/beautiful_dashboard.rs
+++ b/examples/beautiful_dashboard.rs
@@ -551,7 +551,7 @@ fn render_progress(state: &State, frame: &mut Frame, area: Rect, theme: &Theme) 
 // =============================================================================
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<DashboardApp, _>::virtual_terminal(80, 30)?;
+    let mut vt = Runtime::<DashboardApp, _>::virtual_builder(80, 30).build()?;
 
     println!("=== Beautiful Dashboard ===\n");
     println!("Demonstrating Envision + Catppuccin Mocha theme.\n");

--- a/examples/big_text.rs
+++ b/examples/big_text.rs
@@ -118,7 +118,7 @@ impl App for BigTextApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<BigTextApp, _>::virtual_terminal(60, 24)?;
+    let mut vt = Runtime::<BigTextApp, _>::virtual_builder(60, 24).build()?;
 
     println!("=== BigText Dashboard Example ===\n");
 

--- a/examples/box_plot.rs
+++ b/examples/box_plot.rs
@@ -78,7 +78,7 @@ impl App for BoxPlotApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<BoxPlotApp, _>::virtual_terminal(70, 22)?;
+    let mut vt = Runtime::<BoxPlotApp, _>::virtual_builder(70, 22).build()?;
 
     println!("=== Box Plot Example ===\n");
 

--- a/examples/breadcrumb.rs
+++ b/examples/breadcrumb.rs
@@ -117,7 +117,7 @@ impl App for BreadcrumbApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<BreadcrumbApp, _>::virtual_terminal(65, 14)?;
+    let mut vt = Runtime::<BreadcrumbApp, _>::virtual_builder(65, 14).build()?;
 
     println!("=== Breadcrumb Example ===\n");
 

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -159,7 +159,7 @@ impl App for ButtonApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<ButtonApp, _>::virtual_terminal(50, 16)?;
+    let mut vt = Runtime::<ButtonApp, _>::virtual_builder(50, 16).build()?;
 
     println!("=== Button Example ===\n");
 

--- a/examples/calendar.rs
+++ b/examples/calendar.rs
@@ -89,7 +89,7 @@ impl App for CalendarApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<CalendarApp, _>::virtual_terminal(40, 14)?;
+    let mut vt = Runtime::<CalendarApp, _>::virtual_builder(40, 14).build()?;
 
     println!("=== Calendar Example ===\n");
 

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -112,7 +112,7 @@ impl App for CanvasApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<CanvasApp, _>::virtual_terminal(70, 25)?;
+    let mut vt = Runtime::<CanvasApp, _>::virtual_builder(70, 25).build()?;
 
     println!("=== Canvas Example ===\n");
 

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -89,7 +89,7 @@ impl App for ChartApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<ChartApp, _>::virtual_terminal(70, 20)?;
+    let mut vt = Runtime::<ChartApp, _>::virtual_builder(70, 20).build()?;
 
     println!("=== Chart Example ===\n");
 

--- a/examples/chart_enhanced.rs
+++ b/examples/chart_enhanced.rs
@@ -101,7 +101,7 @@ impl App for ChartEnhancedApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<ChartEnhancedApp, _>::virtual_terminal(70, 30)?;
+    let mut vt = Runtime::<ChartEnhancedApp, _>::virtual_builder(70, 30).build()?;
 
     println!("=== Enhanced Chart Example ===\n");
 

--- a/examples/chat_client.rs
+++ b/examples/chat_client.rs
@@ -448,7 +448,7 @@ fn generate_response(msg_num: usize) -> String {
 // ---------------------------------------------------------------------------
 
 fn main() -> envision::Result<()> {
-    let mut vt = Runtime::<ChatClient, _>::virtual_terminal(90, 28)?;
+    let mut vt = Runtime::<ChatClient, _>::virtual_builder(90, 28).build()?;
 
     // Simulate a conversation using vt.dispatch() so that returned
     // Command::message() values are automatically processed on tick().

--- a/examples/checkbox.rs
+++ b/examples/checkbox.rs
@@ -165,7 +165,7 @@ impl App for CheckboxApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<CheckboxApp, _>::virtual_terminal(55, 16)?;
+    let mut vt = Runtime::<CheckboxApp, _>::virtual_builder(55, 16).build()?;
 
     println!("=== Checkbox Example ===\n");
 

--- a/examples/code_block.rs
+++ b/examples/code_block.rs
@@ -123,7 +123,7 @@ fn main() {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<CodeBlockApp, _>::virtual_terminal(80, 24)?;
+    let mut vt = Runtime::<CodeBlockApp, _>::virtual_builder(80, 24).build()?;
 
     println!("=== CodeBlock Example ===\n");
 

--- a/examples/collapsible.rs
+++ b/examples/collapsible.rs
@@ -104,7 +104,7 @@ impl App for CollapsibleApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<CollapsibleApp, _>::virtual_terminal(60, 12)?;
+    let mut vt = Runtime::<CollapsibleApp, _>::virtual_builder(60, 12).build()?;
 
     println!("=== Collapsible Example ===\n");
 

--- a/examples/command_palette.rs
+++ b/examples/command_palette.rs
@@ -173,7 +173,7 @@ impl App for CommandPaletteApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<CommandPaletteApp, _>::virtual_terminal(60, 24)?;
+    let mut vt = Runtime::<CommandPaletteApp, _>::virtual_builder(60, 24).build()?;
 
     println!("=== CommandPalette Example ===\n");
 

--- a/examples/component_showcase.rs
+++ b/examples/component_showcase.rs
@@ -785,7 +785,7 @@ fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
 // ---------------------------------------------------------------------------
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<ShowcaseApp, _>::virtual_terminal(80, 40)?;
+    let mut vt = Runtime::<ShowcaseApp, _>::virtual_builder(80, 40).build()?;
 
     println!("=== Component Showcase ===\n");
     println!("Demonstrating 18 Envision components with simplified event routing.\n");

--- a/examples/confirm_dialog.rs
+++ b/examples/confirm_dialog.rs
@@ -152,7 +152,8 @@ impl App for ConfirmDialogApp {
 
 #[tokio::main]
 async fn main() -> envision::Result<()> {
-    let _final_state = TerminalRuntime::<ConfirmDialogApp>::new_terminal()?
+    let _final_state = TerminalRuntime::<ConfirmDialogApp>::terminal_builder()?
+        .build()?
         .run_terminal()
         .await?;
     Ok(())

--- a/examples/conversation_view.rs
+++ b/examples/conversation_view.rs
@@ -170,7 +170,7 @@ impl App for ConversationApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<ConversationApp, _>::virtual_terminal(80, 30)?;
+    let mut vt = Runtime::<ConversationApp, _>::virtual_builder(80, 30).build()?;
 
     println!("=== Conversation View Example ===\n");
 

--- a/examples/counter_app.rs
+++ b/examples/counter_app.rs
@@ -167,7 +167,7 @@ impl App for CounterApp {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a virtual terminal for demonstration
-    let mut vt = Runtime::<CounterApp, _>::virtual_terminal(60, 20)?;
+    let mut vt = Runtime::<CounterApp, _>::virtual_builder(60, 20).build()?;
 
     // Simulate some user interactions
     println!("=== Counter App Demo ===\n");

--- a/examples/dashboard_builder.rs
+++ b/examples/dashboard_builder.rs
@@ -419,7 +419,7 @@ impl std::fmt::Display for DashTab {
 // ---------------------------------------------------------------------------
 
 fn main() -> envision::Result<()> {
-    let mut vt = Runtime::<Dashboard, _>::virtual_terminal(100, 30)?;
+    let mut vt = Runtime::<Dashboard, _>::virtual_builder(100, 30).build()?;
 
     // Run a few ticks to populate data
     for _ in 0..10 {

--- a/examples/dashboard_demo.rs
+++ b/examples/dashboard_demo.rs
@@ -501,13 +501,15 @@ async fn main() -> envision::Result<()> {
     let (state, _) = <DashboardApp as App>::init();
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Msg>();
 
-    let mut runtime = TerminalRuntime::<DashboardChannelApp>::new_terminal_with_state(
-        ChannelState {
-            inner: state,
-            build_tx: tx,
-        },
-        Command::none(),
-    )?;
+    let mut runtime = Runtime::<DashboardChannelApp, _>::terminal_builder()?
+        .state(
+            ChannelState {
+                inner: state,
+                build_tx: tx,
+            },
+            Command::none(),
+        )
+        .build()?;
 
     runtime.subscribe(UnboundedChannelSubscription::new(rx));
 

--- a/examples/data_grid.rs
+++ b/examples/data_grid.rs
@@ -121,7 +121,7 @@ impl App for DataGridApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<DataGridApp, _>::virtual_terminal(70, 12)?;
+    let mut vt = Runtime::<DataGridApp, _>::virtual_builder(70, 12).build()?;
 
     println!("=== DataGrid Example ===\n");
 

--- a/examples/dependency_graph.rs
+++ b/examples/dependency_graph.rs
@@ -142,7 +142,7 @@ impl App for DependencyGraphApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<DependencyGraphApp, _>::virtual_terminal(100, 24)?;
+    let mut vt = Runtime::<DependencyGraphApp, _>::virtual_builder(100, 24).build()?;
 
     println!("=== DependencyGraph Example ===\n");
 

--- a/examples/dialog.rs
+++ b/examples/dialog.rs
@@ -112,7 +112,7 @@ impl App for DialogApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<DialogApp, _>::virtual_terminal(60, 14)?;
+    let mut vt = Runtime::<DialogApp, _>::virtual_builder(60, 14).build()?;
 
     println!("=== Dialog Example ===\n");
 

--- a/examples/diff_viewer.rs
+++ b/examples/diff_viewer.rs
@@ -112,7 +112,7 @@ fn main() {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<DiffViewerApp, _>::virtual_terminal(80, 24)?;
+    let mut vt = Runtime::<DiffViewerApp, _>::virtual_builder(80, 24).build()?;
 
     println!("=== DiffViewer Example ===\n");
 

--- a/examples/divider.rs
+++ b/examples/divider.rs
@@ -101,7 +101,7 @@ impl App for DividerApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<DividerApp, _>::virtual_terminal(40, 10)?;
+    let mut vt = Runtime::<DividerApp, _>::virtual_builder(40, 10).build()?;
 
     println!("=== Divider Example ===\n");
 

--- a/examples/dropdown.rs
+++ b/examples/dropdown.rs
@@ -85,7 +85,7 @@ impl App for DropdownApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<DropdownApp, _>::virtual_terminal(40, 15)?;
+    let mut vt = Runtime::<DropdownApp, _>::virtual_builder(40, 15).build()?;
 
     println!("=== Dropdown Example ===\n");
 

--- a/examples/event_stream.rs
+++ b/examples/event_stream.rs
@@ -210,7 +210,7 @@ fn push_event(
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<EventStreamApp, _>::virtual_terminal(90, 22)?;
+    let mut vt = Runtime::<EventStreamApp, _>::virtual_builder(90, 22).build()?;
 
     println!("=== EventStream Example ===\n");
 

--- a/examples/file_browser.rs
+++ b/examples/file_browser.rs
@@ -115,7 +115,8 @@ impl App for FileBrowserApp {
 
 #[tokio::main]
 async fn main() -> envision::Result<()> {
-    let _final_state = TerminalRuntime::<FileBrowserApp>::new_terminal()?
+    let _final_state = TerminalRuntime::<FileBrowserApp>::terminal_builder()?
+        .build()?
         .run_terminal()
         .await?;
     Ok(())

--- a/examples/file_manager.rs
+++ b/examples/file_manager.rs
@@ -505,7 +505,7 @@ fn main() {
 // ---------------------------------------------------------------------------
 
 fn main() -> envision::Result<()> {
-    let mut vt = Runtime::<FileManager, _>::virtual_terminal(100, 30)?;
+    let mut vt = Runtime::<FileManager, _>::virtual_builder(100, 30).build()?;
 
     // Simulate selecting a file using vt.dispatch() for proper command processing
     vt.dispatch(Msg::Browser(FileBrowserMessage::Down));

--- a/examples/flame_graph.rs
+++ b/examples/flame_graph.rs
@@ -119,7 +119,7 @@ impl App for FlameGraphApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<FlameGraphApp, _>::virtual_terminal(70, 18)?;
+    let mut vt = Runtime::<FlameGraphApp, _>::virtual_builder(70, 18).build()?;
 
     println!("=== FlameGraph Example ===\n");
 

--- a/examples/focus_manager.rs
+++ b/examples/focus_manager.rs
@@ -208,7 +208,7 @@ fn panel_name(panel: Option<&Panel>) -> &'static str {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<FocusManagerApp, _>::virtual_terminal(80, 18)?;
+    let mut vt = Runtime::<FocusManagerApp, _>::virtual_builder(80, 18).build()?;
 
     println!("=== FocusManager Example ===\n");
 

--- a/examples/form.rs
+++ b/examples/form.rs
@@ -113,7 +113,7 @@ impl App for FormApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<FormApp, _>::virtual_terminal(60, 20)?;
+    let mut vt = Runtime::<FormApp, _>::virtual_builder(60, 20).build()?;
 
     println!("=== Form Example ===\n");
 

--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -122,7 +122,7 @@ impl App for GaugeApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<GaugeApp, _>::virtual_terminal(60, 14)?;
+    let mut vt = Runtime::<GaugeApp, _>::virtual_builder(60, 14).build()?;
 
     println!("=== Gauge Example ===\n");
 

--- a/examples/heatmap.rs
+++ b/examples/heatmap.rs
@@ -79,7 +79,7 @@ impl App for HeatmapApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<HeatmapApp, _>::virtual_terminal(60, 12)?;
+    let mut vt = Runtime::<HeatmapApp, _>::virtual_builder(60, 12).build()?;
 
     println!("=== Heatmap Example ===\n");
 

--- a/examples/help_panel.rs
+++ b/examples/help_panel.rs
@@ -120,7 +120,7 @@ impl App for HelpPanelApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<HelpPanelApp, _>::virtual_terminal(50, 24)?;
+    let mut vt = Runtime::<HelpPanelApp, _>::virtual_builder(50, 24).build()?;
 
     println!("=== HelpPanel Example ===\n");
 

--- a/examples/histogram.rs
+++ b/examples/histogram.rs
@@ -73,7 +73,7 @@ impl App for HistogramApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<HistogramApp, _>::virtual_terminal(70, 20)?;
+    let mut vt = Runtime::<HistogramApp, _>::virtual_builder(70, 20).build()?;
 
     println!("=== Histogram Example ===\n");
 

--- a/examples/input_field.rs
+++ b/examples/input_field.rs
@@ -113,7 +113,7 @@ impl App for InputFieldApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<InputFieldApp, _>::virtual_terminal(55, 14)?;
+    let mut vt = Runtime::<InputFieldApp, _>::virtual_builder(55, 14).build()?;
 
     println!("=== InputField Example ===\n");
 

--- a/examples/key_hints.rs
+++ b/examples/key_hints.rs
@@ -119,7 +119,7 @@ impl App for KeyHintsApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<KeyHintsApp, _>::virtual_terminal(70, 10)?;
+    let mut vt = Runtime::<KeyHintsApp, _>::virtual_builder(70, 10).build()?;
 
     println!("=== KeyHints Example ===\n");
 

--- a/examples/line_input.rs
+++ b/examples/line_input.rs
@@ -102,7 +102,7 @@ impl App for LineInputApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<LineInputApp, _>::virtual_terminal(60, 16)?;
+    let mut vt = Runtime::<LineInputApp, _>::virtual_builder(60, 16).build()?;
 
     println!("=== LineInput Example ===\n");
 

--- a/examples/loading_list.rs
+++ b/examples/loading_list.rs
@@ -101,7 +101,7 @@ impl App for LoadingListApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<LoadingListApp, _>::virtual_terminal(55, 12)?;
+    let mut vt = Runtime::<LoadingListApp, _>::virtual_builder(55, 12).build()?;
 
     println!("=== LoadingList Example ===\n");
 

--- a/examples/log_correlation.rs
+++ b/examples/log_correlation.rs
@@ -170,7 +170,7 @@ impl App for LogCorrelationApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<LogCorrelationApp, _>::virtual_terminal(85, 20)?;
+    let mut vt = Runtime::<LogCorrelationApp, _>::virtual_builder(85, 20).build()?;
 
     println!("=== LogCorrelation Example ===\n");
 

--- a/examples/log_explorer.rs
+++ b/examples/log_explorer.rs
@@ -490,7 +490,7 @@ fn simulated_event(counter: u64) -> (String, EventLevel, Vec<(String, String)>) 
 // ---------------------------------------------------------------------------
 
 fn main() -> envision::Result<()> {
-    let mut vt = Runtime::<LogExplorer, _>::virtual_terminal(100, 30)?;
+    let mut vt = Runtime::<LogExplorer, _>::virtual_builder(100, 30).build()?;
 
     // Simulate some initial data
     for _ in 0..8 {

--- a/examples/log_viewer.rs
+++ b/examples/log_viewer.rs
@@ -104,7 +104,7 @@ impl App for LogViewerApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<LogViewerApp, _>::virtual_terminal(75, 18)?;
+    let mut vt = Runtime::<LogViewerApp, _>::virtual_builder(75, 18).build()?;
 
     println!("=== LogViewer Example ===\n");
 

--- a/examples/markdown_renderer.rs
+++ b/examples/markdown_renderer.rs
@@ -135,7 +135,7 @@ impl App for MarkdownRendererApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<MarkdownRendererApp, _>::virtual_terminal(70, 30)?;
+    let mut vt = Runtime::<MarkdownRendererApp, _>::virtual_builder(70, 30).build()?;
 
     println!("=== MarkdownRenderer Example ===\n");
 

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -100,7 +100,7 @@ impl App for MenuApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<MenuApp, _>::virtual_terminal(60, 10)?;
+    let mut vt = Runtime::<MenuApp, _>::virtual_builder(60, 10).build()?;
 
     println!("=== Menu Example ===\n");
 

--- a/examples/metrics_dashboard.rs
+++ b/examples/metrics_dashboard.rs
@@ -88,7 +88,7 @@ impl App for MetricsDashboardApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<MetricsDashboardApp, _>::virtual_terminal(66, 14)?;
+    let mut vt = Runtime::<MetricsDashboardApp, _>::virtual_builder(66, 14).build()?;
 
     println!("=== MetricsDashboard Example ===\n");
 

--- a/examples/multi_progress.rs
+++ b/examples/multi_progress.rs
@@ -84,7 +84,7 @@ impl App for MultiProgressApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<MultiProgressApp, _>::virtual_terminal(60, 10)?;
+    let mut vt = Runtime::<MultiProgressApp, _>::virtual_builder(60, 10).build()?;
 
     println!("=== MultiProgress Example ===\n");
 

--- a/examples/number_input.rs
+++ b/examples/number_input.rs
@@ -162,7 +162,7 @@ impl App for NumberInputApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<NumberInputApp, _>::virtual_terminal(60, 16)?;
+    let mut vt = Runtime::<NumberInputApp, _>::virtual_builder(60, 16).build()?;
 
     println!("=== Number Input Example ===\n");
 

--- a/examples/paginator.rs
+++ b/examples/paginator.rs
@@ -140,7 +140,7 @@ impl App for PaginatorApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<PaginatorApp, _>::virtual_terminal(50, 14)?;
+    let mut vt = Runtime::<PaginatorApp, _>::virtual_builder(50, 14).build()?;
 
     println!("=== Paginator Example ===\n");
 

--- a/examples/pane_layout.rs
+++ b/examples/pane_layout.rs
@@ -124,7 +124,8 @@ impl App for PaneLayoutApp {
 
 #[tokio::main]
 async fn main() -> envision::Result<()> {
-    let _final_state = TerminalRuntime::<PaneLayoutApp>::new_terminal()?
+    let _final_state = TerminalRuntime::<PaneLayoutApp>::terminal_builder()?
+        .build()?
         .run_terminal()
         .await?;
     Ok(())

--- a/examples/production_app.rs
+++ b/examples/production_app.rs
@@ -301,11 +301,10 @@ async fn main() -> envision::Result<()> {
         });
 
     // ── 5. Create the runtime with pre-built state (bypass App::init) ──
-    let mut runtime = TerminalRuntime::<ProcessorApp>::terminal_with_state_and_config(
-        state,
-        Command::none(),
-        runtime_config,
-    )?;
+    let mut runtime = Runtime::<ProcessorApp, _>::terminal_builder()?
+        .state(state, Command::none())
+        .config(runtime_config)
+        .build()?;
 
     // ── 6. Subscribe to background worker updates ───────────────────────
     //

--- a/examples/progress_bar.rs
+++ b/examples/progress_bar.rs
@@ -95,7 +95,7 @@ impl App for ProgressBarApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<ProgressBarApp, _>::virtual_terminal(50, 10)?;
+    let mut vt = Runtime::<ProgressBarApp, _>::virtual_builder(50, 10).build()?;
 
     println!("=== ProgressBar Example ===\n");
 

--- a/examples/radio_group.rs
+++ b/examples/radio_group.rs
@@ -96,7 +96,7 @@ impl App for RadioGroupApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<RadioGroupApp, _>::virtual_terminal(50, 14)?;
+    let mut vt = Runtime::<RadioGroupApp, _>::virtual_builder(50, 14).build()?;
 
     println!("=== RadioGroup Example ===\n");
 

--- a/examples/router.rs
+++ b/examples/router.rs
@@ -136,7 +136,7 @@ impl App for RouterApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<RouterApp, _>::virtual_terminal(50, 14)?;
+    let mut vt = Runtime::<RouterApp, _>::virtual_builder(50, 14).build()?;
 
     println!("=== Router Example ===\n");
 

--- a/examples/scroll_view.rs
+++ b/examples/scroll_view.rs
@@ -105,7 +105,7 @@ impl App for ScrollViewApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<ScrollViewApp, _>::virtual_terminal(70, 20)?;
+    let mut vt = Runtime::<ScrollViewApp, _>::virtual_builder(70, 20).build()?;
 
     println!("=== ScrollView Example ===\n");
 

--- a/examples/scrollable_text.rs
+++ b/examples/scrollable_text.rs
@@ -88,7 +88,7 @@ impl App for ScrollableTextApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<ScrollableTextApp, _>::virtual_terminal(70, 20)?;
+    let mut vt = Runtime::<ScrollableTextApp, _>::virtual_builder(70, 20).build()?;
 
     println!("=== ScrollableText Example ===\n");
 

--- a/examples/searchable_list.rs
+++ b/examples/searchable_list.rs
@@ -122,7 +122,7 @@ impl App for SearchableListApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<SearchableListApp, _>::virtual_terminal(50, 22)?;
+    let mut vt = Runtime::<SearchableListApp, _>::virtual_builder(50, 22).build()?;
 
     println!("=== SearchableList Example ===\n");
 

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -141,7 +141,7 @@ impl App for SelectApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<SelectApp, _>::virtual_terminal(50, 14)?;
+    let mut vt = Runtime::<SelectApp, _>::virtual_builder(50, 14).build()?;
 
     println!("=== Select Example ===\n");
 

--- a/examples/selectable_list.rs
+++ b/examples/selectable_list.rs
@@ -89,7 +89,7 @@ impl App for SelectableListApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<SelectableListApp, _>::virtual_terminal(40, 12)?;
+    let mut vt = Runtime::<SelectableListApp, _>::virtual_builder(40, 12).build()?;
 
     println!("=== SelectableList Example ===\n");
 

--- a/examples/slider.rs
+++ b/examples/slider.rs
@@ -166,7 +166,7 @@ impl App for SliderApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<SliderApp, _>::virtual_terminal(60, 24)?;
+    let mut vt = Runtime::<SliderApp, _>::virtual_builder(60, 24).build()?;
 
     println!("=== Slider Example ===\n");
 

--- a/examples/span_tree.rs
+++ b/examples/span_tree.rs
@@ -110,7 +110,7 @@ impl App for SpanTreeApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<SpanTreeApp, _>::virtual_terminal(70, 16)?;
+    let mut vt = Runtime::<SpanTreeApp, _>::virtual_builder(70, 16).build()?;
 
     println!("=== SpanTree Example ===\n");
 

--- a/examples/sparkline.rs
+++ b/examples/sparkline.rs
@@ -94,7 +94,7 @@ impl App for SparklineApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<SparklineApp, _>::virtual_terminal(40, 8)?;
+    let mut vt = Runtime::<SparklineApp, _>::virtual_builder(40, 8).build()?;
 
     println!("=== Sparkline Example ===\n");
 

--- a/examples/spinner.rs
+++ b/examples/spinner.rs
@@ -101,7 +101,7 @@ impl App for SpinnerApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<SpinnerApp, _>::virtual_terminal(40, 6)?;
+    let mut vt = Runtime::<SpinnerApp, _>::virtual_builder(40, 6).build()?;
 
     println!("=== Spinner Example ===\n");
 

--- a/examples/split_panel.rs
+++ b/examples/split_panel.rs
@@ -110,7 +110,7 @@ impl App for SplitPanelApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<SplitPanelApp, _>::virtual_terminal(60, 14)?;
+    let mut vt = Runtime::<SplitPanelApp, _>::virtual_builder(60, 14).build()?;
 
     println!("=== SplitPanel Example ===\n");
 

--- a/examples/status_bar.rs
+++ b/examples/status_bar.rs
@@ -138,7 +138,7 @@ impl App for StatusBarApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<StatusBarApp, _>::virtual_terminal(60, 10)?;
+    let mut vt = Runtime::<StatusBarApp, _>::virtual_builder(60, 10).build()?;
 
     println!("=== StatusBar Example ===\n");
 

--- a/examples/status_log.rs
+++ b/examples/status_log.rs
@@ -79,7 +79,7 @@ impl App for StatusLogApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<StatusLogApp, _>::virtual_terminal(55, 14)?;
+    let mut vt = Runtime::<StatusLogApp, _>::virtual_builder(55, 14).build()?;
 
     println!("=== StatusLog Example ===\n");
 

--- a/examples/step_indicator.rs
+++ b/examples/step_indicator.rs
@@ -148,7 +148,8 @@ impl App for StepIndicatorApp {
 
 #[tokio::main]
 async fn main() -> envision::Result<()> {
-    let _final_state = TerminalRuntime::<StepIndicatorApp>::new_terminal()?
+    let _final_state = TerminalRuntime::<StepIndicatorApp>::terminal_builder()?
+        .build()?
         .run_terminal()
         .await?;
     Ok(())

--- a/examples/styled_text.rs
+++ b/examples/styled_text.rs
@@ -160,7 +160,8 @@ impl App for StyledTextApp {
 
 #[tokio::main]
 async fn main() -> envision::Result<()> {
-    let _final_state = TerminalRuntime::<StyledTextApp>::new_terminal()?
+    let _final_state = TerminalRuntime::<StyledTextApp>::terminal_builder()?
+        .build()?
         .run_terminal()
         .await?;
     Ok(())

--- a/examples/styling_showcase.rs
+++ b/examples/styling_showcase.rs
@@ -229,7 +229,7 @@ fn build_rich_text_content() -> styled_text::StyledContent {
         .text("Code blocks for source code:")
         .code_block(
             Some("rust"),
-            "use envision::prelude::*;\n\nfn main() -> envision::Result<()> {\n    let _state = TerminalRuntime::<MyApp>::new_terminal()?\n        .run_terminal()\n        .await?;\n    Ok(())\n}",
+            "use envision::prelude::*;\n\nfn main() -> envision::Result<()> {\n    let _state = TerminalRuntime::<MyApp>::terminal_builder()?.build()?\n        .run_terminal()\n        .await?;\n    Ok(())\n}",
         )
         .horizontal_rule()
         .text("Use Up/Down to scroll. Press Tab to switch panels. Press T to change themes.")
@@ -496,7 +496,8 @@ fn render_footer(frame: &mut Frame, area: Rect, theme: &Theme) {
 
 #[tokio::main]
 async fn main() -> envision::Result<()> {
-    let _final_state = TerminalRuntime::<StylingShowcaseApp>::new_terminal()?
+    let _final_state = TerminalRuntime::<StylingShowcaseApp>::terminal_builder()?
+        .build()?
         .run_terminal()
         .await?;
     Ok(())

--- a/examples/switch.rs
+++ b/examples/switch.rs
@@ -196,7 +196,7 @@ impl App for SwitchApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<SwitchApp, _>::virtual_terminal(60, 14)?;
+    let mut vt = Runtime::<SwitchApp, _>::virtual_builder(60, 14).build()?;
 
     println!("=== Switch Example ===\n");
 

--- a/examples/tab_bar.rs
+++ b/examples/tab_bar.rs
@@ -127,7 +127,7 @@ impl App for TabBarApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<TabBarApp, _>::virtual_terminal(70, 10)?;
+    let mut vt = Runtime::<TabBarApp, _>::virtual_builder(70, 10).build()?;
 
     println!("=== TabBar Example ===\n");
 

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -129,7 +129,7 @@ impl App for TableApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<TableApp, _>::virtual_terminal(60, 12)?;
+    let mut vt = Runtime::<TableApp, _>::virtual_builder(60, 12).build()?;
 
     println!("=== Table Example ===\n");
 

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -100,7 +100,7 @@ impl App for TabsApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<TabsApp, _>::virtual_terminal(60, 10)?;
+    let mut vt = Runtime::<TabsApp, _>::virtual_builder(60, 10).build()?;
 
     println!("=== Tabs Example ===\n");
 

--- a/examples/terminal_output.rs
+++ b/examples/terminal_output.rs
@@ -103,7 +103,7 @@ impl App for TerminalOutputApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<TerminalOutputApp, _>::virtual_terminal(70, 25)?;
+    let mut vt = Runtime::<TerminalOutputApp, _>::virtual_builder(70, 25).build()?;
 
     println!("=== TerminalOutput Example ===\n");
 

--- a/examples/test_harness.rs
+++ b/examples/test_harness.rs
@@ -138,8 +138,10 @@ fn demo_basic_harness() {
 fn demo_runtime_testing() {
     println!("=== Demo 2: Virtual Terminal for App Testing ===\n");
 
-    // Use Runtime::virtual_terminal to test App implementations
-    let mut vt = Runtime::<TodoApp, _>::virtual_terminal(60, 12).unwrap();
+    // Use Runtime::virtual_builder to test App implementations
+    let mut vt = Runtime::<TodoApp, _>::virtual_builder(60, 12)
+        .build()
+        .unwrap();
 
     // Check initial state
     vt.tick().unwrap();

--- a/examples/text_area.rs
+++ b/examples/text_area.rs
@@ -75,7 +75,7 @@ impl App for TextAreaApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<TextAreaApp, _>::virtual_terminal(50, 10)?;
+    let mut vt = Runtime::<TextAreaApp, _>::virtual_builder(50, 10).build()?;
 
     println!("=== TextArea Example ===\n");
 

--- a/examples/themed_app.rs
+++ b/examples/themed_app.rs
@@ -282,7 +282,7 @@ impl App for ThemedApp {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a virtual terminal for demonstration
-    let mut vt = Runtime::<ThemedApp, _>::virtual_terminal(60, 24)?;
+    let mut vt = Runtime::<ThemedApp, _>::virtual_builder(60, 24).build()?;
 
     println!("=== Themed App Demo ===\n");
     println!("This example demonstrates Envision's theming system.\n");

--- a/examples/timeline.rs
+++ b/examples/timeline.rs
@@ -97,7 +97,7 @@ impl App for TimelineApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<TimelineApp, _>::virtual_terminal(80, 20)?;
+    let mut vt = Runtime::<TimelineApp, _>::virtual_builder(80, 20).build()?;
 
     println!("=== Timeline Example ===\n");
 

--- a/examples/title_card.rs
+++ b/examples/title_card.rs
@@ -115,7 +115,7 @@ impl App for TitleCardApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<TitleCardApp, _>::virtual_terminal(60, 20)?;
+    let mut vt = Runtime::<TitleCardApp, _>::virtual_builder(60, 20).build()?;
 
     println!("=== TitleCard Example ===\n");
 

--- a/examples/toast.rs
+++ b/examples/toast.rs
@@ -93,7 +93,7 @@ impl App for ToastApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<ToastApp, _>::virtual_terminal(60, 16)?;
+    let mut vt = Runtime::<ToastApp, _>::virtual_builder(60, 16).build()?;
 
     println!("=== Toast Example ===\n");
 

--- a/examples/tooltip.rs
+++ b/examples/tooltip.rs
@@ -128,7 +128,7 @@ impl App for TooltipApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<TooltipApp, _>::virtual_terminal(55, 16)?;
+    let mut vt = Runtime::<TooltipApp, _>::virtual_builder(55, 16).build()?;
 
     println!("=== Tooltip Example ===\n");
 

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -96,7 +96,7 @@ impl App for TreeApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<TreeApp, _>::virtual_terminal(50, 15)?;
+    let mut vt = Runtime::<TreeApp, _>::virtual_builder(50, 15).build()?;
 
     println!("=== Tree Example ===\n");
 

--- a/examples/treemap.rs
+++ b/examples/treemap.rs
@@ -107,7 +107,7 @@ impl App for TreemapApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<TreemapApp, _>::virtual_terminal(60, 16)?;
+    let mut vt = Runtime::<TreemapApp, _>::virtual_builder(60, 16).build()?;
 
     println!("=== Treemap Example ===\n");
 

--- a/examples/usage_display.rs
+++ b/examples/usage_display.rs
@@ -115,7 +115,7 @@ impl App for UsageDisplayApp {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut vt = Runtime::<UsageDisplayApp, _>::virtual_terminal(60, 20)?;
+    let mut vt = Runtime::<UsageDisplayApp, _>::virtual_builder(60, 20).build()?;
 
     println!("=== UsageDisplay Example ===\n");
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -35,25 +35,22 @@
 //!
 //! There are two ways to provide the initial state:
 //!
-//! - **Standard pattern**: Use [`Runtime::new_terminal()`] or
-//!   [`Runtime::virtual_terminal()`]. These call [`App::init()`] to create
+//! - **Standard pattern**: Use [`Runtime::terminal_builder()`] or
+//!   [`Runtime::virtual_builder()`]. These call [`App::init()`] to create
 //!   the initial state and any startup commands.
 //!
-//! - **External state pattern**: Use the `with_state` constructors
-//!   ([`Runtime::new_terminal_with_state()`],
-//!   [`Runtime::virtual_terminal_with_state()`], etc.). These accept a
-//!   pre-built state directly and **do not call** [`App::init()`]. This is
-//!   useful when initial state comes from CLI arguments, config files,
-//!   databases, or test fixtures.
+//! - **External state pattern**: Use the builder's `.state()` method
+//!   (e.g., `Runtime::virtual_builder(80, 24).state(s, cmd).build()?`).
+//!   This accepts a pre-built state directly and **does not call**
+//!   [`App::init()`]. Useful when initial state comes from CLI arguments,
+//!   config files, databases, or test fixtures.
 //!
-//! Even when using `with_state` constructors, [`App::init()`] must still
-//! be implemented because it is a required trait method. A simple stub
-//! returning default values is sufficient.
+//! Even when using `.state()`, [`App::init()`] must still be implemented
+//! because it is a required trait method. A simple stub returning default
+//! values is sufficient.
 //!
-//! [`Runtime::new_terminal()`]: Runtime::new_terminal
-//! [`Runtime::virtual_terminal()`]: Runtime::virtual_terminal
-//! [`Runtime::new_terminal_with_state()`]: Runtime::new_terminal_with_state
-//! [`Runtime::virtual_terminal_with_state()`]: Runtime::virtual_terminal_with_state
+//! [`Runtime::terminal_builder()`]: Runtime::terminal_builder
+//! [`Runtime::virtual_builder()`]: Runtime::virtual_builder
 //!
 //! # Example
 //!

--- a/src/app/model/mod.rs
+++ b/src/app/model/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! ## Standard pattern — `init()` creates the state
 //!
-//! Use [`Runtime::new_terminal()`] or [`Runtime::virtual_terminal()`].
+//! Use [`Runtime::terminal_builder()`] or [`Runtime::virtual_builder()`].
 //! These call [`App::init()`] internally to create the initial state and
 //! any startup commands.
 //!
@@ -25,17 +25,16 @@
 //! #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
 //! #     fn view(state: &MyState, frame: &mut Frame) {}
 //! # }
-//! let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+//! let mut vt = Runtime::<MyApp, _>::virtual_builder(80, 24).build()?;
 //! # Ok::<(), envision::EnvisionError>(())
 //! ```
 //!
 //! ## External state pattern — `init()` is bypassed
 //!
-//! Use [`Runtime::new_terminal_with_state()`],
-//! [`Runtime::virtual_terminal_with_state()`], or any `with_state` variant.
-//! These accept a pre-built state directly, so [`App::init()`] is **never
-//! called**. This is useful when initial state comes from external sources
-//! such as CLI arguments, config files, or databases.
+//! Use the builder's `.state()` method to provide a pre-built state directly.
+//! [`App::init()`] is **never called**. This is useful when initial state
+//! comes from external sources such as CLI arguments, config files, or
+//! databases.
 //!
 //! ```rust
 //! # use envision::prelude::*;
@@ -52,20 +51,18 @@
 //! #     fn view(state: &MyState, frame: &mut Frame) {}
 //! # }
 //! let state = MyState::default();
-//! let mut vt = Runtime::<MyApp, _>::virtual_terminal_with_state(
-//!     80, 24, state, Command::none(),
-//! )?;
+//! let mut vt = Runtime::<MyApp, _>::virtual_builder(80, 24)
+//!     .state(state, Command::none())
+//!     .build()?;
 //! # Ok::<(), envision::EnvisionError>(())
 //! ```
 //!
-//! When using `with_state` constructors, `App::init()` does **not** need to
-//! be implemented — the default implementation will panic if called, which
-//! is safe because `with_state` constructors never call it.
+//! When using `.state()`, `App::init()` does **not** need to be
+//! implemented — the default implementation will panic if called, which
+//! is safe because `.state()` prevents it from being called.
 //!
-//! [`Runtime::new_terminal()`]: crate::app::Runtime::new_terminal
-//! [`Runtime::virtual_terminal()`]: crate::app::Runtime::virtual_terminal
-//! [`Runtime::new_terminal_with_state()`]: crate::app::Runtime::new_terminal_with_state
-//! [`Runtime::virtual_terminal_with_state()`]: crate::app::Runtime::virtual_terminal_with_state
+//! [`Runtime::terminal_builder()`]: crate::app::Runtime::terminal_builder
+//! [`Runtime::virtual_builder()`]: crate::app::Runtime::virtual_builder
 
 use ratatui::Frame;
 
@@ -93,14 +90,12 @@ use crate::input::Event;
 /// There are two ways to start an application, which determine whether
 /// [`init()`](App::init) is called:
 ///
-/// - **Standard**: [`Runtime::new_terminal()`](crate::app::Runtime::new_terminal) and
-///   [`Runtime::virtual_terminal()`](crate::app::Runtime::virtual_terminal) call `init()`
-///   to create the initial state.
-/// - **External state**: The `with_state` constructors
-///   ([`Runtime::new_terminal_with_state()`](crate::app::Runtime::new_terminal_with_state),
-///   [`Runtime::virtual_terminal_with_state()`](crate::app::Runtime::virtual_terminal_with_state),
-///   etc.) accept a pre-built state and **skip** `init()` entirely. In this
-///   case, `init()` does not need to be implemented.
+/// - **Standard**: [`Runtime::terminal_builder()`](crate::app::Runtime::terminal_builder) and
+///   [`Runtime::virtual_builder()`](crate::app::Runtime::virtual_builder) call `init()`
+///   to create the initial state (when `.state()` is not called on the builder).
+/// - **External state**: Use `.state(s, cmd)` on the builder to provide a
+///   pre-built state and **skip** `init()` entirely. In this case, `init()`
+///   does not need to be implemented.
 ///
 /// # Examples
 ///
@@ -196,30 +191,23 @@ pub trait App: Sized {
 
     /// Initializes the application state and optional startup commands.
     ///
-    /// This is called automatically when using [`Runtime::new_terminal()`] or
-    /// [`Runtime::virtual_terminal()`]. When using the `with_state` constructors
-    /// ([`Runtime::new_terminal_with_state()`],
-    /// [`Runtime::virtual_terminal_with_state()`]), this method is **not
+    /// This is called automatically when using the builder without `.state()`.
+    /// When using `.state(s, cmd)` on the builder, this method is **not
     /// called** — the provided state is used directly instead.
     ///
     /// # Panics
     ///
     /// The default implementation panics if called without being overridden.
-    /// This allows applications that exclusively use `with_state` constructors
+    /// This allows applications that exclusively use `.state()` on the builder
     /// to omit `init()` entirely, since it will never be called. If you
-    /// use [`Runtime::new_terminal()`] or [`Runtime::virtual_terminal()`],
-    /// you **must** override this method to provide valid initial state.
-    ///
-    /// [`Runtime::new_terminal()`]: crate::app::Runtime::new_terminal
-    /// [`Runtime::virtual_terminal()`]: crate::app::Runtime::virtual_terminal
-    /// [`Runtime::new_terminal_with_state()`]: crate::app::Runtime::new_terminal_with_state
-    /// [`Runtime::virtual_terminal_with_state()`]: crate::app::Runtime::virtual_terminal_with_state
+    /// build a runtime without calling `.state()`, you **must** override this
+    /// method to provide valid initial state.
     fn init() -> (Self::State, Command<Self::Message>) {
         panic!(
             "App::init() is not implemented. \
-             Override this method when using Runtime::new_terminal() or \
-             Runtime::virtual_terminal(). When using with_state constructors, \
-             this method is never called and can be left unimplemented."
+             Override this method when building a Runtime without .state(). \
+             When using .state() on the builder, this method is never called \
+             and can be left unimplemented."
         );
     }
 

--- a/src/app/runtime/mod.rs
+++ b/src/app/runtime/mod.rs
@@ -28,7 +28,10 @@
 //! # }
 //! #[tokio::main]
 //! async fn main() -> envision::Result<()> {
-//!     let _final_state = Runtime::<MyApp, _>::new_terminal()?.run_terminal().await?;
+//!     let _final_state = Runtime::<MyApp, _>::terminal_builder()?
+//!         .build()?
+//!         .run_terminal()
+//!         .await?;
 //!     Ok(())
 //! }
 //! ```
@@ -55,7 +58,7 @@
 //! #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
 //! #     fn view(state: &MyState, frame: &mut Frame) {}
 //! # }
-//! let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+//! let mut vt = Runtime::<MyApp, _>::virtual_builder(80, 24).build()?;
 //! vt.send(Event::key(Key::Char('j')));
 //! vt.tick()?;
 //! println!("{}", vt.display());
@@ -123,9 +126,9 @@ pub struct Runtime<A: App, B: Backend> {
 
 /// Alias for a runtime using the crossterm terminal backend (production).
 ///
-/// This is the type returned by [`Runtime::new_terminal()`] and
-/// [`Runtime::terminal_with_config()`]. Use this alias when you need to
-/// store or pass a terminal-mode runtime without spelling out the backend type.
+/// This is the type returned by [`Runtime::terminal_builder()`] followed by
+/// `.build()`. Use this alias when you need to store or pass a terminal-mode
+/// runtime without spelling out the backend type.
 ///
 /// # Example
 ///
@@ -144,16 +147,16 @@ pub struct Runtime<A: App, B: Backend> {
 /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
 /// #     fn view(state: &MyState, frame: &mut Frame) {}
 /// # }
-/// let runtime: TerminalRuntime<MyApp> = Runtime::new_terminal()?;
+/// let runtime: TerminalRuntime<MyApp> = Runtime::terminal_builder()?.build()?;
 /// # Ok::<(), envision::EnvisionError>(())
 /// ```
 pub type TerminalRuntime<A> = Runtime<A, CrosstermBackend<Stdout>>;
 
 /// Alias for a runtime using the virtual capture backend (testing/automation).
 ///
-/// This is the type returned by [`Runtime::virtual_terminal()`] and
-/// [`Runtime::virtual_terminal_with_config()`]. Use this alias when you need
-/// to store or pass a virtual-terminal runtime without spelling out the backend type.
+/// This is the type returned by [`Runtime::virtual_builder()`] followed by
+/// `.build()`. Use this alias when you need to store or pass a
+/// virtual-terminal runtime without spelling out the backend type.
 ///
 /// # Example
 ///
@@ -172,7 +175,7 @@ pub type TerminalRuntime<A> = Runtime<A, CrosstermBackend<Stdout>>;
 /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
 /// #     fn view(state: &MyState, frame: &mut Frame) {}
 /// # }
-/// let vt: VirtualRuntime<MyApp> = Runtime::virtual_terminal(80, 24)?;
+/// let vt: VirtualRuntime<MyApp> = Runtime::virtual_builder(80, 24).build()?;
 /// # Ok::<(), envision::EnvisionError>(())
 /// ```
 pub type VirtualRuntime<A> = Runtime<A, CaptureBackend>;
@@ -181,88 +184,19 @@ pub type VirtualRuntime<A> = Runtime<A, CaptureBackend>;
 // =============================================================================
 
 impl<A: App, B: Backend> Runtime<A, B> {
-    /// Creates a new runtime with the specified backend.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if creating the ratatui `Terminal` with the
-    /// provided backend fails.
-    pub fn with_backend(backend: B) -> error::Result<Self> {
-        Self::with_backend_and_config(backend, RuntimeConfig::default())
-    }
-
-    /// Creates a new runtime with a pre-built state, bypassing [`App::init()`].
-    ///
-    /// [`App::init()`] is **not called** — the provided `state` and `init_cmd`
-    /// are used instead. This is the simplest way to construct a runtime with
-    /// external state. Uses default configuration and executes the provided
-    /// startup command.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if creating the ratatui `Terminal` with the
-    /// provided backend fails.
-    pub fn with_backend_and_state(
-        backend: B,
-        state: A::State,
-        init_cmd: Command<A::Message>,
-    ) -> error::Result<Self> {
-        Self::with_backend_state_and_config(backend, state, init_cmd, RuntimeConfig::default())
-    }
-
-    /// Creates a new runtime with backend and config.
-    ///
-    /// Calls [`App::init()`] to obtain the initial state and startup command.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if creating the ratatui `Terminal` with the
-    /// provided backend fails.
-    pub fn with_backend_and_config(backend: B, config: RuntimeConfig) -> error::Result<Self> {
-        let (state, init_cmd) = A::init();
-        Self::with_backend_state_and_config(backend, state, init_cmd, config)
-    }
-
     /// Creates a new runtime with a pre-built state and startup command.
     ///
-    /// [`App::init()`] is **not called**. This allows callers to construct
-    /// the initial state from external sources (CLI arguments, config files,
-    /// databases, etc.) and pass it directly.
-    ///
-    /// The `init_cmd` parameter mirrors the command returned by `init()`.
-    /// Pass [`Command::none()`] if no startup command is needed.
+    /// This is an internal constructor used by [`RuntimeBuilder::build()`].
+    /// External callers should use the builder API instead:
+    /// - [`Runtime::builder()`] for any backend
+    /// - [`Runtime::terminal_builder()`] for real terminals
+    /// - [`Runtime::virtual_builder()`] for virtual terminals
     ///
     /// # Errors
     ///
     /// Returns an error if creating the ratatui `Terminal` with the
     /// provided backend fails.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use envision::prelude::*;
-    /// # struct MyApp;
-    /// # #[derive(Default, Clone)]
-    /// # struct MyState { count: i32 }
-    /// # #[derive(Clone)]
-    /// # enum MyMsg {}
-    /// # impl App for MyApp {
-    /// #     type State = MyState;
-    /// #     type Message = MyMsg;
-    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState::default(), Command::none()) }
-    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
-    /// #     fn view(state: &MyState, frame: &mut Frame) {}
-    /// # }
-    /// // Build state from external data instead of App::init()
-    /// let state = MyState { count: 42 };
-    /// let backend = CaptureBackend::new(80, 24);
-    /// let vt = Runtime::<MyApp, _>::with_backend_state_and_config(
-    ///     backend, state, Command::none(), RuntimeConfig::default(),
-    /// )?;
-    /// assert_eq!(vt.state().count, 42);
-    /// # Ok::<(), envision::EnvisionError>(())
-    /// ```
-    pub fn with_backend_state_and_config(
+    pub(crate) fn with_backend_state_and_config(
         backend: B,
         state: A::State,
         init_cmd: Command<A::Message>,
@@ -320,7 +254,7 @@ impl<A: App, B: Backend> Runtime<A, B> {
     /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
     /// #     fn view(state: &MyState, frame: &mut Frame) {}
     /// # }
-    /// let vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+    /// let vt = Runtime::<MyApp, _>::virtual_builder(80, 24).build()?;
     /// assert_eq!(vt.state().count, 0);
     /// # Ok::<(), envision::EnvisionError>(())
     /// ```
@@ -346,7 +280,7 @@ impl<A: App, B: Backend> Runtime<A, B> {
     /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
     /// #     fn view(state: &MyState, frame: &mut Frame) {}
     /// # }
-    /// let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+    /// let mut vt = Runtime::<MyApp, _>::virtual_builder(80, 24).build()?;
     /// vt.state_mut().count = 42;
     /// assert_eq!(vt.state().count, 42);
     /// # Ok::<(), envision::EnvisionError>(())
@@ -414,7 +348,7 @@ impl<A: App, B: Backend> Runtime<A, B> {
     /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
     /// #     fn view(state: &MyState, frame: &mut Frame) {}
     /// # }
-    /// # let runtime = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+    /// # let runtime = Runtime::<MyApp, _>::virtual_builder(80, 24).build()?;
     /// let error_tx = runtime.error_sender();
     /// // error_tx can be sent to async tasks to report errors
     /// # Ok::<(), envision::EnvisionError>(())
@@ -444,7 +378,7 @@ impl<A: App, B: Backend> Runtime<A, B> {
     /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
     /// #     fn view(state: &MyState, frame: &mut Frame) {}
     /// # }
-    /// # let mut runtime = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+    /// # let mut runtime = Runtime::<MyApp, _>::virtual_builder(80, 24).build()?;
     /// for error in runtime.take_errors() {
     ///     eprintln!("Async error: {}", error);
     /// }
@@ -541,7 +475,7 @@ impl<A: App, B: Backend> Runtime<A, B> {
     /// #     }
     /// #     fn view(state: &MyState, frame: &mut Frame) {}
     /// # }
-    /// let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+    /// let mut vt = Runtime::<MyApp, _>::virtual_builder(80, 24).build()?;
     /// vt.dispatch(MyMsg::Increment);
     /// assert_eq!(vt.state().count, 1);
     /// # Ok::<(), envision::EnvisionError>(())
@@ -692,7 +626,7 @@ impl<A: App, B: Backend> Runtime<A, B> {
     /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
     /// #     fn view(state: &MyState, frame: &mut Frame) {}
     /// # }
-    /// let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+    /// let mut vt = Runtime::<MyApp, _>::virtual_builder(80, 24).build()?;
     /// vt.send(Event::key(Key::Char('j')));
     /// vt.tick()?; // processes the 'j' event and re-renders
     /// # Ok::<(), envision::EnvisionError>(())
@@ -849,7 +783,7 @@ impl<A: App, B: Backend> Runtime<A, B> {
     /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
     /// #     fn view(state: &MyState, frame: &mut Frame) {}
     /// # }
-    /// let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+    /// let mut vt = Runtime::<MyApp, _>::virtual_builder(80, 24).build()?;
     /// vt.run_ticks(5)?;
     /// # Ok::<(), envision::EnvisionError>(())
     /// ```

--- a/src/app/runtime/terminal.rs
+++ b/src/app/runtime/terminal.rs
@@ -16,7 +16,6 @@ use ratatui::backend::CrosstermBackend;
 
 use super::Runtime;
 use super::config::RuntimeConfig;
-use crate::app::command::Command;
 use crate::app::model::App;
 
 /// Restores the terminal to its normal state.
@@ -60,118 +59,6 @@ use crate::overlay::OverlayAction;
 // =============================================================================
 
 impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
-    /// Creates a new runtime connected to a real terminal.
-    ///
-    /// This sets up the terminal for TUI operation:
-    /// - Enables raw mode (input is not line-buffered)
-    /// - Enters alternate screen (preserves the original terminal content)
-    /// - Enables mouse capture
-    ///
-    /// Call `run_terminal()` to start the interactive event loop.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if enabling raw mode, entering alternate screen,
-    /// enabling mouse capture, or creating the terminal fails.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// # use envision::prelude::*;
-    /// # struct MyApp;
-    /// # #[derive(Default, Clone)]
-    /// # struct MyState;
-    /// # #[derive(Clone)]
-    /// # enum MyMsg {}
-    /// # impl App for MyApp {
-    /// #     type State = MyState;
-    /// #     type Message = MyMsg;
-    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState, Command::none()) }
-    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
-    /// #     fn view(state: &MyState, frame: &mut Frame) {}
-    /// # }
-    /// #[tokio::main]
-    /// async fn main() -> envision::Result<()> {
-    ///     let _final_state = Runtime::<MyApp, _>::new_terminal()?.run_terminal().await?;
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn new_terminal() -> error::Result<Self> {
-        Self::terminal_with_config(RuntimeConfig::default())
-    }
-
-    /// Creates a terminal runtime with custom configuration.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if enabling raw mode, entering alternate screen,
-    /// enabling mouse capture, or creating the terminal fails.
-    pub fn terminal_with_config(config: RuntimeConfig) -> error::Result<Self> {
-        let backend = Self::setup_terminal(&config)?;
-        Self::with_backend_and_config(backend, config)
-    }
-
-    /// Creates a terminal runtime with a pre-built state, bypassing [`App::init()`].
-    ///
-    /// This allows constructing the initial state from external sources
-    /// (CLI arguments, config files, databases, etc.) and passing it directly.
-    /// [`App::init()`] is **not called** — the provided `state` and `init_cmd`
-    /// are used instead.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if enabling raw mode, entering alternate screen,
-    /// enabling mouse capture, or creating the terminal fails.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// # use envision::prelude::*;
-    /// # struct MyApp;
-    /// # #[derive(Default, Clone)]
-    /// # struct MyState;
-    /// # #[derive(Clone)]
-    /// # enum MyMsg {}
-    /// # impl App for MyApp {
-    /// #     type State = MyState;
-    /// #     type Message = MyMsg;
-    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState, Command::none()) }
-    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
-    /// #     fn view(state: &MyState, frame: &mut Frame) {}
-    /// # }
-    /// # #[tokio::main]
-    /// # async fn main() -> envision::Result<()> {
-    /// let state = MyState::default();
-    /// let runtime = Runtime::<MyApp, _>::new_terminal_with_state(state, Command::none())?;
-    /// runtime.run_terminal().await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn new_terminal_with_state(
-        state: A::State,
-        init_cmd: Command<A::Message>,
-    ) -> error::Result<Self> {
-        Self::terminal_with_state_and_config(state, init_cmd, RuntimeConfig::default())
-    }
-
-    /// Creates a terminal runtime with a pre-built state and custom configuration.
-    ///
-    /// [`App::init()`] is **not called** — the provided `state` and `init_cmd`
-    /// are used instead.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if enabling raw mode, entering alternate screen,
-    /// enabling mouse capture, or creating the terminal fails.
-    pub fn terminal_with_state_and_config(
-        state: A::State,
-        init_cmd: Command<A::Message>,
-        config: RuntimeConfig,
-    ) -> error::Result<Self> {
-        let backend = Self::setup_terminal(&config)?;
-        Self::with_backend_state_and_config(backend, state, init_cmd, config)
-    }
-
     /// Runs the interactive event loop until the application quits.
     ///
     /// This is the main entry point for terminal applications. It uses
@@ -204,7 +91,10 @@ impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
     /// # }
     /// #[tokio::main]
     /// async fn main() -> envision::Result<()> {
-    ///     let final_state = Runtime::<MyApp, _>::new_terminal()?.run_terminal().await?;
+    ///     let final_state = Runtime::<MyApp, _>::terminal_builder()?
+    ///         .build()?
+    ///         .run_terminal()
+    ///         .await?;
     ///     println!("Final count: {}", final_state.count);
     ///     Ok(())
     /// }
@@ -352,7 +242,9 @@ impl<A: App> Runtime<A, CrosstermBackend<Stdout>> {
     /// #     fn view(state: &MyState, frame: &mut Frame) {}
     /// # }
     /// fn main() -> envision::Result<()> {
-    ///     let final_state = Runtime::<MyApp, _>::new_terminal()?.run_terminal_blocking()?;
+    ///     let final_state = Runtime::<MyApp, _>::terminal_builder()?
+    ///         .build()?
+    ///         .run_terminal_blocking()?;
     ///     println!("Final count: {}", final_state.count);
     ///     Ok(())
     /// }

--- a/src/app/runtime/tests/async_tests.rs
+++ b/src/app/runtime/tests/async_tests.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 #[tokio::test]
 async fn test_runtime_async_command() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
     // Create an async command
     let cmd = Command::perform_async(async { Some(CounterMsg::IncrementBy(5)) });
@@ -27,7 +27,7 @@ async fn test_runtime_async_command() {
 
 #[tokio::test]
 async fn test_runtime_message_channel() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
     let sender = runtime.message_sender();
 
     // Send a message via the channel
@@ -45,7 +45,7 @@ async fn test_runtime_message_channel() {
 
 #[tokio::test]
 async fn test_runtime_take_errors() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
     let error_tx = runtime.error_sender();
 
     // No errors initially
@@ -68,7 +68,7 @@ async fn test_runtime_take_errors() {
 
 #[tokio::test]
 async fn test_runtime_has_errors() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
     let error_tx = runtime.error_sender();
 
     // No errors initially
@@ -93,7 +93,7 @@ async fn test_runtime_has_errors() {
 
 #[tokio::test]
 async fn test_runtime_error_from_spawned_task() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
     let error_tx = runtime.error_sender();
 
     // Spawn a task that reports an error
@@ -116,7 +116,7 @@ async fn test_runtime_error_from_spawned_task() {
 
 #[tokio::test]
 async fn test_runtime_multiple_errors() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
     let error_tx = runtime.error_sender();
 
     // Send multiple errors
@@ -184,7 +184,7 @@ impl App for FallibleApp {
 
 #[tokio::test]
 async fn test_runtime_try_perform_async_success() {
-    let mut runtime: Runtime<FallibleApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<FallibleApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
     // Dispatch a message that triggers a successful async operation
     runtime.dispatch(FallibleMsg::FetchSuccess);
@@ -204,7 +204,7 @@ async fn test_runtime_try_perform_async_success() {
 
 #[tokio::test]
 async fn test_runtime_try_perform_async_failure() {
-    let mut runtime: Runtime<FallibleApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<FallibleApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
     // Dispatch a message that triggers a failing async operation
     runtime.dispatch(FallibleMsg::FetchFailure);
@@ -232,7 +232,7 @@ async fn test_runtime_try_perform_async_failure() {
 async fn test_runtime_subscribe() {
     use crate::app::subscription::TickSubscription;
 
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
     // Subscribe to a tick that fires every 10ms
     let sub = TickSubscription::new(Duration::from_millis(10), || CounterMsg::Increment);
@@ -256,7 +256,7 @@ async fn test_runtime_subscribe() {
 async fn test_runtime_subscribe_all() {
     use crate::app::subscription::{BoxedSubscription, TickSubscription};
 
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
     // Create multiple subscriptions
     let sub1: BoxedSubscription<CounterMsg> =
@@ -283,7 +283,7 @@ async fn test_runtime_subscribe_all() {
 
 #[tokio::test]
 async fn test_runtime_run() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(40, 10).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(40, 10).build().unwrap();
 
     // Increment counter
     runtime.dispatch(CounterMsg::Increment);
@@ -305,7 +305,7 @@ async fn test_runtime_run() {
 
 #[tokio::test]
 async fn test_runtime_run_cancelled() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
     let token = runtime.cancellation_token();
 
@@ -362,7 +362,7 @@ impl App for InitCommandApp {
 
 #[test]
 fn test_runtime_init_command() {
-    let mut runtime: Runtime<InitCommandApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<InitCommandApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
     // Process sync commands from init
     runtime.process_pending();
@@ -420,7 +420,7 @@ impl App for TickingApp {
 
 #[test]
 fn test_runtime_ticking_app() {
-    let mut runtime: Runtime<TickingApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<TickingApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
     // Each tick should increment
     runtime.tick().unwrap();
@@ -437,7 +437,7 @@ fn test_runtime_ticking_app() {
 
 #[tokio::test]
 async fn test_runtime_run_with_on_tick() {
-    let mut runtime: Runtime<TickingApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<TickingApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
     // Run the event loop - should quit after 3 ticks
     runtime.run().await.unwrap();

--- a/src/app/runtime/tests/mod.rs
+++ b/src/app/runtime/tests/mod.rs
@@ -54,13 +54,13 @@ impl App for CounterApp {
 
 #[test]
 fn test_runtime_headless() {
-    let runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
     assert_eq!(runtime.state().count, 0);
 }
 
 #[test]
 fn test_runtime_dispatch() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
     runtime.dispatch(CounterMsg::Increment);
     assert_eq!(runtime.state().count, 1);
@@ -75,7 +75,7 @@ fn test_runtime_dispatch() {
 
 #[test]
 fn test_runtime_render() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(40, 10).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(40, 10).build().unwrap();
     runtime.dispatch(CounterMsg::Increment);
     runtime.dispatch(CounterMsg::Increment);
     runtime.render().unwrap();
@@ -85,7 +85,7 @@ fn test_runtime_render() {
 
 #[test]
 fn test_runtime_quit() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
     assert!(!runtime.should_quit());
 
     runtime.dispatch(CounterMsg::Quit);
@@ -96,7 +96,7 @@ fn test_runtime_quit() {
 
 #[test]
 fn test_runtime_tick() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(40, 10).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(40, 10).build().unwrap();
 
     // Queue some events - we'd need to implement handle_event for this
     runtime.dispatch(CounterMsg::Increment);
@@ -136,29 +136,33 @@ fn test_runtime_config_default() {
 #[test]
 fn test_runtime_headless_with_config() {
     let config = RuntimeConfig::new().with_history(5);
-    let runtime: Runtime<CounterApp, _> =
-        Runtime::virtual_terminal_with_config(80, 24, config).unwrap();
+    let runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24)
+        .config(config)
+        .build()
+        .unwrap();
     assert_eq!(runtime.state().count, 0);
 }
 
 #[test]
 fn test_runtime_headless_with_config_no_history() {
     let config = RuntimeConfig::new();
-    let runtime: Runtime<CounterApp, _> =
-        Runtime::virtual_terminal_with_config(80, 24, config).unwrap();
+    let runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24)
+        .config(config)
+        .build()
+        .unwrap();
     assert_eq!(runtime.state().count, 0);
 }
 
 #[test]
 fn test_runtime_state_mut() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
     runtime.state_mut().count = 42;
     assert_eq!(runtime.state().count, 42);
 }
 
 #[test]
 fn test_runtime_terminal_access() {
-    let runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
     let terminal = runtime.terminal();
     assert_eq!(terminal.backend().width(), 80);
     assert_eq!(terminal.backend().height(), 24);
@@ -166,35 +170,35 @@ fn test_runtime_terminal_access() {
 
 #[test]
 fn test_runtime_terminal_mut() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
     let _terminal = runtime.terminal_mut();
     // Just verify we can get mutable access
 }
 
 #[test]
 fn test_runtime_backend_access() {
-    let runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
     let backend = runtime.backend();
     assert_eq!(backend.width(), 80);
 }
 
 #[test]
 fn test_runtime_backend_mut() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
     let backend = runtime.backend_mut();
     assert_eq!(backend.width(), 80);
 }
 
 #[test]
 fn test_runtime_events_access() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
     let events = runtime.events();
     assert!(events.is_empty());
 }
 
 #[test]
 fn test_runtime_cancellation_token() {
-    let runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
     let token = runtime.cancellation_token();
     assert!(!token.is_cancelled());
 }
@@ -229,7 +233,7 @@ fn test_command_request_cancel_token() {
         fn view(_state: &TokenState, _frame: &mut ratatui::Frame) {}
     }
 
-    let mut runtime: Runtime<TokenApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<TokenApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
     runtime.tick().unwrap();
 
     // The cancel token should now be stored in state
@@ -246,19 +250,19 @@ fn test_command_request_cancel_token() {
 
 #[test]
 fn test_runtime_message_sender() {
-    let runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
     let _sender = runtime.message_sender();
 }
 
 #[test]
 fn test_runtime_error_sender() {
-    let runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
     let _error_tx = runtime.error_sender();
 }
 
 #[test]
 fn test_runtime_dispatch_all() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
     runtime.dispatch_all(vec![
         CounterMsg::Increment,
@@ -271,7 +275,7 @@ fn test_runtime_dispatch_all() {
 
 #[test]
 fn test_runtime_manual_quit() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
     assert!(!runtime.should_quit());
     assert!(!runtime.cancellation_token().is_cancelled());
 
@@ -282,7 +286,7 @@ fn test_runtime_manual_quit() {
 
 #[test]
 fn test_runtime_run_ticks() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(40, 10).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(40, 10).build().unwrap();
     runtime.dispatch(CounterMsg::Increment);
 
     runtime.run_ticks(3).unwrap();
@@ -291,7 +295,7 @@ fn test_runtime_run_ticks() {
 
 #[test]
 fn test_runtime_run_ticks_with_quit() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(40, 10).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(40, 10).build().unwrap();
     runtime.dispatch(CounterMsg::Quit);
     runtime.tick().unwrap();
 
@@ -302,7 +306,7 @@ fn test_runtime_run_ticks_with_quit() {
 
 #[test]
 fn test_runtime_captured_output() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(40, 10).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(40, 10).build().unwrap();
     runtime.render().unwrap();
 
     let output = runtime.display();
@@ -311,7 +315,7 @@ fn test_runtime_captured_output() {
 
 #[test]
 fn test_runtime_captured_ansi() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(40, 10).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(40, 10).build().unwrap();
     runtime.render().unwrap();
 
     let ansi = runtime.display_ansi();
@@ -320,7 +324,7 @@ fn test_runtime_captured_ansi() {
 
 #[test]
 fn test_runtime_find_text() {
-    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_terminal(40, 10).unwrap();
+    let mut runtime: Runtime<CounterApp, _> = Runtime::virtual_builder(40, 10).build().unwrap();
     runtime.render().unwrap();
 
     let positions = runtime.find_text("Count");
@@ -396,7 +400,7 @@ impl App for EventApp {
 fn test_runtime_process_event() {
     use crate::input::Event;
 
-    let mut runtime: Runtime<EventApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<EventApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
     runtime.events().push(Event::char('a'));
     assert!(runtime.process_event());
@@ -410,7 +414,7 @@ fn test_runtime_process_event() {
 fn test_runtime_process_all_events() {
     use crate::input::Event;
 
-    let mut runtime: Runtime<EventApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<EventApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
     runtime.events().push(Event::char('a'));
     runtime.events().push(Event::char('b'));
@@ -422,7 +426,7 @@ fn test_runtime_process_all_events() {
 
 #[test]
 fn test_runtime_tick_with_on_tick() {
-    let mut runtime: Runtime<EventApp, _> = Runtime::virtual_terminal(40, 10).unwrap();
+    let mut runtime: Runtime<EventApp, _> = Runtime::virtual_builder(40, 10).build().unwrap();
 
     runtime.tick().unwrap();
     assert_eq!(runtime.state().ticks, 1);
@@ -435,7 +439,7 @@ fn test_runtime_tick_with_on_tick() {
 fn test_runtime_event_causes_quit() {
     use crate::input::Event;
 
-    let mut runtime: Runtime<EventApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<EventApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
     runtime.events().push(Event::char('q'));
 
     runtime.tick().unwrap();
@@ -489,7 +493,7 @@ fn test_runtime_process_commands() {
         fn view(_state: &Self::State, _frame: &mut ratatui::Frame) {}
     }
 
-    let mut runtime: Runtime<CmdApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut runtime: Runtime<CmdApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
     // Process init command (Set(10))
     runtime.process_commands();
@@ -506,8 +510,10 @@ fn test_runtime_max_messages_per_tick() {
     use crate::input::Event;
 
     let config = RuntimeConfig::new().max_messages(2);
-    let mut runtime: Runtime<EventApp, _> =
-        Runtime::virtual_terminal_with_config(80, 24, config).unwrap();
+    let mut runtime: Runtime<EventApp, _> = Runtime::virtual_builder(80, 24)
+        .config(config)
+        .build()
+        .unwrap();
 
     // Queue more events than max_messages_per_tick
     for _ in 0..5 {
@@ -528,7 +534,7 @@ fn test_runtime_max_messages_per_tick() {
 fn test_virtual_terminal_send_and_tick() {
     use crate::input::Event;
 
-    let mut vt: Runtime<EventApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut vt: Runtime<EventApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
     // Send events
     vt.send(Event::char('a'));
@@ -542,7 +548,7 @@ fn test_virtual_terminal_send_and_tick() {
 
 #[test]
 fn test_virtual_terminal_display() {
-    let mut vt: Runtime<CounterApp, _> = Runtime::virtual_terminal(40, 10).unwrap();
+    let mut vt: Runtime<CounterApp, _> = Runtime::virtual_builder(40, 10).build().unwrap();
     vt.dispatch(CounterMsg::Increment);
     vt.tick().unwrap();
 
@@ -552,7 +558,7 @@ fn test_virtual_terminal_display() {
 
 #[test]
 fn test_virtual_terminal_display_ansi() {
-    let mut vt: Runtime<CounterApp, _> = Runtime::virtual_terminal(40, 10).unwrap();
+    let mut vt: Runtime<CounterApp, _> = Runtime::virtual_builder(40, 10).build().unwrap();
     vt.dispatch(CounterMsg::Increment);
     vt.tick().unwrap();
 
@@ -564,7 +570,7 @@ fn test_virtual_terminal_display_ansi() {
 fn test_virtual_terminal_quit_via_event() {
     use crate::input::Event;
 
-    let mut vt: Runtime<EventApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut vt: Runtime<EventApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
     vt.send(Event::char('q'));
     vt.tick().unwrap();
@@ -576,7 +582,7 @@ fn test_virtual_terminal_quit_via_event() {
 fn test_virtual_terminal_multiple_ticks() {
     use crate::input::Event;
 
-    let mut vt: Runtime<EventApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+    let mut vt: Runtime<EventApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
     // First tick with one event
     vt.send(Event::char('a'));
@@ -592,7 +598,7 @@ fn test_virtual_terminal_multiple_ticks() {
 
 #[test]
 fn test_virtual_terminal_cell_at() {
-    let mut vt: Runtime<CounterApp, _> = Runtime::virtual_terminal(40, 10).unwrap();
+    let mut vt: Runtime<CounterApp, _> = Runtime::virtual_builder(40, 10).build().unwrap();
     vt.tick().unwrap();
 
     // Cell at (0,0) should have the 'C' from "Count: 0"
@@ -605,7 +611,7 @@ fn test_virtual_terminal_cell_at() {
 
 #[test]
 fn test_virtual_terminal_contains_text() {
-    let mut vt: Runtime<CounterApp, _> = Runtime::virtual_terminal(40, 10).unwrap();
+    let mut vt: Runtime<CounterApp, _> = Runtime::virtual_builder(40, 10).build().unwrap();
     vt.tick().unwrap();
 
     assert!(vt.contains_text("Count: 0"));
@@ -614,7 +620,7 @@ fn test_virtual_terminal_contains_text() {
 
 #[test]
 fn test_virtual_terminal_find_text() {
-    let mut vt: Runtime<CounterApp, _> = Runtime::virtual_terminal(40, 10).unwrap();
+    let mut vt: Runtime<CounterApp, _> = Runtime::virtual_builder(40, 10).build().unwrap();
     vt.tick().unwrap();
 
     let positions = vt.find_text("Count");
@@ -685,7 +691,7 @@ mod overlay_tests {
 
     #[test]
     fn test_runtime_overlay_push_pop() {
-        let mut vt: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+        let mut vt: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
         assert!(!vt.has_overlays());
         assert_eq!(vt.overlay_count(), 0);
@@ -707,7 +713,7 @@ mod overlay_tests {
 
     #[test]
     fn test_runtime_overlay_consumes_events() {
-        let mut vt: Runtime<EventApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+        let mut vt: Runtime<EventApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
         // Push an overlay that consumes all events
         struct ConsumeAll;
@@ -730,7 +736,7 @@ mod overlay_tests {
 
     #[test]
     fn test_runtime_overlay_propagates_events() {
-        let mut vt: Runtime<EventApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+        let mut vt: Runtime<EventApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
         // Push an overlay that propagates all events
         vt.push_overlay(Box::new(PropagateOverlay));
@@ -744,7 +750,7 @@ mod overlay_tests {
 
     #[test]
     fn test_runtime_overlay_dismiss() {
-        let mut vt: Runtime<EventApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+        let mut vt: Runtime<EventApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
         vt.push_overlay(Box::new(DialogOverlay));
         assert_eq!(vt.overlay_count(), 1);
@@ -758,7 +764,7 @@ mod overlay_tests {
 
     #[test]
     fn test_runtime_overlay_dismiss_with_message() {
-        let mut vt: Runtime<EventApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+        let mut vt: Runtime<EventApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
         vt.push_overlay(Box::new(DialogOverlay));
 
@@ -817,7 +823,7 @@ mod overlay_tests {
             fn view(_state: &Self::State, _frame: &mut ratatui::Frame) {}
         }
 
-        let mut vt: Runtime<CmdOverlayApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+        let mut vt: Runtime<CmdOverlayApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
         // Dispatch push overlay message
         vt.dispatch(CmdOverlayMsg::PushOverlay);
@@ -833,7 +839,7 @@ mod overlay_tests {
 
     #[test]
     fn test_runtime_theme_access() {
-        let mut vt: Runtime<CounterApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+        let mut vt: Runtime<CounterApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
         // Default theme should be set
         let _theme = vt.theme();
@@ -848,7 +854,7 @@ mod overlay_tests {
     #[test]
     fn test_runtime_render_with_overlay() {
         // Verifies the overlay rendering path in render()
-        let mut vt: Runtime<CounterApp, _> = Runtime::virtual_terminal(40, 10).unwrap();
+        let mut vt: Runtime<CounterApp, _> = Runtime::virtual_builder(40, 10).build().unwrap();
 
         vt.push_overlay(Box::new(ConsumeOverlay));
         vt.render().unwrap();
@@ -868,7 +874,7 @@ mod overlay_tests {
             fn view(&self, _ctx: &mut RenderContext<'_, '_>) {}
         }
 
-        let mut vt: Runtime<EventApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+        let mut vt: Runtime<EventApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
         vt.push_overlay(Box::new(MsgOverlay));
 
         vt.send(Event::char('x'));
@@ -919,7 +925,7 @@ mod overlay_tests {
             fn view(_state: &Self::State, _frame: &mut ratatui::Frame) {}
         }
 
-        let mut vt: Runtime<CmdApp, _> = Runtime::virtual_terminal(80, 24).unwrap();
+        let mut vt: Runtime<CmdApp, _> = Runtime::virtual_builder(80, 24).build().unwrap();
 
         // Push two overlays via commands
         vt.dispatch(CmdMsg::Push);

--- a/src/app/runtime/virtual_terminal.rs
+++ b/src/app/runtime/virtual_terminal.rs
@@ -4,11 +4,7 @@
 //! capture backend, useful for programmatic control (AI agents, automation,
 //! testing).
 
-use crate::error;
-
 use super::Runtime;
-use super::config::RuntimeConfig;
-use crate::app::command::Command;
 use crate::app::model::App;
 use crate::backend::CaptureBackend;
 use crate::input::Event;
@@ -18,140 +14,6 @@ use crate::input::Event;
 // =============================================================================
 
 impl<A: App> Runtime<A, CaptureBackend> {
-    /// Creates a virtual terminal for programmatic control.
-    ///
-    /// A virtual terminal is not connected to a physical terminal. Instead:
-    /// - Events are injected via `send()`
-    /// - The application is advanced via `tick()`
-    /// - The display can be inspected via `display()`
-    ///
-    /// This is useful for:
-    /// - AI agents driving the application
-    /// - Automation and scripting
-    /// - Testing
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if creating the ratatui `Terminal` with the
-    /// capture backend fails.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use envision::prelude::*;
-    /// # struct MyApp;
-    /// # #[derive(Default, Clone)]
-    /// # struct MyState;
-    /// # #[derive(Clone)]
-    /// # enum MyMsg {}
-    /// # impl App for MyApp {
-    /// #     type State = MyState;
-    /// #     type Message = MyMsg;
-    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState, Command::none()) }
-    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
-    /// #     fn view(state: &MyState, frame: &mut Frame) {}
-    /// # }
-    /// let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
-    /// vt.send(Event::key(Key::Char('j')));
-    /// vt.tick()?;
-    /// # Ok::<(), envision::EnvisionError>(())
-    /// ```
-    pub fn virtual_terminal(width: u16, height: u16) -> error::Result<Self> {
-        let backend = CaptureBackend::new(width, height);
-        Self::with_backend(backend)
-    }
-
-    /// Creates a virtual terminal with custom configuration.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if creating the ratatui `Terminal` with the
-    /// capture backend fails.
-    pub fn virtual_terminal_with_config(
-        width: u16,
-        height: u16,
-        config: RuntimeConfig,
-    ) -> error::Result<Self> {
-        let backend = if config.capture_history {
-            CaptureBackend::with_history(width, height, config.history_capacity)
-        } else {
-            CaptureBackend::new(width, height)
-        };
-        Self::with_backend_and_config(backend, config)
-    }
-
-    /// Creates a virtual terminal with a pre-built state, bypassing [`App::init()`].
-    ///
-    /// [`App::init()`] is **not called** — the provided `state` and `init_cmd`
-    /// are used instead. This is the primary way to test or automate an
-    /// application starting from a specific state. The `init_cmd` is executed
-    /// immediately; pass [`Command::none()`] if no startup command is needed.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if creating the ratatui `Terminal` with the
-    /// capture backend fails.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use envision::prelude::*;
-    /// # struct MyApp;
-    /// # #[derive(Default, Clone)]
-    /// # struct MyState { count: i32 }
-    /// # #[derive(Clone)]
-    /// # enum MyMsg {}
-    /// # impl App for MyApp {
-    /// #     type State = MyState;
-    /// #     type Message = MyMsg;
-    /// #     fn init() -> (MyState, Command<MyMsg>) { (MyState::default(), Command::none()) }
-    /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
-    /// #     fn view(state: &MyState, frame: &mut Frame) {}
-    /// # }
-    /// // Start from a specific state instead of App::init()
-    /// let state = MyState { count: 10 };
-    /// let mut vt = Runtime::<MyApp, _>::virtual_terminal_with_state(
-    ///     80, 24, state, Command::none(),
-    /// )?;
-    /// assert_eq!(vt.state().count, 10);
-    /// # Ok::<(), envision::EnvisionError>(())
-    /// ```
-    pub fn virtual_terminal_with_state(
-        width: u16,
-        height: u16,
-        state: A::State,
-        init_cmd: Command<A::Message>,
-    ) -> error::Result<Self> {
-        let backend = CaptureBackend::new(width, height);
-        Self::with_backend_and_state(backend, state, init_cmd)
-    }
-
-    /// Creates a virtual terminal with a pre-built state and custom configuration.
-    ///
-    /// [`App::init()`] is **not called** — the provided `state` and `init_cmd`
-    /// are used instead. Combines
-    /// [`virtual_terminal_with_state`](Self::virtual_terminal_with_state)
-    /// with custom [`RuntimeConfig`] options.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if creating the ratatui `Terminal` with the
-    /// capture backend fails.
-    pub fn virtual_terminal_with_state_and_config(
-        width: u16,
-        height: u16,
-        state: A::State,
-        init_cmd: Command<A::Message>,
-        config: RuntimeConfig,
-    ) -> error::Result<Self> {
-        let backend = if config.capture_history {
-            CaptureBackend::with_history(width, height, config.history_capacity)
-        } else {
-            CaptureBackend::new(width, height)
-        };
-        Self::with_backend_state_and_config(backend, state, init_cmd, config)
-    }
-
     /// Sends an event to the virtual terminal.
     ///
     /// The event is queued and will be processed on the next `tick()`.
@@ -172,7 +34,7 @@ impl<A: App> Runtime<A, CaptureBackend> {
     /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
     /// #     fn view(state: &MyState, frame: &mut Frame) {}
     /// # }
-    /// let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+    /// let mut vt = Runtime::<MyApp, _>::virtual_builder(80, 24).build()?;
     /// vt.send(Event::key(Key::Enter));
     /// vt.tick()?;
     /// # Ok::<(), envision::EnvisionError>(())
@@ -201,7 +63,7 @@ impl<A: App> Runtime<A, CaptureBackend> {
     /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
     /// #     fn view(state: &MyState, frame: &mut Frame) {}
     /// # }
-    /// let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+    /// let mut vt = Runtime::<MyApp, _>::virtual_builder(80, 24).build()?;
     /// vt.tick()?;
     /// let screen = vt.display();
     /// # Ok::<(), envision::EnvisionError>(())
@@ -238,7 +100,7 @@ impl<A: App> Runtime<A, CaptureBackend> {
     /// #     fn update(state: &mut MyState, msg: MyMsg) -> Command<MyMsg> { Command::none() }
     /// #     fn view(state: &MyState, frame: &mut Frame) {}
     /// # }
-    /// # let vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+    /// # let vt = Runtime::<MyApp, _>::virtual_builder(80, 24).build()?;
     /// let cell = vt.cell_at(5, 3);
     /// # Ok::<(), envision::EnvisionError>(())
     /// ```
@@ -268,7 +130,7 @@ impl<A: App> Runtime<A, CaptureBackend> {
     /// #         frame.render_widget(ratatui::widgets::Paragraph::new("Hello"), frame.area());
     /// #     }
     /// # }
-    /// let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+    /// let mut vt = Runtime::<MyApp, _>::virtual_builder(80, 24).build()?;
     /// vt.tick()?;
     /// assert!(vt.contains_text("Hello"));
     /// # Ok::<(), envision::EnvisionError>(())

--- a/src/harness/app_harness/mod.rs
+++ b/src/harness/app_harness/mod.rs
@@ -82,7 +82,7 @@ impl<A: App> AppHarness<A> {
     /// # Ok::<(), envision::EnvisionError>(())
     /// ```
     pub fn new(width: u16, height: u16) -> error::Result<Self> {
-        let runtime = Runtime::virtual_terminal(width, height)?;
+        let runtime = Runtime::virtual_builder(width, height).build()?;
         Ok(Self { runtime })
     }
 
@@ -92,7 +92,9 @@ impl<A: App> AppHarness<A> {
     ///
     /// Returns an error if creating the virtual terminal fails.
     pub fn with_config(width: u16, height: u16, config: RuntimeConfig) -> error::Result<Self> {
-        let runtime = Runtime::virtual_terminal_with_config(width, height, config)?;
+        let runtime = Runtime::virtual_builder(width, height)
+            .config(config)
+            .build()?;
         Ok(Self { runtime })
     }
 
@@ -133,7 +135,9 @@ impl<A: App> AppHarness<A> {
         state: A::State,
         init_cmd: Command<A::Message>,
     ) -> error::Result<Self> {
-        let runtime = Runtime::virtual_terminal_with_state(width, height, state, init_cmd)?;
+        let runtime = Runtime::virtual_builder(width, height)
+            .state(state, init_cmd)
+            .build()?;
         Ok(Self { runtime })
     }
 
@@ -149,9 +153,10 @@ impl<A: App> AppHarness<A> {
         init_cmd: Command<A::Message>,
         config: RuntimeConfig,
     ) -> error::Result<Self> {
-        let runtime = Runtime::virtual_terminal_with_state_and_config(
-            width, height, state, init_cmd, config,
-        )?;
+        let runtime = Runtime::virtual_builder(width, height)
+            .state(state, init_cmd)
+            .config(config)
+            .build()?;
         Ok(Self { runtime })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,10 @@
 //! # }
 //! #[tokio::main]
 //! async fn main() -> envision::Result<()> {
-//!     let _final_state = Runtime::<MyApp, _>::new_terminal()?.run_terminal().await?;
+//!     let _final_state = Runtime::<MyApp, _>::terminal_builder()?
+//!         .build()?
+//!         .run_terminal()
+//!         .await?;
 //!     Ok(())
 //! }
 //! ```
@@ -49,7 +52,9 @@
 //! #     fn view(state: &MyState, frame: &mut Frame) {}
 //! # }
 //! fn main() -> envision::Result<()> {
-//!     let _final_state = Runtime::<MyApp, _>::new_terminal()?.run_terminal_blocking()?;
+//!     let _final_state = Runtime::<MyApp, _>::terminal_builder()?
+//!         .build()?
+//!         .run_terminal_blocking()?;
 //!     Ok(())
 //! }
 //! ```
@@ -71,7 +76,7 @@
 //! #     fn view(state: &MyState, frame: &mut Frame) {}
 //! # }
 //! // Create a virtual terminal
-//! let mut vt = Runtime::<MyApp, _>::virtual_terminal(80, 24)?;
+//! let mut vt = Runtime::<MyApp, _>::virtual_builder(80, 24).build()?;
 //!
 //! // Inject events programmatically
 //! vt.send(Event::char('j'));

--- a/tests/integration_async.rs
+++ b/tests/integration_async.rs
@@ -218,7 +218,9 @@ impl App for ChainedApp {
 
 #[tokio::test]
 async fn test_command_perform_async_updates_state() {
-    let mut vt = Runtime::<AsyncLoaderApp, _>::virtual_terminal(40, 10).unwrap();
+    let mut vt = Runtime::<AsyncLoaderApp, _>::virtual_builder(40, 10)
+        .build()
+        .unwrap();
 
     assert!(vt.state().data.is_none());
     assert!(!vt.state().loading);
@@ -237,7 +239,9 @@ async fn test_command_perform_async_updates_state() {
 
 #[tokio::test]
 async fn test_command_perform_async_chained() {
-    let mut vt = Runtime::<ChainedApp, _>::virtual_terminal(40, 10).unwrap();
+    let mut vt = Runtime::<ChainedApp, _>::virtual_builder(40, 10)
+        .build()
+        .unwrap();
 
     // Start the chain
     vt.dispatch(ChainedMsg::StartChain);
@@ -260,7 +264,9 @@ async fn test_command_perform_async_chained() {
 
 #[tokio::test]
 async fn test_try_perform_async_error_reporting() {
-    let mut vt = Runtime::<FallibleApp, _>::virtual_terminal(40, 10).unwrap();
+    let mut vt = Runtime::<FallibleApp, _>::virtual_builder(40, 10)
+        .build()
+        .unwrap();
 
     vt.dispatch(FallibleMsg::StartFailing);
     tokio::time::sleep(Duration::from_millis(50)).await;
@@ -277,7 +283,9 @@ async fn test_try_perform_async_error_reporting() {
 
 #[tokio::test]
 async fn test_try_perform_async_success_updates_state() {
-    let mut vt = Runtime::<FallibleApp, _>::virtual_terminal(40, 10).unwrap();
+    let mut vt = Runtime::<FallibleApp, _>::virtual_builder(40, 10)
+        .build()
+        .unwrap();
 
     vt.dispatch(FallibleMsg::StartSucceeding);
     tokio::time::sleep(Duration::from_millis(50)).await;
@@ -288,7 +296,9 @@ async fn test_try_perform_async_success_updates_state() {
 
 #[tokio::test]
 async fn test_try_perform_async_error_then_success() {
-    let mut vt = Runtime::<FallibleApp, _>::virtual_terminal(40, 10).unwrap();
+    let mut vt = Runtime::<FallibleApp, _>::virtual_builder(40, 10)
+        .build()
+        .unwrap();
 
     // First: a failing command
     vt.dispatch(FallibleMsg::StartFailing);
@@ -315,7 +325,9 @@ async fn test_try_perform_async_error_then_success() {
 
 #[tokio::test]
 async fn test_message_channel_delivers_messages() {
-    let mut vt = Runtime::<TickCounterApp, _>::virtual_terminal(40, 10).unwrap();
+    let mut vt = Runtime::<TickCounterApp, _>::virtual_builder(40, 10)
+        .build()
+        .unwrap();
     let tx = vt.message_sender();
 
     // Send messages via the channel
@@ -329,7 +341,9 @@ async fn test_message_channel_delivers_messages() {
 
 #[tokio::test]
 async fn test_message_channel_interleaved_with_dispatch() {
-    let mut vt = Runtime::<TickCounterApp, _>::virtual_terminal(40, 10).unwrap();
+    let mut vt = Runtime::<TickCounterApp, _>::virtual_builder(40, 10)
+        .build()
+        .unwrap();
     let tx = vt.message_sender();
 
     // Direct dispatch
@@ -348,7 +362,9 @@ async fn test_message_channel_interleaved_with_dispatch() {
 
 #[tokio::test]
 async fn test_message_channel_from_spawned_task() {
-    let mut vt = Runtime::<TickCounterApp, _>::virtual_terminal(40, 10).unwrap();
+    let mut vt = Runtime::<TickCounterApp, _>::virtual_builder(40, 10)
+        .build()
+        .unwrap();
     let tx = vt.message_sender();
 
     // Spawn a task that sends messages
@@ -371,7 +387,9 @@ async fn test_message_channel_from_spawned_task() {
 
 #[tokio::test]
 async fn test_render_reflects_async_state() {
-    let mut vt = Runtime::<AsyncLoaderApp, _>::virtual_terminal(40, 10).unwrap();
+    let mut vt = Runtime::<AsyncLoaderApp, _>::virtual_builder(40, 10)
+        .build()
+        .unwrap();
 
     vt.render().unwrap();
     assert!(vt.contains_text("Idle"));
@@ -389,7 +407,9 @@ async fn test_render_reflects_async_state() {
 
 #[tokio::test]
 async fn test_render_after_chained_async() {
-    let mut vt = Runtime::<ChainedApp, _>::virtual_terminal(60, 10).unwrap();
+    let mut vt = Runtime::<ChainedApp, _>::virtual_builder(60, 10)
+        .build()
+        .unwrap();
 
     vt.render().unwrap();
     assert!(vt.contains_text("pending"));
@@ -518,7 +538,9 @@ mod app_harness_tests {
 async fn test_tick_subscription_delivers_messages() {
     use envision::app::TickSubscription;
 
-    let mut vt = Runtime::<TickCounterApp, _>::virtual_terminal(40, 10).unwrap();
+    let mut vt = Runtime::<TickCounterApp, _>::virtual_builder(40, 10)
+        .build()
+        .unwrap();
 
     // Subscribe with a 10ms tick interval
     let sub = TickSubscription::new(Duration::from_millis(10), || TickCounterMsg::Tick);
@@ -540,7 +562,9 @@ async fn test_tick_subscription_delivers_messages() {
 async fn test_timer_subscription_fires_once() {
     use envision::app::TimerSubscription;
 
-    let mut vt = Runtime::<TickCounterApp, _>::virtual_terminal(40, 10).unwrap();
+    let mut vt = Runtime::<TickCounterApp, _>::virtual_builder(40, 10)
+        .build()
+        .unwrap();
 
     let sub = TimerSubscription::after(Duration::from_millis(20), TickCounterMsg::Tick);
     vt.subscribe(sub);
@@ -562,7 +586,9 @@ async fn test_timer_subscription_fires_once() {
 async fn test_channel_subscription_forwards_messages() {
     use tokio::sync::mpsc;
 
-    let mut vt = Runtime::<TickCounterApp, _>::virtual_terminal(40, 10).unwrap();
+    let mut vt = Runtime::<TickCounterApp, _>::virtual_builder(40, 10)
+        .build()
+        .unwrap();
 
     let (tx, rx) = mpsc::channel::<TickCounterMsg>(10);
     let sub = envision::app::ChannelSubscription::new(rx);
@@ -584,7 +610,9 @@ async fn test_channel_subscription_forwards_messages() {
 async fn test_subscription_cancellation() {
     use envision::app::TickSubscription;
 
-    let mut vt = Runtime::<TickCounterApp, _>::virtual_terminal(40, 10).unwrap();
+    let mut vt = Runtime::<TickCounterApp, _>::virtual_builder(40, 10)
+        .build()
+        .unwrap();
 
     let sub = TickSubscription::new(Duration::from_millis(10), || TickCounterMsg::Tick);
     vt.subscribe(sub);

--- a/tests/integration_with_state.rs
+++ b/tests/integration_with_state.rs
@@ -98,7 +98,7 @@ impl App for InitCmdApp {
 }
 
 // ===========================================================================
-// Tests: Runtime::virtual_terminal_with_state
+// Tests: Runtime::virtual_builder().state().build()
 // ===========================================================================
 
 #[test]
@@ -107,7 +107,9 @@ fn test_virtual_terminal_with_state_bypasses_init() {
         count: 42,
         label: "custom".into(),
     };
-    let vt = Runtime::<CounterApp, _>::virtual_terminal_with_state(80, 24, state, Command::none())
+    let vt = Runtime::<CounterApp, _>::virtual_builder(80, 24)
+        .state(state, Command::none())
+        .build()
         .unwrap();
 
     assert_eq!(vt.state().count, 42);
@@ -120,9 +122,10 @@ fn test_virtual_terminal_with_state_renders_correctly() {
         count: 99,
         label: "score".into(),
     };
-    let mut vt =
-        Runtime::<CounterApp, _>::virtual_terminal_with_state(80, 24, state, Command::none())
-            .unwrap();
+    let mut vt = Runtime::<CounterApp, _>::virtual_builder(80, 24)
+        .state(state, Command::none())
+        .build()
+        .unwrap();
 
     vt.render().unwrap();
     assert!(vt.contains_text("score: 99"));
@@ -134,9 +137,10 @@ fn test_virtual_terminal_with_state_dispatch_works() {
         count: 10,
         label: "test".into(),
     };
-    let mut vt =
-        Runtime::<CounterApp, _>::virtual_terminal_with_state(80, 24, state, Command::none())
-            .unwrap();
+    let mut vt = Runtime::<CounterApp, _>::virtual_builder(80, 24)
+        .state(state, Command::none())
+        .build()
+        .unwrap();
 
     vt.dispatch(CounterMsg::Increment);
     assert_eq!(vt.state().count, 11);
@@ -151,8 +155,10 @@ fn test_virtual_terminal_with_state_init_cmd_executes() {
     let state = InitCmdState::default();
     let init_cmd = Command::message(InitCmdMsg::SetInitialized("from cmd".into()));
 
-    let mut vt =
-        Runtime::<InitCmdApp, _>::virtual_terminal_with_state(80, 24, state, init_cmd).unwrap();
+    let mut vt = Runtime::<InitCmdApp, _>::virtual_builder(80, 24)
+        .state(state, init_cmd)
+        .build()
+        .unwrap();
 
     // Synchronous init commands are queued and dispatched on process_commands()
     vt.process_commands();
@@ -167,16 +173,17 @@ fn test_virtual_terminal_with_state_negative_count() {
         count: -100,
         label: "negative".into(),
     };
-    let mut vt =
-        Runtime::<CounterApp, _>::virtual_terminal_with_state(80, 24, state, Command::none())
-            .unwrap();
+    let mut vt = Runtime::<CounterApp, _>::virtual_builder(80, 24)
+        .state(state, Command::none())
+        .build()
+        .unwrap();
 
     vt.render().unwrap();
     assert!(vt.contains_text("negative: -100"));
 }
 
 // ===========================================================================
-// Tests: Runtime::virtual_terminal_with_state_and_config
+// Tests: Runtime::virtual_builder().state().config().build()
 // ===========================================================================
 
 #[test]
@@ -192,25 +199,22 @@ fn test_virtual_terminal_with_state_and_config() {
         history_capacity: 5,
         ..RuntimeConfig::default()
     };
-    let mut vt = Runtime::<CounterApp, _>::virtual_terminal_with_state_and_config(
-        80,
-        24,
-        state,
-        Command::none(),
-        config,
-    )
-    .unwrap();
+    let mut vt = Runtime::<CounterApp, _>::virtual_builder(80, 24)
+        .state(state, Command::none())
+        .config(config)
+        .build()
+        .unwrap();
 
     vt.render().unwrap();
     assert!(vt.contains_text("config: 7"));
 }
 
 // ===========================================================================
-// Tests: Runtime::with_backend_and_state
+// Tests: Runtime::builder() with CaptureBackend
 // ===========================================================================
 
 #[test]
-fn test_with_backend_and_state() {
+fn test_builder_with_backend_and_state() {
     use envision::backend::CaptureBackend;
 
     let backend = CaptureBackend::new(60, 20);
@@ -218,8 +222,10 @@ fn test_with_backend_and_state() {
         count: 55,
         label: "backend".into(),
     };
-    let vt =
-        Runtime::<CounterApp, _>::with_backend_and_state(backend, state, Command::none()).unwrap();
+    let vt = Runtime::<CounterApp, _>::builder(backend)
+        .state(state, Command::none())
+        .build()
+        .unwrap();
 
     assert_eq!(vt.state().count, 55);
     assert_eq!(vt.state().label, "backend");
@@ -298,7 +304,9 @@ fn test_harness_with_state_and_config() {
 
 #[test]
 fn test_default_init_unchanged() {
-    let vt = Runtime::<CounterApp, _>::virtual_terminal(80, 24).unwrap();
+    let vt = Runtime::<CounterApp, _>::virtual_builder(80, 24)
+        .build()
+        .unwrap();
 
     assert_eq!(vt.state().count, 0);
     assert_eq!(vt.state().label, "default");


### PR DESCRIPTION
## Summary

- **Delete 12 old Runtime constructors.** `new_terminal()`, `terminal_with_config()`, `new_terminal_with_state()`, `terminal_with_state_and_config()`, `virtual_terminal()`, `virtual_terminal_with_config()`, `virtual_terminal_with_state()`, `virtual_terminal_with_state_and_config()`, `with_backend()`, `with_backend_and_config()`, `with_backend_and_state()`, and `with_backend_state_and_config()` are removed. The `RuntimeBuilder` (from #421) is now the sole construction path. The internal `with_backend_state_and_config` is retained as `pub(crate)` since the builder calls it.
- **Complete CHANGELOG [Unreleased] section** with all 7 missing entries: Clone bound removal (#420), `view_from` removal (#423), markdown gate (#424), constructor deletion, consistency sweep (#425), `terminal::restore` (#422), `InputMode` (#426), and `StepIndicator` style overrides (#417).
- **Add MIGRATION.md v0.14-to-v0.15 section** with before/after examples for every breaking change: builder migration, Clone bound, `view_from` removal, markdown feature gate, API renames, and new features.

Updates 101 files: all examples, benchmarks, tests, integration tests, app harness, and doc comments.

## Test plan

- [x] `cargo check -p envision --all-targets --all-features` (0 errors)
- [x] `cargo clippy -p envision --all-targets --all-features -- -D warnings` (0 warnings)
- [x] `cargo nextest run -p envision` (7212 tests pass)
- [x] `cargo test --doc -p envision` (2003 doc tests pass)
- [x] `cargo build --examples --all-features` (all examples compile)
- [x] `cargo fmt -- --check` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)