### PR TITLE
Doc tests batch A: 7 components to 100%

### DIFF
--- a/src/component/event_stream/state.rs
+++ b/src/component/event_stream/state.rs
@@ -399,6 +399,15 @@ impl EventStreamState {
     }
 
     /// Returns the maximum number of events to retain.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let state = EventStreamState::new();
+    /// assert_eq!(state.max_events(), 5000); // default
+    /// ```
     pub fn max_events(&self) -> usize {
         self.max_events
     }
@@ -421,46 +430,129 @@ impl EventStreamState {
     }
 
     /// Returns the current text filter.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let mut state = EventStreamState::new();
+    /// state.set_filter("warn".to_string());
+    /// assert_eq!(state.filter_text(), "warn");
+    /// ```
     pub fn filter_text(&self) -> &str {
         &self.filter_text
     }
 
     /// Returns the current level filter.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{EventStreamState, EventLevel, EventStreamMessage};
+    ///
+    /// let state = EventStreamState::new();
+    /// assert_eq!(state.level_filter(), None);
+    /// ```
     pub fn level_filter(&self) -> Option<&EventLevel> {
         self.level_filter.as_ref()
     }
 
     /// Returns the current source filter.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let state = EventStreamState::new();
+    /// assert_eq!(state.source_filter(), None);
+    /// ```
     pub fn source_filter(&self) -> Option<&str> {
         self.source_filter.as_deref()
     }
 
     /// Returns the visible column keys.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let state = EventStreamState::new()
+    ///     .with_visible_columns(vec!["path".into()]);
+    /// assert_eq!(state.visible_columns(), &["path"]);
+    /// ```
     pub fn visible_columns(&self) -> &[String] {
         &self.visible_columns
     }
 
     /// Returns whether auto-scroll is enabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let state = EventStreamState::new();
+    /// assert!(state.auto_scroll()); // enabled by default
+    /// ```
     pub fn auto_scroll(&self) -> bool {
         self.auto_scroll
     }
 
     /// Returns whether the timestamp column is shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let state = EventStreamState::new();
+    /// assert!(state.show_timestamps()); // shown by default
+    /// ```
     pub fn show_timestamps(&self) -> bool {
         self.show_timestamps
     }
 
     /// Returns whether the level column is shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let state = EventStreamState::new();
+    /// assert!(state.show_level()); // shown by default
+    /// ```
     pub fn show_level(&self) -> bool {
         self.show_level
     }
 
     /// Returns whether the source column is shown.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let state = EventStreamState::new();
+    /// assert!(state.show_source()); // shown by default
+    /// ```
     pub fn show_source(&self) -> bool {
         self.show_source
     }
 
     /// Returns the title.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let state = EventStreamState::new().with_title("Events");
+    /// assert_eq!(state.title(), Some("Events"));
+    /// ```
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
@@ -578,21 +670,57 @@ impl EventStreamState {
     }
 
     /// Returns the scroll offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let state = EventStreamState::new();
+    /// assert_eq!(state.scroll_offset(), 0);
+    /// ```
     pub fn scroll_offset(&self) -> usize {
         self.scroll.offset()
     }
 
     /// Returns whether the search bar is focused.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let state = EventStreamState::new();
+    /// assert!(!state.is_search_focused());
+    /// ```
     pub fn is_search_focused(&self) -> bool {
         self.focus == Focus::Search
     }
 
     /// Returns the current value of the search input field.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let state = EventStreamState::new();
+    /// assert_eq!(state.search_value(), "");
+    /// ```
     pub fn search_value(&self) -> &str {
         self.search.value()
     }
 
     /// Returns the cursor display position in the search field.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::EventStreamState;
+    ///
+    /// let state = EventStreamState::new();
+    /// assert_eq!(state.search_cursor_position(), 0);
+    /// ```
     pub fn search_cursor_position(&self) -> usize {
         self.search.cursor_display_position()
     }
