### PR TITLE
Doc test coverage: 84.4% → 99.3% (1536/1547 methods)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,12 @@ jobs:
 
       - name: Run doc tests
         shell: bash
+        env:
+          # Windows defaults the main thread stack to 1 MB. The merged doctest
+          # binary exceeds that at init under Rust 1.85; bump to 8 MB to match
+          # Linux/macOS defaults. Scoped to Windows to avoid cache invalidation
+          # on other platforms.
+          RUSTFLAGS: ${{ matrix.os == 'windows-latest' && '-C link-args=/STACK:8388608' || '' }}
         run: |
           if [ "${{ matrix.rust }}" = "stable" ]; then
             cargo test --doc --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,10 @@ jobs:
         shell: bash
         env:
           # Windows defaults the main thread stack to 1 MB. The merged doctest
-          # binary exceeds that at init under Rust 1.85; bump to 8 MB to match
-          # Linux/macOS defaults. Scoped to Windows to avoid cache invalidation
-          # on other platforms.
-          RUSTFLAGS: ${{ matrix.os == 'windows-latest' && '-C link-args=/STACK:8388608' || '' }}
+          # binary exceeds that at init under Rust 1.85; bump to 16 MB to leave
+          # headroom over Linux/macOS's 8 MB default. RUSTDOCFLAGS is what
+          # rustdoc reads to compile doctest binaries. Scoped to Windows.
+          RUSTDOCFLAGS: ${{ matrix.os == 'windows-latest' && '-C link-args=/STACK:16777216' || '' }}
         run: |
           if [ "${{ matrix.rust }}" = "stable" ]; then
             cargo test --doc --all-features

--- a/src/component/box_plot/mod.rs
+++ b/src/component/box_plot/mod.rs
@@ -142,41 +142,116 @@ impl BoxPlotData {
     }
 
     /// Returns the label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BoxPlotData;
+    ///
+    /// let data = BoxPlotData::new("P99 Latency", 1.0, 2.0, 3.0, 4.0, 5.0);
+    /// assert_eq!(data.label(), "P99 Latency");
+    /// ```
     pub fn label(&self) -> &str {
         &self.label
     }
 
     /// Returns the minimum value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BoxPlotData;
+    ///
+    /// let data = BoxPlotData::new("Latency", 5.0, 15.0, 25.0, 35.0, 45.0);
+    /// assert_eq!(data.min(), 5.0);
+    /// ```
     pub fn min(&self) -> f64 {
         self.min
     }
 
     /// Returns the first quartile (Q1).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BoxPlotData;
+    ///
+    /// let data = BoxPlotData::new("Latency", 5.0, 15.0, 25.0, 35.0, 45.0);
+    /// assert_eq!(data.q1(), 15.0);
+    /// ```
     pub fn q1(&self) -> f64 {
         self.q1
     }
 
     /// Returns the median.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BoxPlotData;
+    ///
+    /// let data = BoxPlotData::new("Latency", 5.0, 15.0, 25.0, 35.0, 45.0);
+    /// assert_eq!(data.median(), 25.0);
+    /// ```
     pub fn median(&self) -> f64 {
         self.median
     }
 
     /// Returns the third quartile (Q3).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BoxPlotData;
+    ///
+    /// let data = BoxPlotData::new("Latency", 5.0, 15.0, 25.0, 35.0, 45.0);
+    /// assert_eq!(data.q3(), 35.0);
+    /// ```
     pub fn q3(&self) -> f64 {
         self.q3
     }
 
     /// Returns the maximum value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BoxPlotData;
+    ///
+    /// let data = BoxPlotData::new("Latency", 5.0, 15.0, 25.0, 35.0, 45.0);
+    /// assert_eq!(data.max(), 45.0);
+    /// ```
     pub fn max(&self) -> f64 {
         self.max
     }
 
     /// Returns the outliers.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BoxPlotData;
+    ///
+    /// let data = BoxPlotData::new("Latency", 5.0, 15.0, 25.0, 35.0, 45.0)
+    ///     .with_outliers(vec![100.0]);
+    /// assert_eq!(data.outliers(), &[100.0]);
+    /// ```
     pub fn outliers(&self) -> &[f64] {
         &self.outliers
     }
 
     /// Returns the color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BoxPlotData;
+    /// use ratatui::style::Color;
+    ///
+    /// let data = BoxPlotData::new("CPU", 1.0, 2.0, 3.0, 4.0, 5.0)
+    ///     .with_color(Color::Blue);
+    /// assert_eq!(data.color(), Color::Blue);
+    /// ```
     pub fn color(&self) -> Color {
         self.color
     }
