### PR TITLE
Fix audit to scan all files + add 16 missing getters (0 gaps)

### DIFF
--- a/examples/component_showcase.rs
+++ b/examples/component_showcase.rs
@@ -423,13 +423,12 @@ impl App for ShowcaseApp {
                         );
                     }
                     Some(FocusId::SubmitButton) => {
-                        if Button::dispatch_event(
+                        let output = Button::dispatch_event(
                             &mut state.submit_button,
                             &event,
                             &EventContext::new().focused(true),
-                        )
-                        .is_some()
-                        {
+                        );
+                        if output.is_some() {
                             Dialog::update(&mut state.dialog, DialogMessage::Open);
                         }
                     }

--- a/src/component/chart/state.rs
+++ b/src/component/chart/state.rs
@@ -785,6 +785,24 @@ impl ChartState {
         self.y_max = max;
     }
 
+    /// Returns the manual Y-axis range as a `(min, max)` tuple.
+    ///
+    /// Each bound is `None` when auto-scaling from data is used.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ChartState, DataSeries};
+    ///
+    /// let mut state = ChartState::area(vec![DataSeries::new("CPU", vec![50.0])]);
+    /// assert_eq!(state.y_range(), (None, None));
+    /// state.set_y_range(Some(0.0), Some(100.0));
+    /// assert_eq!(state.y_range(), (Some(0.0), Some(100.0)));
+    /// ```
+    pub fn y_range(&self) -> (Option<f64>, Option<f64>) {
+        (self.y_min, self.y_max)
+    }
+
     // ---- Computed properties ----
 
     /// Computes the global min value across all series.

--- a/src/component/command_palette/mod.rs
+++ b/src/component/command_palette/mod.rs
@@ -556,7 +556,7 @@ impl CommandPaletteState {
                     fuzzy_score(&self.query, &item.label).map(|score| (i, score))
                 })
                 .collect();
-            scored.sort_by(|a, b| b.1.cmp(&a.1));
+            scored.sort_by_key(|b| std::cmp::Reverse(b.1));
             self.filtered_indices = scored.into_iter().map(|(i, _)| i).collect();
         }
 

--- a/src/component/conversation_view/state.rs
+++ b/src/component/conversation_view/state.rs
@@ -180,6 +180,28 @@ impl ConversationViewState {
         self.role_style_overrides.get(role)
     }
 
+    /// Returns the style override for a specific role, if one has been set.
+    ///
+    /// This is an alias for [`role_style_override`](Self::role_style_override).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{ConversationViewState, ConversationRole};
+    /// use ratatui::style::{Color, Style};
+    ///
+    /// let mut state = ConversationViewState::new();
+    /// state.set_role_style(ConversationRole::User, Style::default().fg(Color::Cyan));
+    /// assert_eq!(
+    ///     state.role_style(&ConversationRole::User),
+    ///     Some(&Style::default().fg(Color::Cyan)),
+    /// );
+    /// assert!(state.role_style(&ConversationRole::Assistant).is_none());
+    /// ```
+    pub fn role_style(&self, role: &ConversationRole) -> Option<&Style> {
+        self.role_style_override(role)
+    }
+
     /// Sets a style override for a specific role.
     ///
     /// # Example

--- a/src/component/dependency_graph/types.rs
+++ b/src/component/dependency_graph/types.rs
@@ -160,6 +160,24 @@ impl GraphNode {
         self.color = color;
     }
 
+    /// Returns the override color, if one has been set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::GraphNode;
+    /// use ratatui::style::Color;
+    ///
+    /// let node = GraphNode::new("svc", "Service").with_color(Color::Cyan);
+    /// assert_eq!(node.color(), Some(Color::Cyan));
+    ///
+    /// let plain = GraphNode::new("svc", "Service");
+    /// assert_eq!(plain.color(), None);
+    /// ```
+    pub fn color(&self) -> Option<Color> {
+        self.color
+    }
+
     /// Adds a metadata key-value pair (builder pattern).
     ///
     /// # Example
@@ -277,5 +295,23 @@ impl GraphEdge {
     /// ```
     pub fn set_color(&mut self, color: Option<Color>) {
         self.color = color;
+    }
+
+    /// Returns the override color, if one has been set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::GraphEdge;
+    /// use ratatui::style::Color;
+    ///
+    /// let edge = GraphEdge::new("a", "b").with_color(Color::Red);
+    /// assert_eq!(edge.color(), Some(Color::Red));
+    ///
+    /// let plain = GraphEdge::new("a", "b");
+    /// assert_eq!(plain.color(), None);
+    /// ```
+    pub fn color(&self) -> Option<Color> {
+        self.color
     }
 }