@@ -669,6 +797,17 @@ impl EventStreamState {
     // =========================================================================
 
     /// Updates the state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{EventStreamState, EventStreamMessage, EventStreamOutput, EventLevel, StreamEvent};
+    ///
+    /// let mut state = EventStreamState::new();
+    /// let event = StreamEvent::new(1, 0.0, EventLevel::Info, "hello");
+    /// let output = state.update(EventStreamMessage::PushEvent(event));
+    /// assert!(matches!(output, Some(EventStreamOutput::EventAdded(1))));
+    /// ```
     pub fn update(&mut self, msg: EventStreamMessage) -> Option<EventStreamOutput> {
         EventStream::update(self, msg)
     }

--- a/src/component/log_viewer/state.rs
+++ b/src/component/log_viewer/state.rs
@@ -288,6 +288,16 @@ impl LogViewerState {
     }
 
     /// Adds a success-level entry with a timestamp, returning its ID.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new().with_show_timestamps(true);
+    /// let id = state.push_success_with_timestamp("Build passed", "14:30:00");
+    /// assert_eq!(state.len(), 1);
+    /// ```
     pub fn push_success_with_timestamp(
         &mut self,
         message: impl Into<String>,
@@ -301,6 +311,16 @@ impl LogViewerState {
     }
 
     /// Adds a warning-level entry with a timestamp, returning its ID.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new().with_show_timestamps(true);
+    /// let id = state.push_warning_with_timestamp("Disk space low", "15:00:00");
+    /// assert_eq!(state.len(), 1);
+    /// ```
     pub fn push_warning_with_timestamp(
         &mut self,
         message: impl Into<String>,
@@ -314,6 +334,16 @@ impl LogViewerState {
     }
 
     /// Adds an error-level entry with a timestamp, returning its ID.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new().with_show_timestamps(true);
+    /// let id = state.push_error_with_timestamp("Connection refused", "15:30:00");
+    /// assert_eq!(state.len(), 1);
+    /// ```
     pub fn push_error_with_timestamp(
         &mut self,
         message: impl Into<String>,
@@ -450,6 +480,15 @@ impl LogViewerState {
     }
 
     /// Returns the maximum number of entries.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let state = LogViewerState::new();
+    /// assert_eq!(state.max_entries(), 1000); // default
+    /// ```
     pub fn max_entries(&self) -> usize {
         self.max_entries
     }
@@ -503,6 +542,18 @@ impl LogViewerState {
     }
 
     /// Sets the scroll offset.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new();
+    /// state.push_info("entry 1");
+    /// state.push_info("entry 2");
+    /// state.set_scroll_offset(1);
+    /// assert_eq!(state.scroll_offset(), 1);
+    /// ```
     pub fn set_scroll_offset(&mut self, offset: usize) {
         let len = self.visible_entries().len();
         self.scroll.set_content_length(len);
@@ -702,6 +753,16 @@ impl LogViewerState {
     }
 
     /// Sets follow mode.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new();
+    /// state.set_follow(false);
+    /// assert!(!state.follow());
+    /// ```
     pub fn set_follow(&mut self, follow: bool) {
         self.follow = follow;
     }
@@ -721,21 +782,59 @@ impl LogViewerState {
     }
 
     /// Sets regex search mode.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new();
+    /// state.set_use_regex(true);
+    /// assert!(state.use_regex());
+    /// ```
     pub fn set_use_regex(&mut self, use_regex: bool) {
         self.use_regex = use_regex;
     }
 
     /// Returns the search history.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let state = LogViewerState::new();
+    /// assert!(state.search_history().is_empty());
+    /// ```
     pub fn search_history(&self) -> &[String] {
         &self.search_history
     }
 
     /// Returns the maximum search history size.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let state = LogViewerState::new();
+    /// assert_eq!(state.max_history(), 20); // default
+    /// ```
     pub fn max_history(&self) -> usize {
         self.max_history
     }
 
     /// Sets the maximum search history size.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let mut state = LogViewerState::new();
+    /// state.set_max_history(50);
+    /// assert_eq!(state.max_history(), 50);
+    /// ```
     pub fn set_max_history(&mut self, max: usize) {
         self.max_history = max;
         if self.search_history.len() > max {
@@ -745,16 +844,43 @@ impl LogViewerState {
     }
 
     /// Returns whether the search bar is focused.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let state = LogViewerState::new();
+    /// assert!(!state.is_search_focused());
+    /// ```
     pub fn is_search_focused(&self) -> bool {
         self.focus == Focus::Search
     }
 
     /// Returns the current value of the search input field.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let state = LogViewerState::new();
+    /// assert_eq!(state.search_value(), "");
+    /// ```
     pub fn search_value(&self) -> &str {
         self.search.value()
     }
 
     /// Returns the cursor display position in the search field.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::LogViewerState;
+    ///
+    /// let state = LogViewerState::new();
+    /// assert_eq!(state.search_cursor_position(), 0);
+    /// ```
     pub fn search_cursor_position(&self) -> usize {
         self.search.cursor_display_position()
     }
@@ -832,6 +958,18 @@ impl LogViewerState {
     // ---- Instance methods ----
 
     /// Updates the state with a message, returning any output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{LogViewerState, LogViewerMessage, LogViewerOutput};
+    ///
+    /// let mut state = LogViewerState::new();
+    /// state.push_info("hello");
+    /// let output = state.update(LogViewerMessage::Clear);
+    /// assert_eq!(output, Some(LogViewerOutput::Cleared));
+    /// assert!(state.is_empty());
+    /// ```
     pub fn update(&mut self, msg: LogViewerMessage) -> Option<LogViewerOutput> {
         LogViewer::update(self, msg)
     }

--- a/src/component/span_tree/types.rs
+++ b/src/component/span_tree/types.rs
@@ -141,26 +141,72 @@ impl SpanNode {
     }
 
     /// Returns the node's unique identifier.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SpanNode;
+    ///
+    /// let node = SpanNode::new("svc-1", "api/handler", 0.0, 100.0);
+    /// assert_eq!(node.id(), "svc-1");
+    /// ```
     pub fn id(&self) -> &str {
         &self.id
     }
 
     /// Returns the node's display label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SpanNode;
+    ///
+    /// let node = SpanNode::new("id", "api/handler", 0.0, 100.0);
+    /// assert_eq!(node.label(), "api/handler");
+    /// ```
     pub fn label(&self) -> &str {
         &self.label
     }
 
     /// Returns the start time.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SpanNode;
+    ///
+    /// let node = SpanNode::new("id", "svc", 42.0, 100.0);
+    /// assert_eq!(node.start(), 42.0);
+    /// ```
     pub fn start(&self) -> f64 {
         self.start
     }
 
     /// Returns the end time.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SpanNode;
+    ///
+    /// let node = SpanNode::new("id", "svc", 0.0, 250.0);
+    /// assert_eq!(node.end(), 250.0);
+    /// ```
     pub fn end(&self) -> f64 {
         self.end
     }
 
     /// Returns the bar color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SpanNode;
+    /// use ratatui::style::Color;
+    ///
+    /// let node = SpanNode::new("id", "svc", 0.0, 10.0);
+    /// assert_eq!(node.color(), Color::Cyan); // default color
+    /// ```
     pub fn color(&self) -> Color {
         self.color
     }
@@ -182,11 +228,34 @@ impl SpanNode {
     }
 
     /// Returns the status text, if set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SpanNode;
+    ///
+    /// let node = SpanNode::new("id", "svc", 0.0, 10.0).with_status("200 OK");
+    /// assert_eq!(node.status(), Some("200 OK"));
+    ///
+    /// let plain = SpanNode::new("id", "svc", 0.0, 10.0);
+    /// assert_eq!(plain.status(), None);
+    /// ```
     pub fn status(&self) -> Option<&str> {
         self.status.as_deref()
     }
 
     /// Returns the children.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SpanNode;
+    ///
+    /// let node = SpanNode::new("p", "parent", 0.0, 100.0)
+    ///     .with_child(SpanNode::new("c", "child", 10.0, 50.0));
+    /// assert_eq!(node.children().len(), 1);
+    /// assert_eq!(node.children()[0].id(), "c");
+    /// ```
     pub fn children(&self) -> &[SpanNode] {
         &self.children
     }
@@ -206,6 +275,19 @@ impl SpanNode {
     }
 
     /// Returns true if this node has children.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::SpanNode;
+    ///
+    /// let leaf = SpanNode::new("l", "leaf", 0.0, 10.0);
+    /// assert!(!leaf.has_children());
+    ///
+    /// let parent = SpanNode::new("p", "parent", 0.0, 10.0)
+    ///     .with_child(SpanNode::new("c", "child", 1.0, 5.0));
+    /// assert!(parent.has_children());
+    /// ```
     pub fn has_children(&self) -> bool {
         !self.children.is_empty()
     }
@@ -243,51 +325,162 @@ pub struct FlatSpan {
 
 impl FlatSpan {
     /// Returns the span's unique identifier.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SpanTreeState, SpanNode};
+    ///
+    /// let state = SpanTreeState::new(vec![SpanNode::new("r", "root", 0.0, 10.0)]);
+    /// let flat = state.flatten();
+    /// assert_eq!(flat[0].id(), "r");
+    /// ```
     pub fn id(&self) -> &str {
         &self.id
     }
 
     /// Returns the display label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SpanTreeState, SpanNode};
+    ///
+    /// let state = SpanTreeState::new(vec![SpanNode::new("r", "api/handler", 0.0, 10.0)]);
+    /// let flat = state.flatten();
+    /// assert_eq!(flat[0].label(), "api/handler");
+    /// ```
     pub fn label(&self) -> &str {
         &self.label
     }
 
     /// Returns the start time.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SpanTreeState, SpanNode};
+    ///
+    /// let state = SpanTreeState::new(vec![SpanNode::new("r", "root", 50.0, 200.0)]);
+    /// let flat = state.flatten();
+    /// assert_eq!(flat[0].start(), 50.0);
+    /// ```
     pub fn start(&self) -> f64 {
         self.start
     }
 
     /// Returns the end time.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SpanTreeState, SpanNode};
+    ///
+    /// let state = SpanTreeState::new(vec![SpanNode::new("r", "root", 0.0, 200.0)]);
+    /// let flat = state.flatten();
+    /// assert_eq!(flat[0].end(), 200.0);
+    /// ```
     pub fn end(&self) -> f64 {
         self.end
     }
 
     /// Returns the bar color.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SpanTreeState, SpanNode};
+    /// use ratatui::style::Color;
+    ///
+    /// let node = SpanNode::new("r", "root", 0.0, 10.0).with_color(Color::Red);
+    /// let state = SpanTreeState::new(vec![node]);
+    /// let flat = state.flatten();
+    /// assert_eq!(flat[0].color(), Color::Red);
+    /// ```
     pub fn color(&self) -> Color {
         self.color
     }
 
     /// Returns the status text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SpanTreeState, SpanNode};
+    ///
+    /// let node = SpanNode::new("r", "root", 0.0, 10.0).with_status("200 OK");
+    /// let state = SpanTreeState::new(vec![node]);
+    /// let flat = state.flatten();
+    /// assert_eq!(flat[0].status(), Some("200 OK"));
+    /// ```
     pub fn status(&self) -> Option<&str> {
         self.status.as_deref()
     }
 
     /// Returns the depth in the hierarchy.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SpanTreeState, SpanNode};
+    ///
+    /// let root = SpanNode::new("r", "root", 0.0, 100.0)
+    ///     .with_child(SpanNode::new("c", "child", 10.0, 50.0));
+    /// let state = SpanTreeState::new(vec![root]);
+    /// let flat = state.flatten();
+    /// assert_eq!(flat[0].depth(), 0);
+    /// assert_eq!(flat[1].depth(), 1);
+    /// ```
     pub fn depth(&self) -> usize {
         self.depth
     }
 
     /// Returns true if this node has children.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SpanTreeState, SpanNode};
+    ///
+    /// let root = SpanNode::new("r", "root", 0.0, 100.0)
+    ///     .with_child(SpanNode::new("c", "child", 10.0, 50.0));
+    /// let state = SpanTreeState::new(vec![root]);
+    /// let flat = state.flatten();
+    /// assert!(flat[0].has_children());
+    /// assert!(!flat[1].has_children());
+    /// ```
     pub fn has_children(&self) -> bool {
         self.has_children
     }
 
     /// Returns true if this node is expanded.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SpanTreeState, SpanNode};
+    ///
+    /// let root = SpanNode::new("r", "root", 0.0, 100.0)
+    ///     .with_child(SpanNode::new("c", "child", 10.0, 50.0));
+    /// let state = SpanTreeState::new(vec![root]);
+    /// let flat = state.flatten();
+    /// assert!(flat[0].is_expanded()); // expanded by default
+    /// ```
     pub fn is_expanded(&self) -> bool {
         self.is_expanded
     }
 
     /// Returns the duration (end - start).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{SpanTreeState, SpanNode};
+    ///
+    /// let state = SpanTreeState::new(vec![SpanNode::new("r", "root", 50.0, 200.0)]);
+    /// let flat = state.flatten();
+    /// assert_eq!(flat[0].duration(), 150.0);
+    /// ```
     pub fn duration(&self) -> f64 {
         self.end - self.start
     }

--- a/src/component/status_bar/item.rs
+++ b/src/component/status_bar/item.rs
@@ -51,11 +51,29 @@ pub enum StatusBarItemContent {
 
 impl StatusBarItemContent {
     /// Creates static text content.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarItemContent;
+    ///
+    /// let content = StatusBarItemContent::static_text("Ready");
+    /// assert!(matches!(content, StatusBarItemContent::Static(_)));
+    /// ```
     pub fn static_text(text: impl Into<String>) -> Self {
         Self::Static(text.into())
     }
 
     /// Creates an elapsed time display.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarItemContent;
+    ///
+    /// let content = StatusBarItemContent::elapsed_time();
+    /// assert!(matches!(content, StatusBarItemContent::ElapsedTime { .. }));
+    /// ```
     pub fn elapsed_time() -> Self {
         Self::ElapsedTime {
             elapsed_ms: 0,
@@ -65,6 +83,15 @@ impl StatusBarItemContent {
     }
 
     /// Creates a counter display.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarItemContent;
+    ///
+    /// let content = StatusBarItemContent::counter();
+    /// assert!(matches!(content, StatusBarItemContent::Counter { value: 0, label: None }));
+    /// ```
     pub fn counter() -> Self {
         Self::Counter {
             value: 0,
@@ -73,6 +100,15 @@ impl StatusBarItemContent {
     }
 
     /// Creates a heartbeat indicator.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarItemContent;
+    ///
+    /// let content = StatusBarItemContent::heartbeat();
+    /// assert!(matches!(content, StatusBarItemContent::Heartbeat { active: false, .. }));
+    /// ```
     pub fn heartbeat() -> Self {
         Self::Heartbeat {
             active: false,
@@ -213,6 +249,15 @@ impl StatusBarItem {
     }
 
     /// Creates an elapsed time display with long format (HH:MM:SS).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarItem;
+    ///
+    /// let item = StatusBarItem::elapsed_time_long();
+    /// assert_eq!(item.text(), "00:00:00");
+    /// ```
     pub fn elapsed_time_long() -> Self {
         Self {
             content: StatusBarItemContent::ElapsedTime {
@@ -262,6 +307,15 @@ impl StatusBarItem {
     /// Sets the label for counter items.
     ///
     /// This only has an effect on Counter content types.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarItem;
+    ///
+    /// let item = StatusBarItem::counter().with_label("Items");
+    /// assert_eq!(item.text(), "Items: 0");
+    /// ```
     pub fn with_label(mut self, label: impl Into<String>) -> Self {
         if let StatusBarItemContent::Counter {
             value,
@@ -280,6 +334,15 @@ impl StatusBarItem {
     /// Sets long format for elapsed time items.
     ///
     /// This only has an effect on ElapsedTime content types.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarItem;
+    ///
+    /// let item = StatusBarItem::elapsed_time().with_long_format(true);
+    /// assert_eq!(item.text(), "00:00:00");
+    /// ```
     pub fn with_long_format(mut self, long: bool) -> Self {
         if let StatusBarItemContent::ElapsedTime {
             elapsed_ms,
@@ -327,46 +390,134 @@ impl StatusBarItem {
     }
 
     /// Returns the display text for this item.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarItem;
+    ///
+    /// let item = StatusBarItem::new("Ready");
+    /// assert_eq!(item.text(), "Ready");
+    /// ```
     pub fn text(&self) -> String {
         self.content.display_text()
     }
 
     /// Returns the content.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{StatusBarItem, StatusBarItemContent};
+    ///
+    /// let item = StatusBarItem::new("Status");
+    /// assert!(matches!(item.content(), StatusBarItemContent::Static(_)));
+    /// ```
     pub fn content(&self) -> &StatusBarItemContent {
         &self.content
     }
 
     /// Returns a mutable reference to the content.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{StatusBarItem, StatusBarItemContent};
+    ///
+    /// let mut item = StatusBarItem::new("Status");
+    /// *item.content_mut() = StatusBarItemContent::static_text("Updated");
+    /// assert_eq!(item.text(), "Updated");
+    /// ```
     pub fn content_mut(&mut self) -> &mut StatusBarItemContent {
         &mut self.content
     }
 
     /// Sets the text content (converts to static content).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarItem;
+    ///
+    /// let mut item = StatusBarItem::new("Old");
+    /// item.set_text("New");
+    /// assert_eq!(item.text(), "New");
+    /// ```
     pub fn set_text(&mut self, text: impl Into<String>) {
         self.content = StatusBarItemContent::Static(text.into());
     }
 
     /// Returns the style.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{StatusBarItem, StatusBarStyle};
+    ///
+    /// let item = StatusBarItem::new("OK").with_style(StatusBarStyle::Success);
+    /// assert_eq!(item.style(), StatusBarStyle::Success);
+    /// ```
     pub fn style(&self) -> StatusBarStyle {
         self.style
     }
 
     /// Sets the style.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{StatusBarItem, StatusBarStyle};
+    ///
+    /// let mut item = StatusBarItem::new("Error");
+    /// item.set_style(StatusBarStyle::Error);
+    /// assert_eq!(item.style(), StatusBarStyle::Error);
+    /// ```
     pub fn set_style(&mut self, style: StatusBarStyle) {
         self.style = style;
     }
 
     /// Returns whether this item has a separator.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarItem;
+    ///
+    /// let item = StatusBarItem::new("Text");
+    /// assert!(item.has_separator()); // enabled by default
+    /// ```
     pub fn has_separator(&self) -> bool {
         self.separator
     }
 
     /// Sets whether to show a separator.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarItem;
+    ///
+    /// let mut item = StatusBarItem::new("Last");
+    /// item.set_separator(false);
+    /// assert!(!item.has_separator());
+    /// ```
     pub fn set_separator(&mut self, separator: bool) {
         self.separator = separator;
     }
 
     /// Returns true if this item has dynamic content.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarItem;
+    ///
+    /// let static_item = StatusBarItem::new("Text");
+    /// assert!(!static_item.is_dynamic());
+    ///
+    /// let timer = StatusBarItem::elapsed_time();
+    /// assert!(timer.is_dynamic());
+    /// ```
     pub fn is_dynamic(&self) -> bool {
         self.content.is_dynamic()
     }

--- a/src/component/styled_text/content.rs
+++ b/src/component/styled_text/content.rs
@@ -91,6 +91,16 @@ pub struct StyledContent {
 
 impl StyledContent {
     /// Creates an empty styled content builder.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::styled_text::StyledContent;
+    ///
+    /// let content = StyledContent::new();
+    /// assert!(content.is_empty());
+    /// assert_eq!(content.len(), 0);
+    /// ```
     pub fn new() -> Self {
         Self::default()
     }
@@ -114,6 +124,17 @@ impl StyledContent {
     }
 
     /// Adds a heading block.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::styled_text::StyledContent;
+    ///
+    /// let content = StyledContent::new()
+    ///     .heading(1, "Main Title")
+    ///     .heading(2, "Subtitle");
+    /// assert_eq!(content.len(), 2);
+    /// ```
     pub fn heading(mut self, level: u8, text: impl Into<String>) -> Self {
         self.blocks.push(StyledBlock::Heading {
             level: level.clamp(1, 3),
@@ -123,6 +144,19 @@ impl StyledContent {
     }
 
     /// Adds a paragraph composed of inline elements.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::styled_text::{StyledContent, StyledInline};
+    ///
+    /// let content = StyledContent::new()
+    ///     .paragraph(vec![
+    ///         StyledInline::Plain("Hello, ".to_string()),
+    ///         StyledInline::Bold("world".to_string()),
+    ///     ]);
+    /// assert_eq!(content.len(), 1);
+    /// ```
     pub fn paragraph(mut self, inlines: Vec<StyledInline>) -> Self {
         self.blocks.push(StyledBlock::Paragraph(inlines));
         self
@@ -144,18 +178,54 @@ impl StyledContent {
     }
 
     /// Adds a bulleted list.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::styled_text::{StyledContent, StyledInline};
+    ///
+    /// let content = StyledContent::new()
+    ///     .bullet_list(vec![
+    ///         vec![StyledInline::Plain("First item".to_string())],
+    ///         vec![StyledInline::Plain("Second item".to_string())],
+    ///     ]);
+    /// assert_eq!(content.len(), 1);
+    /// ```
     pub fn bullet_list(mut self, items: Vec<Vec<StyledInline>>) -> Self {
         self.blocks.push(StyledBlock::BulletList(items));
         self
     }
 
     /// Adds a numbered list.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::styled_text::{StyledContent, StyledInline};
+    ///
+    /// let content = StyledContent::new()
+    ///     .numbered_list(vec![
+    ///         vec![StyledInline::Plain("Step one".to_string())],
+    ///         vec![StyledInline::Plain("Step two".to_string())],
+    ///     ]);
+    /// assert_eq!(content.len(), 1);
+    /// ```
     pub fn numbered_list(mut self, items: Vec<Vec<StyledInline>>) -> Self {
         self.blocks.push(StyledBlock::NumberedList(items));
         self
     }
 
     /// Adds a code block with optional language annotation.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::styled_text::StyledContent;
+    ///
+    /// let content = StyledContent::new()
+    ///     .code_block(Some("rust"), "let x = 42;");
+    /// assert_eq!(content.len(), 1);
+    /// ```
     pub fn code_block(
         mut self,
         language: Option<impl Into<String>>,
@@ -169,40 +239,118 @@ impl StyledContent {
     }
 
     /// Adds a horizontal rule.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::styled_text::StyledContent;
+    ///
+    /// let content = StyledContent::new()
+    ///     .text("Above")
+    ///     .horizontal_rule()
+    ///     .text("Below");
+    /// assert_eq!(content.len(), 3);
+    /// ```
     pub fn horizontal_rule(mut self) -> Self {
         self.blocks.push(StyledBlock::HorizontalRule);
         self
     }
 
     /// Adds a blank line.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::styled_text::StyledContent;
+    ///
+    /// let content = StyledContent::new()
+    ///     .text("Paragraph 1")
+    ///     .blank_line()
+    ///     .text("Paragraph 2");
+    /// assert_eq!(content.len(), 3);
+    /// ```
     pub fn blank_line(mut self) -> Self {
         self.blocks.push(StyledBlock::BlankLine);
         self
     }
 
     /// Adds raw pre-rendered lines.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::styled_text::StyledContent;
+    /// use ratatui::text::Line;
+    ///
+    /// let content = StyledContent::new()
+    ///     .raw(vec![Line::from("Custom rendered line")]);
+    /// assert_eq!(content.len(), 1);
+    /// ```
     pub fn raw(mut self, lines: Vec<RatLine<'static>>) -> Self {
         self.blocks.push(StyledBlock::Raw(lines));
         self
     }
 
     /// Pushes any block element.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::styled_text::{StyledContent, StyledBlock};
+    ///
+    /// let content = StyledContent::new()
+    ///     .push(StyledBlock::HorizontalRule)
+    ///     .push(StyledBlock::BlankLine);
+    /// assert_eq!(content.len(), 2);
+    /// ```
     pub fn push(mut self, block: StyledBlock) -> Self {
         self.blocks.push(block);
         self
     }
 
     /// Returns true if there are no blocks.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::styled_text::StyledContent;
+    ///
+    /// assert!(StyledContent::new().is_empty());
+    /// assert!(!StyledContent::new().text("hello").is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.blocks.is_empty()
     }
 
     /// Returns the number of blocks.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::styled_text::StyledContent;
+    ///
+    /// let content = StyledContent::new()
+    ///     .heading(1, "Title")
+    ///     .text("Body");
+    /// assert_eq!(content.len(), 2);
+    /// ```
     pub fn len(&self) -> usize {
         self.blocks.len()
     }
 
     /// Returns a reference to the blocks.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::styled_text::{StyledContent, StyledBlock};
+    ///
+    /// let content = StyledContent::new()
+    ///     .heading(1, "Title")
+    ///     .blank_line();
+    /// assert_eq!(content.blocks().len(), 2);
+    /// assert!(matches!(content.blocks()[1], StyledBlock::BlankLine));
+    /// ```
     pub fn blocks(&self) -> &[StyledBlock] {
         &self.blocks
     }

--- a/src/component/text_area/search.rs
+++ b/src/component/text_area/search.rs
@@ -7,26 +7,80 @@ use super::TextAreaState;
 
 impl TextAreaState {
     /// Returns the current search query, if any.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TextArea, TextAreaMessage, TextAreaState, Component};
+    ///
+    /// let mut state = TextAreaState::new().with_value("hello world");
+    /// assert_eq!(state.search_query(), None);
+    ///
+    /// TextArea::update(&mut state, TextAreaMessage::SetSearchQuery("hello".into()));
+    /// assert_eq!(state.search_query(), Some("hello"));
+    /// ```
     pub fn search_query(&self) -> Option<&str> {
         self.search_query.as_deref()
     }
 
     /// Returns the list of search matches as (line, byte_col) pairs.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TextArea, TextAreaMessage, TextAreaState, Component};
+    ///
+    /// let mut state = TextAreaState::new().with_value("foo bar foo");
+    /// TextArea::update(&mut state, TextAreaMessage::SetSearchQuery("foo".into()));
+    /// assert_eq!(state.search_matches().len(), 2);
+    /// ```
     pub fn search_matches(&self) -> &[(usize, usize)] {
         &self.search_matches
     }
 
     /// Returns the index of the current match within the match list.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TextArea, TextAreaMessage, TextAreaState, Component};
+    ///
+    /// let mut state = TextAreaState::new().with_value("aaa");
+    /// TextArea::update(&mut state, TextAreaMessage::SetSearchQuery("a".into()));
+    /// assert_eq!(state.current_match_index(), 0);
+    /// ```
     pub fn current_match_index(&self) -> usize {
         self.current_match
     }
 
     /// Returns the current match as (line, byte_col), if any.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TextArea, TextAreaMessage, TextAreaState, Component};
+    ///
+    /// let mut state = TextAreaState::new().with_value("hello");
+    /// TextArea::update(&mut state, TextAreaMessage::SetSearchQuery("hello".into()));
+    /// assert_eq!(state.current_match_position(), Some((0, 0)));
+    /// ```
     pub fn current_match_position(&self) -> Option<(usize, usize)> {
         self.search_matches.get(self.current_match).copied()
     }
 
     /// Returns true if search mode is active.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TextArea, TextAreaMessage, TextAreaState, Component};
+    ///
+    /// let mut state = TextAreaState::new();
+    /// assert!(!state.is_searching());
+    ///
+    /// TextArea::update(&mut state, TextAreaMessage::StartSearch);
+    /// assert!(state.is_searching());
+    /// ```
     pub fn is_searching(&self) -> bool {
         self.search_query.is_some()
     }

--- a/src/component/text_area/selection.rs
+++ b/src/component/text_area/selection.rs
@@ -6,6 +6,18 @@ use super::TextAreaState;
 
 impl TextAreaState {
     /// Returns true if there is an active text selection.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TextArea, TextAreaMessage, TextAreaState, Component};
+    ///
+    /// let mut state = TextAreaState::new().with_value("hello");
+    /// assert!(!state.has_selection());
+    ///
+    /// TextArea::update(&mut state, TextAreaMessage::SelectAll);
+    /// assert!(state.has_selection());
+    /// ```
     pub fn has_selection(&self) -> bool {
         match self.selection_anchor {
             Some((r, c)) => r != self.cursor_row || c != self.cursor_col,
@@ -14,6 +26,17 @@ impl TextAreaState {
     }
 
     /// Returns the ordered selection positions as `((start_row, start_col), (end_row, end_col))`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TextArea, TextAreaMessage, TextAreaState, Component};
+    ///
+    /// let mut state = TextAreaState::new().with_value("hello");
+    /// TextArea::update(&mut state, TextAreaMessage::SelectAll);
+    /// let positions = state.selection_positions();
+    /// assert_eq!(positions, Some(((0, 0), (0, 5))));
+    /// ```
     pub fn selection_positions(&self) -> Option<((usize, usize), (usize, usize))> {
         let (ar, ac) = self.selection_anchor?;
         if ar == self.cursor_row && ac == self.cursor_col {
@@ -25,6 +48,18 @@ impl TextAreaState {
     }
 
     /// Returns the selected text, or None if no selection.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TextArea, TextAreaMessage, TextAreaState, Component};
+    ///
+    /// let mut state = TextAreaState::new().with_value("hello");
+    /// assert_eq!(state.selected_text(), None);
+    ///
+    /// TextArea::update(&mut state, TextAreaMessage::SelectAll);
+    /// assert_eq!(state.selected_text(), Some("hello".to_string()));
+    /// ```
     pub fn selected_text(&self) -> Option<String> {
         let ((sr, sc), (er, ec)) = self.selection_positions()?;
         if sr == er {
@@ -42,6 +77,17 @@ impl TextAreaState {
     }
 
     /// Returns the internal clipboard contents.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::{TextArea, TextAreaMessage, TextAreaState, Component};
+    ///
+    /// let mut state = TextAreaState::new().with_value("hello");
+    /// TextArea::update(&mut state, TextAreaMessage::SelectAll);
+    /// TextArea::update(&mut state, TextAreaMessage::Copy);
+    /// assert_eq!(state.clipboard(), "hello");
+    /// ```
     pub fn clipboard(&self) -> &str {
         &self.clipboard
     }


### PR DESCRIPTION
## Summary
- Add doc tests to 85 public methods across 7 components: span_tree, status_bar, event_stream, log_viewer, styled_text, text_area (selection + search modules)
- All doc tests demonstrate realistic usage patterns, not just trivial assertions
- No functionality changes -- doc comments only

### Components covered
| Component | File(s) | Methods |
|-----------|---------|---------|
| span_tree | `types.rs` | SpanNode: id, label, start, end, color, status, children, has_children; FlatSpan: id, label, start, end, color, status, depth, has_children, is_expanded, duration (18) |
| status_bar | `item.rs` | StatusBarItemContent: static_text, elapsed_time, counter, heartbeat; StatusBarItem: elapsed_time_long, with_label, with_long_format, text, content, content_mut, set_text, style, set_style, has_separator, set_separator, is_dynamic (16) |
| event_stream | `state.rs` | max_events, filter_text, level_filter, source_filter, visible_columns, auto_scroll, show_timestamps, show_level, show_source, title, scroll_offset, is_search_focused, search_value, search_cursor_position, update (15) |
| log_viewer | `state.rs` | push_success_with_timestamp, push_warning_with_timestamp, push_error_with_timestamp, max_entries, set_scroll_offset, set_follow, set_use_regex, search_history, max_history, set_max_history, is_search_focused, search_value, search_cursor_position, update (14) |
| styled_text | `content.rs` | StyledContent: new, heading, paragraph, bullet_list, numbered_list, code_block, horizontal_rule, blank_line, raw, push, is_empty, len, blocks (13) |
| text_area | `selection.rs`, `search.rs` | has_selection, selection_positions, selected_text, clipboard, search_query, search_matches, current_match_index, current_match_position, is_searching (9) |

## Test plan
- [x] `cargo test --doc --all-features` passes (2412 passed, 0 failed)
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] No file exceeds 1000 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)