### PR TITLE
Add standard trait derives where possible, fix audit generic-impl detection

### DIFF
--- a/src/component/calendar/mod.rs
+++ b/src/component/calendar/mod.rs
@@ -213,6 +213,29 @@ pub struct CalendarState {
     title: Option<String>,
 }
 
+impl Default for CalendarState {
+    /// Returns a calendar for January 1970 with no selected day, no events,
+    /// and no title.
+    ///
+    /// This mirrors the conventional Unix epoch default used by date libraries
+    /// like `chrono`'s `NaiveDate::default()`. For meaningful UI, construct
+    /// state with [`CalendarState::new`] for the desired year and month.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::CalendarState;
+    ///
+    /// let state = CalendarState::default();
+    /// assert_eq!(state.year(), 1970);
+    /// assert_eq!(state.month(), 1);
+    /// assert_eq!(state.selected_day(), None);
+    /// ```
+    fn default() -> Self {
+        Self::new(1970, 1)
+    }
+}
+
 impl CalendarState {
     /// Creates a new calendar for the given year and month.
     ///

--- a/tools/audit/src/code_analysis.rs
+++ b/tools/audit/src/code_analysis.rs
@@ -948,30 +948,23 @@ fn extract_state_derives(content: &str) -> Vec<String> {
         }
     }
 
