### PR TITLE
Diagram Phase 9: docs, example, deprecation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,10 @@ name = "canvas"
 required-features = ["display-components"]
 
 [[example]]
+name = "diagram"
+required-features = ["compound-components"]
+
+[[example]]
 name = "chart"
 required-features = ["compound-components"]
 

--- a/examples/dependency_graph.rs
+++ b/examples/dependency_graph.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)] // DependencyGraph is deprecated in favor of Diagram
 //! DependencyGraph example -- microservice architecture visualization.
 //!
 //! Demonstrates the DependencyGraph component displaying service

--- a/examples/diagram.rs
+++ b/examples/diagram.rs
@@ -70,17 +70,11 @@ impl envision::app::App for App {
     }
 
     fn update(state: &mut AppState, msg: Msg) -> Command<Msg> {
-        match msg {
-            Msg::Diagram(diagram_msg) => {
-                if let Some(output) = Diagram::update(&mut state.diagram, diagram_msg) {
-                    match output {
-                        DiagramOutput::NodeSelected(id) => {
-                            let _ = id;
-                        }
-                        _ => {}
-                    }
-                }
-            }
+        let Msg::Diagram(diagram_msg) = msg;
+        if let Some(DiagramOutput::NodeSelected(_id)) =
+            Diagram::update(&mut state.diagram, diagram_msg)
+        {
+            // Could update a status bar or detail panel here
         }
         Command::none()
     }

--- a/examples/diagram.rs
+++ b/examples/diagram.rs
@@ -1,0 +1,108 @@
+//! Diagram component example showing a service topology.
+//!
+//! Demonstrates the Diagram component with nodes, edges, clusters,
+//! edge styles, and interactive navigation.
+//!
+//! Run with: cargo run --example diagram
+
+use envision::component::diagram::{
+    Diagram, DiagramCluster, DiagramEdge, DiagramMessage, DiagramNode, DiagramOutput, DiagramState,
+    EdgeStyle, NodeStatus,
+};
+use envision::prelude::*;
+
+struct App;
+
+#[derive(Clone)]
+struct AppState {
+    diagram: DiagramState,
+}
+
+#[derive(Clone, Debug)]
+enum Msg {
+    Diagram(DiagramMessage),
+}
+
+impl envision::app::App for App {
+    type State = AppState;
+    type Message = Msg;
+
+    fn init() -> (AppState, Command<Msg>) {
+        let diagram = DiagramState::new()
+            .with_cluster(DiagramCluster::new("us-east", "US East"))
+            .with_cluster(DiagramCluster::new("eu-west", "EU West"))
+            .with_node(
+                DiagramNode::new("lb", "Load Balancer")
+                    .with_status(NodeStatus::Healthy)
+                    .with_metadata("type", "ALB"),
+            )
+            .with_node(
+                DiagramNode::new("api-1", "API v2.1")
+                    .with_status(NodeStatus::Healthy)
+                    .with_cluster("us-east"),
+            )
+            .with_node(
+                DiagramNode::new("api-2", "API v2.1")
+                    .with_status(NodeStatus::Degraded)
+                    .with_cluster("eu-west"),
+            )
+            .with_node(
+                DiagramNode::new("db", "PostgreSQL")
+                    .with_status(NodeStatus::Healthy)
+                    .with_cluster("us-east"),
+            )
+            .with_node(DiagramNode::new("cache", "Redis").with_status(NodeStatus::Healthy))
+            .with_node(
+                DiagramNode::new("queue", "RabbitMQ")
+                    .with_status(NodeStatus::Down)
+                    .with_cluster("eu-west"),
+            )
+            .with_edge(DiagramEdge::new("lb", "api-1").with_label("HTTP"))
+            .with_edge(DiagramEdge::new("lb", "api-2").with_label("HTTP"))
+            .with_edge(DiagramEdge::new("api-1", "db").with_label("SQL"))
+            .with_edge(DiagramEdge::new("api-1", "cache").with_style(EdgeStyle::Dashed))
+            .with_edge(DiagramEdge::new("api-2", "queue").with_style(EdgeStyle::Dotted))
+            .with_edge(DiagramEdge::new("api-2", "cache"))
+            .with_show_edge_labels(true)
+            .with_title("Service Topology");
+
+        (AppState { diagram }, Command::none())
+    }
+
+    fn update(state: &mut AppState, msg: Msg) -> Command<Msg> {
+        match msg {
+            Msg::Diagram(diagram_msg) => {
+                if let Some(output) = Diagram::update(&mut state.diagram, diagram_msg) {
+                    match output {
+                        DiagramOutput::NodeSelected(id) => {
+                            let _ = id;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        Command::none()
+    }
+
+    fn view(state: &AppState, frame: &mut Frame) {
+        let area = frame.area();
+        let theme = Theme::default();
+        let mut ctx = RenderContext::new(frame, area, &theme);
+        ctx.focused = true;
+        Diagram::view(&state.diagram, &mut ctx);
+    }
+
+    fn handle_event_with_state(state: &AppState, event: &Event) -> Option<Msg> {
+        let ctx = EventContext::new().focused(true);
+        Diagram::handle_event(&state.diagram, event, &ctx).map(Msg::Diagram)
+    }
+}
+
+fn main() {
+    // Virtual terminal demo (no real terminal needed)
+    let mut vt = Runtime::<App, _>::virtual_builder(100, 30).build().unwrap();
+    vt.send(Event::char('j')); // Select first node
+    vt.tick().unwrap();
+    println!("{}", vt.display());
+}

--- a/src/component/dependency_graph/mod.rs
+++ b/src/component/dependency_graph/mod.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)] // This module uses its own deprecated type internally
 //! A dependency graph component for visualizing service/component relationships.
 //!
 //! [`DependencyGraph`] renders a directed graph of nodes and edges,
@@ -715,6 +716,10 @@ impl DependencyGraphState {
 /// DependencyGraph::update(&mut state, DependencyGraphMessage::SelectNext);
 /// assert_eq!(state.selected_node().unwrap().id, "api");
 /// ```
+#[deprecated(
+    since = "0.16.0",
+    note = "Use `Diagram` instead, which provides crossing minimization, spatial navigation, force-directed layout, clusters, search, and viewport scrolling."
+)]
 pub struct DependencyGraph;
 
 impl Component for DependencyGraph {

--- a/src/component/diagram/types.rs
+++ b/src/component/diagram/types.rs
@@ -790,3 +790,34 @@ impl DiagramCluster {
         self.label = label.into();
     }
 }
+
+// ---------------------------------------------------------------------------
+// Migration from DependencyGraph
+// ---------------------------------------------------------------------------
+
+impl From<crate::component::dependency_graph::GraphNode> for DiagramNode {
+    fn from(node: crate::component::dependency_graph::GraphNode) -> Self {
+        Self {
+            id: node.id.clone(),
+            label: node.label.clone(),
+            status: node.status.clone(),
+            color: node.color(),
+            shape: NodeShape::default(),
+            metadata: node.metadata.clone(),
+            cluster_id: None,
+        }
+    }
+}
+
+impl From<crate::component::dependency_graph::GraphEdge> for DiagramEdge {
+    fn from(edge: crate::component::dependency_graph::GraphEdge) -> Self {
+        Self {
+            from: edge.from.clone(),
+            to: edge.to.clone(),
+            label: edge.label.clone(),
+            color: edge.color,
+            style: EdgeStyle::default(),
+            bidirectional: false,
+        }
+    }
+}

--- a/src/component/diagram/viewport.rs
+++ b/src/component/diagram/viewport.rs
@@ -269,6 +269,21 @@ impl Viewport2D {
         self.zoom = (self.zoom / Self::ZOOM_STEP).max(Self::MIN_ZOOM);
     }
 
+    /// Returns the viewport width in graph units.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::component::diagram::Viewport2D;
+    ///
+    /// let mut vp = Viewport2D::new();
+    /// vp.set_viewport_size(120, 40);
+    /// assert_eq!(vp.viewport_size(), (120.0, 40.0));
+    /// ```
+    pub fn viewport_size(&self) -> (f64, f64) {
+        (self.viewport_width, self.viewport_height)
+    }
+
     /// Sets the viewport size in terminal cells.
     ///
     /// # Examples
@@ -278,10 +293,26 @@ impl Viewport2D {
     ///
     /// let mut vp = Viewport2D::new();
     /// vp.set_viewport_size(120, 40);
+    /// assert_eq!(vp.viewport_size(), (120.0, 40.0));
     /// ```
     pub fn set_viewport_size(&mut self, width: u16, height: u16) {
         self.viewport_width = f64::from(width);
         self.viewport_height = f64::from(height);
+    }
+
+    /// Returns the content bounding box.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use envision::component::diagram::{Viewport2D, BoundingBox};
+    ///
+    /// let mut vp = Viewport2D::new();
+    /// vp.set_content_bounds(BoundingBox::new(10.0, 20.0, 100.0, 50.0));
+    /// assert_eq!(vp.content_bounds().min_x, 10.0);
+    /// ```
+    pub fn content_bounds(&self) -> &BoundingBox {
+        &self.content_bbox
     }
 
     /// Updates the content bounding box (from layout results).
@@ -293,6 +324,7 @@ impl Viewport2D {
     ///
     /// let mut vp = Viewport2D::new();
     /// vp.set_content_bounds(BoundingBox::new(0.0, 0.0, 200.0, 100.0));
+    /// assert_eq!(vp.content_bounds().width(), 200.0);
     /// ```
     pub fn set_content_bounds(&mut self, bbox: BoundingBox) {
         self.content_bbox = bbox;

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -353,6 +353,7 @@ pub use conversation_view::{
 #[cfg(feature = "compound-components")]
 pub use data_grid::{DataGrid, DataGridMessage, DataGridOutput, DataGridState};
 #[cfg(feature = "compound-components")]
+#[allow(deprecated)]
 pub use dependency_graph::{
     DependencyGraph, DependencyGraphMessage, DependencyGraphOutput, DependencyGraphState,
     GraphEdge, GraphNode, GraphOrientation, NodeStatus,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,6 +245,7 @@ pub use component::{
 
 // Compound components
 #[cfg(feature = "compound-components")]
+#[allow(deprecated)] // DependencyGraph is deprecated but still re-exported
 pub use component::{
     AlertMetric, AlertPanel, AlertPanelMessage, AlertPanelOutput, AlertPanelState, AlertState,
     AlertThreshold, BarMode, BinMethod, BoxPlot, BoxPlotData, BoxPlotMessage, BoxPlotOrientation,


### PR DESCRIPTION
## Summary
- **Example**: `examples/diagram.rs` with service topology, clusters, edge styles
- **Accessor symmetry**: Added `viewport_size()` and `content_bounds()` getters
- **DependencyGraph deprecated**: `#[deprecated(since = "0.16.0")]` with migration note
- **From impls**: `From<GraphNode> for DiagramNode`, `From<GraphEdge> for DiagramEdge`
- **Scorecard**: 9/9 ALL CHECKS PASSING

This completes all 9 phases of the Diagram component.

## Test plan
- [x] 81 diagram tests pass
- [x] 2557 doc tests pass (100% coverage: 1769/1769)
- [x] `cargo build --example diagram` compiles
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] Scorecard 9/9

🤖 Generated with [Claude Code](https://claude.com/claude-code)