### PR TITLE
Doc tests batch B: 7 components to 100%

### DIFF
--- a/src/component/dependency_graph/layout.rs
+++ b/src/component/dependency_graph/layout.rs
@@ -120,6 +120,27 @@ fn assign_layers(nodes: &[GraphNode], edges: &[GraphEdge]) -> HashMap<String, us
 ///
 /// Returns `(layout_nodes, layout_edges)` where each node has a position and
 /// size, and each edge has start and end coordinates.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::component::dependency_graph::layout::compute_layout;
+/// use envision::component::{GraphNode, GraphEdge, GraphOrientation};
+/// use ratatui::prelude::Rect;
+///
+/// let nodes = vec![
+///     GraphNode::new("api", "API"),
+///     GraphNode::new("db", "Database"),
+/// ];
+/// let edges = vec![GraphEdge::new("api", "db")];
+/// let area = Rect::new(0, 0, 80, 24);
+///
+/// let (layout_nodes, layout_edges) = compute_layout(
+///     &nodes, &edges, area, &GraphOrientation::LeftToRight,
+/// );
+/// assert_eq!(layout_nodes.len(), 2);
+/// assert_eq!(layout_edges.len(), 1);
+/// ```
 pub fn compute_layout(
     nodes: &[GraphNode],
     edges: &[GraphEdge],

--- a/src/component/file_browser/types.rs
+++ b/src/component/file_browser/types.rs
@@ -192,26 +192,80 @@ impl FileEntry {
     }
 
     /// Returns the entry name.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::FileEntry;
+    ///
+    /// let entry = FileEntry::file("README.md", "/README.md");
+    /// assert_eq!(entry.name(), "README.md");
+    /// ```
     pub fn name(&self) -> &str {
         &self.name
     }
 
     /// Returns the full path.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::FileEntry;
+    ///
+    /// let entry = FileEntry::file("main.rs", "/src/main.rs");
+    /// assert_eq!(entry.path(), "/src/main.rs");
+    /// ```
     pub fn path(&self) -> &str {
         &self.path
     }
 
     /// Returns true if this is a directory.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::FileEntry;
+    ///
+    /// let file = FileEntry::file("main.rs", "/main.rs");
+    /// assert!(!file.is_dir());
+    ///
+    /// let dir = FileEntry::directory("src", "/src");
+    /// assert!(dir.is_dir());
+    /// ```
     pub fn is_dir(&self) -> bool {
         self.is_dir
     }
 
     /// Returns the file size in bytes, if known.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::FileEntry;
+    ///
+    /// let entry = FileEntry::file("data.bin", "/data.bin");
+    /// assert_eq!(entry.size(), None);
+    ///
+    /// let sized = entry.with_size(4096);
+    /// assert_eq!(sized.size(), Some(4096));
+    /// ```
     pub fn size(&self) -> Option<u64> {
         self.size
     }
 
     /// Returns the modification timestamp, if known.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::file_browser::FileEntry;
+    ///
+    /// let entry = FileEntry::file("data.bin", "/data.bin");
+    /// assert_eq!(entry.modified(), None);
+    ///
+    /// let timed = entry.with_modified(1700000000);
+    /// assert_eq!(timed.modified(), Some(1700000000));
+    /// ```
     pub fn modified(&self) -> Option<u64> {
         self.modified
     }

--- a/src/component/form/field.rs
+++ b/src/component/form/field.rs
@@ -166,6 +166,18 @@ impl FormField {
     }
 
     /// Returns the field kind.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{FormField, FormFieldKind};
+    ///
+    /// let text_field = FormField::text("name", "Name");
+    /// assert!(matches!(text_field.kind(), FormFieldKind::Text));
+    ///
+    /// let checkbox = FormField::checkbox("agree", "I agree");
+    /// assert!(matches!(checkbox.kind(), FormFieldKind::Checkbox));
+    /// ```
     pub fn kind(&self) -> &FormFieldKind {
         &self.kind
     }

--- a/src/component/loading_list/items.rs
+++ b/src/component/loading_list/items.rs
@@ -86,6 +86,22 @@ impl ItemState {
     }
 
     /// Returns the symbol for this state.
+    ///
+    /// The `spinner_frame` parameter controls which animation frame is
+    /// displayed for the loading state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ItemState;
+    ///
+    /// assert_eq!(ItemState::Ready.symbol(0), " ");
+    /// assert_eq!(ItemState::Error("failed".into()).symbol(0), "✗");
+    ///
+    /// // Loading state cycles through braille spinner frames
+    /// let sym = ItemState::Loading.symbol(0);
+    /// assert!(!sym.is_empty());
+    /// ```
     pub fn symbol(&self, spinner_frame: usize) -> &'static str {
         match self {
             Self::Ready => " ",

--- a/src/component/markdown_renderer/render.rs
+++ b/src/component/markdown_renderer/render.rs
@@ -26,6 +26,17 @@ use crate::theme::Theme;
 /// Paragraph text and list items are word-wrapped at `width` to prevent
 /// overflow, preserving inline styling (bold, italic, etc.) across
 /// wrapped lines.
+///
+/// # Example
+///
+/// ```rust
+/// use envision::component::markdown_renderer::render::render_markdown;
+/// use envision::Theme;
+///
+/// let theme = Theme::default();
+/// let lines = render_markdown("# Hello\n\nSome text.", 40, &theme);
+/// assert!(!lines.is_empty());
+/// ```
 pub fn render_markdown(source: &str, width: u16, theme: &Theme) -> Vec<Line<'static>> {
     let mut options = Options::empty();
     options.insert(Options::ENABLE_STRIKETHROUGH);

--- a/src/component/multi_progress/types.rs
+++ b/src/component/multi_progress/types.rs
@@ -22,6 +22,19 @@ pub enum ProgressItemStatus {
 
 impl ProgressItemStatus {
     /// Returns the style for this status using the theme.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressItemStatus;
+    /// use envision::Theme;
+    ///
+    /// let theme = Theme::default();
+    /// let pending_style = ProgressItemStatus::Pending.style(&theme);
+    /// let active_style = ProgressItemStatus::Active.style(&theme);
+    /// // Different statuses produce different styles
+    /// assert_ne!(pending_style, active_style);
+    /// ```
     pub fn style(&self, theme: &Theme) -> Style {
         match self {
             Self::Pending => theme.disabled_style(),
@@ -32,6 +45,17 @@ impl ProgressItemStatus {
     }
 
     /// Returns the symbol for this status.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressItemStatus;
+    ///
+    /// assert_eq!(ProgressItemStatus::Pending.symbol(), "○");
+    /// assert_eq!(ProgressItemStatus::Active.symbol(), "●");
+    /// assert_eq!(ProgressItemStatus::Completed.symbol(), "✓");
+    /// assert_eq!(ProgressItemStatus::Failed.symbol(), "✗");
+    /// ```
     pub fn symbol(&self) -> &'static str {
         match self {
             Self::Pending => "○",
@@ -114,6 +138,15 @@ impl ProgressItem {
     }
 
     /// Returns the progress (0.0 to 1.0).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressItem;
+    ///
+    /// let item = ProgressItem::new("dl", "Download");
+    /// assert_eq!(item.progress(), 0.0);
+    /// ```
     pub fn progress(&self) -> f32 {
         self.progress
     }
@@ -147,6 +180,15 @@ impl ProgressItem {
     }
 
     /// Returns the progress as a percentage (0-100).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::ProgressItem;
+    ///
+    /// let item = ProgressItem::new("dl", "Download");
+    /// assert_eq!(item.percentage(), 0);
+    /// ```
     pub fn percentage(&self) -> u16 {
         (self.progress * 100.0).round() as u16
     }

--- a/src/component/table/types.rs
+++ b/src/component/table/types.rs
@@ -162,11 +162,31 @@ impl Column {
     }
 
     /// Returns the column header text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Column;
+    /// use ratatui::layout::Constraint;
+    ///
+    /// let col = Column::new("Name", Constraint::Length(20));
+    /// assert_eq!(col.header(), "Name");
+    /// ```
     pub fn header(&self) -> &str {
         &self.header
     }
 
     /// Returns the column width constraint.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Column;
+    /// use ratatui::layout::Constraint;
+    ///
+    /// let col = Column::new("Price", Constraint::Length(10));
+    /// assert_eq!(col.width(), Constraint::Length(10));
+    /// ```
     pub fn width(&self) -> Constraint {
         self.width
     }
@@ -218,6 +238,19 @@ impl Column {
     }
 
     /// Returns whether this column is sortable.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Column;
+    /// use ratatui::layout::Constraint;
+    ///
+    /// let col = Column::new("Name", Constraint::Length(20));
+    /// assert!(!col.is_sortable());
+    ///
+    /// let sortable = col.sortable();
+    /// assert!(sortable.is_sortable());
+    /// ```
     pub fn is_sortable(&self) -> bool {
         self.sortable
     }
@@ -244,6 +277,19 @@ impl Column {
     /// Returns whether this column is editable.
     ///
     /// Defaults to `true`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Column;
+    /// use ratatui::layout::Constraint;
+    ///
+    /// let col = Column::new("Name", Constraint::Length(10));
+    /// assert!(col.is_editable());
+    ///
+    /// let read_only = col.with_editable(false);
+    /// assert!(!read_only.is_editable());
+    /// ```
     pub fn is_editable(&self) -> bool {
         self.editable
     }
@@ -270,16 +316,53 @@ impl Column {
     /// Returns whether this column is visible.
     ///
     /// Defaults to `true`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Column;
+    /// use ratatui::layout::Constraint;
+    ///
+    /// let col = Column::new("Name", Constraint::Length(10));
+    /// assert!(col.is_visible());
+    ///
+    /// let hidden = col.with_visible(false);
+    /// assert!(!hidden.is_visible());
+    /// ```
     pub fn is_visible(&self) -> bool {
         self.visible
     }
 
     /// Sets column visibility.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Column;
+    /// use ratatui::layout::Constraint;
+    ///
+    /// let mut col = Column::new("Internal", Constraint::Length(10));
+    /// assert!(col.is_visible());
+    /// col.set_visible(false);
+    /// assert!(!col.is_visible());
+    /// ```
     pub fn set_visible(&mut self, visible: bool) {
         self.visible = visible;
     }
 
     /// Sets whether this column is editable.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Column;
+    /// use ratatui::layout::Constraint;
+    ///
+    /// let mut col = Column::new("Name", Constraint::Length(10));
+    /// assert!(col.is_editable());
+    /// col.set_editable(false);
+    /// assert!(!col.is_editable());
+    /// ```
     pub fn set_editable(&mut self, editable: bool) {
         self.editable = editable;
     }
@@ -309,6 +392,18 @@ impl Column {
     }
 
     /// Returns the custom comparator for this column, if any.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{Column, numeric_comparator};
+    ///
+    /// let col = Column::fixed("Name", 10);
+    /// assert!(col.comparator().is_none());
+    ///
+    /// let numeric = Column::fixed("Price", 10).with_comparator(numeric_comparator());
+    /// assert!(numeric.comparator().is_some());
+    /// ```
     pub fn comparator(&self) -> Option<&SortComparator> {
         self.comparator.as_ref()
     }
@@ -316,6 +411,18 @@ impl Column {
     /// Sets the width of this column (builder method).
     ///
     /// This is useful for column resizing operations.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::Column;
+    /// use ratatui::layout::Constraint;
+    ///
+    /// let mut col = Column::fixed("Name", 10);
+    /// assert_eq!(col.width(), Constraint::Length(10));
+    /// col.set_width(Constraint::Length(20));
+    /// assert_eq!(col.width(), Constraint::Length(20));
+    /// ```
     pub fn set_width(&mut self, width: Constraint) {
         self.width = width;
     }


### PR DESCRIPTION
## Summary

- Add doc tests for 22 public methods across 7 components that were missing coverage
- **table**: 9 methods in `types.rs` (header, width, is_sortable, is_editable, is_visible, set_visible, set_editable, comparator, set_width)
- **file_browser**: 5 methods in `types.rs` (name, path, is_dir, size, modified)
- **multi_progress**: 4 methods in `types.rs` (style, symbol, progress, percentage)
- **form**: 1 method in `field.rs` (kind)
- **markdown_renderer**: 1 function in `render.rs` (render_markdown)
- **dependency_graph**: 1 function in `layout.rs` (compute_layout)
- **loading_list**: 1 method in `items.rs` (symbol)

## Test plan

- [x] All 22 new doc tests pass (`cargo test --doc --all-features`)
- [x] Clippy passes with no warnings (`cargo clippy --all-features -- -D warnings`)
- [x] Formatting verified (`cargo fmt -- --check`)
- [x] No file exceeds 1000 lines
- [ ] CI checks pass on all platforms

Generated with [Claude Code](https://claude.com/claude-code)