### PR TITLE
CellStyle::Severity(Severity) (D15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,42 @@ distinguishable. Consumers wanting full palette fidelity should use
 `Theme::catppuccin_mocha()` or another full-palette theme. Documented on
 `Theme::default()`.
 
+### CellStyle::Severity(Severity) (D15)
+
+`Cell` gains a new severity-styled variant resolved at render time, closing
+the loop on the D6+D9 theme palette + severity helper. Eliminates the need
+for consumers to construct `Theme::catppuccin_mocha()` inline at row-build
+time to access `theme.severity_style(sev)`.
+
+**New variants:**
+
+- `CellStyle::Severity(Severity)` — resolves to `theme.severity_style(*sev)`
+  at render time. Color routes through the theme's palette (Good→Green,
+  Mild→Yellow, Bad→Peach, Critical→Red); `Critical` adds `BOLD`.
+
+**New `Cell` constructors:**
+
+- `Cell::severity(text, sev)` — semantic shorthand mirroring
+  `Cell::success/warning/error/muted`.
+- `Cell::with_severity(sev)` — typed-cell builder for the G7 chain
+  `Cell::number(x).with_text(formatted).with_severity(sev)`. Preserves the
+  typed `SortKey` while layering severity color. Last-call-wins precedence
+  with `with_style(...)`.
+
+**Breaking change:**
+
+- `CellStyle` is now `#[non_exhaustive]`. External code that pattern-matches
+  `CellStyle` exhaustively must add a `_` arm. Matches the convention set
+  by `Severity` and `NamedColor` in the prior release. Internal `match` arms
+  inside the crate are still exhaustive — the attribute applies only to
+  external consumers.
+
+**Migration for severity-aware cells:** drop any `severity_cell_style`-style
+helper that constructs a hardcoded theme. Replace with
+`Severity::from_thresholds(...)` + `CellStyle::Severity(sev)` (or
+`Cell::severity(text, sev)` / `.with_severity(sev)` shortcuts). Theme-swap
+now works correctly.
+
 ## [Unreleased] — Breaking: `App::init` takes args; `RuntimeBuilder` split
 
 ### Breaking changes — `App::init` takes args