--- a/src/component/event_stream/state.rs
+++ b/src/component/event_stream/state.rs
@@ -404,6 +404,23 @@ impl EventStreamState {
     }
 
     /// Returns the current text filter.
+    ///
+    /// This is an alias for [`filter_text`](Self::filter_text).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let mut state = EventStreamState::new();
+    /// state.set_filter("error".to_string());
+    /// assert_eq!(state.filter(), "error");
+    /// ```
+    pub fn filter(&self) -> &str {
+        self.filter_text()
+    }
+
+    /// Returns the current text filter.
     pub fn filter_text(&self) -> &str {
         &self.filter_text
     }

--- a/src/component/loading_list/mod.rs
+++ b/src/component/loading_list/mod.rs
@@ -520,6 +520,79 @@ impl<T: Clone> LoadingListState<T> {
         }
     }
 
+    /// Returns whether the item at the given index is in the loading state.
+    ///
+    /// Returns `false` if the index is out of bounds.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let mut state = LoadingListState::with_items(
+    ///     vec!["task".to_string()],
+    ///     |s| s.clone(),
+    /// );
+    /// assert!(!state.is_loading(0));
+    /// state.set_loading(0);
+    /// assert!(state.is_loading(0));
+    /// assert!(!state.is_loading(99));
+    /// ```
+    pub fn is_loading(&self, index: usize) -> bool {
+        self.items
+            .get(index)
+            .is_some_and(|item| item.state == ItemState::Loading)
+    }
+
+    /// Returns whether the item at the given index is in the ready state.
+    ///
+    /// Returns `false` if the index is out of bounds.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let mut state = LoadingListState::with_items(
+    ///     vec!["task".to_string()],
+    ///     |s| s.clone(),
+    /// );
+    /// assert!(state.is_ready(0));
+    /// state.set_loading(0);
+    /// assert!(!state.is_ready(0));
+    /// state.set_ready(0);
+    /// assert!(state.is_ready(0));
+    /// ```
+    pub fn is_ready(&self, index: usize) -> bool {
+        self.items
+            .get(index)
+            .is_some_and(|item| item.state == ItemState::Ready)
+    }
+
+    /// Returns whether the item at the given index is in an error state.
+    ///
+    /// Returns `false` if the index is out of bounds.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LoadingListState;
+    ///
+    /// let mut state = LoadingListState::with_items(
+    ///     vec!["task".to_string()],
+    ///     |s| s.clone(),
+    /// );
+    /// assert!(!state.is_error(0));
+    /// state.set_error(0, "Connection refused");
+    /// assert!(state.is_error(0));
+    /// assert!(!state.is_error(99));
+    /// ```
+    pub fn is_error(&self, index: usize) -> bool {
+        self.items
+            .get(index)
+            .is_some_and(|item| item.state.is_error())
+    }
+
     /// Returns the number of items currently loading.
     ///
     /// # Example

--- a/src/component/metrics_dashboard/widget.rs
+++ b/src/component/metrics_dashboard/widget.rs
@@ -216,6 +216,98 @@ impl MetricWidget {
         }
     }
 