-    // Also scan for manual trait impls: `impl TraitName for ...State`
-    // Handles both short (`impl Debug for`) and fully-qualified
-    // (`impl std::fmt::Debug for`, `impl core::fmt::Debug for`) paths.
+    // Also scan for manual trait impls. Handles both short (`impl Debug for`),
+    // fully-qualified (`impl std::fmt::Debug for`, `impl core::fmt::Debug for`),
+    // and generic (`impl<T: Clone> PartialEq for FooState<T>`) impls.
     if let Some(ref state_name) = state_type_name {
         let trait_patterns: &[(&str, &[&str])] = &[
             (
                 "Debug",
-                &[
-                    "impl Debug for",
-                    "impl std::fmt::Debug for",
-                    "impl core::fmt::Debug for",
-                ],
+                &["Debug for", "std::fmt::Debug for", "core::fmt::Debug for"],
             ),
-            ("Clone", &["impl Clone for", "impl std::clone::Clone for"]),
-            (
-                "Default",
-                &["impl Default for", "impl std::default::Default for"],
-            ),
+            ("Clone", &["Clone for", "std::clone::Clone for"]),
+            ("Default", &["Default for", "std::default::Default for"]),
             (
                 "PartialEq",
                 &[
-                    "impl PartialEq for",
-                    "impl std::cmp::PartialEq for",
-                    "impl core::cmp::PartialEq for",
+                    "PartialEq for",
+                    "std::cmp::PartialEq for",
+                    "core::cmp::PartialEq for",
                 ],
             ),
         ];
@@ -980,17 +973,52 @@ fn extract_state_derives(content: &str) -> Vec<String> {
             if derives.iter().any(|d| d == *trait_name) {
                 continue; // Already found via derive
             }
-            for pattern_prefix in *patterns {
-                let pattern = format!("{} {}", pattern_prefix, state_name);
-                if content.contains(&pattern) {
-                    derives.push(trait_name.to_string());
-                    break;
-                }
+            if has_manual_trait_impl(content, patterns, state_name) {
+                derives.push(trait_name.to_string());
             }
         }
     }
 
     derives
+}
+
+/// Returns true if `content` contains a manual trait impl for `state_name`
+/// matching any of the given trait path patterns (e.g. `"PartialEq for"`).
+///
+/// Handles both non-generic (`impl PartialEq for FooState`) and generic
+/// (`impl<T: Clone> PartialEq for FooState<T>`) impls by scanning lines that
+/// begin with `impl` and checking for the `{trait} for {state_name}` signature
+/// anywhere on that line. A word-boundary check prevents `FooState` from
+/// matching `FooStateExt`.
+fn has_manual_trait_impl(content: &str, trait_patterns: &[&str], state_name: &str) -> bool {
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if !trimmed.starts_with("impl") {
+            continue;
+        }
+        // After the `impl` keyword we expect either whitespace (`impl Foo`) or
+        // a generic parameter list (`impl<T> Foo`). Anything else (e.g. an
+        // identifier like `implementation`) is not an impl block.
+        let after_impl = &trimmed[4..];
+        if !after_impl.starts_with(' ') && !after_impl.starts_with('<') {
+            continue;
+        }
+        for pattern in trait_patterns {
+            let needle = format!("{pattern} {state_name}");
+            if let Some(idx) = trimmed.find(&needle) {
+                let end = idx + needle.len();
+                let next_char = trimmed[end..].chars().next();
+                let is_boundary = match next_char {
+                    None => true,
+                    Some(c) => !c.is_alphanumeric() && c != '_',
+                };
+                if is_boundary {
+                    return true;
+                }
+            }
+        }
+    }
+    false
 }
 
 fn extract_fn_name(line: &str) -> Option<String> {

--- a/tools/audit/src/scorecard.rs
+++ b/tools/audit/src/scorecard.rs
@@ -372,7 +372,11 @@ fn extract_method_names(content: &str, prefix: &str) -> Vec<String> {
         let trimmed = line.trim();
         if let Some(rest) = trimmed.strip_prefix(prefix) {
             if let Some(name_end) = rest.find(['(', '<', ' ']) {
-                names.push(format!("{}{}", prefix.strip_prefix("pub fn ").unwrap_or(prefix), &rest[..name_end]));
+                names.push(format!(
+                    "{}{}",
+                    prefix.strip_prefix("pub fn ").unwrap_or(prefix),
+                    &rest[..name_end]
+                ));
             }
         }
     }
@@ -501,26 +505,23 @@ fn extract_state_derives(content: &str) -> Vec<String> {
     }
 
     if let Some(ref state_name) = state_type_name {
+        // Trait paths to recognize. The leading `impl` token may be followed by
+        // a generic parameter list (e.g. `impl<T: TableRow + PartialEq>`), so we
+        // scan impl lines for the `{TraitPath} for {StateName}` signature rather
+        // than anchoring on `impl {TraitPath} for`.
         let trait_patterns: &[(&str, &[&str])] = &[
             (
                 "Debug",
-                &[
-                    "impl Debug for",
-                    "impl std::fmt::Debug for",
-                    "impl core::fmt::Debug for",
-                ],
+                &["Debug for", "std::fmt::Debug for", "core::fmt::Debug for"],
             ),
-            ("Clone", &["impl Clone for", "impl std::clone::Clone for"]),
-            (
-                "Default",
-                &["impl Default for", "impl std::default::Default for"],
-            ),
+            ("Clone", &["Clone for", "std::clone::Clone for"]),
+            ("Default", &["Default for", "std::default::Default for"]),
             (
                 "PartialEq",
                 &[
-                    "impl PartialEq for",
-                    "impl std::cmp::PartialEq for",
-                    "impl core::cmp::PartialEq for",
+                    "PartialEq for",
+                    "std::cmp::PartialEq for",
+                    "core::cmp::PartialEq for",
                 ],
             ),
         ];
@@ -529,15 +530,113 @@ fn extract_state_derives(content: &str) -> Vec<String> {
             if derives.iter().any(|d| d == *trait_name) {
                 continue;
             }
-            for pattern_prefix in *patterns {
-                let pattern = format!("{} {}", pattern_prefix, state_name);
-                if content.contains(&pattern) {
-                    derives.push(trait_name.to_string());
-                    break;
-                }
+            if has_manual_trait_impl(content, patterns, state_name) {
+                derives.push(trait_name.to_string());
             }
         }
     }
 
     derives
+}
+
+/// Returns true if `content` contains a manual trait impl for `state_name`
+/// matching any of the given trait path patterns (e.g. `"PartialEq for"`).
+///
+/// Handles both non-generic (`impl PartialEq for FooState`) and generic
+/// (`impl<T: Clone> PartialEq for FooState<T>`) impls by scanning lines that
+/// begin with `impl` and checking for the `{trait} for {state_name}` signature
+/// anywhere on that line. A word-boundary check prevents `FooState` from
+/// matching `FooStateExt`.
+fn has_manual_trait_impl(content: &str, trait_patterns: &[&str], state_name: &str) -> bool {
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if !trimmed.starts_with("impl") {
+            continue;
+        }
+        // After the `impl` keyword we expect either whitespace (`impl Foo`) or
+        // a generic parameter list (`impl<T> Foo`). Anything else (e.g. an
+        // identifier like `implementation`) is not an impl block.
+        let after_impl = &trimmed[4..];
+        if !after_impl.starts_with(' ') && !after_impl.starts_with('<') {
+            continue;
+        }
+        for pattern in trait_patterns {
+            let needle = format!("{pattern} {state_name}");
+            if let Some(idx) = trimmed.find(&needle) {
+                let end = idx + needle.len();
+                let next_char = trimmed[end..].chars().next();
+                let is_boundary = match next_char {
+                    None => true,
+                    Some(c) => !c.is_alphanumeric() && c != '_',
+                };
+                if is_boundary {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_derive_list_from_attribute() {
+        let content = "#[derive(Clone, Debug, PartialEq)]\npub struct FooState { x: u8 }";
+        let derives = extract_state_derives(content);
+        assert!(derives.contains(&"Clone".to_string()));
+        assert!(derives.contains(&"Debug".to_string()));
+        assert!(derives.contains(&"PartialEq".to_string()));
+        assert!(!derives.contains(&"Default".to_string()));
+    }
+
+    #[test]
+    fn detects_manual_non_generic_impl() {
+        let content =
+            "pub struct FooState { x: u8 }\nimpl Default for FooState { fn default() -> Self { unimplemented!() } }";
+        let derives = extract_state_derives(content);
+        assert!(derives.contains(&"Default".to_string()));
+    }
+
+    #[test]
+    fn detects_manual_generic_impl() {
+        // Regression test: audit previously missed generic manual impls.
+        let content = "pub struct FooState<T: Clone> { x: T }\nimpl<T: Clone + PartialEq> PartialEq for FooState<T> { fn eq(&self, other: &Self) -> bool { true } }";
+        let derives = extract_state_derives(content);
+        assert!(derives.contains(&"PartialEq".to_string()));
+    }
+
+    #[test]
+    fn detects_manual_generic_default_impl() {
+        let content = "pub struct FooState<T: Clone> { x: T }\nimpl<T: Clone> Default for FooState<T> { fn default() -> Self { unimplemented!() } }";
+        let derives = extract_state_derives(content);
+        assert!(derives.contains(&"Default".to_string()));
+    }
+
+    #[test]
+    fn detects_fully_qualified_path() {
+        let content =
+            "pub struct FooState;\nimpl std::cmp::PartialEq for FooState { fn eq(&self, _other: &Self) -> bool { true } }";
+        let derives = extract_state_derives(content);
+        assert!(derives.contains(&"PartialEq".to_string()));
+    }
+
+    #[test]
+    fn does_not_match_state_with_extended_name() {
+        // `FooState` should not match `FooStateExt` due to word boundary.
+        let content = "pub struct FooState;\nimpl PartialEq for FooStateExt { fn eq(&self, _other: &Self) -> bool { true } }";
+        let derives = extract_state_derives(content);
+        assert!(!derives.contains(&"PartialEq".to_string()));
+    }
+
+    #[test]
+    fn ignores_impl_like_words_in_comments() {
+        // Lines like `// implementation notes` should not trigger detection.
+        let content =
+            "pub struct FooState;\n// implementation of PartialEq for FooState would be...";
+        let derives = extract_state_derives(content);
+        assert!(!derives.contains(&"PartialEq".to_string()));
+    }
 }


### PR DESCRIPTION
## Summary

Brings State-type trait coverage to 100% on the audit scorecard by fixing two issues: one genuine missing impl and one audit-tool false positive affecting 8 components.

### 1. `CalendarState` now implements `Default`

Calendar was the single State type genuinely missing a `Default` impl. Added one that returns January 1970 (matching `chrono::NaiveDate::default()` convention). The doc comment on the `Default` impl directs users to `CalendarState::new(year, month)` for meaningful UI, since any arbitrary default date is inherently a placeholder.

### 2. Audit tool now detects generic manual impls

The scorecard and code-analysis scanners used literal substring checks like `impl PartialEq for FooState`, which fail to match generic impls such as:

```rust
impl<T: Clone + PartialEq> PartialEq for FooState<T> { ... }
```

Because of this, 8 components were falsely reported as missing `Default`/`PartialEq` derives even though they all had correct manual impls:

- `data_grid`, `loading_list`, `radio_group`, `router`, `selectable_list`, `table`, `tabs`, `tree`

All 8 use generic manual impls with bounds like `T: Clone + PartialEq` (rather than `#[derive]`) specifically to avoid the overly strict `T: Default` / `T: PartialEq` bounds that `#[derive]` would add. This is the idiomatic pattern for generic state — the manual impls are correct; the audit had a bug.

**Fix:** replaced the substring check with a line-scanner helper (`has_manual_trait_impl`) that:
- Only considers lines starting with `impl` (after trim).
- Requires either whitespace or `<` after `impl` (so identifiers like `implementation` don't match).
- Finds `{Trait} for {StateName}` anywhere on the line.
- Applies a word-boundary check so `FooState` doesn't match `FooStateExt`.

Added 7 unit tests covering the derive-attribute path, non-generic impls, generic impls (regression test), fully-qualified paths, the word-boundary case, and a negative test for the comment-line case.

### Components reviewed (no change needed)

All 8 generic components already had correct manual `Default` + `PartialEq` impls — the audit simply wasn't detecting them. These manual impls are intentional and should not be replaced with `#[derive]`, because `#[derive]` would add `T: Default` / `T: PartialEq` bounds that the types don't actually require (e.g. `Vec<T>::default()` doesn't need `T: Default`).

### Scorecard before / after

```
Before:                                           After:
  Default on State types     62/71 FAIL             72/72 PASS
  PartialEq on State types   63/71 FAIL             72/72 PASS
  Debug on State types       71/71 PASS             72/72 PASS
  Clone on State types       71/71 PASS             72/72 PASS
```

(Total increased from 71 to 72 because one component that previously had only generic manual impls was skipped entirely by the old counter.)

## Test plan

- [x] `cargo test --all-features` — 7057 unit + all doctests pass
- [x] `cargo clippy --all-features -- -D warnings` — clean
- [x] `cargo test --manifest-path tools/audit/Cargo.toml` — 7 new tests pass
- [x] `cargo clippy --manifest-path tools/audit/Cargo.toml -- -D warnings` — clean
- [x] `cargo fmt --check` — clean (both workspace and audit tool)
- [x] `./tools/audit/target/release/envision-audit scorecard` — 4 trait-derive checks all PASS