--- a/src/component/cell.rs
+++ b/src/component/cell.rs
@@ -109,6 +109,12 @@ impl SortKey {
 /// `Default` renders with no override (theme-driven). `Success`,
 /// `Warning`, `Error`, `Muted` map to the theme's semantic colors.
 /// `Custom(Style)` applies a raw `ratatui::style::Style` directly.
+/// `Severity(Severity)` (added in PR γ) resolves the four-band severity
+/// gradient through the active theme at render time.
+///
+/// `#[non_exhaustive]` so envision can add cell-style variants later without
+/// breaking downstream `match` arms in consumer crates.
+#[non_exhaustive]
 #[derive(Clone, Debug, Default, PartialEq)]
 pub enum CellStyle {
     /// No override — render with the theme's default cell style.

--- a/src/component/cell.rs
+++ b/src/component/cell.rs
@@ -308,6 +308,22 @@ impl Cell {
     pub fn muted(text: impl Into<CompactString>) -> Self {
         Self::new(text).with_style(CellStyle::Muted)
     }
+
+    /// Severity-styled cell. Resolves color through the active theme at
+    /// render time via [`crate::theme::Theme::severity_style`].
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::cell::Cell;
+    /// use envision::theme::Severity;
+    ///
+    /// let cell = Cell::severity("CrashLoopBackOff", Severity::Critical);
+    /// // Renders as the theme's red + BOLD on Catppuccin Mocha.
+    /// ```
+    pub fn severity(text: impl Into<CompactString>, sev: Severity) -> Self {
+        Self::new(text).with_style(CellStyle::Severity(sev))
+    }
 }
 
 impl From<&str> for Cell {
@@ -633,6 +649,15 @@ mod cell_style_constructor_tests {
     #[test]
     fn muted_sets_style() {
         assert_eq!(*Cell::muted("idle").style(), CellStyle::Muted);
+    }
+
+    #[test]
+    fn severity_sets_style() {
+        use crate::theme::Severity;
+        let c = Cell::severity("crash", Severity::Critical);
+        assert_eq!(c.text(), "crash");
+        assert_eq!(*c.style(), CellStyle::Severity(Severity::Critical));
+        assert_eq!(c.sort_key(), None);
     }
 }
 

--- a/src/component/cell.rs
+++ b/src/component/cell.rs
@@ -10,6 +10,8 @@
 use compact_str::CompactString;
 use ratatui::style::{Color, Style};
 
+use crate::theme::Severity;
+
 /// A typed sort key carried by a `Cell` for typed comparison.
 ///
 /// **DO NOT REORDER VARIANTS** — discriminant order is part of the
@@ -130,6 +132,10 @@ pub enum CellStyle {
     Muted,
     /// Applies a raw `ratatui::style::Style` directly, bypassing theme mapping.
     Custom(Style),
+    /// Resolves to the theme's severity color + style at render time.
+    /// `Critical` adds a `BOLD` modifier; other variants are color-only.
+    /// See [`crate::theme::Theme::severity_style`].
+    Severity(Severity),
 }
 
 /// Optional row-level status indicator. Renders as a colored symbol

--- a/src/component/cell.rs
+++ b/src/component/cell.rs
@@ -204,6 +204,33 @@ impl Cell {
         self
     }
 
+    /// Builder: set the cell style to severity-styled.
+    ///
+    /// Composes with the typed-cell pattern from G7 (preserves a typed
+    /// [`SortKey`]):
+    ///
+    /// ```rust
+    /// use envision::component::cell::Cell;
+    /// use envision::theme::Severity;
+    ///
+    /// let ratio = 5.2;
+    /// let cell = Cell::number(ratio)
+    ///     .with_text(format!("{:.2}x", ratio))
+    ///     .with_severity(Severity::Bad);
+    /// // Numeric SortKey preserved; severity color layered on top.
+    /// ```
+    ///
+    /// # Precedence
+    ///
+    /// Last-call-wins with [`with_style`](Self::with_style). Calling
+    /// `.with_style(CellStyle::Custom(...)).with_severity(Bad)` ends with
+    /// `CellStyle::Severity(Bad)`; the prior `Custom` is dropped. Natural
+    /// builder-pattern semantics — each setter overwrites.
+    pub fn with_severity(mut self, sev: Severity) -> Self {
+        self.style = CellStyle::Severity(sev);
+        self
+    }
+
     /// Builder: set the typed sort key.
     pub fn with_sort_key(mut self, key: SortKey) -> Self {
         self.sort_key = Some(key);
@@ -562,6 +589,30 @@ mod cell_struct_tests {
         assert_eq!(c.text(), "");
         assert_eq!(*c.style(), CellStyle::Default);
         assert_eq!(c.sort_key(), None);
+    }
+
+    #[test]
+    fn with_severity_preserves_text_and_sort_key() {
+        use crate::theme::Severity;
+
+        let c = Cell::number(5.2)
+            .with_text(format!("{:.2}x", 5.2))
+            .with_severity(Severity::Bad);
+        assert_eq!(c.text(), "5.20x");
+        assert_eq!(c.sort_key(), Some(&SortKey::F64(5.2)));
+        assert_eq!(*c.style(), CellStyle::Severity(Severity::Bad));
+    }
+
+    #[test]
+    fn with_severity_overwrites_with_style() {
+        use crate::theme::Severity;
+        use ratatui::style::{Color, Style};
+
+        // Last-call-wins: with_severity drops the prior with_style(Custom(...)).
+        let c = Cell::new("x")
+            .with_style(CellStyle::Custom(Style::default().fg(Color::Magenta)))
+            .with_severity(Severity::Critical);
+        assert_eq!(*c.style(), CellStyle::Severity(Severity::Critical));
     }
 }
 

--- a/src/component/table/render.rs
+++ b/src/component/table/render.rs
@@ -27,6 +27,7 @@ fn cell_style_to_ratatui(style: &CellStyle, theme: &Theme, disabled: bool) -> St
         CellStyle::Error => theme.error_style(),
         CellStyle::Muted => Style::default().fg(Color::DarkGray),
         CellStyle::Custom(s) => *s,
+        CellStyle::Severity(sev) => theme.severity_style(*sev),
     }
 }
 

--- a/src/component/table/snapshots/envision__component__table__view_tests__snapshot_table_cells_severity_disabled_renders_dark_gray_no_bold.snap
+++ b/src/component/table/snapshots/envision__component__table__view_tests__snapshot_table_cells_severity_disabled_renders_dark_gray_no_bold.snap
@@ -1,0 +1,14 @@
+---
+source: src/component/table/view_tests.rs
+expression: plain
+---
+┌──────────────────────────────────────┐
+│G        M        B        C          │
+│                                      │
+│good     mild     bad      crit       │
+│                                      │
+│                                      │
+│                                      │
+│                                      │
+│                                      │
+└──────────────────────────────────────┘

--- a/src/component/table/snapshots/envision__component__table__view_tests__snapshot_table_cells_with_severity_style.snap
+++ b/src/component/table/snapshots/envision__component__table__view_tests__snapshot_table_cells_with_severity_style.snap
@@ -1,0 +1,14 @@
+---
+source: src/component/table/view_tests.rs
+expression: plain
+---
+┌──────────────────────────────────────┐
+│G        M        B        C          │
+│                                      │
+│good     mild     bad      crit       │
+│                                      │
+│                                      │
+│                                      │
+│                                      │
+│                                      │
+└──────────────────────────────────────┘

--- a/src/component/table/view_tests.rs
+++ b/src/component/table/view_tests.rs
@@ -561,3 +561,60 @@ fn test_view_no_outer_border_when_chrome_owned() {
     let display = terminal.backend().to_string();
     insta::assert_snapshot!("view_chrome_owned_no_outer_border", display);
 }
+
+#[test]
+fn snapshot_table_cells_with_severity_style() {
+    use crate::component::cell::{Cell, CellStyle};
+    use crate::theme::Severity;
+
+    // Render four severity bands in one row. Default theme: Good=Green,
+    // Mild=Yellow, Bad=Yellow (collapses with Mild on Default — documented
+    // behavior from D6+D9), Critical=Red+BOLD.
+    let columns = vec![
+        Column::new("G", Constraint::Length(8)),
+        Column::new("M", Constraint::Length(8)),
+        Column::new("B", Constraint::Length(8)),
+        Column::new("C", Constraint::Length(8)),
+    ];
+    let cells = vec![
+        Cell::new("good").with_style(CellStyle::Severity(Severity::Good)),
+        Cell::new("mild").with_style(CellStyle::Severity(Severity::Mild)),
+        Cell::new("bad").with_style(CellStyle::Severity(Severity::Bad)),
+        Cell::new("crit").with_style(CellStyle::Severity(Severity::Critical)),
+    ];
+    let mut state = TableState::new(vec![StyledRow { cells }], columns);
+    state.set_selected(None);
+
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
+    terminal
+        .draw(|frame| {
+            Table::<StyledRow>::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
+        })
+        .unwrap();
+
+    let plain = terminal.backend().to_string();
+    let ansi = terminal.backend().to_ansi();
+
+    // ANSI assertions pin per-band coloring. Default theme: Mild and Bad
+    // both render as Color::Yellow (\x1b[33m) — the documented collapse
+    // from D6+D9 means severity bands degrade from four to three on
+    // Default. Critical stays distinguishable via BOLD.
+    assert!(
+        ansi.contains("\x1b[32m"),
+        "expected green (32m) for Severity::Good, got:\n{ansi}",
+    );
+    assert!(
+        ansi.contains("\x1b[33m"),
+        "expected yellow (33m) for Severity::Mild and Severity::Bad, got:\n{ansi}",
+    );
+    assert!(
+        ansi.contains("\x1b[31m"),
+        "expected red (31m) for Severity::Critical, got:\n{ansi}",
+    );
+    assert!(
+        ansi.contains("\x1b[1m"),
+        "expected BOLD (1m) for Severity::Critical, got:\n{ansi}",
+    );
+
+    insta::assert_snapshot!(plain);
+}

--- a/src/component/table/view_tests.rs
+++ b/src/component/table/view_tests.rs
@@ -564,7 +564,7 @@ fn test_view_no_outer_border_when_chrome_owned() {
 
 #[test]
 fn snapshot_table_cells_with_severity_style() {
-    use crate::component::cell::{Cell, CellStyle};
+    use crate::component::cell::Cell;
     use crate::theme::Severity;
 
     // Render four severity bands in one row. Default theme: Good=Green,
@@ -577,10 +577,10 @@ fn snapshot_table_cells_with_severity_style() {
         Column::new("C", Constraint::Length(8)),
     ];
     let cells = vec![
-        Cell::new("good").with_style(CellStyle::Severity(Severity::Good)),
-        Cell::new("mild").with_style(CellStyle::Severity(Severity::Mild)),
-        Cell::new("bad").with_style(CellStyle::Severity(Severity::Bad)),
-        Cell::new("crit").with_style(CellStyle::Severity(Severity::Critical)),
+        Cell::severity("good", Severity::Good),
+        Cell::severity("mild", Severity::Mild),
+        Cell::severity("bad", Severity::Bad),
+        Cell::severity("crit", Severity::Critical),
     ];
     let mut state = TableState::new(vec![StyledRow { cells }], columns);
     state.set_selected(None);

--- a/src/component/table/view_tests.rs
+++ b/src/component/table/view_tests.rs
@@ -618,3 +618,61 @@ fn snapshot_table_cells_with_severity_style() {
 
     insta::assert_snapshot!(plain);
 }
+
+#[test]
+fn snapshot_table_cells_severity_disabled_renders_dark_gray_no_bold() {
+    use crate::component::cell::{Cell, CellStyle};
+    use crate::theme::Severity;
+
+    // Same row as snapshot_table_cells_with_severity_style, but the
+    // RenderContext is marked disabled. Disabled override wins: every
+    // cell renders dark-gray (\x1b[90m), no BOLD.
+    let columns = vec![
+        Column::new("G", Constraint::Length(8)),
+        Column::new("M", Constraint::Length(8)),
+        Column::new("B", Constraint::Length(8)),
+        Column::new("C", Constraint::Length(8)),
+    ];
+    let cells = vec![
+        Cell::new("good").with_style(CellStyle::Severity(Severity::Good)),
+        Cell::new("mild").with_style(CellStyle::Severity(Severity::Mild)),
+        Cell::new("bad").with_style(CellStyle::Severity(Severity::Bad)),
+        Cell::new("crit").with_style(CellStyle::Severity(Severity::Critical)),
+    ];
+    let mut state = TableState::new(vec![StyledRow { cells }], columns);
+    state.set_selected(None);
+
+    let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
+    terminal
+        .draw(|frame| {
+            Table::<StyledRow>::view(
+                &state,
+                &mut RenderContext::new(frame, frame.area(), &theme).disabled(true),
+            );
+        })
+        .unwrap();
+
+    let plain = terminal.backend().to_string();
+    let ansi = terminal.backend().to_ansi();
+
+    // Disabled override: all cells render as dark-gray. No severity-band
+    // colors should appear.
+    assert!(
+        ansi.contains("\x1b[90m"),
+        "expected dark-gray (90m) for all cells under disabled, got:\n{ansi}",
+    );
+    assert!(
+        !ansi.contains("\x1b[32m"),
+        "did not expect green (32m) under disabled — Severity::Good should collapse to dark-gray, got:\n{ansi}",
+    );
+    assert!(
+        !ansi.contains("\x1b[31m"),
+        "did not expect red (31m) under disabled — Severity::Critical should collapse to dark-gray, got:\n{ansi}",
+    );
+    assert!(
+        !ansi.contains("\x1b[1m"),
+        "did not expect BOLD (1m) under disabled — Severity::Critical's BOLD must drop, got:\n{ansi}",
+    );
+
+    insta::assert_snapshot!(plain);
+}


### PR DESCRIPTION
## Summary

Implementation of leadline gap **D15** — \`TableRow::cells(&self)\` takes no \`&Theme\`; severity-aware cell construction can't reach the active theme at row-build time. Closes the loop on the D6+D9 theme palette + severity helper landing.

- Spec: PR #476 (\`docs/superpowers/specs/2026-05-08-cellstyle-severity-design.md\`)
- Plan: PR #477 (\`docs/superpowers/plans/2026-05-08-cellstyle-severity.md\`)

## What changed

**New variant (in \`src/component/cell.rs\`):**

- \`CellStyle::Severity(Severity)\` — resolves at render time via \`theme.severity_style(*sev)\`. Color routes through the theme's palette (Good→Green, Mild→Yellow, Bad→Peach, Critical→Red); \`Critical\` adds \`Modifier::BOLD\`.

**New \`Cell\` constructors:**

- \`Cell::severity(text, sev)\` — semantic shorthand mirroring \`Cell::success/warning/error/muted\`.
- \`Cell::with_severity(sev)\` — typed-cell builder for the G7 chain \`Cell::number(x).with_text(formatted).with_severity(sev)\`. Preserves the typed \`SortKey\` while layering severity color. Last-call-wins precedence with \`with_style(...)\` documented in docstring per leadline's plan-time review.

**Render arm:**

- \`cell_style_to_ratatui\` in \`src/component/table/render.rs\` gets one new arm: \`CellStyle::Severity(sev) => theme.severity_style(*sev)\`. No new render-path plumbing.

**Breaking change:**

- \`CellStyle\` is now \`#[non_exhaustive]\`. Matches the convention set by \`Severity\` and \`NamedColor\` in PR #473. Bundled in same PR per the brainstorming decision (one breakage beats two). Internal \`match\` arms inside the crate are still exhaustive — the attribute applies only to external consumers.

## Stats

- 6 signed commits (Tasks 1, 2, 3, 4, 5, 7 — Task 6 was verification-only with no commit)
- 4 new tests (1 in cell.rs cell_style_constructor_tests, 2 in cell.rs cell_struct_tests, 2 in table/view_tests.rs)
- 2 new doc tests (Cell::severity, Cell::with_severity)
- File sizes after: cell.rs 745 lines, table/render.rs 189 lines, table/view_tests.rs 681 lines, all under 1000-line cap

## Verification

- \`cargo build --all-features\`: clean
- \`cargo clippy --all-features --all-targets -- -D warnings\`: clean
- \`cargo fmt --all -- --check\`: clean
- \`cargo nextest run --all-features\`: **7412/7412** passed
- \`cargo test --all-features --doc\`: clean
- \`RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps\`: clean
- \`./tools/audit/target/release/envision-audit scorecard\`: **8/9** (same baseline as main; the \`resource_gauge::set_values\` accessor symmetry gap is pre-existing)

## Test plan

- [ ] CI green on all platforms
- [ ] leadline migrates the two \`severity_cell_style\` helpers; deletes inline \`Theme::catppuccin_mocha()\` constructions; replaces with \`Severity::from_thresholds(...)\` + \`with_severity(sev)\` chains

🤖 Generated with [Claude Code](https://claude.com/claude-code)