### PR TITLE
StyledText DX: line primitive + paragraph rename (D5 + D14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,45 @@ helper that constructs a hardcoded theme. Replace with
 `Cell::severity(text, sev)` / `.with_severity(sev)` shortcuts). Theme-swap
 now works correctly.
 
+### StyledText DX: line primitive + `paragraph` rename (D5 + D14)
+
+Two coupled changes in one PR, both targeting `StyledText` / `StyledContent`
+ergonomics:
+
+**New `envision::render` module + primitive:**
+
+- `envision::render::styled_line(frame, area, &[StyledInline], theme)` —
+  free-function primitive that renders one styled line into the given area.
+  Replaces the six-types-three-methods construction pattern (`StyledTextState::new()
+  .with_content(StyledContent::new().line(...)).with_show_border(false)` +
+  `StyledText::view(...)`) with one call. Also re-exported at the crate root
+  as `envision::styled_line`.
+
+**Method + variant rename:**
+
+- `StyledContent::paragraph(inlines)` → `StyledContent::line(inlines)`. The
+  method always produced one line, not a wrapped block-level paragraph; the
+  old name was a misnomer.
+- `StyledBlock::Paragraph(Vec<StyledInline>)` → `StyledBlock::Line(Vec<StyledInline>)`.
+  Internal coherence with the method rename; source-spelunkers no longer hit
+  the misnomer from the variant side.
+- Private helper `render_paragraph` → `render_line` (no API impact;
+  source-level coherence).
+
+Both renames delete the old names outright — no `#[deprecated]` shim. envision
+is pre-1.0; one mechanical migration in the same PR.
+
+**Breaking change:** any external code that matches `StyledBlock::Paragraph` or
+calls `.paragraph(...)` on `StyledContent` must rename to `StyledBlock::Line`
+and `.line(...)` respectively. Renamed APIs are functionally identical; no
+behavior changes.
+
+**Reserved for future:** the `paragraph` name is now free for real block-level
+wrapped-text semantics. Lands as a separate PR when a consumer needs it.
+
+**Migration count:** 17 call sites updated in this PR (10 in
+`examples/styling_showcase.rs`, 7 internal across `src/component/styled_text/`).
+
 ## [Unreleased] — Breaking: `App::init` takes args; `RuntimeBuilder` split
 
 ### Breaking changes — `App::init` takes args