@@ -787,6 +862,16 @@ impl BoxPlotState {
     // ---- Instance methods ----
 
     /// Updates the state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{BoxPlotState, BoxPlotData, BoxPlotMessage, BoxPlotOrientation};
+    ///
+    /// let mut state = BoxPlotState::default();
+    /// state.update(BoxPlotMessage::SetOrientation(BoxPlotOrientation::Horizontal));
+    /// assert_eq!(state.orientation(), &BoxPlotOrientation::Horizontal);
+    /// ```
     pub fn update(&mut self, msg: BoxPlotMessage) -> Option<()> {
         BoxPlot::update(self, msg)
     }

--- a/src/component/breadcrumb/mod.rs
+++ b/src/component/breadcrumb/mod.rs
@@ -100,11 +100,32 @@ impl BreadcrumbSegment {
     }
 
     /// Returns the display label for this segment.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BreadcrumbSegment;
+    ///
+    /// let segment = BreadcrumbSegment::new("Products");
+    /// assert_eq!(segment.label(), "Products");
+    /// ```
     pub fn label(&self) -> &str {
         &self.label
     }
 
     /// Returns the data associated with this segment, if any.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::BreadcrumbSegment;
+    ///
+    /// let segment = BreadcrumbSegment::new("Products").with_data("/products");
+    /// assert_eq!(segment.data(), Some("/products"));
+    ///
+    /// let no_data = BreadcrumbSegment::new("Home");
+    /// assert_eq!(no_data.data(), None);
+    /// ```
     pub fn data(&self) -> Option<&str> {
         self.data.as_deref()
     }
@@ -536,6 +557,16 @@ impl BreadcrumbState {
     }
 
     /// Updates the breadcrumb state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{BreadcrumbMessage, BreadcrumbOutput, BreadcrumbState};
+    ///
+    /// let mut state = BreadcrumbState::from_labels(vec!["Home", "Products", "Item"]);
+    /// let output = state.update(BreadcrumbMessage::Right);
+    /// assert_eq!(output, Some(BreadcrumbOutput::FocusChanged(1)));
+    /// ```
     pub fn update(&mut self, msg: BreadcrumbMessage) -> Option<BreadcrumbOutput> {
         Breadcrumb::update(self, msg)
     }

--- a/src/component/canvas/mod.rs
+++ b/src/component/canvas/mod.rs
@@ -432,11 +432,29 @@ impl CanvasState {
     }
 
     /// Returns the x-axis bounds.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CanvasState;
+    ///
+    /// let state = CanvasState::new().with_x_bounds(0.0, 50.0);
+    /// assert_eq!(state.x_bounds(), [0.0, 50.0]);
+    /// ```
     pub fn x_bounds(&self) -> [f64; 2] {
         self.x_bounds
     }
 
     /// Returns the y-axis bounds.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CanvasState;
+    ///
+    /// let state = CanvasState::new().with_y_bounds(0.0, 200.0);
+    /// assert_eq!(state.y_bounds(), [0.0, 200.0]);
+    /// ```
     pub fn y_bounds(&self) -> [f64; 2] {
         self.y_bounds
     }
@@ -472,21 +490,59 @@ impl CanvasState {
     }
 
     /// Returns the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CanvasState;
+    ///
+    /// let state = CanvasState::new().with_title("Overview");
+    /// assert_eq!(state.title(), Some("Overview"));
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
 
     /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CanvasState;
+    ///
+    /// let mut state = CanvasState::new();
+    /// state.set_title(Some("Updated".to_string()));
+    /// assert_eq!(state.title(), Some("Updated"));
+    /// ```
     pub fn set_title(&mut self, title: Option<String>) {
         self.title = title;
     }
 
     /// Returns the marker type.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{CanvasMarker, CanvasState};
+    ///
+    /// let state = CanvasState::new().with_marker(CanvasMarker::Dot);
+    /// assert_eq!(state.marker(), &CanvasMarker::Dot);
+    /// ```
     pub fn marker(&self) -> &CanvasMarker {
         &self.marker
     }
 
     /// Sets the marker type.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{CanvasMarker, CanvasState};
+    ///
+    /// let mut state = CanvasState::new();
+    /// state.set_marker(CanvasMarker::Block);
+    /// assert_eq!(state.marker(), &CanvasMarker::Block);
+    /// ```
     pub fn set_marker(&mut self, marker: CanvasMarker) {
         self.marker = marker;
     }
@@ -494,6 +550,19 @@ impl CanvasState {
     // ---- Instance methods ----
 
     /// Updates the state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{CanvasState, CanvasMessage, CanvasShape};
+    /// use ratatui::style::Color;
+    ///
+    /// let mut state = CanvasState::new();
+    /// state.update(CanvasMessage::AddShape(CanvasShape::Circle {
+    ///     x: 50.0, y: 50.0, radius: 10.0, color: Color::Cyan,
+    /// }));
+    /// assert_eq!(state.shapes().len(), 1);
+    /// ```
     pub fn update(&mut self, msg: CanvasMessage) -> Option<()> {
         Canvas::update(self, msg)
     }

--- a/src/component/chart/mod.rs
+++ b/src/component/chart/mod.rs
@@ -201,6 +201,18 @@ pub struct VerticalLine {
 
 impl VerticalLine {
     /// Creates a new vertical reference line.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::VerticalLine;
+    /// use ratatui::style::Color;
+    ///
+    /// let vline = VerticalLine::new(500.0, "Deploy", Color::Green);
+    /// assert_eq!(vline.x_value, 500.0);
+    /// assert_eq!(vline.label, "Deploy");
+    /// assert_eq!(vline.color, Color::Green);
+    /// ```
     pub fn new(x_value: f64, label: impl Into<String>, color: Color) -> Self {
         Self {
             x_value,
@@ -402,6 +414,17 @@ impl ChartState {
     }
 
     /// Creates a horizontal bar chart state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartKind, ChartState, DataSeries};
+    ///
+    /// let state = ChartState::bar_horizontal(vec![
+    ///     DataSeries::new("Memory", vec![512.0, 768.0, 1024.0]),
+    /// ]);
+    /// assert_eq!(state.kind(), &ChartKind::BarHorizontal);
+    /// ```
     pub fn bar_horizontal(series: Vec<DataSeries>) -> Self {
         Self {
             series: Self::apply_palette_colors(series),
@@ -487,30 +510,80 @@ impl ChartState {
     }
 
     /// Sets the Y-axis label (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::line(vec![DataSeries::new("CPU", vec![50.0])])
+    ///     .with_y_label("Percent");
+    /// assert_eq!(state.y_label(), Some("Percent"));
+    /// ```
     pub fn with_y_label(mut self, label: impl Into<String>) -> Self {
         self.y_label = Some(label.into());
         self
     }
 
     /// Sets whether to show the legend (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::line(vec![DataSeries::new("CPU", vec![50.0])])
+    ///     .with_show_legend(false);
+    /// assert!(!state.show_legend());
+    /// ```
     pub fn with_show_legend(mut self, show: bool) -> Self {
         self.show_legend = show;
         self
     }
 
     /// Sets the maximum display points for line charts (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::line(vec![DataSeries::new("Temp", vec![20.0, 22.0])])
+    ///     .with_max_display_points(200);
+    /// assert_eq!(state.max_display_points(), 200);
+    /// ```
     pub fn with_max_display_points(mut self, max: usize) -> Self {
         self.max_display_points = max;
         self
     }
 
     /// Sets the bar width (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::bar_vertical(vec![DataSeries::new("Sales", vec![10.0])])
+    ///     .with_bar_width(5);
+    /// assert_eq!(state.bar_width(), 5);
+    /// ```
     pub fn with_bar_width(mut self, width: u16) -> Self {
         self.bar_width = width.max(1);
         self
     }
 
     /// Sets the bar gap (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::bar_vertical(vec![DataSeries::new("Sales", vec![10.0])])
+    ///     .with_bar_gap(2);
+    /// assert_eq!(state.bar_gap(), 2);
+    /// ```
     pub fn with_bar_gap(mut self, gap: u16) -> Self {
         self.bar_gap = gap;
         self
@@ -640,6 +713,16 @@ impl ChartState {
     }
 
     /// Sets whether to show grid lines at tick positions (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::line(vec![DataSeries::new("CPU", vec![50.0])])
+    ///     .with_grid(true);
+    /// assert!(state.show_grid());
+    /// ```
     pub fn with_grid(mut self, show: bool) -> Self {
         self.show_grid = show;
         self

--- a/src/component/chart/series.rs
+++ b/src/component/chart/series.rs
@@ -165,18 +165,49 @@ impl DataSeries {
     }
 
     /// Sets the upper bound values for error bands (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    ///
+    /// let series = DataSeries::new("CPU", vec![50.0, 60.0])
+    ///     .with_upper_bound(vec![55.0, 65.0]);
+    /// assert_eq!(series.upper_bound(), Some([55.0, 65.0].as_slice()));
+    /// ```
     pub fn with_upper_bound(mut self, upper: Vec<f64>) -> Self {
         self.upper_bound = Some(upper);
         self
     }
 
     /// Sets the lower bound values for error bands (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    ///
+    /// let series = DataSeries::new("CPU", vec![50.0, 60.0])
+    ///     .with_lower_bound(vec![45.0, 55.0]);
+    /// assert_eq!(series.lower_bound(), Some([45.0, 55.0].as_slice()));
+    /// ```
     pub fn with_lower_bound(mut self, lower: Vec<f64>) -> Self {
         self.lower_bound = Some(lower);
         self
     }
 
     /// Sets both upper and lower bound values for error bands (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    ///
+    /// let series = DataSeries::new("CPU", vec![50.0])
+    ///     .with_bounds(vec![45.0], vec![55.0]);
+    /// assert!(series.lower_bound().is_some());
+    /// assert!(series.upper_bound().is_some());
+    /// ```
     pub fn with_bounds(mut self, lower: Vec<f64>, upper: Vec<f64>) -> Self {
         self.lower_bound = Some(lower);
         self.upper_bound = Some(upper);
@@ -184,16 +215,44 @@ impl DataSeries {
     }
 
     /// Returns the label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    ///
+    /// let series = DataSeries::new("Temperature", vec![20.0, 22.0]);
+    /// assert_eq!(series.label(), "Temperature");
+    /// ```
     pub fn label(&self) -> &str {
         &self.label
     }
 
     /// Returns the values.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    ///
+    /// let series = DataSeries::new("CPU", vec![10.0, 20.0, 30.0]);
+    /// assert_eq!(series.values(), &[10.0, 20.0, 30.0]);
+    /// ```
     pub fn values(&self) -> &[f64] {
         &self.values
     }
 
     /// Returns the color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    /// use ratatui::style::Color;
+    ///
+    /// let series = DataSeries::new("CPU", vec![50.0]).with_color(Color::Green);
+    /// assert_eq!(series.color(), Color::Green);
+    /// ```
     pub fn color(&self) -> Color {
         self.color
     }
@@ -219,11 +278,31 @@ impl DataSeries {
     }
 
     /// Returns the upper bound values, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    ///
+    /// let series = DataSeries::new("CPU", vec![50.0]).with_upper_bound(vec![55.0]);
+    /// assert_eq!(series.upper_bound(), Some([55.0].as_slice()));
+    /// assert_eq!(DataSeries::new("A", vec![1.0]).upper_bound(), None);
+    /// ```
     pub fn upper_bound(&self) -> Option<&[f64]> {
         self.upper_bound.as_deref()
     }
 
     /// Returns the lower bound values, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    ///
+    /// let series = DataSeries::new("CPU", vec![50.0]).with_lower_bound(vec![45.0]);
+    /// assert_eq!(series.lower_bound(), Some([45.0].as_slice()));
+    /// assert_eq!(DataSeries::new("A", vec![1.0]).lower_bound(), None);
+    /// ```
     pub fn lower_bound(&self) -> Option<&[f64]> {
         self.lower_bound.as_deref()
     }
@@ -295,31 +374,90 @@ impl DataSeries {
     }
 
     /// Returns the most recent value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    ///
+    /// let series = DataSeries::new("Temp", vec![10.0, 20.0, 30.0]);
+    /// assert_eq!(series.last(), Some(30.0));
+    /// assert_eq!(DataSeries::new("Empty", vec![]).last(), None);
+    /// ```
     pub fn last(&self) -> Option<f64> {
         self.values.last().copied()
     }
 
     /// Returns the number of data points.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    ///
+    /// let series = DataSeries::new("CPU", vec![10.0, 20.0, 30.0]);
+    /// assert_eq!(series.len(), 3);
+    /// ```
     pub fn len(&self) -> usize {
         self.values.len()
     }
 
     /// Returns true if the series has no data points.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    ///
+    /// assert!(DataSeries::new("Empty", vec![]).is_empty());
+    /// assert!(!DataSeries::new("CPU", vec![50.0]).is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.values.is_empty()
     }
 
     /// Clears all values.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    ///
+    /// let mut series = DataSeries::new("CPU", vec![10.0, 20.0]);
+    /// series.clear();
+    /// assert!(series.is_empty());
+    /// ```
     pub fn clear(&mut self) {
         self.values.clear();
     }
 
     /// Sets the label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    ///
+    /// let mut series = DataSeries::new("Old", vec![1.0]);
+    /// series.set_label("New");
+    /// assert_eq!(series.label(), "New");
+    /// ```
     pub fn set_label(&mut self, label: impl Into<String>) {
         self.label = label.into();
     }
 
     /// Sets the color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    /// use ratatui::style::Color;
+    ///
+    /// let mut series = DataSeries::new("CPU", vec![50.0]);
+    /// series.set_color(Color::Red);
+    /// assert_eq!(series.color(), Color::Red);
+    /// ```
     pub fn set_color(&mut self, color: Color) {
         self.color = color;
     }
@@ -348,11 +486,35 @@ impl DataSeries {
     }
 
     /// Sets the upper bound values for error bands.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    ///
+    /// let mut series = DataSeries::new("CPU", vec![50.0]);
+    /// series.set_upper_bound(Some(vec![55.0]));
+    /// assert_eq!(series.upper_bound(), Some([55.0].as_slice()));
+    /// series.set_upper_bound(None);
+    /// assert_eq!(series.upper_bound(), None);
+    /// ```
     pub fn set_upper_bound(&mut self, upper: Option<Vec<f64>>) {
         self.upper_bound = upper;
     }
 
     /// Sets the lower bound values for error bands.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DataSeries;
+    ///
+    /// let mut series = DataSeries::new("CPU", vec![50.0]);
+    /// series.set_lower_bound(Some(vec![45.0]));
+    /// assert_eq!(series.lower_bound(), Some([45.0].as_slice()));
+    /// series.set_lower_bound(None);
+    /// assert_eq!(series.lower_bound(), None);
+    /// ```
     pub fn set_lower_bound(&mut self, lower: Option<Vec<f64>>) {
         self.lower_bound = lower;
     }

--- a/src/component/chart/state.rs
+++ b/src/component/chart/state.rs
@@ -12,61 +12,175 @@ impl ChartState {
     // ---- Accessors ----
 
     /// Returns the data series.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::line(vec![DataSeries::new("CPU", vec![50.0])]);
+    /// assert_eq!(state.series().len(), 1);
+    /// ```
     pub fn series(&self) -> &[DataSeries] {
         &self.series
     }
 
     /// Returns a mutable reference to the series.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let mut state = ChartState::line(vec![DataSeries::new("CPU", vec![50.0])]);
+    /// assert_eq!(state.series_mut().len(), 1);
+    /// ```
     pub fn series_mut(&mut self) -> &mut [DataSeries] {
         &mut self.series
     }
 
     /// Returns the series at the given index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::line(vec![DataSeries::new("CPU", vec![50.0])]);
+    /// assert!(state.get_series(0).is_some());
+    /// assert!(state.get_series(1).is_none());
+    /// ```
     pub fn get_series(&self, index: usize) -> Option<&DataSeries> {
         self.series.get(index)
     }
 
     /// Returns a mutable reference to the series at the given index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let mut state = ChartState::line(vec![DataSeries::new("CPU", vec![50.0])]);
+    /// assert!(state.get_series_mut(0).is_some());
+    /// assert!(state.get_series_mut(1).is_none());
+    /// ```
     pub fn get_series_mut(&mut self, index: usize) -> Option<&mut DataSeries> {
         self.series.get_mut(index)
     }
 
     /// Returns the chart kind.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartKind, ChartState};
+    ///
+    /// let state = ChartState::line(vec![]);
+    /// assert_eq!(state.kind(), &ChartKind::Line);
+    /// ```
     pub fn kind(&self) -> &ChartKind {
         &self.kind
     }
 
     /// Sets the chart kind.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartKind, ChartState};
+    ///
+    /// let mut state = ChartState::line(vec![]);
+    /// state.set_kind(ChartKind::BarVertical);
+    /// assert_eq!(state.kind(), &ChartKind::BarVertical);
+    /// ```
     pub fn set_kind(&mut self, kind: ChartKind) {
         self.kind = kind;
     }
 
     /// Returns the active series index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::line(vec![DataSeries::new("CPU", vec![50.0])]);
+    /// assert_eq!(state.active_series(), 0);
+    /// ```
     pub fn active_series(&self) -> usize {
         self.active_series
     }
 
     /// Returns the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::line(vec![]).with_title("My Chart");
+    /// assert_eq!(state.title(), Some("My Chart"));
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
 
     /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ChartState;
+    ///
+    /// let mut state = ChartState::line(vec![]);
+    /// state.set_title(Some("Updated".to_string()));
+    /// assert_eq!(state.title(), Some("Updated"));
+    /// ```
     pub fn set_title(&mut self, title: Option<String>) {
         self.title = title;
     }
 
     /// Returns the X-axis label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::line(vec![DataSeries::new("CPU", vec![50.0])])
+    ///     .with_x_label("Time");
+    /// assert_eq!(state.x_label(), Some("Time"));
+    /// ```
     pub fn x_label(&self) -> Option<&str> {
         self.x_label.as_deref()
     }
 
     /// Returns the Y-axis label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::line(vec![DataSeries::new("CPU", vec![50.0])])
+    ///     .with_y_label("Percent");
+    /// assert_eq!(state.y_label(), Some("Percent"));
+    /// ```
     pub fn y_label(&self) -> Option<&str> {
         self.y_label.as_deref()
     }
 
     /// Returns whether the legend is shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ChartState;
+    ///
+    /// let state = ChartState::line(vec![]);
+    /// assert!(state.show_legend());
+    /// ```
     pub fn show_legend(&self) -> bool {
         self.show_legend
     }
@@ -87,6 +201,15 @@ impl ChartState {
     }
 
     /// Returns the maximum display points.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ChartState;
+    ///
+    /// let state = ChartState::line(vec![]).with_max_display_points(100);
+    /// assert_eq!(state.max_display_points(), 100);
+    /// ```
     pub fn max_display_points(&self) -> usize {
         self.max_display_points
     }
@@ -107,6 +230,15 @@ impl ChartState {
     }
 
     /// Returns the bar width.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ChartState;
+    ///
+    /// let state = ChartState::bar_vertical(vec![]).with_bar_width(4);
+    /// assert_eq!(state.bar_width(), 4);
+    /// ```
     pub fn bar_width(&self) -> u16 {
         self.bar_width
     }
@@ -127,6 +259,15 @@ impl ChartState {
     }
 
     /// Returns the bar gap.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ChartState;
+    ///
+    /// let state = ChartState::bar_vertical(vec![]).with_bar_gap(2);
+    /// assert_eq!(state.bar_gap(), 2);
+    /// ```
     pub fn bar_gap(&self) -> u16 {
         self.bar_gap
     }
@@ -257,31 +398,92 @@ impl ChartState {
     }
 
     /// Returns the number of series.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::line(vec![
+    ///     DataSeries::new("A", vec![1.0]),
+    ///     DataSeries::new("B", vec![2.0]),
+    /// ]);
+    /// assert_eq!(state.series_count(), 2);
+    /// ```
     pub fn series_count(&self) -> usize {
         self.series.len()
     }
 
     /// Returns true if there are no series.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ChartState;
+    ///
+    /// let state = ChartState::line(vec![]);
+    /// assert!(state.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.series.is_empty()
     }
 
     /// Returns the threshold lines.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    /// use ratatui::style::Color;
+    ///
+    /// let state = ChartState::area(vec![DataSeries::new("CPU", vec![50.0])])
+    ///     .with_threshold(90.0, "SLO", Color::Yellow);
+    /// assert_eq!(state.thresholds().len(), 1);
+    /// ```
     pub fn thresholds(&self) -> &[ThresholdLine] {
         &self.thresholds
     }
 
     /// Returns the manual Y-axis minimum, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::area(vec![DataSeries::new("CPU", vec![50.0])])
+    ///     .with_y_range(0.0, 100.0);
+    /// assert_eq!(state.y_min(), Some(0.0));
+    /// ```
     pub fn y_min(&self) -> Option<f64> {
         self.y_min
     }
 
     /// Returns the manual Y-axis maximum, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::area(vec![DataSeries::new("CPU", vec![50.0])])
+    ///     .with_y_range(0.0, 100.0);
+    /// assert_eq!(state.y_max(), Some(100.0));
+    /// ```
     pub fn y_max(&self) -> Option<f64> {
         self.y_max
     }
 
     /// Returns the Y-axis scale.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, Scale};
+    ///
+    /// let state = ChartState::line(vec![]).with_y_scale(Scale::Log10);
+    /// assert_eq!(state.y_scale(), &Scale::Log10);
+    /// ```
     pub fn y_scale(&self) -> &Scale {
         &self.y_scale
     }
@@ -379,36 +581,104 @@ impl ChartState {
     }
 
     /// Returns the cursor position (data index), if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ChartState;
+    ///
+    /// let state = ChartState::line(vec![]);
+    /// assert!(state.cursor_position().is_none());
+    /// ```
     pub fn cursor_position(&self) -> Option<usize> {
         self.cursor_position
     }
 
     /// Sets the cursor position.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ChartState;
+    ///
+    /// let mut state = ChartState::line(vec![]);
+    /// state.set_cursor_position(Some(3));
+    /// assert_eq!(state.cursor_position(), Some(3));
+    /// ```
     pub fn set_cursor_position(&mut self, position: Option<usize>) {
         self.cursor_position = position;
     }
 
     /// Returns whether the crosshair is visible.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ChartState;
+    ///
+    /// let state = ChartState::line(vec![]);
+    /// assert!(!state.show_crosshair());
+    /// ```
     pub fn show_crosshair(&self) -> bool {
         self.show_crosshair
     }
 
     /// Sets crosshair visibility.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ChartState;
+    ///
+    /// let mut state = ChartState::line(vec![]);
+    /// state.set_show_crosshair(true);
+    /// assert!(state.show_crosshair());
+    /// ```
     pub fn set_show_crosshair(&mut self, show: bool) {
         self.show_crosshair = show;
     }
 
     /// Returns whether grid lines are visible.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ChartState;
+    ///
+    /// let state = ChartState::line(vec![]).with_grid(true);
+    /// assert!(state.show_grid());
+    /// ```
     pub fn show_grid(&self) -> bool {
         self.show_grid
     }
 
     /// Sets grid line visibility.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ChartState;
+    ///
+    /// let mut state = ChartState::line(vec![]);
+    /// state.set_show_grid(true);
+    /// assert!(state.show_grid());
+    /// ```
     pub fn set_show_grid(&mut self, show: bool) {
         self.show_grid = show;
     }
 
     /// Returns the vertical reference lines.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    /// use ratatui::style::Color;
+    ///
+    /// let state = ChartState::line(vec![DataSeries::new("CPU", vec![50.0, 60.0])])
+    ///     .with_vertical_line(1.0, "Deploy", Color::Yellow);
+    /// assert_eq!(state.vertical_lines().len(), 1);
+    /// ```
     pub fn vertical_lines(&self) -> &[VerticalLine] {
         &self.vertical_lines
     }
@@ -518,6 +788,18 @@ impl ChartState {
     // ---- Computed properties ----
 
     /// Computes the global min value across all series.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::line(vec![
+    ///     DataSeries::new("A", vec![5.0, 10.0]),
+    ///     DataSeries::new("B", vec![2.0, 8.0]),
+    /// ]);
+    /// assert_eq!(state.global_min(), 2.0);
+    /// ```
     pub fn global_min(&self) -> f64 {
         self.series
             .iter()
@@ -527,6 +809,18 @@ impl ChartState {
     }
 
     /// Computes the global max value across all series.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::line(vec![
+    ///     DataSeries::new("A", vec![5.0, 10.0]),
+    ///     DataSeries::new("B", vec![2.0, 8.0]),
+    /// ]);
+    /// assert_eq!(state.global_max(), 10.0);
+    /// ```
     pub fn global_max(&self) -> f64 {
         self.series
             .iter()
@@ -539,6 +833,16 @@ impl ChartState {
     ///
     /// If `y_min` is set, uses that value. Otherwise auto-scales from data,
     /// also considering threshold line values.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::area(vec![DataSeries::new("CPU", vec![20.0, 80.0])])
+    ///     .with_y_range(0.0, 100.0);
+    /// assert_eq!(state.effective_min(), 0.0);
+    /// ```
     pub fn effective_min(&self) -> f64 {
         self.y_min.unwrap_or_else(|| {
             let data_min = self.global_min();
@@ -562,6 +866,16 @@ impl ChartState {
     }
 
     /// Computes the effective maximum for the Y-axis, considering manual override.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let state = ChartState::area(vec![DataSeries::new("CPU", vec![20.0, 80.0])])
+    ///     .with_y_range(0.0, 100.0);
+    /// assert_eq!(state.effective_max(), 100.0);
+    /// ```
     pub fn effective_max(&self) -> f64 {
         self.y_max.unwrap_or_else(|| {
             let data_max = self.global_max();
@@ -587,6 +901,17 @@ impl ChartState {
     // ---- Instance methods ----
 
     /// Updates the state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, ChartMessage, ChartOutput, DataSeries, Scale};
+    ///
+    /// let mut state = ChartState::line(vec![DataSeries::new("CPU", vec![50.0])]);
+    /// let output = state.update(ChartMessage::SetYScale(Scale::Log10));
+    /// assert!(output.is_none());
+    /// assert_eq!(state.y_scale(), &Scale::Log10);
+    /// ```
     pub fn update(&mut self, msg: ChartMessage) -> Option<ChartOutput> {
         Chart::update(self, msg)
     }

--- a/src/component/checkbox/mod.rs
+++ b/src/component/checkbox/mod.rs
@@ -124,6 +124,18 @@ impl CheckboxState {
     }
 
     /// Returns true if the checkbox is checked.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CheckboxState;
+    ///
+    /// let unchecked = CheckboxState::new("Accept");
+    /// assert!(!unchecked.is_checked());
+    ///
+    /// let checked = CheckboxState::checked("Remember me");
+    /// assert!(checked.is_checked());
+    /// ```
     pub fn is_checked(&self) -> bool {
         self.checked
     }

--- a/src/component/confirm_dialog/mod.rs
+++ b/src/component/confirm_dialog/mod.rs
@@ -340,6 +340,15 @@ impl ConfirmDialogState {
     }
 
     /// Returns the button configuration.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ConfirmDialogState, confirm_dialog::ButtonConfig};
+    ///
+    /// let state = ConfirmDialogState::yes_no("Delete?", "Are you sure?");
+    /// assert_eq!(state.button_config(), &ButtonConfig::YesNo);
+    /// ```
     pub fn button_config(&self) -> &ButtonConfig {
         &self.button_config
     }
@@ -359,6 +368,15 @@ impl ConfirmDialogState {
     }
 
     /// Returns the destructive button index, if any.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ConfirmDialogState;
+    ///
+    /// let state = ConfirmDialogState::new("Title", "Message");
+    /// assert_eq!(state.destructive_button(), None);
+    /// ```
     pub fn destructive_button(&self) -> Option<usize> {
         self.destructive_button
     }

--- a/src/component/conversation_view/mod.rs
+++ b/src/component/conversation_view/mod.rs
@@ -267,6 +267,15 @@ impl ConversationViewState {
     ///
     /// Always returns `false` when the `markdown` Cargo feature is not
     /// enabled (since the setter methods are not available).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ConversationViewState;
+    ///
+    /// let state = ConversationViewState::new();
+    /// assert!(!state.markdown_enabled());
+    /// ```
     pub fn markdown_enabled(&self) -> bool {
         self.markdown_enabled
     }
@@ -311,6 +320,18 @@ impl ConversationViewState {
     }
 
     /// Returns the style override for a role, if one is set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ConversationViewState, ConversationRole};
+    /// use ratatui::style::{Color, Style};
+    ///
+    /// let state = ConversationViewState::new()
+    ///     .with_role_style(ConversationRole::User, Style::default().fg(Color::Cyan));
+    /// assert!(state.role_style_override(&ConversationRole::User).is_some());
+    /// assert!(state.role_style_override(&ConversationRole::Assistant).is_none());
+    /// ```
     pub fn role_style_override(&self, role: &ConversationRole) -> Option<&Style> {
         self.role_style_overrides.get(role)
     }
@@ -335,6 +356,18 @@ impl ConversationViewState {
     }
 
     /// Removes a style override for a role, reverting to the default color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ConversationViewState, ConversationRole};
+    /// use ratatui::style::{Color, Style};
+    ///
+    /// let mut state = ConversationViewState::new()
+    ///     .with_role_style(ConversationRole::User, Style::default().fg(Color::Cyan));
+    /// state.clear_role_style(&ConversationRole::User);
+    /// assert!(state.role_style_override(&ConversationRole::User).is_none());
+    /// ```
     pub fn clear_role_style(&mut self, role: &ConversationRole) {
         self.role_style_overrides.remove(role);
     }
@@ -578,16 +611,44 @@ impl ConversationViewState {
     }
 
     /// Returns the number of messages.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ConversationViewState;
+    ///
+    /// let mut state = ConversationViewState::new();
+    /// state.push_user("Hello");
+    /// assert_eq!(state.message_count(), 1);
+    /// ```
     pub fn message_count(&self) -> usize {
         self.messages.len()
     }
 
     /// Returns true if there are no messages.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ConversationViewState;
+    ///
+    /// let state = ConversationViewState::new();
+    /// assert!(state.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.messages.is_empty()
     }
 
     /// Returns the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ConversationViewState;
+    ///
+    /// let state = ConversationViewState::new().with_title("Chat");
+    /// assert_eq!(state.title(), Some("Chat"));
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
@@ -636,16 +697,46 @@ impl ConversationViewState {
     /// When `Some`, a single line is rendered at the bottom of the
     /// viewport inside the border. When `None`, the full viewport
     /// is used for messages.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ConversationViewState;
+    ///
+    /// let mut state = ConversationViewState::new();
+    /// state.set_status(Some("Connecting..."));
+    /// assert_eq!(state.status(), Some("Connecting..."));
+    /// state.set_status(None::<&str>);
+    /// assert!(state.status().is_none());
+    /// ```
     pub fn set_status(&mut self, status: Option<impl Into<String>>) {
         self.status = status.map(|s| s.into());
     }
 
     /// Returns the scroll offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ConversationViewState;
+    ///
+    /// let state = ConversationViewState::new();
+    /// assert_eq!(state.scroll_offset(), 0);
+    /// ```
     pub fn scroll_offset(&self) -> usize {
         self.scroll.offset()
     }
 
     /// Returns the maximum number of messages.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ConversationViewState;
+    ///
+    /// let state = ConversationViewState::new();
+    /// assert_eq!(state.max_messages(), 1000);
+    /// ```
     pub fn max_messages(&self) -> usize {
         self.max_messages
     }
@@ -671,31 +762,88 @@ impl ConversationViewState {
     }
 
     /// Returns whether timestamps are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ConversationViewState;
+    ///
+    /// let state = ConversationViewState::new().with_show_timestamps(true);
+    /// assert!(state.show_timestamps());
+    /// ```
     pub fn show_timestamps(&self) -> bool {
         self.show_timestamps
     }
 
     /// Sets whether timestamps are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ConversationViewState;
+    ///
+    /// let mut state = ConversationViewState::new();
+    /// state.set_show_timestamps(true);
+    /// assert!(state.show_timestamps());
+    /// ```
     pub fn set_show_timestamps(&mut self, show: bool) {
         self.show_timestamps = show;
     }
 
     /// Returns whether role labels are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ConversationViewState;
+    ///
+    /// let state = ConversationViewState::new();
+    /// assert!(state.show_role_labels());
+    /// ```
     pub fn show_role_labels(&self) -> bool {
         self.show_role_labels
     }
 
     /// Sets whether role labels are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ConversationViewState;
+    ///
+    /// let mut state = ConversationViewState::new();
+    /// state.set_show_role_labels(false);
+    /// assert!(!state.show_role_labels());
+    /// ```
     pub fn set_show_role_labels(&mut self, show: bool) {
         self.show_role_labels = show;
     }
 
     /// Returns whether auto-scroll is enabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ConversationViewState;
+    ///
+    /// let state = ConversationViewState::new();
+    /// assert!(state.auto_scroll());
+    /// ```
     pub fn auto_scroll(&self) -> bool {
         self.auto_scroll
     }
 
     /// Sets whether auto-scroll is enabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ConversationViewState;
+    ///
+    /// let mut state = ConversationViewState::new();
+    /// state.set_auto_scroll(false);
+    /// assert!(!state.auto_scroll());
+    /// ```
     pub fn set_auto_scroll(&mut self, auto_scroll: bool) {
         self.auto_scroll = auto_scroll;
     }
@@ -725,16 +873,48 @@ impl ConversationViewState {
     }
 
     /// Returns whether a block is collapsed.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ConversationViewState;
+    ///
+    /// let mut state = ConversationViewState::new();
+    /// assert!(!state.is_collapsed("thinking"));
+    /// state.collapse("thinking");
+    /// assert!(state.is_collapsed("thinking"));
+    /// ```
     pub fn is_collapsed(&self, key: &str) -> bool {
         self.collapsed_blocks.contains(key)
     }
 
     /// Collapses a named block.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ConversationViewState;
+    ///
+    /// let mut state = ConversationViewState::new();
+    /// state.collapse("tool-use");
+    /// assert!(state.is_collapsed("tool-use"));
+    /// ```
     pub fn collapse(&mut self, key: &str) {
         self.collapsed_blocks.insert(key.to_string());
     }
 
     /// Expands a named block.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ConversationViewState;
+    ///
+    /// let mut state = ConversationViewState::new();
+    /// state.collapse("thinking");
+    /// state.expand("thinking");
+    /// assert!(!state.is_collapsed("thinking"));
+    /// ```
     pub fn expand(&mut self, key: &str) {
         self.collapsed_blocks.remove(key);
     }

--- a/src/component/conversation_view/types.rs
+++ b/src/component/conversation_view/types.rs
@@ -306,26 +306,71 @@ impl MessageBlock {
     }
 
     /// Returns true if this is a text block.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MessageBlock;
+    ///
+    /// assert!(MessageBlock::text("hello").is_text());
+    /// assert!(!MessageBlock::thinking("thoughts").is_text());
+    /// ```
     pub fn is_text(&self) -> bool {
         matches!(self, Self::Text(_))
     }
 
     /// Returns true if this is a code block.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MessageBlock;
+    ///
+    /// assert!(MessageBlock::code("let x = 1;", Some("rust")).is_code());
+    /// assert!(!MessageBlock::text("hello").is_code());
+    /// ```
     pub fn is_code(&self) -> bool {
         matches!(self, Self::Code { .. })
     }
 
     /// Returns true if this is a tool use block.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MessageBlock;
+    ///
+    /// assert!(MessageBlock::tool_use("search").is_tool_use());
+    /// assert!(!MessageBlock::text("hello").is_tool_use());
+    /// ```
     pub fn is_tool_use(&self) -> bool {
         matches!(self, Self::ToolUse { .. })
     }
 
     /// Returns true if this is a thinking block.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MessageBlock;
+    ///
+    /// assert!(MessageBlock::thinking("reasoning...").is_thinking());
+    /// assert!(!MessageBlock::text("hello").is_thinking());
+    /// ```
     pub fn is_thinking(&self) -> bool {
         matches!(self, Self::Thinking(_))
     }
 
     /// Returns true if this is an error block.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MessageBlock;
+    ///
+    /// assert!(MessageBlock::error("timeout").is_error());
+    /// assert!(!MessageBlock::text("hello").is_error());
+    /// ```
     pub fn is_error(&self) -> bool {
         matches!(self, Self::Error(_))
     }
@@ -445,11 +490,29 @@ impl ConversationMessage {
     }
 
     /// Returns the role of the message sender.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ConversationMessage, ConversationRole};
+    ///
+    /// let msg = ConversationMessage::new(ConversationRole::User, "Hi");
+    /// assert_eq!(*msg.role(), ConversationRole::User);
+    /// ```
     pub fn role(&self) -> &ConversationRole {
         &self.role
     }
 
     /// Returns the content blocks.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ConversationMessage, ConversationRole};
+    ///
+    /// let msg = ConversationMessage::new(ConversationRole::Assistant, "Hello");
+    /// assert_eq!(msg.blocks().len(), 1);
+    /// ```
     pub fn blocks(&self) -> &[MessageBlock] {
         &self.blocks
     }
@@ -487,16 +550,50 @@ impl ConversationMessage {
     }
 
     /// Returns the timestamp if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ConversationMessage, ConversationRole};
+    ///
+    /// let msg = ConversationMessage::new(ConversationRole::User, "Hi");
+    /// assert_eq!(msg.timestamp(), None);
+    ///
+    /// let msg = ConversationMessage::new(ConversationRole::User, "Hi")
+    ///     .with_timestamp("14:30");
+    /// assert_eq!(msg.timestamp(), Some("14:30"));
+    /// ```
     pub fn timestamp(&self) -> Option<&str> {
         self.timestamp.as_deref()
     }
 
     /// Returns whether the message is still being streamed.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ConversationMessage, ConversationRole};
+    ///
+    /// let msg = ConversationMessage::new(ConversationRole::Assistant, "Thinking")
+    ///     .with_streaming(true);
+    /// assert!(msg.is_streaming());
+    /// ```
     pub fn is_streaming(&self) -> bool {
         self.streaming
     }
 
     /// Sets the streaming flag.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ConversationMessage, ConversationRole};
+    ///
+    /// let mut msg = ConversationMessage::new(ConversationRole::Assistant, "Thinking");
+    /// assert!(!msg.is_streaming());
+    /// msg.set_streaming(true);
+    /// assert!(msg.is_streaming());
+    /// ```
     pub fn set_streaming(&mut self, streaming: bool) {
         self.streaming = streaming;
     }

--- a/src/component/data_grid/mod.rs
+++ b/src/component/data_grid/mod.rs
@@ -263,6 +263,25 @@ impl<T: TableRow> DataGridState<T> {
     }
 
     /// Returns the currently selected row index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Column, DataGridState, TableRow};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = DataGridState::new(
+    ///     vec![Item { name: "A".into() }],
+    ///     vec![Column::new("Name", Constraint::Min(10))],
+    /// );
+    /// assert_eq!(state.selected_index(), Some(0));
+    /// ```
     pub fn selected_index(&self) -> Option<usize> {
         self.selected_row
     }
@@ -380,6 +399,25 @@ impl<T: TableRow> DataGridState<T> {
     }
 
     /// Returns the currently selected column index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Column, DataGridState, TableRow};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = DataGridState::new(
+    ///     vec![Item { name: "A".into() }],
+    ///     vec![Column::new("Name", Constraint::Min(10))],
+    /// );
+    /// assert_eq!(state.selected_column(), 0);
+    /// ```
     pub fn selected_column(&self) -> usize {
         self.selected_column
     }
@@ -568,6 +606,26 @@ impl<T: TableRow> DataGridState<T> {
 
 impl<T: TableRow + 'static> DataGridState<T> {
     /// Updates the state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Column, DataGridMessage, DataGridOutput, DataGridState, TableRow};
+    /// use ratatui::layout::Constraint;
+    ///
+    /// #[derive(Clone, Debug, PartialEq)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let mut state = DataGridState::new(
+    ///     vec![Item { name: "A".into() }, Item { name: "B".into() }],
+    ///     vec![Column::new("Name", Constraint::Min(10))],
+    /// );
+    /// let output = state.update(DataGridMessage::Down);
+    /// assert_eq!(output, Some(DataGridOutput::SelectionChanged(1)));
+    /// ```
     pub fn update(&mut self, msg: DataGridMessage) -> Option<DataGridOutput<T>> {
         DataGrid::<T>::update(self, msg)
     }

--- a/src/component/dialog/mod.rs
+++ b/src/component/dialog/mod.rs
@@ -80,11 +80,29 @@ impl DialogButton {
     }
 
     /// Returns the button's unique identifier.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DialogButton;
+    ///
+    /// let button = DialogButton::new("confirm", "Confirm");
+    /// assert_eq!(button.id(), "confirm");
+    /// ```
     pub fn id(&self) -> &str {
         &self.id
     }
 
     /// Returns the button's display label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DialogButton;
+    ///
+    /// let button = DialogButton::new("save", "Save Changes");
+    /// assert_eq!(button.label(), "Save Changes");
+    /// ```
     pub fn label(&self) -> &str {
         &self.label
     }
@@ -356,6 +374,19 @@ impl DialogState {
     /// Sets the dialog buttons.
     ///
     /// Resets focus to the first button or primary button index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{DialogState, DialogButton};
+    ///
+    /// let mut state = DialogState::alert("Info", "Done");
+    /// state.set_buttons(vec![
+    ///     DialogButton::new("yes", "Yes"),
+    ///     DialogButton::new("no", "No"),
+    /// ]);
+    /// assert_eq!(state.buttons().len(), 2);
+    /// ```
     pub fn set_buttons(&mut self, buttons: Vec<DialogButton>) {
         self.buttons = buttons;
         if self.buttons.is_empty() {

--- a/src/component/diff_viewer/mod.rs
+++ b/src/component/diff_viewer/mod.rs
@@ -402,16 +402,43 @@ impl DiffViewerState {
     }
 
     /// Returns a reference to the diff hunks.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let state = DiffViewerState::from_texts("old", "new");
+    /// assert!(!state.hunks().is_empty());
+    /// ```
     pub fn hunks(&self) -> &[DiffHunk] {
         &self.hunks
     }
 
     /// Returns the number of hunks in the diff.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let state = DiffViewerState::from_texts("old line", "new line");
+    /// assert_eq!(state.hunk_count(), 1);
+    /// ```
     pub fn hunk_count(&self) -> usize {
         self.hunks.len()
     }
 
     /// Returns the current hunk index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let state = DiffViewerState::new();
+    /// assert_eq!(state.current_hunk(), 0);
+    /// ```
     pub fn current_hunk(&self) -> usize {
         self.current_hunk
     }
@@ -599,6 +626,15 @@ impl DiffViewerState {
     }
 
     /// Returns the current scroll offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::DiffViewerState;
+    ///
+    /// let state = DiffViewerState::new();
+    /// assert_eq!(state.scroll_offset(), 0);
+    /// ```
     pub fn scroll_offset(&self) -> usize {
         self.scroll.offset()
     }

--- a/src/component/file_browser/mod.rs
+++ b/src/component/file_browser/mod.rs
@@ -180,6 +180,26 @@ impl FileBrowserState {
     }
 
     /// Creates a new file browser with a directory provider.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use std::sync::Arc;
+    /// use envision::component::file_browser::{
+    ///     FileBrowserState, DirectoryProvider, FileEntry,
+    /// };
+    ///
+    /// struct TestProvider;
+    /// impl DirectoryProvider for TestProvider {
+    ///     fn list_entries(&self, _path: &str) -> Vec<FileEntry> {
+    ///         vec![FileEntry::file("main.rs", "/main.rs")]
+    ///     }
+    ///     fn parent_path(&self, _path: &str) -> Option<String> { None }
+    /// }
+    ///
+    /// let state = FileBrowserState::with_provider("/", Arc::new(TestProvider));
+    /// assert_eq!(state.entries().len(), 1);
+    /// ```
     pub fn with_provider(path: impl Into<String>, provider: Arc<dyn DirectoryProvider>) -> Self {
         let path_str = path.into();
         let entries = provider.list_entries(&path_str);
@@ -253,6 +273,19 @@ impl FileBrowserState {
     }
 
     /// Sets whether directories are shown first (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState};
+    ///
+    /// // With directories_first=true (default), directories sort before files.
+    /// let state = FileBrowserState::new("/", vec![
+    ///     FileEntry::file("a.txt", "/a.txt"),
+    ///     FileEntry::directory("src", "/src"),
+    /// ]).with_directories_first(true);
+    /// assert_eq!(state.filtered_entries()[0].name(), "src");
+    /// ```
     pub fn with_directories_first(mut self, directories_first: bool) -> Self {
         self.directories_first = directories_first;
         self.sort_and_filter();
@@ -260,6 +293,15 @@ impl FileBrowserState {
     }
 
     /// Sets whether hidden files are shown (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState};
+    ///
+    /// let state = FileBrowserState::new("/", vec![]).with_show_hidden(true);
+    /// assert!(state.show_hidden());
+    /// ```
     pub fn with_show_hidden(mut self, show: bool) -> Self {
         self.show_hidden = show;
         self.sort_and_filter();
@@ -314,6 +356,18 @@ impl FileBrowserState {
     }
 
     /// Returns the indices of visible (filtered) entries.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState};
+    ///
+    /// let state = FileBrowserState::new("/", vec![
+    ///     FileEntry::file("a.txt", "/a.txt"),
+    ///     FileEntry::file("b.txt", "/b.txt"),
+    /// ]);
+    /// assert_eq!(state.filtered_indices(), &[0, 1]);
+    /// ```
     pub fn filtered_indices(&self) -> &[usize] {
         &self.filtered_indices
     }
@@ -378,6 +432,15 @@ impl FileBrowserState {
     ///
     /// This is an alias for [`selected_index()`](Self::selected_index) that provides a
     /// consistent accessor name across all selection-based components.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState};
+    ///
+    /// let state = FileBrowserState::new("/", vec![FileEntry::file("a.txt", "/a.txt")]);
+    /// assert_eq!(state.selected(), Some(0));
+    /// ```
     pub fn selected(&self) -> Option<usize> {
         self.selected_index()
     }
@@ -386,6 +449,15 @@ impl FileBrowserState {
     ///
     /// This is an alias for [`selected_entry()`](Self::selected_entry) that provides a
     /// consistent accessor name across all selection-based components.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState};
+    ///
+    /// let state = FileBrowserState::new("/", vec![FileEntry::file("notes.txt", "/notes.txt")]);
+    /// assert_eq!(state.selected_item().unwrap().name(), "notes.txt");
+    /// ```
     pub fn selected_item(&self) -> Option<&FileEntry> {
         self.selected_entry()
     }
@@ -448,6 +520,16 @@ impl FileBrowserState {
     }
 
     /// Returns the sort direction.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::{FileEntry, FileBrowserState, FileSortDirection};
+    ///
+    /// let state = FileBrowserState::new("/", vec![])
+    ///     .with_sort_direction(FileSortDirection::Descending);
+    /// assert_eq!(state.sort_direction(), &FileSortDirection::Descending);
+    /// ```
     pub fn sort_direction(&self) -> &FileSortDirection {
         &self.sort_direction
     }

--- a/src/component/flame_graph/mod.rs
+++ b/src/component/flame_graph/mod.rs
@@ -540,6 +540,20 @@ impl FlameGraphState {
     /// Moves selection up to parent depth.
     ///
     /// Returns true if the selection changed.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{FlameGraphState, FlameNode};
+    ///
+    /// let root = FlameNode::new("main()", 500)
+    ///     .with_child(FlameNode::new("compute()", 300));
+    /// let mut state = FlameGraphState::with_root(root);
+    /// state.select_down();
+    /// assert_eq!(state.selected_depth(), 1);
+    /// assert!(state.select_up());
+    /// assert_eq!(state.selected_depth(), 0);
+    /// ```
     pub fn select_up(&mut self) -> bool {
         if self.root.is_none() {
             return false;
@@ -561,6 +575,18 @@ impl FlameGraphState {
     /// at the next depth level.
     ///
     /// Returns true if the selection changed.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{FlameGraphState, FlameNode};
+    ///
+    /// let root = FlameNode::new("main()", 500)
+    ///     .with_child(FlameNode::new("compute()", 300));
+    /// let mut state = FlameGraphState::with_root(root);
+    /// assert!(state.select_down());
+    /// assert_eq!(state.selected_depth(), 1);
+    /// ```
     pub fn select_down(&mut self) -> bool {
         let view_root = match self.current_view_root() {
             Some(r) => r,
@@ -595,6 +621,22 @@ impl FlameGraphState {
     /// Moves selection to the previous sibling at the current depth.
     ///
     /// Returns true if the selection changed.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{FlameGraphState, FlameNode};
+    ///
+    /// let root = FlameNode::new("main()", 500)
+    ///     .with_child(FlameNode::new("a()", 200))
+    ///     .with_child(FlameNode::new("b()", 300));
+    /// let mut state = FlameGraphState::with_root(root);
+    /// state.select_down();
+    /// state.select_right();
+    /// assert_eq!(state.selected_index(), 1);
+    /// assert!(state.select_left());
+    /// assert_eq!(state.selected_index(), 0);
+    /// ```
     pub fn select_left(&mut self) -> bool {
         if self.root.is_none() {
             return false;
@@ -610,6 +652,21 @@ impl FlameGraphState {
     /// Moves selection to the next sibling at the current depth.
     ///
     /// Returns true if the selection changed.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{FlameGraphState, FlameNode};
+    ///
+    /// let root = FlameNode::new("main()", 500)
+    ///     .with_child(FlameNode::new("a()", 200))
+    ///     .with_child(FlameNode::new("b()", 300));
+    /// let mut state = FlameGraphState::with_root(root);
+    /// state.select_down();
+    /// assert_eq!(state.selected_index(), 0);
+    /// assert!(state.select_right());
+    /// assert_eq!(state.selected_index(), 1);
+    /// ```
     pub fn select_right(&mut self) -> bool {
         let view_root = match self.current_view_root() {
             Some(r) => r,
@@ -627,6 +684,18 @@ impl FlameGraphState {
     // ---- Instance methods ----
 
     /// Updates the state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{FlameGraphMessage, FlameGraphOutput, FlameGraphState, FlameNode};
+    ///
+    /// let root = FlameNode::new("main()", 500)
+    ///     .with_child(FlameNode::new("compute()", 300));
+    /// let mut state = FlameGraphState::with_root(root);
+    /// let output = state.update(FlameGraphMessage::SelectDown);
+    /// assert!(matches!(output, Some(FlameGraphOutput::FrameSelected { .. })));
+    /// ```
     pub fn update(&mut self, msg: FlameGraphMessage) -> Option<FlameGraphOutput> {
         FlameGraph::update(self, msg)
     }

--- a/src/component/gauge/mod.rs
+++ b/src/component/gauge/mod.rs
@@ -327,21 +327,59 @@ impl GaugeState {
     }
 
     /// Returns the current value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::GaugeState;
+    ///
+    /// let state = GaugeState::new(42.0, 100.0);
+    /// assert_eq!(state.value(), 42.0);
+    /// ```
     pub fn value(&self) -> f64 {
         self.value
     }
 
     /// Returns the maximum value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::GaugeState;
+    ///
+    /// let state = GaugeState::new(0.0, 200.0);
+    /// assert_eq!(state.max(), 200.0);
+    /// ```
     pub fn max(&self) -> f64 {
         self.max
     }
 
     /// Sets the current value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::GaugeState;
+    ///
+    /// let mut state = GaugeState::new(0.0, 100.0);
+    /// state.set_value(60.0);
+    /// assert_eq!(state.value(), 60.0);
+    /// ```
     pub fn set_value(&mut self, value: f64) {
         self.value = value;
     }
 
     /// Sets the maximum value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::GaugeState;
+    ///
+    /// let mut state = GaugeState::new(50.0, 100.0);
+    /// state.set_max(200.0);
+    /// assert_eq!(state.max(), 200.0);
+    /// ```
     pub fn set_max(&mut self, max: f64) {
         self.max = max;
     }
@@ -472,6 +510,16 @@ impl GaugeState {
     /// Maps an event to a gauge message, if applicable.
     ///
     /// Since Gauge is display-only, this always returns `None`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::GaugeState;
+    /// use envision::input::Event;
+    ///
+    /// let state = GaugeState::new(50.0, 100.0);
+    /// assert!(state.handle_event(&Event::char('k')).is_none());
+    /// ```
     pub fn handle_event(&self, event: &crate::input::Event) -> Option<GaugeMessage> {
         Gauge::handle_event(self, event, &EventContext::default())
     }
@@ -479,6 +527,16 @@ impl GaugeState {
     /// Dispatches an event, updating state and returning any output.
     ///
     /// Since Gauge is display-only, this always returns `None`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::GaugeState;
+    /// use envision::input::Event;
+    ///
+    /// let mut state = GaugeState::new(50.0, 100.0);
+    /// assert!(state.dispatch_event(&Event::char('k')).is_none());
+    /// ```
     pub fn dispatch_event(&mut self, event: &crate::input::Event) -> Option<GaugeOutput> {
         Gauge::dispatch_event(self, event, &EventContext::default())
     }

--- a/src/component/heatmap/mod.rs
+++ b/src/component/heatmap/mod.rs
@@ -523,21 +523,63 @@ impl HeatmapState {
     }
 
     /// Returns the row labels.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HeatmapState;
+    ///
+    /// let state = HeatmapState::new(2, 3)
+    ///     .with_row_labels(vec!["Row A".into(), "Row B".into()]);
+    /// assert_eq!(state.row_labels(), &["Row A", "Row B"]);
+    /// ```
     pub fn row_labels(&self) -> &[String] {
         &self.row_labels
     }
 
     /// Returns the column labels.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HeatmapState;
+    ///
+    /// let state = HeatmapState::new(2, 3)
+    ///     .with_col_labels(vec!["Mon".into(), "Tue".into(), "Wed".into()]);
+    /// assert_eq!(state.col_labels(), &["Mon", "Tue", "Wed"]);
+    /// ```
     pub fn col_labels(&self) -> &[String] {
         &self.col_labels
     }
 
     /// Returns the color scale.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{HeatmapState, HeatmapColorScale};
+    ///
+    /// let state = HeatmapState::new(2, 2)
+    ///     .with_color_scale(HeatmapColorScale::BlueToRed);
+    /// assert_eq!(state.color_scale(), &HeatmapColorScale::BlueToRed);
+    /// ```
     pub fn color_scale(&self) -> &HeatmapColorScale {
         &self.color_scale
     }
 
     /// Returns the title, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HeatmapState;
+    ///
+    /// let state = HeatmapState::new(2, 2).with_title("Error Rates");
+    /// assert_eq!(state.title(), Some("Error Rates"));
+    ///
+    /// let no_title = HeatmapState::new(2, 2);
+    /// assert_eq!(no_title.title(), None);
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
@@ -558,6 +600,15 @@ impl HeatmapState {
     }
 
     /// Returns whether values are shown in cells.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HeatmapState;
+    ///
+    /// let state = HeatmapState::new(2, 2).with_show_values(true);
+    /// assert!(state.show_values());
+    /// ```
     pub fn show_values(&self) -> bool {
         self.show_values
     }
@@ -580,6 +631,16 @@ impl HeatmapState {
     // ---- Instance methods ----
 
     /// Updates the state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{HeatmapMessage, HeatmapOutput, HeatmapState};
+    ///
+    /// let mut state = HeatmapState::new(3, 3);
+    /// let output = state.update(HeatmapMessage::SelectDown);
+    /// assert_eq!(output, Some(HeatmapOutput::SelectionChanged { row: 1, col: 0 }));
+    /// ```
     pub fn update(&mut self, msg: HeatmapMessage) -> Option<HeatmapOutput> {
         Heatmap::update(self, msg)
     }

--- a/src/component/help_panel/mod.rs
+++ b/src/component/help_panel/mod.rs
@@ -87,11 +87,29 @@ impl KeyBinding {
     }
 
     /// Returns the key string.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyBinding;
+    ///
+    /// let binding = KeyBinding::new("Ctrl+S", "Save");
+    /// assert_eq!(binding.key(), "Ctrl+S");
+    /// ```
     pub fn key(&self) -> &str {
         &self.key
     }
 
     /// Returns the description.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyBinding;
+    ///
+    /// let binding = KeyBinding::new("q", "Quit");
+    /// assert_eq!(binding.description(), "Quit");
+    /// ```
     pub fn description(&self) -> &str {
         &self.description
     }
@@ -148,11 +166,29 @@ impl KeyBindingGroup {
     }
 
     /// Returns the group title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{KeyBinding, KeyBindingGroup};
+    ///
+    /// let group = KeyBindingGroup::new("Navigation", vec![]);
+    /// assert_eq!(group.title(), "Navigation");
+    /// ```
     pub fn title(&self) -> &str {
         &self.title
     }
 
     /// Returns the bindings in this group.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{KeyBinding, KeyBindingGroup};
+    ///
+    /// let group = KeyBindingGroup::new("General", vec![KeyBinding::new("q", "Quit")]);
+    /// assert_eq!(group.bindings().len(), 1);
+    /// ```
     pub fn bindings(&self) -> &[KeyBinding] {
         &self.bindings
     }

--- a/src/component/histogram/mod.rs
+++ b/src/component/histogram/mod.rs
@@ -469,26 +469,73 @@ impl HistogramState {
     }
 
     /// Returns the effective number of bins.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HistogramState;
+    ///
+    /// let state = HistogramState::new().with_bin_count(15);
+    /// assert_eq!(state.bin_count(), 15);
+    /// ```
     pub fn bin_count(&self) -> usize {
         self.bin_method.compute_bin_count(&self.data)
     }
 
     /// Sets the number of bins (convenience, sets `Fixed` method).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HistogramState;
+    ///
+    /// let mut state = HistogramState::new();
+    /// state.set_bin_count(25);
+    /// assert_eq!(state.bin_count(), 25);
+    /// ```
     pub fn set_bin_count(&mut self, count: usize) {
         self.bin_method = BinMethod::Fixed(count.max(1));
     }
 
     /// Returns the current binning method.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{BinMethod, HistogramState};
+    ///
+    /// let state = HistogramState::new();
+    /// assert_eq!(state.bin_method(), &BinMethod::Fixed(10));
+    /// ```
     pub fn bin_method(&self) -> &BinMethod {
         &self.bin_method
     }
 
     /// Sets the binning method.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{BinMethod, HistogramState};
+    ///
+    /// let mut state = HistogramState::new();
+    /// state.set_bin_method(BinMethod::Sturges);
+    /// assert_eq!(state.bin_method(), &BinMethod::Sturges);
+    /// ```
     pub fn set_bin_method(&mut self, method: BinMethod) {
         self.bin_method = method;
     }
 
     /// Returns the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HistogramState;
+    ///
+    /// let state = HistogramState::new().with_title("Distribution");
+    /// assert_eq!(state.title(), Some("Distribution"));
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
@@ -509,16 +556,44 @@ impl HistogramState {
     }
 
     /// Returns the x-axis label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HistogramState;
+    ///
+    /// let state = HistogramState::new().with_x_label("Value");
+    /// assert_eq!(state.x_label(), Some("Value"));
+    /// ```
     pub fn x_label(&self) -> Option<&str> {
         self.x_label.as_deref()
     }
 
     /// Returns the y-axis label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HistogramState;
+    ///
+    /// let state = HistogramState::new().with_y_label("Count");
+    /// assert_eq!(state.y_label(), Some("Count"));
+    /// ```
     pub fn y_label(&self) -> Option<&str> {
         self.y_label.as_deref()
     }
 
     /// Returns the bar color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HistogramState;
+    /// use ratatui::style::Color;
+    ///
+    /// let state = HistogramState::new().with_color(Color::Green);
+    /// assert_eq!(state.color(), Some(Color::Green));
+    /// ```
     pub fn color(&self) -> Option<Color> {
         self.color
     }
@@ -540,6 +615,15 @@ impl HistogramState {
     }
 
     /// Returns whether count labels are shown on bars.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HistogramState;
+    ///
+    /// let state = HistogramState::new().with_show_counts(true);
+    /// assert!(state.show_counts());
+    /// ```
     pub fn show_counts(&self) -> bool {
         self.show_counts
     }
@@ -678,16 +762,50 @@ impl HistogramState {
     // ---- Instance methods ----
 
     /// Maps an input event to a histogram message.
+    ///
+    /// The histogram is display-only; this always returns `None`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HistogramState;
+    /// use envision::input::Event;
+    ///
+    /// let state = HistogramState::new();
+    /// assert!(state.handle_event(&Event::key(envision::input::Key::Enter)).is_none());
+    /// ```
     pub fn handle_event(&self, event: &Event) -> Option<HistogramMessage> {
         Histogram::handle_event(self, event, &EventContext::default())
     }
 
     /// Dispatches an event, updating state and returning any output.
+    ///
+    /// The histogram is display-only; this always returns `None`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::HistogramState;
+    /// use envision::input::Event;
+    ///
+    /// let mut state = HistogramState::new();
+    /// assert!(state.dispatch_event(&Event::key(envision::input::Key::Enter)).is_none());
+    /// ```
     pub fn dispatch_event(&mut self, event: &Event) -> Option<()> {
         Histogram::dispatch_event(self, event, &EventContext::default())
     }
 
     /// Updates the state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{HistogramState, HistogramMessage};
+    ///
+    /// let mut state = HistogramState::new();
+    /// state.update(HistogramMessage::PushData(42.0));
+    /// assert_eq!(state.data(), &[42.0]);
+    /// ```
     pub fn update(&mut self, msg: HistogramMessage) -> Option<()> {
         Histogram::update(self, msg)
     }

--- a/src/component/key_hints/mod.rs
+++ b/src/component/key_hints/mod.rs
@@ -129,21 +129,57 @@ impl KeyHint {
     }
 
     /// Returns the key string.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHint;
+    ///
+    /// let hint = KeyHint::new("Ctrl+S", "Save");
+    /// assert_eq!(hint.key(), "Ctrl+S");
+    /// ```
     pub fn key(&self) -> &str {
         &self.key
     }
 
     /// Returns the action description.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHint;
+    ///
+    /// let hint = KeyHint::new("Enter", "Select");
+    /// assert_eq!(hint.action(), "Select");
+    /// ```
     pub fn action(&self) -> &str {
         &self.action
     }
 
     /// Returns whether the hint is enabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHint;
+    ///
+    /// let hint = KeyHint::new("q", "Quit");
+    /// assert!(hint.is_enabled()); // enabled by default
+    /// ```
     pub fn is_enabled(&self) -> bool {
         self.enabled
     }
 
     /// Returns the priority value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHint;
+    ///
+    /// let hint = KeyHint::new("q", "Quit").with_priority(5);
+    /// assert_eq!(hint.priority(), 5);
+    /// ```
     pub fn priority(&self) -> u8 {
         self.priority
     }
@@ -469,16 +505,43 @@ impl KeyHintsState {
     }
 
     /// Returns the layout style.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{KeyHintsState, KeyHintsLayout};
+    ///
+    /// let state = KeyHintsState::new().with_layout(KeyHintsLayout::Spaced);
+    /// assert_eq!(state.layout(), KeyHintsLayout::Spaced);
+    /// ```
     pub fn layout(&self) -> KeyHintsLayout {
         self.layout
     }
 
     /// Returns the number of hints.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHintsState;
+    ///
+    /// let state = KeyHintsState::new().hint("q", "Quit").hint("Enter", "Select");
+    /// assert_eq!(state.len(), 2);
+    /// ```
     pub fn len(&self) -> usize {
         self.hints.len()
     }
 
     /// Returns true if there are no hints.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::KeyHintsState;
+    ///
+    /// let state = KeyHintsState::new();
+    /// assert!(state.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.hints.is_empty()
     }

--- a/src/component/loading_list/items.rs
+++ b/src/component/loading_list/items.rs
@@ -100,6 +100,19 @@ impl ItemState {
     }
 
     /// Returns the style for this state using the theme.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ItemState;
+    /// use envision::Theme;
+    ///
+    /// let theme = Theme::default();
+    /// let ready_style = ItemState::Ready.style(&theme);
+    /// let loading_style = ItemState::Loading.style(&theme);
+    /// // Styles are non-equal for ready vs loading states
+    /// assert_ne!(ready_style, loading_style);
+    /// ```
     pub fn style(&self, theme: &Theme) -> Style {
         match self {
             Self::Ready => theme.normal_style(),
@@ -194,6 +207,16 @@ impl<T: Clone> LoadingListItem<T> {
     }
 
     /// Sets the label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListItem;
+    ///
+    /// let mut item = LoadingListItem::new("data", "Old Name");
+    /// item.set_label("New Name");
+    /// assert_eq!(item.label(), "New Name");
+    /// ```
     pub fn set_label(&mut self, label: impl Into<String>) {
         self.label = label.into();
     }
@@ -228,16 +251,47 @@ impl<T: Clone> LoadingListItem<T> {
     }
 
     /// Returns true if the item is loading.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ItemState, LoadingListItem};
+    ///
+    /// let mut item = LoadingListItem::new("data", "Task");
+    /// assert!(!item.is_loading());
+    /// item.set_state(ItemState::Loading);
+    /// assert!(item.is_loading());
+    /// ```
     pub fn is_loading(&self) -> bool {
         self.state.is_loading()
     }
 
     /// Returns true if the item has an error.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ItemState, LoadingListItem};
+    ///
+    /// let mut item = LoadingListItem::new("data", "Task");
+    /// assert!(!item.is_error());
+    /// item.set_state(ItemState::Error("failed".into()));
+    /// assert!(item.is_error());
+    /// ```
     pub fn is_error(&self) -> bool {
         self.state.is_error()
     }
 
     /// Returns true if the item is ready.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ItemState, LoadingListItem};
+    ///
+    /// let item = LoadingListItem::new("data", "Task");
+    /// assert!(item.is_ready());
+    /// ```
     pub fn is_ready(&self) -> bool {
         self.state.is_ready()
     }

--- a/src/component/loading_list/mod.rs
+++ b/src/component/loading_list/mod.rs
@@ -276,6 +276,19 @@ impl<T: Clone> LoadingListState<T> {
     }
 
     /// Returns a mutable reference to all items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let mut state = LoadingListState::with_items(
+    ///     vec!["a".to_string()],
+    ///     |s| s.clone(),
+    /// );
+    /// state.items_mut()[0].set_label("updated");
+    /// assert_eq!(state.get(0).unwrap().label(), "updated");
+    /// ```
     pub fn items_mut(&mut self) -> &mut Vec<LoadingListItem<T>> {
         &mut self.items
     }
@@ -329,6 +342,18 @@ impl<T: Clone> LoadingListState<T> {
     }
 
     /// Alias for [`selected_index()`](Self::selected_index).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let state = LoadingListState::with_items(
+    ///     vec!["a".to_string()],
+    ///     |s| s.clone(),
+    /// ).with_selected(0);
+    /// assert_eq!(state.selected(), Some(0));
+    /// ```
     pub fn selected(&self) -> Option<usize> {
         self.selected_index()
     }
@@ -359,21 +384,74 @@ impl<T: Clone> LoadingListState<T> {
     }
 
     /// Returns the selected item's data.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let state = LoadingListState::with_items(
+    ///     vec!["hello".to_string()],
+    ///     |s| s.clone(),
+    /// ).with_selected(0);
+    /// assert_eq!(state.selected_data(), Some(&"hello".to_string()));
+    /// ```
     pub fn selected_data(&self) -> Option<&T> {
         self.selected_item().map(|item| item.data())
     }
 
     /// Sets the selected index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let mut state = LoadingListState::with_items(
+    ///     vec!["a".to_string(), "b".to_string()],
+    ///     |s| s.clone(),
+    /// );
+    /// state.set_selected(Some(1));
+    /// assert_eq!(state.selected_index(), Some(1));
+    /// ```
     pub fn set_selected(&mut self, index: Option<usize>) {
         self.selected = index.map(|i| i.min(self.items.len().saturating_sub(1)));
     }
 
     /// Returns an item by index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let state = LoadingListState::with_items(
+    ///     vec!["first".to_string()],
+    ///     |s| s.clone(),
+    /// );
+    /// assert_eq!(state.get(0).unwrap().label(), "first");
+    /// assert!(state.get(99).is_none());
+    /// ```
     pub fn get(&self, index: usize) -> Option<&LoadingListItem<T>> {
         self.items.get(index)
     }
 
     /// Returns a mutable item by index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let mut state = LoadingListState::with_items(
+    ///     vec!["task".to_string()],
+    ///     |s| s.clone(),
+    /// );
+    /// if let Some(item) = state.get_mut(0) {
+    ///     item.set_label("updated");
+    /// }
+    /// assert_eq!(state.get(0).unwrap().label(), "updated");
+    /// ```
     pub fn get_mut(&mut self, index: usize) -> Option<&mut LoadingListItem<T>> {
         self.items.get_mut(index)
     }
@@ -402,6 +480,20 @@ impl<T: Clone> LoadingListState<T> {
     }
 
     /// Sets the ready state for an item.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{LoadingListState, ItemState};
+    ///
+    /// let mut state = LoadingListState::with_items(
+    ///     vec!["item".to_string()],
+    ///     |s| s.clone(),
+    /// );
+    /// state.set_loading(0);
+    /// state.set_ready(0);
+    /// assert!(!state.has_loading());
+    /// ```
     pub fn set_ready(&mut self, index: usize) {
         if let Some(item) = self.items.get_mut(index) {
             item.state = ItemState::Ready;
@@ -409,6 +501,19 @@ impl<T: Clone> LoadingListState<T> {
     }
 
     /// Sets the error state for an item.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let mut state = LoadingListState::with_items(
+    ///     vec!["item".to_string()],
+    ///     |s| s.clone(),
+    /// );
+    /// state.set_error(0, "Connection refused");
+    /// assert!(state.has_errors());
+    /// ```
     pub fn set_error(&mut self, index: usize, message: impl Into<String>) {
         if let Some(item) = self.items.get_mut(index) {
             item.state = ItemState::Error(message.into());
@@ -465,6 +570,20 @@ impl<T: Clone> LoadingListState<T> {
     }
 
     /// Returns true if any item is loading.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let mut state = LoadingListState::with_items(
+    ///     vec!["item".to_string()],
+    ///     |s| s.clone(),
+    /// );
+    /// assert!(!state.has_loading());
+    /// state.set_loading(0);
+    /// assert!(state.has_loading());
+    /// ```
     pub fn has_loading(&self) -> bool {
         self.items.iter().any(|i| i.is_loading())
     }
@@ -535,11 +654,30 @@ impl<T: Clone> LoadingListState<T> {
     }
 
     /// Sets whether to show indicators.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let mut state = LoadingListState::<String>::new();
+    /// state.set_show_indicators(false);
+    /// assert!(!state.show_indicators());
+    /// ```
     pub fn set_show_indicators(&mut self, show: bool) {
         self.show_indicators = show;
     }
 
     /// Returns the current spinner frame.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let state = LoadingListState::<String>::new();
+    /// assert_eq!(state.spinner_frame(), 0);
+    /// ```
     pub fn spinner_frame(&self) -> usize {
         self.spinner_frame
     }
@@ -568,6 +706,19 @@ impl<T: Clone> LoadingListState<T> {
 
 impl<T: Clone + 'static> LoadingListState<T> {
     /// Updates the loading list state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{LoadingListState, LoadingListMessage, LoadingListOutput, ItemState};
+    ///
+    /// let mut state = LoadingListState::with_items(
+    ///     vec!["task".to_string()],
+    ///     |s| s.clone(),
+    /// );
+    /// let output = state.update(LoadingListMessage::SetLoading(0));
+    /// assert!(matches!(output, Some(LoadingListOutput::ItemStateChanged { state: ItemState::Loading, .. })));
+    /// ```
     pub fn update(&mut self, msg: LoadingListMessage<T>) -> Option<LoadingListOutput<T>> {
         LoadingList::update(self, msg)
     }

--- a/src/component/log_correlation/mod.rs
+++ b/src/component/log_correlation/mod.rs
@@ -63,6 +63,16 @@ pub enum CorrelationLevel {
 
 impl CorrelationLevel {
     /// Returns the display color for this severity level.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CorrelationLevel;
+    /// use ratatui::prelude::Color;
+    ///
+    /// assert_eq!(CorrelationLevel::Error.color(), Color::Red);
+    /// assert_eq!(CorrelationLevel::Info.color(), Color::Blue);
+    /// ```
     pub fn color(&self) -> Color {
         match self {
             CorrelationLevel::Debug => Color::DarkGray,
@@ -73,6 +83,15 @@ impl CorrelationLevel {
     }
 
     /// Returns the short label for this severity level.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CorrelationLevel;
+    ///
+    /// assert_eq!(CorrelationLevel::Warning.label(), "WRN");
+    /// assert_eq!(CorrelationLevel::Debug.label(), "DBG");
+    /// ```
     pub fn label(&self) -> &'static str {
         match self {
             CorrelationLevel::Debug => "DBG",

--- a/src/component/markdown_renderer/mod.rs
+++ b/src/component/markdown_renderer/mod.rs
@@ -212,6 +212,16 @@ impl MarkdownRendererState {
     }
 
     /// Sets the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MarkdownRendererState;
+    ///
+    /// let mut state = MarkdownRendererState::new();
+    /// state.set_title(Some("Document".to_string()));
+    /// assert_eq!(state.title(), Some("Document"));
+    /// ```
     pub fn set_title(&mut self, title: Option<String>) {
         self.title = title;
     }
@@ -233,6 +243,16 @@ impl MarkdownRendererState {
     }
 
     /// Sets whether to show raw source.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MarkdownRendererState;
+    ///
+    /// let mut state = MarkdownRendererState::new();
+    /// state.set_show_source(true);
+    /// assert!(state.show_source());
+    /// ```
     pub fn set_show_source(&mut self, show: bool) {
         self.show_source = show;
     }
@@ -254,6 +274,17 @@ impl MarkdownRendererState {
     }
 
     /// Sets the scroll offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MarkdownRendererState;
+    ///
+    /// let mut state = MarkdownRendererState::new()
+    ///     .with_source("line1\nline2\nline3\nline4\nline5");
+    /// state.set_scroll_offset(2);
+    /// assert_eq!(state.scroll_offset(), 2);
+    /// ```
     pub fn set_scroll_offset(&mut self, offset: usize) {
         self.scroll.set_offset(offset);
     }

--- a/src/component/multi_progress/mod.rs
+++ b/src/component/multi_progress/mod.rs
@@ -392,6 +392,16 @@ impl MultiProgressState {
     }
 
     /// Sets the maximum visible items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let mut state = MultiProgressState::new();
+    /// state.set_max_visible(5);
+    /// assert_eq!(state.max_visible(), 5);
+    /// ```
     pub fn set_max_visible(&mut self, max: usize) {
         self.max_visible = max;
     }
@@ -411,16 +421,48 @@ impl MultiProgressState {
     }
 
     /// Returns the currently selected item index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let mut state = MultiProgressState::new();
+    /// state.add("t1", "Task 1");
+    /// assert_eq!(state.selected(), Some(0));
+    /// ```
     pub fn selected(&self) -> Option<usize> {
         self.selected
     }
 
     /// Returns a reference to the currently selected item.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let mut state = MultiProgressState::new();
+    /// state.add("t1", "Task 1");
+    /// assert_eq!(state.selected_item().unwrap().label(), "Task 1");
+    /// ```
     pub fn selected_item(&self) -> Option<&ProgressItem> {
         self.selected.and_then(|i| self.items.get(i))
     }
 
     /// Sets the selected item index. Clamped to valid range.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MultiProgressState;
+    ///
+    /// let mut state = MultiProgressState::new();
+    /// state.add("t1", "Task 1");
+    /// state.add("t2", "Task 2");
+    /// state.set_selected(Some(1));
+    /// assert_eq!(state.selected(), Some(1));
+    /// ```
     pub fn set_selected(&mut self, index: Option<usize>) {
         self.selected = index.map(|i| i.min(self.items.len().saturating_sub(1)));
     }
@@ -535,6 +577,19 @@ impl MultiProgressState {
     }
 
     /// Updates the multi-progress state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{MultiProgressMessage, MultiProgressOutput, MultiProgressState};
+    ///
+    /// let mut state = MultiProgressState::default();
+    /// let output = state.update(MultiProgressMessage::Add {
+    ///     id: "task1".to_string(),
+    ///     label: "Task 1".to_string(),
+    /// });
+    /// assert_eq!(output, Some(MultiProgressOutput::Added("task1".to_string())));
+    /// ```
     pub fn update(&mut self, msg: MultiProgressMessage) -> Option<MultiProgressOutput> {
         MultiProgress::update(self, msg)
     }

--- a/src/component/number_input/mod.rs
+++ b/src/component/number_input/mod.rs
@@ -293,21 +293,60 @@ impl NumberInputState {
     }
 
     /// Returns true if the component is in text edit mode.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{NumberInputState, NumberInputMessage, NumberInput, Component};
+    ///
+    /// let mut state = NumberInputState::new(0.0);
+    /// assert!(!state.is_editing());
+    /// NumberInput::update(&mut state, NumberInputMessage::StartEdit);
+    /// assert!(state.is_editing());
+    /// ```
     pub fn is_editing(&self) -> bool {
         self.editing
     }
 
     /// Returns the current edit buffer contents.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{NumberInputState, NumberInputMessage, NumberInput, Component};
+    ///
+    /// let mut state = NumberInputState::new(42.0);
+    /// NumberInput::update(&mut state, NumberInputMessage::StartEdit);
+    /// assert_eq!(state.edit_buffer(), "42");
+    /// ```
     pub fn edit_buffer(&self) -> &str {
         &self.edit_buffer
     }
 
     /// Returns the label, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::NumberInputState;
+    ///
+    /// let state = NumberInputState::new(0.0).with_label("Speed");
+    /// assert_eq!(state.label(), Some("Speed"));
+    /// ```
     pub fn label(&self) -> Option<&str> {
         self.label.as_deref()
     }
 
     /// Returns the placeholder, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::NumberInputState;
+    ///
+    /// let state = NumberInputState::new(0.0).with_placeholder("Enter value");
+    /// assert_eq!(state.placeholder(), Some("Enter value"));
+    /// ```
     pub fn placeholder(&self) -> Option<&str> {
         self.placeholder.as_deref()
     }
@@ -328,21 +367,57 @@ impl NumberInputState {
     }
 
     /// Returns the step size.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::NumberInputState;
+    ///
+    /// let state = NumberInputState::new(0.0).with_step(0.5);
+    /// assert_eq!(state.step(), 0.5);
+    /// ```
     pub fn step(&self) -> f64 {
         self.step
     }
 
     /// Returns the precision (decimal places).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::NumberInputState;
+    ///
+    /// let state = NumberInputState::new(0.0).with_precision(2);
+    /// assert_eq!(state.precision(), 2);
+    /// ```
     pub fn precision(&self) -> usize {
         self.precision
     }
 
     /// Returns the minimum bound, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::NumberInputState;
+    ///
+    /// let state = NumberInputState::new(0.0).with_min(0.0);
+    /// assert_eq!(state.min(), Some(0.0));
+    /// ```
     pub fn min(&self) -> Option<f64> {
         self.min
     }
 
     /// Returns the maximum bound, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::NumberInputState;
+    ///
+    /// let state = NumberInputState::new(0.0).with_max(100.0);
+    /// assert_eq!(state.max(), Some(100.0));
+    /// ```
     pub fn max(&self) -> Option<f64> {
         self.max
     }

--- a/src/component/paginator/mod.rs
+++ b/src/component/paginator/mod.rs
@@ -286,21 +286,57 @@ impl PaginatorState {
     }
 
     /// Returns the total number of pages.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::PaginatorState;
+    ///
+    /// let state = PaginatorState::new(12);
+    /// assert_eq!(state.total_pages(), 12);
+    /// ```
     pub fn total_pages(&self) -> usize {
         self.total_pages
     }
 
     /// Returns the total number of items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::PaginatorState;
+    ///
+    /// let state = PaginatorState::from_items(247, 25);
+    /// assert_eq!(state.total_items(), 247);
+    /// ```
     pub fn total_items(&self) -> usize {
         self.total_items
     }
 
     /// Returns the page size (items per page).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::PaginatorState;
+    ///
+    /// let state = PaginatorState::from_items(100, 20);
+    /// assert_eq!(state.page_size(), 20);
+    /// ```
     pub fn page_size(&self) -> usize {
         self.page_size
     }
 
     /// Returns the display style.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{PaginatorState, PaginatorStyle};
+    ///
+    /// let state = PaginatorState::new(5).with_style(PaginatorStyle::Compact);
+    /// assert_eq!(state.style(), &PaginatorStyle::Compact);
+    /// ```
     pub fn style(&self) -> &PaginatorStyle {
         &self.style
     }

--- a/src/component/pane_layout/mod.rs
+++ b/src/component/pane_layout/mod.rs
@@ -171,11 +171,29 @@ impl PaneConfig {
     }
 
     /// Returns the pane ID.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::PaneConfig;
+    ///
+    /// let pane = PaneConfig::new("main");
+    /// assert_eq!(pane.id(), "main");
+    /// ```
     pub fn id(&self) -> &str {
         &self.id
     }
 
     /// Returns the pane title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::PaneConfig;
+    ///
+    /// let pane = PaneConfig::new("sidebar").with_title("Files");
+    /// assert_eq!(pane.title(), Some("Files"));
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
@@ -196,11 +214,29 @@ impl PaneConfig {
     }
 
     /// Returns the pane proportion.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::PaneConfig;
+    ///
+    /// let pane = PaneConfig::new("main").with_proportion(0.6);
+    /// assert!((pane.proportion() - 0.6).abs() < f32::EPSILON);
+    /// ```
     pub fn proportion(&self) -> f32 {
         self.proportion
     }
 
     /// Returns the minimum size.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::PaneConfig;
+    ///
+    /// let pane = PaneConfig::new("sidebar").with_min_size(15);
+    /// assert_eq!(pane.min_size(), 15);
+    /// ```
     pub fn min_size(&self) -> u16 {
         self.min_size
     }
@@ -221,6 +257,17 @@ impl PaneConfig {
     }
 
     /// Returns the maximum size.
+    ///
+    /// A value of 0 means no maximum.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::pane_layout::PaneConfig;
+    ///
+    /// let pane = PaneConfig::new("sidebar").with_max_size(80);
+    /// assert_eq!(pane.max_size(), 80);
+    /// ```
     pub fn max_size(&self) -> u16 {
         self.max_size
     }

--- a/src/component/progress_bar/mod.rs
+++ b/src/component/progress_bar/mod.rs
@@ -169,6 +169,15 @@ impl ProgressBarState {
     }
 
     /// Returns the progress as a percentage (0 to 100).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressBarState;
+    ///
+    /// let state = ProgressBarState::with_progress(0.75);
+    /// assert_eq!(state.percentage(), 75);
+    /// ```
     pub fn percentage(&self) -> u16 {
         (self.progress * 100.0).round() as u16
     }
@@ -336,16 +345,43 @@ impl ProgressBarState {
     }
 
     /// Returns whether the percentage is shown in the label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressBarState;
+    ///
+    /// let state = ProgressBarState::new();
+    /// assert!(state.show_percentage()); // enabled by default
+    /// ```
     pub fn show_percentage(&self) -> bool {
         self.show_percentage
     }
 
     /// Returns whether the ETA is shown in the label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressBarState;
+    ///
+    /// let state = ProgressBarState::new();
+    /// assert!(state.show_eta()); // enabled by default
+    /// ```
     pub fn show_eta(&self) -> bool {
         self.show_eta
     }
 
     /// Returns whether the rate is shown in the label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressBarState;
+    ///
+    /// let state = ProgressBarState::new();
+    /// assert!(state.show_rate()); // enabled by default
+    /// ```
     pub fn show_rate(&self) -> bool {
         self.show_rate
     }

--- a/src/component/radio_group/mod.rs
+++ b/src/component/radio_group/mod.rs
@@ -272,6 +272,16 @@ impl<T: Clone> RadioGroupState<T> {
 
 impl<T: Clone + std::fmt::Display + 'static> RadioGroupState<T> {
     /// Updates the radio group state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{RadioGroupState, RadioGroupMessage, RadioGroupOutput};
+    ///
+    /// let mut state = RadioGroupState::new(vec!["Small", "Medium", "Large"]);
+    /// let output = state.update(RadioGroupMessage::Down);
+    /// assert_eq!(output, Some(RadioGroupOutput::SelectionChanged(1)));
+    /// ```
     pub fn update(&mut self, msg: RadioGroupMessage) -> Option<RadioGroupOutput<T>> {
         RadioGroup::<T>::update(self, msg)
     }

--- a/src/component/router/mod.rs
+++ b/src/component/router/mod.rs
@@ -418,6 +418,19 @@ impl<S: Clone + PartialEq> Router<S> {
     /// This inherent method is available for all screen types that implement
     /// `Clone + PartialEq`. Screen types that also implement `Default` can
     /// use the [`Component`] trait methods instead.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Router, RouterMessage, RouterOutput, RouterState};
+    ///
+    /// #[derive(Clone, Debug, PartialEq, Eq)]
+    /// enum Screen { Home, Settings }
+    ///
+    /// let mut state = RouterState::new(Screen::Home);
+    /// let output = Router::update(&mut state, RouterMessage::Navigate(Screen::Settings));
+    /// assert_eq!(output, Some(RouterOutput::ScreenChanged { from: Screen::Home, to: Screen::Settings }));
+    /// ```
     pub fn update(state: &mut RouterState<S>, msg: RouterMessage<S>) -> Option<RouterOutput<S>> {
         match msg {
             RouterMessage::Navigate(screen) => {
@@ -479,6 +492,20 @@ impl<S: Clone + PartialEq> Router<S> {
     ///
     /// Router is state-only, so this is a no-op. The parent application
     /// should render based on `state.current()`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Router, RouterState};
+    ///
+    /// #[derive(Clone, Debug, PartialEq, Eq)]
+    /// enum Screen { Home }
+    ///
+    /// // Router does not render anything — it is state-only.
+    /// // The parent application renders based on state.current():
+    /// let state = RouterState::new(Screen::Home);
+    /// assert_eq!(state.current(), &Screen::Home);
+    /// ```
     pub fn view(_state: &RouterState<S>, _ctx: &mut RenderContext<'_, '_>) {
         // Router is state-only - no view implementation.
         // The parent application should render based on state.current()

--- a/src/component/scrollable_text/mod.rs
+++ b/src/component/scrollable_text/mod.rs
@@ -213,6 +213,15 @@ impl ScrollableTextState {
     // ---- Scroll accessors ----
 
     /// Returns the current scroll offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ScrollableTextState;
+    ///
+    /// let state = ScrollableTextState::new();
+    /// assert_eq!(state.scroll_offset(), 0);
+    /// ```
     pub fn scroll_offset(&self) -> usize {
         self.scroll.offset()
     }

--- a/src/component/select/mod.rs
+++ b/src/component/select/mod.rs
@@ -210,6 +210,15 @@ impl SelectState {
     }
 
     /// Alias for [`selected_index()`](Self::selected_index).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SelectState};
+    ///
+    /// let state = SelectState::with_selection(vec!["A", "B", "C"], 1);
+    /// assert_eq!(state.selected(), Some(1));
+    /// ```
     pub fn selected(&self) -> Option<usize> {
         self.selected_index()
     }

--- a/src/component/selectable_list/mod.rs
+++ b/src/component/selectable_list/mod.rs
@@ -230,6 +230,15 @@ impl<T: Clone> SelectableListState<T> {
     }
 
     /// Alias for [`selected_index()`](Self::selected_index).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SelectableListState;
+    ///
+    /// let state = SelectableListState::new(vec!["a", "b", "c"]);
+    /// assert_eq!(state.selected(), Some(0));
+    /// ```
     pub fn selected(&self) -> Option<usize> {
         self.selected_index()
     }
@@ -342,11 +351,29 @@ impl<T: Clone> SelectableListState<T> {
     }
 
     /// Returns the current filter text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SelectableListState;
+    ///
+    /// let state = SelectableListState::new(vec!["apple".to_string(), "banana".to_string()]);
+    /// assert_eq!(state.filter_text(), "");
+    /// ```
     pub fn filter_text(&self) -> &str {
         &self.filter_text
     }
 
     /// Returns the number of items visible after filtering.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SelectableListState;
+    ///
+    /// let state = SelectableListState::new(vec!["apple".to_string(), "banana".to_string(), "cherry".to_string()]);
+    /// assert_eq!(state.visible_count(), 3);
+    /// ```
     pub fn visible_count(&self) -> usize {
         self.filtered_indices.len()
     }
@@ -436,12 +463,35 @@ impl<T: Clone + std::fmt::Display + 'static> SelectableListState<T> {
     /// Items whose `Display` output contains the filter text (case-insensitive)
     /// are shown. Selection is preserved if the selected item remains visible,
     /// otherwise it moves to the first visible item.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SelectableListState;
+    ///
+    /// let mut state = SelectableListState::new(vec!["apple".to_string(), "banana".to_string(), "cherry".to_string()]);
+    /// state.set_filter_text("an");
+    /// assert_eq!(state.visible_count(), 1); // only "banana" contains "an"
+    /// assert_eq!(state.filter_text(), "an");
+    /// ```
     pub fn set_filter_text(&mut self, text: &str) {
         self.filter_text = text.to_string();
         self.apply_filter();
     }
 
     /// Clears the filter, showing all items.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SelectableListState;
+    ///
+    /// let mut state = SelectableListState::new(vec!["apple".to_string(), "banana".to_string()]);
+    /// state.set_filter_text("apple");
+    /// assert_eq!(state.visible_count(), 1);
+    /// state.clear_filter();
+    /// assert_eq!(state.visible_count(), 2);
+    /// ```
     pub fn clear_filter(&mut self) {
         self.filter_text.clear();
         self.apply_filter();
@@ -483,6 +533,16 @@ impl<T: Clone + std::fmt::Display + 'static> SelectableListState<T> {
     }
 
     /// Updates the selectable list state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SelectableListState, SelectableListMessage, SelectableListOutput};
+    ///
+    /// let mut state = SelectableListState::new(vec!["a".to_string(), "b".to_string()]);
+    /// let output = state.update(SelectableListMessage::Down);
+    /// assert_eq!(output, Some(SelectableListOutput::SelectionChanged(1)));
+    /// ```
     pub fn update(&mut self, msg: SelectableListMessage) -> Option<SelectableListOutput<T>> {
         SelectableList::<T>::update(self, msg)
     }

--- a/src/component/slider/mod.rs
+++ b/src/component/slider/mod.rs
@@ -251,16 +251,43 @@ impl SliderState {
     }
 
     /// Returns the minimum value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SliderState;
+    ///
+    /// let state = SliderState::new(10.0, 90.0);
+    /// assert_eq!(state.min(), 10.0);
+    /// ```
     pub fn min(&self) -> f64 {
         self.min
     }
 
     /// Returns the maximum value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SliderState;
+    ///
+    /// let state = SliderState::new(10.0, 90.0);
+    /// assert_eq!(state.max(), 90.0);
+    /// ```
     pub fn max(&self) -> f64 {
         self.max
     }
 
     /// Returns the step size.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SliderState;
+    ///
+    /// let state = SliderState::new(0.0, 100.0).with_step(5.0);
+    /// assert_eq!(state.step(), 5.0);
+    /// ```
     pub fn step(&self) -> f64 {
         self.step
     }
@@ -290,11 +317,29 @@ impl SliderState {
     }
 
     /// Returns the label, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SliderState;
+    ///
+    /// let state = SliderState::new(0.0, 100.0).with_label("Volume");
+    /// assert_eq!(state.label(), Some("Volume"));
+    /// ```
     pub fn label(&self) -> Option<&str> {
         self.label.as_deref()
     }
 
     /// Returns whether the value display is enabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SliderState;
+    ///
+    /// let state = SliderState::new(0.0, 100.0).with_show_value(false);
+    /// assert!(!state.show_value());
+    /// ```
     pub fn show_value(&self) -> bool {
         self.show_value
     }
@@ -315,6 +360,15 @@ impl SliderState {
     }
 
     /// Returns the orientation.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SliderState, SliderOrientation};
+    ///
+    /// let state = SliderState::new(0.0, 100.0).with_orientation(SliderOrientation::Vertical);
+    /// assert_eq!(state.orientation(), &SliderOrientation::Vertical);
+    /// ```
     pub fn orientation(&self) -> &SliderOrientation {
         &self.orientation
     }

--- a/src/component/span_tree/mod.rs
+++ b/src/component/span_tree/mod.rs
@@ -347,21 +347,57 @@ impl SpanTreeState {
     }
 
     /// Returns the earliest start time across all spans.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SpanTreeState, SpanNode};
+    ///
+    /// let state = SpanTreeState::new(vec![SpanNode::new("r", "root", 50.0, 200.0)]);
+    /// assert_eq!(state.global_start(), 50.0);
+    /// ```
     pub fn global_start(&self) -> f64 {
         self.global_start
     }
 
     /// Returns the latest end time across all spans.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SpanTreeState, SpanNode};
+    ///
+    /// let state = SpanTreeState::new(vec![SpanNode::new("r", "root", 0.0, 750.0)]);
+    /// assert_eq!(state.global_end(), 750.0);
+    /// ```
     pub fn global_end(&self) -> f64 {
         self.global_end
     }
 
     /// Returns the label column width.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SpanTreeState, SpanNode};
+    ///
+    /// let state = SpanTreeState::new(vec![]).with_label_width(40);
+    /// assert_eq!(state.label_width(), 40);
+    /// ```
     pub fn label_width(&self) -> u16 {
         self.label_width
     }
 
     /// Returns the title, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SpanTreeState;
+    ///
+    /// let state = SpanTreeState::new(vec![]).with_title("Trace View");
+    /// assert_eq!(state.title(), Some("Trace View"));
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
@@ -395,6 +431,17 @@ impl SpanTreeState {
     }
 
     /// Returns the set of expanded node IDs.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SpanTreeState, SpanNode};
+    ///
+    /// let root = SpanNode::new("r", "root", 0.0, 100.0)
+    ///     .with_child(SpanNode::new("c", "child", 10.0, 50.0));
+    /// let state = SpanTreeState::new(vec![root]);
+    /// assert!(state.expanded_ids().contains("r"));
+    /// ```
     pub fn expanded_ids(&self) -> &HashSet<String> {
         &self.expanded
     }
@@ -521,6 +568,18 @@ impl SpanTreeState {
     // ---- Instance methods ----
 
     /// Updates the state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SpanTreeState, SpanTreeMessage, SpanNode};
+    ///
+    /// let root = SpanNode::new("r", "root", 0.0, 100.0)
+    ///     .with_child(SpanNode::new("c", "child", 10.0, 50.0));
+    /// let mut state = SpanTreeState::new(vec![root]);
+    /// state.update(SpanTreeMessage::SelectDown);
+    /// assert_eq!(state.selected_index(), Some(1));
+    /// ```
     pub fn update(&mut self, msg: SpanTreeMessage) -> Option<SpanTreeOutput> {
         SpanTree::update(self, msg)
     }

--- a/src/component/sparkline/mod.rs
+++ b/src/component/sparkline/mod.rs
@@ -218,6 +218,15 @@ impl SparklineState {
     }
 
     /// Returns the data points.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SparklineState;
+    ///
+    /// let state = SparklineState::with_data(vec![1.0, 2.0, 3.0]);
+    /// assert_eq!(state.data(), &[1.0, 2.0, 3.0]);
+    /// ```
     pub fn data(&self) -> &[f64] {
         &self.data
     }
@@ -272,11 +281,29 @@ impl SparklineState {
     }
 
     /// Returns the number of data points.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SparklineState;
+    ///
+    /// let state = SparklineState::with_data(vec![1.0, 2.0, 3.0]);
+    /// assert_eq!(state.len(), 3);
+    /// ```
     pub fn len(&self) -> usize {
         self.data.len()
     }
 
     /// Returns true if there are no data points.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SparklineState;
+    ///
+    /// let state = SparklineState::new();
+    /// assert!(state.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.data.is_empty()
     }
@@ -327,6 +354,15 @@ impl SparklineState {
     }
 
     /// Returns the title, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SparklineState;
+    ///
+    /// let state = SparklineState::new().with_title("Memory");
+    /// assert_eq!(state.title(), Some("Memory"));
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
@@ -347,11 +383,29 @@ impl SparklineState {
     }
 
     /// Returns the render direction.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SparklineDirection, SparklineState};
+    ///
+    /// let state = SparklineState::new().with_direction(SparklineDirection::RightToLeft);
+    /// assert_eq!(state.direction(), &SparklineDirection::RightToLeft);
+    /// ```
     pub fn direction(&self) -> &SparklineDirection {
         &self.direction
     }
 
     /// Returns the maximum display points setting.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SparklineState;
+    ///
+    /// let state = SparklineState::new().with_max_display_points(50);
+    /// assert_eq!(state.max_display_points(), Some(50));
+    /// ```
     pub fn max_display_points(&self) -> Option<usize> {
         self.max_display_points
     }
@@ -372,6 +426,16 @@ impl SparklineState {
     }
 
     /// Returns the color override, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SparklineState;
+    /// use ratatui::style::Color;
+    ///
+    /// let state = SparklineState::new().with_color(Color::Cyan);
+    /// assert_eq!(state.color(), Some(Color::Cyan));
+    /// ```
     pub fn color(&self) -> Option<Color> {
         self.color
     }

--- a/src/component/split_panel/mod.rs
+++ b/src/component/split_panel/mod.rs
@@ -176,6 +176,15 @@ impl SplitPanelState {
     }
 
     /// Returns the current orientation.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SplitPanelState, SplitOrientation};
+    ///
+    /// let state = SplitPanelState::new(SplitOrientation::Horizontal);
+    /// assert_eq!(state.orientation(), &SplitOrientation::Horizontal);
+    /// ```
     pub fn orientation(&self) -> &SplitOrientation {
         &self.orientation
     }
@@ -199,6 +208,15 @@ impl SplitPanelState {
     ///
     /// 0.5 means equal split. Values closer to 1.0 give more space
     /// to the first pane.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SplitPanelState, SplitOrientation};
+    ///
+    /// let state = SplitPanelState::new(SplitOrientation::Vertical).with_ratio(0.4);
+    /// assert!((state.ratio() - 0.4).abs() < f32::EPSILON);
+    /// ```
     pub fn ratio(&self) -> f32 {
         self.ratio
     }
@@ -234,11 +252,30 @@ impl SplitPanelState {
     }
 
     /// Returns true if the second pane has focus.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SplitPanelState, SplitPanelMessage, SplitOrientation};
+    ///
+    /// let mut state = SplitPanelState::new(SplitOrientation::Vertical);
+    /// state.update(SplitPanelMessage::FocusSecond);
+    /// assert!(state.is_second_pane_focused());
+    /// ```
     pub fn is_second_pane_focused(&self) -> bool {
         self.focused_pane == Pane::Second
     }
 
     /// Returns the resize step size (default 0.1 = 10%).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SplitPanelState, SplitOrientation};
+    ///
+    /// let state = SplitPanelState::new(SplitOrientation::Vertical).with_resize_step(0.05);
+    /// assert!((state.resize_step() - 0.05).abs() < f32::EPSILON);
+    /// ```
     pub fn resize_step(&self) -> f32 {
         self.resize_step
     }
@@ -277,6 +314,16 @@ impl SplitPanelState {
     }
 
     /// Updates the state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SplitPanelState, SplitPanelMessage, SplitPanelOutput, SplitOrientation};
+    ///
+    /// let mut state = SplitPanelState::new(SplitOrientation::Vertical);
+    /// let output = state.update(SplitPanelMessage::FocusSecond);
+    /// assert_eq!(output, Some(SplitPanelOutput::FocusedSecond));
+    /// ```
     pub fn update(&mut self, msg: SplitPanelMessage) -> Option<SplitPanelOutput> {
         SplitPanel::update(self, msg)
     }

--- a/src/component/status_bar/mod.rs
+++ b/src/component/status_bar/mod.rs
@@ -413,6 +413,15 @@ impl StatusBarState {
     }
 
     /// Returns the separator string.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarState;
+    ///
+    /// let state = StatusBarState::new();
+    /// assert_eq!(state.separator(), " | "); // default separator
+    /// ```
     pub fn separator(&self) -> &str {
         &self.separator
     }
@@ -560,6 +569,16 @@ impl StatusBarState {
     }
 
     /// Returns a mutable reference to the items in the specified section.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{StatusBarState, StatusBarItem, Section};
+    ///
+    /// let mut state = StatusBarState::new();
+    /// state.push_left(StatusBarItem::new("Mode"));
+    /// assert_eq!(state.section_mut(Section::Left).len(), 1);
+    /// ```
     pub fn section_mut(&mut self, section: Section) -> &mut Vec<StatusBarItem> {
         match section {
             Section::Left => &mut self.left,
@@ -569,6 +588,17 @@ impl StatusBarState {
     }
 
     /// Returns a mutable reference to an item by section and index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{StatusBarState, StatusBarItem, Section};
+    ///
+    /// let mut state = StatusBarState::new();
+    /// state.push_left(StatusBarItem::new("Mode"));
+    /// assert!(state.get_item_mut(Section::Left, 0).is_some());
+    /// assert!(state.get_item_mut(Section::Left, 99).is_none());
+    /// ```
     pub fn get_item_mut(&mut self, section: Section, index: usize) -> Option<&mut StatusBarItem> {
         self.section_mut(section).get_mut(index)
     }

--- a/src/component/status_log/mod.rs
+++ b/src/component/status_log/mod.rs
@@ -418,6 +418,15 @@ impl StatusLogState {
     }
 
     /// Returns the maximum number of entries.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusLogState;
+    ///
+    /// let state = StatusLogState::new();
+    /// assert_eq!(state.max_entries(), 50); // default
+    /// ```
     pub fn max_entries(&self) -> usize {
         self.max_entries
     }
@@ -449,6 +458,15 @@ impl StatusLogState {
     }
 
     /// Returns whether timestamps are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusLogState;
+    ///
+    /// let state = StatusLogState::new();
+    /// assert!(!state.show_timestamps()); // disabled by default
+    /// ```
     pub fn show_timestamps(&self) -> bool {
         self.show_timestamps
     }

--- a/src/component/step_indicator/mod.rs
+++ b/src/component/step_indicator/mod.rs
@@ -143,16 +143,43 @@ impl Step {
     }
 
     /// Returns the step label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::Step;
+    ///
+    /// let step = Step::new("Build");
+    /// assert_eq!(step.label(), "Build");
+    /// ```
     pub fn label(&self) -> &str {
         &self.label
     }
 
     /// Returns the step status.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::{Step, StepStatus};
+    ///
+    /// let step = Step::new("Test");
+    /// assert_eq!(step.status(), &StepStatus::Pending);
+    /// ```
     pub fn status(&self) -> &StepStatus {
         &self.status
     }
 
     /// Returns the step description, if any.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::Step;
+    ///
+    /// let step = Step::new("Deploy");
+    /// assert_eq!(step.description(), None);
+    /// ```
     pub fn description(&self) -> Option<&str> {
         self.description.as_deref()
     }
@@ -328,6 +355,17 @@ impl StepIndicatorState {
     }
 
     /// Sets whether descriptions are shown (builder pattern).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::Step;
+    /// use envision::component::StepIndicatorState;
+    ///
+    /// let state = StepIndicatorState::new(vec![Step::new("A")])
+    ///     .with_show_descriptions(true);
+    /// assert!(state.show_descriptions());
+    /// ```
     pub fn with_show_descriptions(mut self, show: bool) -> Self {
         self.show_descriptions = show;
         self
@@ -415,6 +453,16 @@ impl StepIndicatorState {
     }
 
     /// Returns the steps.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::Step;
+    /// use envision::component::StepIndicatorState;
+    ///
+    /// let state = StepIndicatorState::new(vec![Step::new("Build"), Step::new("Test")]);
+    /// assert_eq!(state.steps().len(), 2);
+    /// ```
     pub fn steps(&self) -> &[Step] {
         &self.steps
     }
@@ -436,6 +484,16 @@ impl StepIndicatorState {
     }
 
     /// Returns the orientation.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::{Step, StepOrientation};
+    /// use envision::component::StepIndicatorState;
+    ///
+    /// let state = StepIndicatorState::new(vec![Step::new("A")]);
+    /// assert_eq!(state.orientation(), &StepOrientation::Horizontal);
+    /// ```
     pub fn orientation(&self) -> &StepOrientation {
         &self.orientation
     }
@@ -499,11 +557,31 @@ impl StepIndicatorState {
     }
 
     /// Returns the connector string.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::Step;
+    /// use envision::component::StepIndicatorState;
+    ///
+    /// let state = StepIndicatorState::new(vec![Step::new("A")]).with_connector("→");
+    /// assert_eq!(state.connector(), "→");
+    /// ```
     pub fn connector(&self) -> &str {
         &self.connector
     }
 
     /// Returns the title, if any.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::Step;
+    /// use envision::component::StepIndicatorState;
+    ///
+    /// let state = StepIndicatorState::new(vec![Step::new("A")]);
+    /// assert_eq!(state.title(), None);
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
@@ -604,6 +682,19 @@ impl StepIndicatorState {
     }
 
     /// Returns the per-status style override, if one is set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::{Step, StepStatus};
+    /// use envision::component::StepIndicatorState;
+    /// use ratatui::style::{Color, Style};
+    ///
+    /// let state = StepIndicatorState::new(vec![Step::new("A")])
+    ///     .with_status_style(StepStatus::Active, Style::default().fg(Color::Yellow));
+    /// assert!(state.status_style_override(&StepStatus::Active).is_some());
+    /// assert!(state.status_style_override(&StepStatus::Pending).is_none());
+    /// ```
     pub fn status_style_override(&self, status: &StepStatus) -> Option<&Style> {
         self.status_style_overrides.get(status)
     }
@@ -626,11 +717,37 @@ impl StepIndicatorState {
     }
 
     /// Removes a per-status style override.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::{Step, StepStatus};
+    /// use envision::component::StepIndicatorState;
+    /// use ratatui::style::{Color, Style};
+    ///
+    /// let mut state = StepIndicatorState::new(vec![Step::new("A")])
+    ///     .with_status_style(StepStatus::Active, Style::default().fg(Color::Yellow));
+    /// state.clear_status_style(&StepStatus::Active);
+    /// assert!(state.status_style_override(&StepStatus::Active).is_none());
+    /// ```
     pub fn clear_status_style(&mut self, status: &StepStatus) {
         self.status_style_overrides.remove(status);
     }
 
     /// Returns the per-step-index style override, if one is set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::Step;
+    /// use envision::component::StepIndicatorState;
+    /// use ratatui::style::{Color, Style};
+    ///
+    /// let state = StepIndicatorState::new(vec![Step::new("A"), Step::new("B")])
+    ///     .with_step_style(0, Style::default().fg(Color::Cyan));
+    /// assert!(state.step_style_override(0).is_some());
+    /// assert!(state.step_style_override(1).is_none());
+    /// ```
     pub fn step_style_override(&self, index: usize) -> Option<&Style> {
         self.step_style_overrides.get(&index)
     }
@@ -653,6 +770,19 @@ impl StepIndicatorState {
     }
 
     /// Removes a per-step-index style override.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::Step;
+    /// use envision::component::StepIndicatorState;
+    /// use ratatui::style::{Color, Style};
+    ///
+    /// let mut state = StepIndicatorState::new(vec![Step::new("A")])
+    ///     .with_step_style(0, Style::default().fg(Color::Cyan));
+    /// state.clear_step_style(0);
+    /// assert!(state.step_style_override(0).is_none());
+    /// ```
     pub fn clear_step_style(&mut self, index: usize) {
         self.step_style_overrides.remove(&index);
     }

--- a/src/component/table/mod.rs
+++ b/src/component/table/mod.rs
@@ -253,6 +253,24 @@ impl<T: TableRow> TableState<T> {
     /// Returns the currently selected display index.
     ///
     /// This is the index in the display order, not the original row index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Column, TableRow, TableState};
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let state = TableState::new(
+    ///     vec![Item { name: "Alice".into() }],
+    ///     vec![Column::fixed("Name", 10)],
+    /// );
+    /// assert_eq!(state.selected_index(), Some(0));
+    /// ```
     pub fn selected_index(&self) -> Option<usize> {
         self.selected
     }
@@ -561,6 +579,25 @@ impl<T: TableRow> TableState<T> {
     ///
     /// Rows where any cell contains the filter text (case-insensitive) are shown.
     /// Selection is preserved if the selected row remains visible.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Column, TableRow, TableState};
+    ///
+    /// #[derive(Clone)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let mut state = TableState::new(
+    ///     vec![Item { name: "Alice".into() }, Item { name: "Bob".into() }],
+    ///     vec![Column::fixed("Name", 10)],
+    /// );
+    /// state.set_filter_text("ali");
+    /// assert_eq!(state.visible_count(), 1);
+    /// ```
     pub fn set_filter_text(&mut self, text: &str) {
         self.filter_text = text.to_string();
         self.rebuild_display_order();
@@ -673,6 +710,25 @@ impl<T: TableRow> TableState<T> {
 
 impl<T: TableRow + 'static> TableState<T> {
     /// Updates the table state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Column, TableRow, TableState, TableMessage, TableOutput};
+    ///
+    /// #[derive(Clone, Debug, PartialEq)]
+    /// struct Item { name: String }
+    /// impl TableRow for Item {
+    ///     fn cells(&self) -> Vec<String> { vec![self.name.clone()] }
+    /// }
+    ///
+    /// let mut state = TableState::new(
+    ///     vec![Item { name: "A".into() }, Item { name: "B".into() }],
+    ///     vec![Column::fixed("Name", 10)],
+    /// );
+    /// let output = state.update(TableMessage::Down);
+    /// assert_eq!(output, Some(TableOutput::SelectionChanged(1)));
+    /// ```
     pub fn update(&mut self, msg: TableMessage) -> Option<TableOutput<T>> {
         Table::update(self, msg)
     }

--- a/src/component/tabs/mod.rs
+++ b/src/component/tabs/mod.rs
@@ -312,6 +312,16 @@ impl<T: Clone> TabsState<T> {
 
 impl<T: Clone + std::fmt::Display + 'static> TabsState<T> {
     /// Updates the tabs state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TabsState, TabsMessage, TabsOutput};
+    ///
+    /// let mut state = TabsState::new(vec!["Home", "Settings"]);
+    /// let output = state.update(TabsMessage::Right);
+    /// assert_eq!(output, Some(TabsOutput::SelectionChanged(1)));
+    /// ```
     pub fn update(&mut self, msg: TabsMessage) -> Option<TabsOutput<T>> {
         Tabs::update(self, msg)
     }

--- a/src/component/text_area/mod.rs
+++ b/src/component/text_area/mod.rs
@@ -314,6 +314,17 @@ impl TextAreaState {
     }
 
     /// Returns the cursor position as (row, char_column).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TextArea, TextAreaMessage, TextAreaState, Component};
+    ///
+    /// let mut state = TextAreaState::new();
+    /// TextArea::update(&mut state, TextAreaMessage::Insert('H'));
+    /// TextArea::update(&mut state, TextAreaMessage::Insert('i'));
+    /// assert_eq!(state.cursor_position(), (0, 2));
+    /// ```
     pub fn cursor_position(&self) -> (usize, usize) {
         let char_col = self.lines[self.cursor_row][..self.cursor_col]
             .chars()
@@ -504,6 +515,22 @@ impl TextAreaState {
     }
 
     /// Ensures the cursor is visible within the viewport.
+    ///
+    /// Adjusts `scroll_offset` so that the cursor row is within the range
+    /// `[scroll_offset, scroll_offset + visible_lines)`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TextArea, TextAreaMessage, TextAreaState, Component};
+    ///
+    /// let mut state = TextAreaState::new();
+    /// for _ in 0..10 {
+    ///     TextArea::update(&mut state, TextAreaMessage::NewLine);
+    /// }
+    /// state.ensure_cursor_visible(5);
+    /// assert!(state.scroll_offset() + 5 > state.cursor_position().0);
+    /// ```
     pub fn ensure_cursor_visible(&mut self, visible_lines: usize) {
         if visible_lines == 0 {
             return;
@@ -612,6 +639,17 @@ impl TextAreaState {
     }
 
     /// Updates the textarea state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TextAreaMessage, TextAreaOutput, TextAreaState};
+    ///
+    /// let mut state = TextAreaState::new();
+    /// state.update(TextAreaMessage::Insert('a'));
+    /// state.update(TextAreaMessage::Insert('b'));
+    /// assert_eq!(state.value(), "ab");
+    /// ```
     pub fn update(&mut self, msg: TextAreaMessage) -> Option<TextAreaOutput> {
         TextArea::update(self, msg)
     }

--- a/src/component/timeline/mod.rs
+++ b/src/component/timeline/mod.rs
@@ -198,6 +198,16 @@ impl TimelineState {
     // ---- Accessors ----
 
     /// Returns the point events.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TimelineState, TimelineEvent};
+    ///
+    /// let state = TimelineState::new()
+    ///     .with_events(vec![TimelineEvent::new("e1", 100.0, "Deploy")]);
+    /// assert_eq!(state.events().len(), 1);
+    /// ```
     pub fn events(&self) -> &[TimelineEvent] {
         &self.events
     }
@@ -222,6 +232,16 @@ impl TimelineState {
     }
 
     /// Returns the duration spans.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TimelineState, TimelineSpan};
+    ///
+    /// let state = TimelineState::new()
+    ///     .with_spans(vec![TimelineSpan::new("s1", 0.0, 500.0, "Request")]);
+    /// assert_eq!(state.spans().len(), 1);
+    /// ```
     pub fn spans(&self) -> &[TimelineSpan] {
         &self.spans
     }
@@ -444,6 +464,15 @@ impl TimelineState {
     }
 
     /// Returns the title, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TimelineState;
+    ///
+    /// let state = TimelineState::new().with_title("Deployment Timeline");
+    /// assert_eq!(state.title(), Some("Deployment Timeline"));
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
@@ -464,6 +493,15 @@ impl TimelineState {
     }
 
     /// Returns whether labels are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TimelineState;
+    ///
+    /// let state = TimelineState::new().with_show_labels(false);
+    /// assert!(!state.show_labels());
+    /// ```
     pub fn show_labels(&self) -> bool {
         self.show_labels
     }
@@ -484,6 +522,17 @@ impl TimelineState {
     }
 
     /// Returns the effective lane count (auto-computed if not set).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TimelineState, TimelineSpan};
+    ///
+    /// let state = TimelineState::new()
+    ///     .with_spans(vec![TimelineSpan::new("s1", 0.0, 500.0, "Request")]);
+    /// // No spans have lane set, so effective count is 1 (lane 0 + 1)
+    /// assert_eq!(state.effective_lane_count(), 1);
+    /// ```
     pub fn effective_lane_count(&self) -> usize {
         if self.lane_count > 0 {
             self.lane_count
@@ -592,6 +641,18 @@ impl TimelineState {
     // ---- Instance methods ----
 
     /// Updates the state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TimelineState, TimelineMessage, TimelineEvent};
+    ///
+    /// let mut state = TimelineState::new()
+    ///     .with_events(vec![TimelineEvent::new("e1", 100.0, "Start")]);
+    /// state.update(TimelineMessage::FitAll);
+    /// let (start, end) = state.view_range();
+    /// assert!(end > start);
+    /// ```
     pub fn update(&mut self, msg: TimelineMessage) -> Option<TimelineOutput> {
         Timeline::update(self, msg)
     }

--- a/src/component/title_card/mod.rs
+++ b/src/component/title_card/mod.rs
@@ -240,11 +240,29 @@ impl TitleCardState {
     }
 
     /// Returns the subtitle text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TitleCardState;
+    ///
+    /// let state = TitleCardState::new("App").with_subtitle("v1.0");
+    /// assert_eq!(state.subtitle(), Some("v1.0"));
+    /// ```
     pub fn subtitle(&self) -> Option<&str> {
         self.subtitle.as_deref()
     }
 
     /// Returns the prefix decoration.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TitleCardState;
+    ///
+    /// let state = TitleCardState::new("App").with_prefix(">> ");
+    /// assert_eq!(state.prefix(), Some(">> "));
+    /// ```
     pub fn prefix(&self) -> Option<&str> {
         self.prefix.as_deref()
     }
@@ -264,16 +282,47 @@ impl TitleCardState {
     }
 
     /// Returns the title style.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TitleCardState;
+    /// use ratatui::style::{Color, Style};
+    ///
+    /// let style = Style::default().fg(Color::Magenta);
+    /// let state = TitleCardState::new("App").with_title_style(style);
+    /// assert_eq!(state.title_style(), style);
+    /// ```
     pub fn title_style(&self) -> Style {
         self.title_style
     }
 
     /// Returns the subtitle style.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TitleCardState;
+    /// use ratatui::style::{Color, Style};
+    ///
+    /// let style = Style::default().fg(Color::Gray);
+    /// let state = TitleCardState::new("App").with_subtitle_style(style);
+    /// assert_eq!(state.subtitle_style(), style);
+    /// ```
     pub fn subtitle_style(&self) -> Style {
         self.subtitle_style
     }
 
     /// Returns whether the border is shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TitleCardState;
+    ///
+    /// let state = TitleCardState::new("App").with_bordered(false);
+    /// assert!(!state.is_bordered());
+    /// ```
     pub fn is_bordered(&self) -> bool {
         self.bordered
     }
@@ -355,11 +404,35 @@ impl TitleCardState {
     }
 
     /// Sets the title style.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TitleCardState;
+    /// use ratatui::style::{Color, Style};
+    ///
+    /// let mut state = TitleCardState::new("App");
+    /// let style = Style::default().fg(Color::Green);
+    /// state.set_title_style(style);
+    /// assert_eq!(state.title_style(), style);
+    /// ```
     pub fn set_title_style(&mut self, style: Style) {
         self.title_style = style;
     }
 
     /// Sets the subtitle style.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TitleCardState;
+    /// use ratatui::style::{Color, Style};
+    ///
+    /// let mut state = TitleCardState::new("App");
+    /// let style = Style::default().fg(Color::White);
+    /// state.set_subtitle_style(style);
+    /// assert_eq!(state.subtitle_style(), style);
+    /// ```
     pub fn set_subtitle_style(&mut self, style: Style) {
         self.subtitle_style = style;
     }

--- a/src/component/tooltip/mod.rs
+++ b/src/component/tooltip/mod.rs
@@ -260,16 +260,43 @@ impl TooltipState {
     }
 
     /// Returns the tooltip content.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TooltipState;
+    ///
+    /// let state = TooltipState::new("Click to submit");
+    /// assert_eq!(state.content(), "Click to submit");
+    /// ```
     pub fn content(&self) -> &str {
         &self.content
     }
 
     /// Returns the tooltip title, if any.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TooltipState;
+    ///
+    /// let state = TooltipState::new("Content").with_title("Info");
+    /// assert_eq!(state.title(), Some("Info"));
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
 
     /// Returns the preferred position.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TooltipState, TooltipPosition};
+    ///
+    /// let state = TooltipState::new("Content").with_position(TooltipPosition::Above);
+    /// assert_eq!(state.position(), TooltipPosition::Above);
+    /// ```
     pub fn position(&self) -> TooltipPosition {
         self.position
     }

--- a/src/component/treemap/mod.rs
+++ b/src/component/treemap/mod.rs
@@ -542,6 +542,15 @@ impl TreemapState {
     }
 
     /// Returns the title, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TreemapState;
+    ///
+    /// let state = TreemapState::new().with_title("Disk Usage");
+    /// assert_eq!(state.title(), Some("Disk Usage"));
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
@@ -562,6 +571,15 @@ impl TreemapState {
     }
 
     /// Returns whether labels are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TreemapState;
+    ///
+    /// let state = TreemapState::new();
+    /// assert!(state.show_labels());
+    /// ```
     pub fn show_labels(&self) -> bool {
         self.show_labels
     }
@@ -582,6 +600,15 @@ impl TreemapState {
     }
 
     /// Returns whether values are shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TreemapState;
+    ///
+    /// let state = TreemapState::new();
+    /// assert!(!state.show_values());
+    /// ```
     pub fn show_values(&self) -> bool {
         self.show_values
     }
@@ -609,6 +636,21 @@ impl TreemapState {
     // ---- Instance methods ----
 
     /// Updates the state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TreemapMessage, TreemapNode, TreemapOutput, TreemapState};
+    ///
+    /// let root = TreemapNode::new("root", 0.0)
+    ///     .with_child(
+    ///         TreemapNode::new("parent", 0.0)
+    ///             .with_child(TreemapNode::new("leaf", 10.0)),
+    ///     );
+    /// let mut state = TreemapState::new().with_root(root);
+    /// let output = state.update(TreemapMessage::ZoomIn);
+    /// assert_eq!(output, Some(TreemapOutput::ZoomedIn("parent".to_string())));
+    /// ```
     pub fn update(&mut self, msg: TreemapMessage) -> Option<TreemapOutput> {
         Treemap::update(self, msg)
     }

--- a/src/component/usage_display/mod.rs
+++ b/src/component/usage_display/mod.rs
@@ -142,21 +142,58 @@ impl UsageMetric {
     }
 
     /// Returns the metric label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::UsageMetric;
+    ///
+    /// let metric = UsageMetric::new("CPU", "45%");
+    /// assert_eq!(metric.label(), "CPU");
+    /// ```
     pub fn label(&self) -> &str {
         &self.label
     }
 
     /// Returns the metric value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::UsageMetric;
+    ///
+    /// let metric = UsageMetric::new("CPU", "45%");
+    /// assert_eq!(metric.value(), "45%");
+    /// ```
     pub fn value(&self) -> &str {
         &self.value
     }
 
     /// Returns the optional color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::UsageMetric;
+    /// use ratatui::style::Color;
+    ///
+    /// let metric = UsageMetric::new("CPU", "45%").with_color(Color::Green);
+    /// assert_eq!(metric.color(), Some(Color::Green));
+    /// ```
     pub fn color(&self) -> Option<Color> {
         self.color
     }
 
     /// Returns the optional icon.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::UsageMetric;
+    ///
+    /// let metric = UsageMetric::new("CPU", "45%").with_icon("*");
+    /// assert_eq!(metric.icon(), Some("*"));
+    /// ```
     pub fn icon(&self) -> Option<&str> {
         self.icon.as_deref()
     }


### PR DESCRIPTION
## Summary

Adds ~290 doc tests across 49 files, bringing coverage from **84.4% to 99.3%**. Every component now has 93%+ doc test coverage. Only 11 public methods remain without doc tests across the entire library.

Also fixes 5 pre-existing doc test failures (stale KeyCode reference, private field access, wrong assertion).

## Test plan

- [x] 2298 doc tests pass, 0 failures
- [x] Clippy clean
- [x] `cargo fmt` clean
- [x] No files over 1000 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)