+    /// Returns the counter value, if this is a counter widget.
+    ///
+    /// Returns `None` for non-counter widgets.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MetricWidget;
+    ///
+    /// let widget = MetricWidget::counter("Requests", 42);
+    /// assert_eq!(widget.counter_value(), Some(42));
+    ///
+    /// let gauge = MetricWidget::gauge("Mem", 50, 100);
+    /// assert_eq!(gauge.counter_value(), None);
+    /// ```
+    pub fn counter_value(&self) -> Option<i64> {
+        if let MetricKind::Counter { value } = &self.kind {
+            Some(*value)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the gauge value and max, if this is a gauge widget.
+    ///
+    /// Returns `None` for non-gauge widgets.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MetricWidget;
+    ///
+    /// let widget = MetricWidget::gauge("Memory", 512, 1024);
+    /// assert_eq!(widget.gauge_value(), Some((512, 1024)));
+    ///
+    /// let counter = MetricWidget::counter("Ops", 0);
+    /// assert_eq!(counter.gauge_value(), None);
+    /// ```
+    pub fn gauge_value(&self) -> Option<(u64, u64)> {
+        if let MetricKind::Gauge { value, max } = &self.kind {
+            Some((*value, *max))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the status (up/down), if this is a status widget.
+    ///
+    /// Returns `None` for non-status widgets.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MetricWidget;
+    ///
+    /// let widget = MetricWidget::status("API", true);
+    /// assert_eq!(widget.is_status(), Some(true));
+    ///
+    /// let counter = MetricWidget::counter("Ops", 0);
+    /// assert_eq!(counter.is_status(), None);
+    /// ```
+    pub fn is_status(&self) -> Option<bool> {
+        if let MetricKind::Status { up } = &self.kind {
+            Some(*up)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the text value, if this is a text widget.
+    ///
+    /// Returns `None` for non-text widgets.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::MetricWidget;
+    ///
+    /// let widget = MetricWidget::text("Version", "1.2.3");
+    /// assert_eq!(widget.text_value(), Some("1.2.3"));
+    ///
+    /// let counter = MetricWidget::counter("Ops", 0);
+    /// assert_eq!(counter.text_value(), None);
+    /// ```
+    pub fn text_value(&self) -> Option<&str> {
+        if let MetricKind::Text { text } = &self.kind {
+            Some(text)
+        } else {
+            None
+        }
+    }
+
     /// Sets the counter value.
     ///
     /// # Example

--- a/src/component/searchable_list/mod.rs
+++ b/src/component/searchable_list/mod.rs
@@ -641,7 +641,7 @@ impl<T: Clone + Display + 'static> SearchableListState<T> {
                     matcher(&self.filter_text, &text).map(|score| (i, score))
                 })
                 .collect();
-            scored.sort_by(|a, b| b.1.cmp(&a.1));
+            scored.sort_by_key(|b| std::cmp::Reverse(b.1));
             self.filtered_indices = scored.into_iter().map(|(i, _)| i).collect();
         } else {
             // Default: case-insensitive substring match

--- a/src/component/status_bar/item.rs
+++ b/src/component/status_bar/item.rs
@@ -378,23 +378,18 @@ impl StatusBarItem {
         match &mut self.content {
             StatusBarItemContent::ElapsedTime {
                 elapsed_ms,
-                running,
+                running: true,
                 ..
             } => {
-                if *running {
-                    *elapsed_ms += delta_ms;
-                    true
-                } else {
-                    false
-                }
+                *elapsed_ms += delta_ms;
+                true
             }
-            StatusBarItemContent::Heartbeat { active, frame } => {
-                if *active {
-                    *frame = (*frame + 1) % 4;
-                    true
-                } else {
-                    false
-                }
+            StatusBarItemContent::Heartbeat {
+                active: true,
+                frame,
+            } => {
+                *frame = (*frame + 1) % 4;
+                true
             }
             _ => false,
         }

--- a/src/component/step_indicator/state.rs
+++ b/src/component/step_indicator/state.rs
@@ -430,6 +430,29 @@ impl StepIndicatorState {
         self.status_style_overrides.get(status)
     }
 
+    /// Returns the per-status style override, if one is set.
+    ///
+    /// This is an alias for [`status_style_override`](Self::status_style_override).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::{Step, StepStatus};
+    /// use envision::component::StepIndicatorState;
+    /// use ratatui::style::{Color, Style};
+    ///
+    /// let mut state = StepIndicatorState::new(vec![Step::new("A")]);
+    /// state.set_status_style(StepStatus::Active, Style::default().fg(Color::Yellow));
+    /// assert_eq!(
+    ///     state.status_style(&StepStatus::Active),
+    ///     Some(&Style::default().fg(Color::Yellow)),
+    /// );
+    /// assert!(state.status_style(&StepStatus::Pending).is_none());
+    /// ```
+    pub fn status_style(&self, status: &StepStatus) -> Option<&Style> {
+        self.status_style_override(status)
+    }
+
     /// Sets a per-status style override.
     ///
     /// # Example
@@ -481,6 +504,29 @@ impl StepIndicatorState {
     /// ```
     pub fn step_style_override(&self, index: usize) -> Option<&Style> {
         self.step_style_overrides.get(&index)
+    }
+
+    /// Returns the per-step-index style override, if one is set.
+    ///
+    /// This is an alias for [`step_style_override`](Self::step_style_override).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::step_indicator::Step;
+    /// use envision::component::StepIndicatorState;
+    /// use ratatui::style::{Color, Style};
+    ///
+    /// let mut state = StepIndicatorState::new(vec![Step::new("A"), Step::new("B")]);
+    /// state.set_step_style(0, Style::default().fg(Color::Cyan));
+    /// assert_eq!(
+    ///     state.step_style(0),
+    ///     Some(&Style::default().fg(Color::Cyan)),
+    /// );
+    /// assert!(state.step_style(1).is_none());
+    /// ```
+    pub fn step_style(&self, index: usize) -> Option<&Style> {
+        self.step_style_override(index)
     }
 
     /// Sets a per-step-index style override.

--- a/src/component/terminal_output/ansi.rs
+++ b/src/component/terminal_output/ansi.rs
@@ -170,14 +170,13 @@ fn apply_sgr(params: &str, mut style: Style) -> Style {
             37 => style = style.fg(Color::White),
 
             // 256-color foreground: 38;5;n
-            38 => {
-                if i + 2 < codes.len() && codes[i + 1] == "5" {
-                    if let Ok(n) = codes[i + 2].parse::<u8>() {
-                        style = style.fg(Color::Indexed(n));
-                        i += 2;
-                    }
+            38 if i + 2 < codes.len() && codes[i + 1] == "5" => {
+                if let Ok(n) = codes[i + 2].parse::<u8>() {
+                    style = style.fg(Color::Indexed(n));
+                    i += 2;
                 }
             }
+            38 => {}
 
             // Default foreground
             39 => style = style.fg(Color::Reset),
@@ -193,14 +192,13 @@ fn apply_sgr(params: &str, mut style: Style) -> Style {
             47 => style = style.bg(Color::White),
 
             // 256-color background: 48;5;n
-            48 => {
-                if i + 2 < codes.len() && codes[i + 1] == "5" {
-                    if let Ok(n) = codes[i + 2].parse::<u8>() {
-                        style = style.bg(Color::Indexed(n));
-                        i += 2;
-                    }
+            48 if i + 2 < codes.len() && codes[i + 1] == "5" => {
+                if let Ok(n) = codes[i + 2].parse::<u8>() {
+                    style = style.bg(Color::Indexed(n));
+                    i += 2;
                 }
             }
+            48 => {}
 
             // Default background
             49 => style = style.bg(Color::Reset),

--- a/src/component/timeline/types.rs
+++ b/src/component/timeline/types.rs
@@ -94,6 +94,21 @@ impl TimelineEvent {
     pub fn set_color(&mut self, color: Color) {
         self.color = color;
     }
+
+    /// Returns the color for this event marker.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TimelineEvent;
+    /// use ratatui::style::Color;
+    ///
+    /// let event = TimelineEvent::new("e1", 0.0, "Start").with_color(Color::Red);
+    /// assert_eq!(event.color(), Color::Red);
+    /// ```
+    pub fn color(&self) -> Color {
+        self.color
+    }
 }
 
 /// A span (duration) on the timeline.
@@ -194,6 +209,21 @@ impl TimelineSpan {
     /// ```
     pub fn set_color(&mut self, color: Color) {
         self.color = color;
+    }
+
+    /// Returns the color for this span bar.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::TimelineSpan;
+    /// use ratatui::style::Color;
+    ///
+    /// let span = TimelineSpan::new("s1", 0.0, 100.0, "task").with_color(Color::Red);
+    /// assert_eq!(span.color(), Color::Red);
+    /// ```
+    pub fn color(&self) -> Color {
+        self.color
     }
 
     /// Sets the lane (builder pattern).

--- a/tools/audit/src/code_analysis.rs
+++ b/tools/audit/src/code_analysis.rs
@@ -72,7 +72,7 @@ fn analyze_components(src: &Path) -> BTreeMap<String, ComponentInfo> {
 
 fn analyze_single_component(dir: &Path) -> ComponentInfo {
     let all_content = read_all_rs_in_dir(dir);
-    let mod_content = fs::read_to_string(dir.join("mod.rs")).unwrap_or_default();
+    let source_content = read_non_test_sources(dir);
 
     let focusable_re = Regex::new(r"impl\b[^{{]*\bFocusable\b\s+for\b").unwrap();
     let toggleable_re = Regex::new(r"impl\b[^{{]*\bToggleable\b\s+for\b").unwrap();
@@ -80,15 +80,15 @@ fn analyze_single_component(dir: &Path) -> ComponentInfo {
     let has_focusable = focusable_re.is_match(&all_content);
     let has_toggleable = toggleable_re.is_match(&all_content);
     let has_disabled =
-        mod_content.contains("fn is_disabled") && mod_content.contains("fn set_disabled");
+        source_content.contains("fn is_disabled") && source_content.contains("fn set_disabled");
     let has_visible =
-        mod_content.contains("fn is_visible") && mod_content.contains("fn set_visible");
+        source_content.contains("fn is_visible") && source_content.contains("fn set_visible");
 
-    let builder_methods = extract_method_names(&mod_content, "pub fn with_");
-    let setter_methods = extract_method_names(&mod_content, "pub fn set_");
-    let getter_methods = extract_getter_methods(&mod_content);
-    let public_method_names = extract_all_public_fn_names(&mod_content);
-    let (pub_fn_count, pub_fn_with_doctest) = count_doctest_coverage(&mod_content);
+    let builder_methods = extract_method_names(&source_content, "pub fn with_");
+    let setter_methods = extract_method_names(&source_content, "pub fn set_");
+    let getter_methods = extract_getter_methods(&source_content);
+    let public_method_names = extract_all_public_fn_names(&source_content);
+    let (pub_fn_count, pub_fn_with_doctest) = count_doctest_coverage(&source_content);
 
     let test_content = read_test_files(dir);
     let unit_test_count =
@@ -97,11 +97,11 @@ fn analyze_single_component(dir: &Path) -> ComponentInfo {
     let snapshot_content = fs::read_to_string(dir.join("snapshot_tests.rs")).unwrap_or_default();
     let snapshot_test_count = snapshot_content.matches("#[test]").count();
 
-    // Instance method checks (methods that take &self or &mut self)
-    let has_instance_handle_event = mod_content.contains("pub fn handle_event(&self")
-        || mod_content.contains("pub fn handle_event(&mut self");
-    let has_instance_dispatch_event = mod_content.contains("pub fn dispatch_event(&mut self");
-    let has_instance_update = mod_content.contains("pub fn update(&mut self");
+    let has_instance_handle_event = source_content.contains("pub fn handle_event(&self")
+        || source_content.contains("pub fn handle_event(&mut self");
+    let has_instance_dispatch_event =
+        source_content.contains("pub fn dispatch_event(&mut self");
+    let has_instance_update = source_content.contains("pub fn update(&mut self");
 
     // Standard trait derives on State type (check all files, not just mod.rs,
     // since some components define their State struct in a separate state.rs)
@@ -813,6 +813,35 @@ fn non_test_lines(content: &str) -> impl Iterator<Item = &str> {
     }
 
     result.into_iter()
+}
+
+fn read_non_test_sources(dir: &Path) -> String {
+    let mut combined = String::new();
+    let test_filenames = ["tests.rs", "snapshot_tests.rs"];
+
+    let Ok(entries) = fs::read_dir(dir) else {
+        return combined;
+    };
+    let mut files: Vec<_> = entries.flatten().collect();
+    files.sort_by_key(|e| e.path());
+
+    for entry in files {
+        let path = entry.path();
+        if !path.is_file() || !path.extension().is_some_and(|e| e == "rs") {
+            continue;
+        }
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            if test_filenames.contains(&name) {
+                continue;
+            }
+        }
+        if let Ok(content) = fs::read_to_string(&path) {
+            let filtered = non_test_content(&content);
+            combined.push_str(&filtered);
+            combined.push('\n');
+        }
+    }
+    combined
 }
 
 fn read_all_rs_in_dir(dir: &Path) -> String {

--- a/tools/audit/src/code_analysis.rs
+++ b/tools/audit/src/code_analysis.rs
@@ -245,10 +245,11 @@ fn print_accessor_symmetry(components: &BTreeMap<String, ComponentInfo>) {
             .iter()
             .filter(|setter| {
                 let getter_name = setter.strip_prefix("set_").unwrap_or(setter);
-                !info
-                    .getter_methods
-                    .iter()
-                    .any(|g| g == getter_name || g == &format!("is_{}", getter_name))
+                !info.getter_methods.iter().any(|g| {
+                    g == getter_name
+                        || g == &format!("is_{}", getter_name)
+                        || g == &format!("{}_value", getter_name)
+                })
             })
             .collect();
         if !missing.is_empty() {

--- a/tools/audit/src/scorecard.rs
+++ b/tools/audit/src/scorecard.rs
@@ -150,10 +150,9 @@ fn count_accessor_gaps(src: &Path) -> usize {
         if !mod_file.exists() {
             continue;
         }
-        let content = fs::read_to_string(&mod_file).unwrap_or_default();
-        let filtered = non_test_content(&content);
-        let setters = extract_method_names(&filtered, "pub fn set_");
-        let getters = extract_getter_methods(&filtered);
+        let content = read_non_test_sources(&entry.path());
+        let setters = extract_method_names(&content, "pub fn set_");
+        let getters = extract_getter_methods(&content);
 
         for setter in &setters {
             let getter_name = setter.strip_prefix("set_").unwrap_or(setter);
@@ -186,7 +185,7 @@ fn count_doctest_coverage(src: &Path) -> (usize, usize) {
         if !mod_file.exists() {
             continue;
         }
-        let content = fs::read_to_string(&mod_file).unwrap_or_default();
+        let content = read_non_test_sources(&entry.path());
         let (pub_fns, with_doctest) = count_doctest_in_content(&content);
         total_pub += pub_fns;
         total_with += with_doctest;
@@ -270,6 +269,35 @@ fn count_clippy_suppressions(src: &Path) -> usize {
 }
 
 // --- Helper functions ---
+
+fn read_non_test_sources(component_dir: &Path) -> String {
+    let mut combined = String::new();
+    let test_filenames = ["tests.rs", "snapshot_tests.rs"];
+
+    let Ok(entries) = fs::read_dir(component_dir) else {
+        return combined;
+    };
+    let mut files: Vec<_> = entries.flatten().collect();
+    files.sort_by_key(|e| e.path());
+
+    for entry in files {
+        let path = entry.path();
+        if !path.is_file() || path.extension().is_some_and(|e| e != "rs") {
+            continue;
+        }
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            if test_filenames.contains(&name) {
+                continue;
+            }
+        }
+        if let Ok(content) = fs::read_to_string(&path) {
+            let filtered = non_test_content(&content);
+            combined.push_str(&filtered);
+            combined.push('\n');
+        }
+    }
+    combined
+}
 
 fn walk_rs_files(dir: &Path, callback: &mut dyn FnMut(&Path, &str)) {
     let Ok(entries) = fs::read_dir(dir) else {

--- a/tools/audit/src/scorecard.rs
+++ b/tools/audit/src/scorecard.rs
@@ -156,9 +156,11 @@ fn count_accessor_gaps(src: &Path) -> usize {
 
         for setter in &setters {
             let getter_name = setter.strip_prefix("set_").unwrap_or(setter);
-            let has_getter = getters
-                .iter()
-                .any(|g| g == getter_name || g == &format!("is_{}", getter_name));
+            let has_getter = getters.iter().any(|g| {
+                g == getter_name
+                    || g == &format!("is_{}", getter_name)
+                    || g == &format!("{}_value", getter_name)
+            });
             if !has_getter {
                 total_gaps += 1;
             }


### PR DESCRIPTION
## Summary

- **Audit tool fix**: Updated `code_analysis.rs` to scan all `.rs` files in each component directory (not just `mod.rs`), catching setters in `state.rs`, `types.rs`, `widget.rs`, etc.
- **Audit tool enhancement**: Accept `X_value()` as a valid match for `set_X()` when a constructor named `X()` prevents using the plain name
- **16 new getter methods** across 8 files to close all accessor symmetry gaps:
  - `chart::y_range()` returns `(Option<f64>, Option<f64>)`
  - `conversation_view::role_style()` alias for `role_style_override()`
  - `dependency_graph::GraphNode::color()` and `GraphEdge::color()`
  - `event_stream::filter()` alias for `filter_text()`
  - `loading_list::is_loading(index)`, `is_ready(index)`, `is_error(index)`
  - `metrics_dashboard::counter_value()`, `gauge_value()`, `is_status()`, `text_value()`
  - `step_indicator::status_style()` and `step_style()` aliases
  - `timeline::TimelineEvent::color()` and `TimelineSpan::color()`

## Verification

- Accessor symmetry gaps: **0** (was 13)
- All 2327 doc tests pass
- Clippy clean, `cargo fmt` clean
- Every new getter has a doc comment with a runnable doc test

## Test plan

- [x] `cargo clippy --all-features` passes with no warnings
- [x] `cargo test --doc --all-features` passes (2327 tests)
- [x] `cargo fmt -- --check` passes
- [x] `envision-audit scorecard` shows 0 accessor symmetry gaps
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)