### PR TITLE
Prelude: re-export envision::render::styled_line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — Chrome ownership protocol (G2 + D2 + D11)
 
+### Prelude: re-export `styled_line`
+
+`envision::prelude::*` now re-exports `styled_line` (gated behind
+`display-components` to match the source module). Consumers using the
+prelude get `styled_line` without an explicit `use envision::render::styled_line;`.
+Follow-up to D5 + D14 (PR #482) surfaced by leadline's migration —
+`render_scrollbar` reached the prelude via `pub use crate::component::*`
+but the new top-level `render` module didn't.
+
 ### Chrome ownership protocol (G2 + D2 + D11)
 
 `RenderContext::chrome_owned: bool` — new public field. `true` signals to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -455,6 +455,10 @@ pub mod prelude {
     // Scroll infrastructure
     pub use crate::scroll::ScrollState;
 
+    // Render primitives (gated like the source module)
+    #[cfg(feature = "display-components")]
+    pub use crate::render::styled_line;
+
     // All component types (the primary user-facing API)
     pub use crate::component::*;
 


### PR DESCRIPTION
## Summary

Follow-up polish to D5 + D14 (PR #482). leadline's migration surfaced that \`envision::prelude::*\` doesn't include \`styled_line\` — other utility functions like \`render_scrollbar\` reach the prelude via \`pub use crate::component::*\`, but the new top-level \`render\` module isn't pulled in.

## What changed

- \`pub use crate::render::styled_line;\` added to the prelude block in \`src/lib.rs\`, gated behind \`display-components\` to match the source module.
- CHANGELOG entry under \`[Unreleased]\`.

## Why a separate PR

Truly orthogonal to G4+G5 (the next brief). G4+G5 is about per-component style overrides on \`PaneLayout\` / \`StatusBarItem\`; this is about prelude re-exports. Mixing scope would muddy the StatusBar PR. Standalone PR keeps the diff focused and the migration history clean.

## Test plan

- [ ] CI green (\`--all-features\` + \`--no-default-features\` both clean locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)