### PR TITLE
Add D15 to leadline gaps tracking doc

### DIFF
--- a/docs/customer-feedback/2026-05-01-leadline-gaps.md
+++ b/docs/customer-feedback/2026-05-01-leadline-gaps.md
@@ -61,6 +61,10 @@ Spec PR #471, plan PR #472, implementation PR #473 (`4d5b05e`).
 - **D13** No quit hook — `Command::quit()` exists but no `App::on_quit(state) -> Result<()>` for autosave. Relationship between `load_state` re-export and quit is undocumented. Want documented `on_quit` lifecycle hook.
 - **D14** `StyledContent::paragraph(...)` produces a single line, not a wrapped paragraph — name conflicts with intuition. Want rename to `line(...)`; reserve `paragraph` for wrapped block-level text.
 
+### Surfaced 2026-05-08 during D6 + D9 leadline-side migration
+
+- **D15** `TableRow::cells(&self)` takes no `&Theme` — severity-aware cell construction can't reach the active theme at row-build time. leadline's two severity-cell helpers in `baseline.rs` and `per_op.rs` work around this by constructing `Theme::catppuccin_mocha()` inline (defeats theme-swap). Two remediation candidates: (a) extend the trait to `cells(&self, theme: &Theme) -> Vec<Cell>` — invasive, breaks every existing `TableRow` impl; (b) `CellStyle::Severity(Severity)` resolved at render time — additive, generalizes beyond severity (any palette-routed cell styling becomes a value-typed style variant). leadline preference: (b). Could be a small focused brief on its own or folded into a future API ergonomics round.
+
 ## Plan of attack (proposed sequencing)
 
 This is a sketch — treat as draft until reviewed.


### PR DESCRIPTION
## Summary

Captures **D15** — a new gap leadline surfaced 2026-05-08 during their D6+D9 migration.

## Finding

\`TableRow::cells(&self)\` takes no \`&Theme\`, so severity-aware cell construction can't reach the active theme at row-build time. leadline's two \`severity_cell_style\` helpers in \`baseline.rs\` / \`per_op.rs\` work around this by constructing \`Theme::catppuccin_mocha()\` inline — defeats theme-swap.

## Two remediation candidates

- **(a)** Extend the trait to \`cells(&self, theme: &Theme) -> Vec<Cell>\` — invasive, breaks every existing \`TableRow\` impl
- **(b)** \`CellStyle::Severity(Severity)\` resolved at render time — additive, generalizes beyond severity (any palette-routed cell styling becomes a value-typed style variant)

leadline preference: **(b)**.

Documented as a candidate for either a small focused brief on its own or folding into a future API ergonomics round.

## Test plan

- [ ] CI green (markdown only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)