--- a/examples/styling_showcase.rs
+++ b/examples/styling_showcase.rs
@@ -118,27 +118,27 @@ impl Default for State {
 fn build_rich_text_content() -> styled_text::StyledContent {
     styled_text::StyledContent::new()
         .heading(1, "StyledInline Variants")
-        .paragraph(vec![styled_text::StyledInline::Plain(
+        .line(vec![styled_text::StyledInline::Plain(
             "This is Plain text — the default inline style.".to_string(),
         )])
-        .paragraph(vec![styled_text::StyledInline::Bold(
+        .line(vec![styled_text::StyledInline::Bold(
             "This is Bold text — for emphasis and headings.".to_string(),
         )])
-        .paragraph(vec![styled_text::StyledInline::Italic(
+        .line(vec![styled_text::StyledInline::Italic(
             "This is Italic text — for subtle emphasis or titles.".to_string(),
         )])
-        .paragraph(vec![styled_text::StyledInline::Underline(
+        .line(vec![styled_text::StyledInline::Underline(
             "This is Underline text — for links or key terms.".to_string(),
         )])
-        .paragraph(vec![styled_text::StyledInline::Strikethrough(
+        .line(vec![styled_text::StyledInline::Strikethrough(
             "This is Strikethrough text — for deprecated or removed items.".to_string(),
         )])
-        .paragraph(vec![styled_text::StyledInline::Code(
+        .line(vec![styled_text::StyledInline::Code(
             "This is Code text — for inline code snippets.".to_string(),
         )])
         .blank_line()
         .heading(2, "Colored Inline Text")
-        .paragraph(vec![
+        .line(vec![
             styled_text::StyledInline::Colored {
                 text: "Red foreground".to_string(),
                 fg: Some(Color::Red),
@@ -157,7 +157,7 @@ fn build_rich_text_content() -> styled_text::StyledContent {
                 bg: None,
             },
         ])
-        .paragraph(vec![
+        .line(vec![
             styled_text::StyledInline::Colored {
                 text: "Cyan foreground".to_string(),
                 fg: Some(Color::Cyan),
@@ -176,14 +176,14 @@ fn build_rich_text_content() -> styled_text::StyledContent {
                 bg: None,
             },
         ])
-        .paragraph(vec![styled_text::StyledInline::Colored {
+        .line(vec![styled_text::StyledInline::Colored {
             text: " Highlighted text with background ".to_string(),
             fg: Some(Color::White),
             bg: Some(Color::Blue),
         }])
         .blank_line()
         .heading(2, "Mixed Inline Styles")
-        .paragraph(vec![
+        .line(vec![
             styled_text::StyledInline::Plain("You can ".to_string()),
             styled_text::StyledInline::Bold("mix".to_string()),
             styled_text::StyledInline::Plain(" and ".to_string()),

--- a/src/component/styled_text/content.rs
+++ b/src/component/styled_text/content.rs
@@ -18,8 +18,9 @@ pub enum StyledBlock {
         /// The heading text.
         text: String,
     },
-    /// A paragraph composed of inline elements.
-    Paragraph(Vec<StyledInline>),
+    /// One line of styled inline elements (renamed from `Paragraph` —
+    /// the variant produces a single line, not a wrapped block).
+    Line(Vec<StyledInline>),
     /// A bulleted list where each item is a list of inline elements.
     BulletList(Vec<Vec<StyledInline>>),
     /// A numbered list where each item is a list of inline elements.
@@ -114,7 +115,7 @@ impl StyledContent {
     ///
     /// let blocks = vec![
     ///     StyledBlock::Heading { level: 1, text: "Title".to_string() },
-    ///     StyledBlock::Paragraph(vec![StyledInline::Plain("Hello".to_string())]),
+    ///     StyledBlock::Line(vec![StyledInline::Plain("Hello".to_string())]),
     /// ];
     /// let content = StyledContent::from_blocks(blocks);
     /// assert_eq!(content.len(), 2);
@@ -143,7 +144,11 @@ impl StyledContent {
         self
     }
 
-    /// Adds a paragraph composed of inline elements.
+    /// Append a single styled line composed of inline elements.
+    ///
+    /// (Renamed from `paragraph(...)` — but the method produces one line,
+    /// not a block-level paragraph. The `paragraph` name is reserved for
+    /// future real block-level wrapped text.)
     ///
     /// # Example
     ///
@@ -151,14 +156,14 @@ impl StyledContent {
     /// use envision::component::styled_text::{StyledContent, StyledInline};
     ///
     /// let content = StyledContent::new()
-    ///     .paragraph(vec![
+    ///     .line(vec![
     ///         StyledInline::Plain("Hello, ".to_string()),
     ///         StyledInline::Bold("world".to_string()),
     ///     ]);
     /// assert_eq!(content.len(), 1);
     /// ```
-    pub fn paragraph(mut self, inlines: Vec<StyledInline>) -> Self {
-        self.blocks.push(StyledBlock::Paragraph(inlines));
+    pub fn line(mut self, inlines: Vec<StyledInline>) -> Self {
+        self.blocks.push(StyledBlock::Line(inlines));
         self
     }
 
@@ -174,7 +179,7 @@ impl StyledContent {
     /// assert_eq!(content.len(), 1);
     /// ```
     pub fn text(self, text: impl Into<String>) -> Self {
-        self.paragraph(vec![StyledInline::Plain(text.into())])
+        self.line(vec![StyledInline::Plain(text.into())])
     }
 
     /// Adds a bulleted list.
@@ -398,8 +403,8 @@ fn render_block(
             };
             lines.push(RatLine::from(RatSpan::styled(text.clone(), style)));
         }
-        StyledBlock::Paragraph(inlines) => {
-            render_paragraph(inlines, theme, base_style, lines);
+        StyledBlock::Line(inlines) => {
+            render_line(inlines, theme, base_style, lines);
         }
         StyledBlock::BulletList(items) => {
             for item in items {
@@ -454,7 +459,7 @@ fn render_block(
     }
 }
 
-fn render_paragraph(
+fn render_line(
     inlines: &[StyledInline],
     theme: &Theme,
     base_style: Style,

--- a/src/component/styled_text/tests.rs
+++ b/src/component/styled_text/tests.rs
@@ -39,17 +39,17 @@ fn test_content_text() {
     assert_eq!(content.len(), 1);
     assert!(matches!(
         &content.blocks()[0],
-        StyledBlock::Paragraph(inlines) if inlines.len() == 1
+        StyledBlock::Line(inlines) if inlines.len() == 1
     ));
 }
 
 #[test]
-fn test_content_paragraph_with_inlines() {
+fn test_content_line_with_inlines() {
     let inlines = vec![
         StyledInline::Bold("bold".to_string()),
         StyledInline::Plain(" text".to_string()),
     ];
-    let content = StyledContent::new().paragraph(inlines);
+    let content = StyledContent::new().line(inlines);
     assert_eq!(content.len(), 1);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,7 @@ pub mod harness;
 pub mod input;
 pub mod layout;
 pub mod overlay;
+pub mod render;
 pub mod scroll;
 pub mod style;
 pub mod theme;
@@ -409,6 +410,7 @@ pub use input::{
     MouseEventKind,
 };
 pub use overlay::{Overlay, OverlayAction, OverlayStack};
+pub use render::styled_line;
 pub use scroll::{ScrollState, render_scrollbar, render_scrollbar_inside_border};
 pub use theme::{NamedColor, Palette, Severity, Theme};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,7 @@ pub mod harness;
 pub mod input;
 pub mod layout;
 pub mod overlay;
+#[cfg(feature = "display-components")]
 pub mod render;
 pub mod scroll;
 pub mod style;
@@ -410,6 +411,7 @@ pub use input::{
     MouseEventKind,
 };
 pub use overlay::{Overlay, OverlayAction, OverlayStack};
+#[cfg(feature = "display-components")]
 pub use render::styled_line;
 pub use scroll::{ScrollState, render_scrollbar, render_scrollbar_inside_border};
 pub use theme::{NamedColor, Palette, Severity, Theme};

--- a/src/render.rs
+++ b/src/render.rs
@@ -76,3 +76,119 @@ pub fn styled_line(
     let paragraph = Paragraph::new(text);
     frame.render_widget(paragraph, area);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::component::styled_text::StyledInline;
+    use crate::component::test_utils::setup_render;
+    use ratatui::style::Color;
+
+    #[test]
+    fn test_styled_line_renders_inlines() {
+        // Plain + Bold + Colored — all three appear in the rendered text in order.
+        let inlines = vec![
+            StyledInline::Plain("hello ".to_string()),
+            StyledInline::Bold("bold".to_string()),
+            StyledInline::Plain(" world".to_string()),
+        ];
+
+        let (mut terminal, theme) = setup_render(40, 1);
+        terminal
+            .draw(|frame| {
+                styled_line(frame, frame.area(), &inlines, &theme);
+            })
+            .unwrap();
+
+        let plain = terminal.backend().to_string();
+        insta::assert_snapshot!(plain);
+    }
+
+    #[test]
+    fn test_styled_line_applies_theme_color() {
+        // StyledInline::Colored carries an explicit fg color. ANSI red = \x1b[31m.
+        let inlines = vec![StyledInline::Colored {
+            text: "err".to_string(),
+            fg: Some(Color::Red),
+            bg: None,
+        }];
+
+        let (mut terminal, theme) = setup_render(20, 1);
+        terminal
+            .draw(|frame| {
+                styled_line(frame, frame.area(), &inlines, &theme);
+            })
+            .unwrap();
+
+        let ansi = terminal.backend().to_ansi();
+        assert!(
+            ansi.contains("\x1b[31m"),
+            "expected red (31m) ANSI fg for Colored(Red) inline, got:\n{ansi}",
+        );
+    }
+
+    #[test]
+    fn test_styled_line_truncates_to_area_width() {
+        // 60 chars of plain text rendered into a 20-wide area — truncates
+        // per ratatui's Paragraph default. Snapshot pins truncation behavior.
+        let inlines = vec![StyledInline::Plain(
+            "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWX".to_string(),
+        )];
+
+        let (mut terminal, theme) = setup_render(20, 1);
+        terminal
+            .draw(|frame| {
+                styled_line(frame, frame.area(), &inlines, &theme);
+            })
+            .unwrap();
+
+        let plain = terminal.backend().to_string();
+        insta::assert_snapshot!(plain);
+    }
+
+    #[test]
+    fn test_styled_line_empty_inlines_renders_nothing() {
+        // Empty slice — primitive returns without panicking; buffer stays empty.
+        let inlines: &[StyledInline] = &[];
+
+        let (mut terminal, theme) = setup_render(40, 1);
+        terminal
+            .draw(|frame| {
+                styled_line(frame, frame.area(), inlines, &theme);
+            })
+            .unwrap();
+
+        let plain = terminal.backend().to_string();
+        insta::assert_snapshot!(plain);
+    }
+
+    #[test]
+    fn test_styled_line_no_chrome_drawn() {
+        // Render into a 40x3 area but only the first row should have content;
+        // rows 2 and 3 stay blank. Pins that the primitive draws no chrome /
+        // no border / no fill in unused rows.
+        let inlines = vec![StyledInline::Plain("only first row".to_string())];
+
+        let (mut terminal, theme) = setup_render(40, 3);
+        terminal
+            .draw(|frame| {
+                // Use the full frame area (40x3). styled_line renders into
+                // row 0 only; rows 1 and 2 must stay blank.
+                styled_line(frame, frame.area(), &inlines, &theme);
+            })
+            .unwrap();
+
+        let plain = terminal.backend().to_string();
+        // Snapshot captures the three-row layout; visual confirmation that
+        // rows 1 and 2 are blank.
+        insta::assert_snapshot!(plain);
+
+        // Also assert rows 1 and 2 are entirely spaces (no chrome glyphs).
+        let rows: Vec<&str> = plain.lines().collect();
+        assert!(rows.len() >= 3, "expected 3 rows, got {}: {plain}", rows.len());
+        let row1_blank = rows[1].chars().all(|c| c == ' ');
+        let row2_blank = rows[2].chars().all(|c| c == ' ');
+        assert!(row1_blank, "row 1 should be blank (no chrome), got: {:?}", rows[1]);
+        assert!(row2_blank, "row 2 should be blank (no chrome), got: {:?}", rows[2]);
+    }
+}

--- a/src/render.rs
+++ b/src/render.rs
@@ -59,12 +59,7 @@ use crate::theme::Theme;
 ///     styled_line(frame, area, &inlines, theme);
 /// }
 /// ```
-pub fn styled_line(
-    frame: &mut Frame,
-    area: Rect,
-    inlines: &[StyledInline],
-    theme: &Theme,
-) {
+pub fn styled_line(frame: &mut Frame, area: Rect, inlines: &[StyledInline], theme: &Theme) {
     if area.width == 0 || area.height == 0 {
         return;
     }
@@ -185,10 +180,22 @@ mod tests {
 
         // Also assert rows 1 and 2 are entirely spaces (no chrome glyphs).
         let rows: Vec<&str> = plain.lines().collect();
-        assert!(rows.len() >= 3, "expected 3 rows, got {}: {plain}", rows.len());
+        assert!(
+            rows.len() >= 3,
+            "expected 3 rows, got {}: {plain}",
+            rows.len()
+        );
         let row1_blank = rows[1].chars().all(|c| c == ' ');
         let row2_blank = rows[2].chars().all(|c| c == ' ');
-        assert!(row1_blank, "row 1 should be blank (no chrome), got: {:?}", rows[1]);
-        assert!(row2_blank, "row 2 should be blank (no chrome), got: {:?}", rows[2]);
+        assert!(
+            row1_blank,
+            "row 1 should be blank (no chrome), got: {:?}",
+            rows[1]
+        );
+        assert!(
+            row2_blank,
+            "row 2 should be blank (no chrome), got: {:?}",
+            rows[2]
+        );
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -174,11 +174,18 @@ mod tests {
             .unwrap();
 
         let plain = terminal.backend().to_string();
-        // Snapshot captures the three-row layout; visual confirmation that
-        // rows 1 and 2 are blank.
+        // Snapshot is INFORMATIONAL: insta trims trailing whitespace and
+        // newlines when serializing terminal.to_string() output, so the
+        // snapshot won't visibly distinguish "blank rows" from "no rows at
+        // all." The row-content `assert!` calls below are the load-bearing
+        // chrome-no-draw assertions — they walk the raw lines() output and
+        // verify every char in rows 1 and 2 is a space, which catches any
+        // chrome / border / fill regression that the trimmed snapshot would
+        // silently mask.
         insta::assert_snapshot!(plain);
 
-        // Also assert rows 1 and 2 are entirely spaces (no chrome glyphs).
+        // Load-bearing chrome assertions: verify rows 1 and 2 are entirely
+        // spaces (no chrome glyphs).
         let rows: Vec<&str> = plain.lines().collect();
         assert!(
             rows.len() >= 3,

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,0 +1,78 @@
+//! Standalone render primitives that don't belong to a single component.
+//!
+//! These functions take a `Frame`, a `Rect`, the data to render, and a `Theme`,
+//! and produce immediate rendered output. They carry no state, draw no chrome,
+//! and own no border — primitives consume an externally-owned area and produce
+//! styled content directly into it.
+//!
+//! Compose freely with the chrome-ownership protocol: a primitive called inside
+//! a chrome_owned context owns no chrome of its own, so there's nothing to
+//! suppress.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use envision::component::styled_text::StyledInline;
+//! use envision::render::styled_line;
+//! use envision::theme::Theme;
+//! use ratatui::layout::Rect;
+//!
+//! fn render(frame: &mut ratatui::Frame, area: Rect, theme: &Theme) {
+//!     let inlines = vec![
+//!         StyledInline::Plain("Hello, ".to_string()),
+//!         StyledInline::Bold("world".to_string()),
+//!     ];
+//!     styled_line(frame, area, &inlines, theme);
+//! }
+//! ```
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::text::Text;
+use ratatui::widgets::Paragraph;
+
+use crate::component::styled_text::{StyledContent, StyledInline};
+use crate::theme::Theme;
+
+/// Render a sequence of styled inline elements as a single line into `area`.
+///
+/// Equivalent to a borderless `StyledText` with one line of content, but with
+/// no state plumbing — pass inlines + frame + area + theme, get rendered output.
+///
+/// Empty inlines render an empty buffer (no error, no panic). Inlines that
+/// exceed the area width are truncated by the underlying `ratatui::Paragraph`
+/// widget; no wrapping is applied (single-line semantics).
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use envision::component::styled_text::StyledInline;
+/// use envision::render::styled_line;
+/// use envision::theme::Theme;
+/// use ratatui::layout::Rect;
+///
+/// fn render(frame: &mut ratatui::Frame, area: Rect, theme: &Theme) {
+///     let inlines = vec![
+///         StyledInline::Plain("status: ".to_string()),
+///         StyledInline::Bold("ready".to_string()),
+///     ];
+///     styled_line(frame, area, &inlines, theme);
+/// }
+/// ```
+pub fn styled_line(
+    frame: &mut Frame,
+    area: Rect,
+    inlines: &[StyledInline],
+    theme: &Theme,
+) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    // Build a one-block StyledContent and use the existing render path.
+    // Reuses render_block -> render_line -> render_inline; no new rendering logic.
+    let content = StyledContent::new().line(inlines.to_vec());
+    let lines = content.render_lines(area.width, theme);
+    let text = Text::from(lines);
+    let paragraph = Paragraph::new(text);
+    frame.render_widget(paragraph, area);
+}

--- a/src/snapshots/envision__render__tests__styled_line_empty_inlines_renders_nothing.snap
+++ b/src/snapshots/envision__render__tests__styled_line_empty_inlines_renders_nothing.snap
@@ -1,0 +1,5 @@
+---
+source: src/render.rs
+expression: plain
+---
+

--- a/src/snapshots/envision__render__tests__styled_line_no_chrome_drawn.snap
+++ b/src/snapshots/envision__render__tests__styled_line_no_chrome_drawn.snap
@@ -1,0 +1,5 @@
+---
+source: src/render.rs
+expression: plain
+---
+only first row

--- a/src/snapshots/envision__render__tests__styled_line_renders_inlines.snap
+++ b/src/snapshots/envision__render__tests__styled_line_renders_inlines.snap
@@ -1,0 +1,5 @@
+---
+source: src/render.rs
+expression: plain
+---
+hello bold world

--- a/src/snapshots/envision__render__tests__styled_line_truncates_to_area_width.snap
+++ b/src/snapshots/envision__render__tests__styled_line_truncates_to_area_width.snap
@@ -1,0 +1,5 @@
+---
+source: src/render.rs
+expression: plain
+---
+abcdefghijklmnopqrst


### PR DESCRIPTION
## Summary

Implementation of leadline gaps **D5** (no "render styled Line into Rect" primitive — six types and three method calls to draw one styled line) and **D14** (\`StyledContent::paragraph(...)\` misleadingly produces a single line, not a wrapped block-level paragraph).

- Spec: PR #480 (\`docs/superpowers/specs/2026-05-09-styled-text-dx-design.md\`)
- Plan: PR #481 (\`docs/superpowers/plans/2026-05-09-styled-text-dx.md\`)

## What changed

**New primitive (in new \`src/render.rs\`):**

- \`envision::render::styled_line(frame, area, &[StyledInline], theme)\` — free-function primitive that renders one styled line into the given area. Internally constructs a one-block \`StyledContent\` and renders via the existing \`render_lines\` path — zero new rendering logic, just an ergonomic surface.
- Re-exported at the crate root as \`envision::styled_line\`.

**Method + variant rename (atomic, single commit):**

- \`StyledContent::paragraph(inlines)\` → \`StyledContent::line(inlines)\` — method rename. Old method deleted outright (pre-1.0 ruthlessness).
- \`StyledBlock::Paragraph(Vec<StyledInline>)\` → \`StyledBlock::Line(Vec<StyledInline>)\` — variant rename. Internal coherence with the method rename.
- Private helper \`fn render_paragraph\` → \`fn render_line\`. No API impact; source-level coherence.

**Migration:**

- 17 call sites updated (10 in \`examples/styling_showcase.rs\`, 7 internal across \`src/component/styled_text/\`, plus 1 doctest example caught during execution that wasn't in the plan grep).
- All insta snapshots byte-identical pre/post — rename is name-only, no rendering changes.

**Breaking change:**

- External code matching \`StyledBlock::Paragraph\` or calling \`.paragraph(...)\` must rename. Functionally identical after the rename. envision is pre-1.0.

**Reserved for future:**

- The \`paragraph\` name is now free for real block-level wrapped-text semantics. Lands as a separate PR when a consumer needs it.

## Stats

- 6 signed commits (Tasks 1, 2, 4, 5, 7 + a small fmt-cleanup commit for Task 4/5 leftovers; Tasks 3 and 6 were verification-only)
- 5 new tests for \`styled_line\` (rendering, theme color, truncation, empty input, no-chrome-in-unused-rows)
- 4 new insta snapshots
- File sizes after: \`src/render.rs\` (NEW) ~200 lines, \`src/component/styled_text/content.rs\` ~521 lines (in-place renames, no size delta), \`src/component/styled_text/tests.rs\` ~713 lines (in-place renames). All under cap.

## Verification

- \`cargo build --all-features\`: clean
- \`cargo clippy --all-features --all-targets -- -D warnings\`: clean
- \`cargo fmt --all -- --check\`: clean
- \`cargo nextest run --all-features\`: **7417/7417** passed (was 7412 on main; +5 new tests)
- \`cargo test --all-features --doc\`: clean
- \`RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps\`: clean
- \`./tools/audit/target/release/envision-audit scorecard\`: **8/9** (same baseline as main; the \`resource_gauge::set_values\` accessor symmetry gap is pre-existing)
- Stale-references check: \`grep -rn "StyledBlock::Paragraph\\|render_paragraph\\|\\.paragraph(" src/ examples/\` → **0 matches**

## Test plan

- [ ] CI green on all platforms
- [ ] leadline migrates \`build_summary_banner_state\` (\`app.rs:392\`) and the empty-state path (\`app.rs:372\`) to direct \`envision::render::styled_line\` calls; updates any \`.paragraph(...)\` call sites to \`.line(...)\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)