### PR TITLE
Doc test coverage: 99.3% → 100%

### DIFF
--- a/src/component/alert_panel/mod.rs
+++ b/src/component/alert_panel/mod.rs
@@ -601,6 +601,24 @@ impl AlertPanelState {
     }
 
     /// Returns the number of rows in the grid.
+    ///
+    /// The row count is derived from the number of metrics and the configured
+    /// column count (rounded up so partial rows still count).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use envision::component::{AlertMetric, AlertPanelState, AlertThreshold};
+    ///
+    /// let state = AlertPanelState::new()
+    ///     .with_metrics(vec![
+    ///         AlertMetric::new("a", "A", AlertThreshold::new(70.0, 90.0)),
+    ///         AlertMetric::new("b", "B", AlertThreshold::new(70.0, 90.0)),
+    ///         AlertMetric::new("c", "C", AlertThreshold::new(70.0, 90.0)),
+    ///     ])
+    ///     .with_columns(2);
+    /// assert_eq!(state.rows(), 2);
+    /// ```
     pub fn rows(&self) -> usize {
         if self.metrics.is_empty() {
             0

--- a/src/component/code_block/mod.rs
+++ b/src/component/code_block/mod.rs
@@ -224,6 +224,15 @@ impl CodeBlockState {
     // ---- Code accessors ----
 
     /// Returns the source code content.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CodeBlockState;
+    ///
+    /// let state = CodeBlockState::new().with_code("fn main() {}");
+    /// assert_eq!(state.code(), "fn main() {}");
+    /// ```
     pub fn code(&self) -> &str {
         &self.code
     }

--- a/src/component/dropdown/mod.rs
+++ b/src/component/dropdown/mod.rs
@@ -222,6 +222,15 @@ impl DropdownState {
     }
 
     /// Alias for [`selected_index()`](Self::selected_index).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::prelude::*;
+    ///
+    /// let state = DropdownState::with_selection(vec!["A", "B"], 1);
+    /// assert_eq!(state.selected(), state.selected_index());
+    /// ```
     pub fn selected(&self) -> Option<usize> {
         self.selected_index()
     }

--- a/src/component/input_field/mod.rs
+++ b/src/component/input_field/mod.rs
@@ -507,6 +507,17 @@ impl InputFieldState {
     }
 
     /// Updates the input field state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{InputFieldMessage, InputFieldState};
+    ///
+    /// let mut state = InputFieldState::new();
+    /// state.update(InputFieldMessage::Insert('h'));
+    /// state.update(InputFieldMessage::Insert('i'));
+    /// assert_eq!(state.value(), "hi");
+    /// ```
     pub fn update(&mut self, msg: InputFieldMessage) -> Option<InputFieldOutput> {
         InputField::update(self, msg)
     }

--- a/src/component/line_input/mod.rs
+++ b/src/component/line_input/mod.rs
@@ -453,11 +453,32 @@ impl LineInputState {
     }
 
     /// Returns the current input keybinding mode.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LineInputState;
+    /// use envision::component::line_input::InputMode;
+    ///
+    /// let state = LineInputState::new().with_input_mode(InputMode::Readline);
+    /// assert_eq!(state.input_mode(), &InputMode::Readline);
+    /// ```
     pub fn input_mode(&self) -> &InputMode {
         &self.input_mode
     }
 
     /// Sets the input keybinding mode.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LineInputState;
+    /// use envision::component::line_input::InputMode;
+    ///
+    /// let mut state = LineInputState::new();
+    /// state.set_input_mode(InputMode::Readline);
+    /// assert_eq!(state.input_mode(), &InputMode::Readline);
+    /// ```
     pub fn set_input_mode(&mut self, mode: InputMode) {
         self.input_mode = mode;
     }

--- a/src/component/searchable_list/mod.rs
+++ b/src/component/searchable_list/mod.rs
@@ -310,6 +310,15 @@ impl<T: Clone> SearchableListState<T> {
     }
 
     /// Alias for [`selected_index()`](Self::selected_index).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SearchableListState;
+    ///
+    /// let state = SearchableListState::new(vec!["A".to_string(), "B".to_string()]);
+    /// assert_eq!(state.selected(), state.selected_index());
+    /// ```
     pub fn selected(&self) -> Option<usize> {
         self.selected_index()
     }

--- a/src/component/spinner/mod.rs
+++ b/src/component/spinner/mod.rs
@@ -95,6 +95,14 @@ impl SpinnerStyle {
     ///
     /// For `Custom` styles, returns the provided frames.
     /// For empty `Custom` styles, returns a single space character.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SpinnerStyle;
+    ///
+    /// assert_eq!(SpinnerStyle::Line.frames(), &['|', '/', '-', '\\']);
+    /// ```
     pub fn frames(&self) -> &[char] {
         // Static arrays for built-in styles
         const DOTS: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];

--- a/src/component/terminal_output/mod.rs
+++ b/src/component/terminal_output/mod.rs
@@ -423,6 +423,18 @@ impl TerminalOutputState {
     // ---- Configuration accessors ----
 
     /// Returns the maximum number of lines.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "display-components")]
+    /// # {
+    /// use envision::component::TerminalOutputState;
+    ///
+    /// let state = TerminalOutputState::new().with_max_lines(500);
+    /// assert_eq!(state.max_lines(), 500);
+    /// # }
+    /// ```
     pub fn max_lines(&self) -> usize {
         self.max_lines
     }

--- a/src/component/tree/mod.rs
+++ b/src/component/tree/mod.rs
@@ -99,6 +99,15 @@ impl<T: Clone> TreeNode<T> {
     }
 
     /// Returns the node's label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TreeNode;
+    ///
+    /// let node = TreeNode::new("Documents", ());
+    /// assert_eq!(node.label(), "Documents");
+    /// ```
     pub fn label(&self) -> &str {
         &self.label
     }
@@ -744,6 +753,18 @@ impl<T: Clone> TreeState<T> {
 
 impl<T: Clone + 'static> TreeState<T> {
     /// Updates the tree state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TreeMessage, TreeNode, TreeState};
+    ///
+    /// let mut root = TreeNode::new("Root", ());
+    /// root.add_child(TreeNode::new("Child", ()));
+    /// let mut state = TreeState::new(vec![root]);
+    /// state.update(TreeMessage::Expand);
+    /// assert!(state.roots()[0].is_expanded());
+    /// ```
     pub fn update(&mut self, msg: TreeMessage) -> Option<TreeOutput> {
         Tree::update(self, msg)
     }


### PR DESCRIPTION
## Summary

- Brings doc test coverage from 99.3% (1536/1547) to 100.0% (1547/1547)
- Adds meaningful doc tests to the 11 public methods that were missing them
- All per-component doc test coverage is now 100%

## Methods documented

- `alert_panel`: `AlertPanelState::rows()`
- `terminal_output`: `TerminalOutputState::max_lines()`
- `code_block`: `CodeBlockState::code()`
- `searchable_list`: `SearchableListState::selected()`
- `input_field`: `InputFieldState::update()`
- `tree`: `TreeNode::label()`, `TreeState::update()`
- `dropdown`: `DropdownState::selected()`
- `line_input`: `LineInputState::input_mode()`, `LineInputState::set_input_mode()`
- `spinner`: `SpinnerStyle::frames()`

## Test plan

- [x] `cargo test --doc --all-features` — 2310 doc tests pass
- [x] `cargo clippy --all-features -- -D warnings` — no warnings
- [x] `cargo fmt --check` — clean
- [x] `envision-audit code` — reports 1547/1547 (100.0%) total