### PR TITLE
StatusBar per-side separator overrides (D12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,61 @@ deletion).
 - `InlineStyle` struct uses `#[non_exhaustive]` — external code cannot
   construct via struct literal; must use the `InlineStyle::new()...` builder.
 
+### StatusBar per-side separator overrides (D12)
+
+Adds three optional per-section separator overrides on `StatusBarState`.
+Per-side override takes precedence over the existing global `separator` at
+render time. Purely additive — default state has all three Options as
+`None`, preserving identical behavior for consumers who don't opt in.
+
+**New fields on `StatusBarState`:**
+
+- `left_separator: Option<String>` (with `#[serde(default)]`)
+- `center_separator: Option<String>` (with `#[serde(default)]`)
+- `right_separator: Option<String>` (with `#[serde(default)]`)
+
+Clustered immediately after the existing global `separator: String` field —
+matches the G4 (`title_style` next to `title`) and G5 (`color`/`style_override`
+next to `style`) field-grouping convention.
+
+**New builder methods + getters:**
+
+- `with_left_separator(impl Into<String>)` / `left_separator() -> Option<&str>`
+- `with_center_separator(impl Into<String>)` / `center_separator() -> Option<&str>`
+- `with_right_separator(impl Into<String>)` / `right_separator() -> Option<&str>`
+
+Builder methods take `mut self` (consistent with existing `with_disabled`).
+Chain cleanly with both `StatusBarState::new()` and `StatusBarState::with_separator(...)`:
+
+```rust
+// Load-bearing use case: global " · " everywhere except the right-section
+// slowdown segments, which use " " (space) instead.
+StatusBarState::with_separator(" · ")
+    .with_right_separator(" ")
+    // ... push items ...
+```
+
+Methods live in `src/component/status_bar/per_side_separators.rs` (a sibling
+file) to keep `mod.rs` under the 1000-line cap. Same multi-module impl pattern
+as `pane_layout/title_style.rs` from G4.
+
+**Layered semantics, not last-call-wins:** per-side override is independent
+of global `separator`. Setting `with_separator(" · ").with_right_separator(" ")`
+results in BOTH fields populated; render-time precedence resolves which
+applies per section (`state.right_separator.as_deref().unwrap_or(&state.separator)`).
+Same model as G4/G5 per-component style overrides.
+
+**Render-path:** three single-line fallback expressions inserted at
+`status_bar/mod.rs:850-852`. `render_section` signature unchanged (it already
+takes `&str`).
+
+**Forward-compat:** `#[serde(default)]` on all three new fields means
+pre-D12 serialized `StatusBarState` blobs deserialize cleanly with all three
+as `None` — behavior identical to pre-D12.
+
+**No struct-literal break** for external consumers — fields are private
+(matches existing field visibility on the struct).
+
 ## [Unreleased] — Breaking: `App::init` takes args; `RuntimeBuilder` split
 
 ### Breaking changes — `App::init` takes args

--- a/src/component/status_bar/mod.rs
+++ b/src/component/status_bar/mod.rs
@@ -55,6 +55,7 @@
 //! ```
 
 mod item;
+mod per_side_separators;
 pub use item::*;
 
 use ratatui::prelude::*;
@@ -186,8 +187,20 @@ pub struct StatusBarState {
     center: Vec<StatusBarItem>,
     /// Items aligned to the right.
     right: Vec<StatusBarItem>,
-    /// The separator character to use between items.
+    /// The separator character to use between items (global default).
     separator: String,
+    /// Per-side override for the left section. When `Some`, takes
+    /// precedence over `separator` for left-section rendering.
+    #[cfg_attr(feature = "serialization", serde(default))]
+    left_separator: Option<String>,
+    /// Per-side override for the center section. When `Some`, takes
+    /// precedence over `separator` for center-section rendering.
+    #[cfg_attr(feature = "serialization", serde(default))]
+    center_separator: Option<String>,
+    /// Per-side override for the right section. When `Some`, takes
+    /// precedence over `separator` for right-section rendering.
+    #[cfg_attr(feature = "serialization", serde(default))]
+    right_separator: Option<String>,
     /// Background style for the entire bar.
     background: Color,
     /// Whether the component is disabled.
@@ -215,6 +228,9 @@ impl Default for StatusBarState {
             center: Vec::new(),
             right: Vec::new(),
             separator: " | ".to_string(),
+            left_separator: None,
+            center_separator: None,
+            right_separator: None,
             background: Color::DarkGray,
             disabled: false,
         }
@@ -847,9 +863,21 @@ impl Component for StatusBar {
         let bg_style = Style::default().bg(state.background);
 
         // Calculate section widths
-        let left_spans = Self::render_section(&state.left, &state.separator, ctx.theme);
-        let center_spans = Self::render_section(&state.center, &state.separator, ctx.theme);
-        let right_spans = Self::render_section(&state.right, &state.separator, ctx.theme);
+        let left_sep = state
+            .left_separator
+            .as_deref()
+            .unwrap_or(&state.separator);
+        let center_sep = state
+            .center_separator
+            .as_deref()
+            .unwrap_or(&state.separator);
+        let right_sep = state
+            .right_separator
+            .as_deref()
+            .unwrap_or(&state.separator);
+        let left_spans = Self::render_section(&state.left, left_sep, ctx.theme);
+        let center_spans = Self::render_section(&state.center, center_sep, ctx.theme);
+        let right_spans = Self::render_section(&state.right, right_sep, ctx.theme);
 
         // Calculate the width of each section
         let left_width: usize = left_spans.iter().map(|s| s.content.len()).sum();

--- a/src/component/status_bar/mod.rs
+++ b/src/component/status_bar/mod.rs
@@ -863,18 +863,12 @@ impl Component for StatusBar {
         let bg_style = Style::default().bg(state.background);
 
         // Calculate section widths
-        let left_sep = state
-            .left_separator
-            .as_deref()
-            .unwrap_or(&state.separator);
+        let left_sep = state.left_separator.as_deref().unwrap_or(&state.separator);
         let center_sep = state
             .center_separator
             .as_deref()
             .unwrap_or(&state.separator);
-        let right_sep = state
-            .right_separator
-            .as_deref()
-            .unwrap_or(&state.separator);
+        let right_sep = state.right_separator.as_deref().unwrap_or(&state.separator);
         let left_spans = Self::render_section(&state.left, left_sep, ctx.theme);
         let center_spans = Self::render_section(&state.center, center_sep, ctx.theme);
         let right_spans = Self::render_section(&state.right, right_sep, ctx.theme);

--- a/src/component/status_bar/per_side_separators.rs
+++ b/src/component/status_bar/per_side_separators.rs
@@ -1,0 +1,122 @@
+use super::StatusBarState;
+
+impl StatusBarState {
+    /// Sets the separator for the left section (builder pattern).
+    ///
+    /// When set, takes precedence over the global `separator` for
+    /// left-section rendering. When `None` (default), the global
+    /// `separator` applies.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarState;
+    ///
+    /// let state = StatusBarState::with_separator(" · ")
+    ///     .with_left_separator(" | ");
+    /// assert_eq!(state.left_separator(), Some(" | "));
+    /// assert_eq!(state.separator(), " · "); // global unchanged
+    /// ```
+    pub fn with_left_separator(mut self, separator: impl Into<String>) -> Self {
+        self.left_separator = Some(separator.into());
+        self
+    }
+
+    /// Sets the separator for the center section (builder pattern).
+    ///
+    /// When set, takes precedence over the global `separator` for
+    /// center-section rendering. When `None` (default), the global
+    /// `separator` applies.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarState;
+    ///
+    /// let state = StatusBarState::new().with_center_separator(" :: ");
+    /// assert_eq!(state.center_separator(), Some(" :: "));
+    /// ```
+    pub fn with_center_separator(mut self, separator: impl Into<String>) -> Self {
+        self.center_separator = Some(separator.into());
+        self
+    }
+
+    /// Sets the separator for the right section (builder pattern).
+    ///
+    /// When set, takes precedence over the global `separator` for
+    /// right-section rendering. When `None` (default), the global
+    /// `separator` applies.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarState;
+    ///
+    /// // Global " · " separator, but " " between right-section items.
+    /// let state = StatusBarState::with_separator(" · ")
+    ///     .with_right_separator(" ");
+    /// assert_eq!(state.right_separator(), Some(" "));
+    /// assert_eq!(state.separator(), " · "); // global unchanged
+    /// ```
+    pub fn with_right_separator(mut self, separator: impl Into<String>) -> Self {
+        self.right_separator = Some(separator.into());
+        self
+    }
+
+    /// Returns the left-section separator override, if set.
+    ///
+    /// `None` means the left section uses the global `separator()`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarState;
+    ///
+    /// let plain = StatusBarState::new();
+    /// assert_eq!(plain.left_separator(), None);
+    ///
+    /// let overridden = plain.with_left_separator(" | ");
+    /// assert_eq!(overridden.left_separator(), Some(" | "));
+    /// ```
+    pub fn left_separator(&self) -> Option<&str> {
+        self.left_separator.as_deref()
+    }
+
+    /// Returns the center-section separator override, if set.
+    ///
+    /// `None` means the center section uses the global `separator()`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarState;
+    ///
+    /// let plain = StatusBarState::new();
+    /// assert_eq!(plain.center_separator(), None);
+    ///
+    /// let overridden = plain.with_center_separator(" :: ");
+    /// assert_eq!(overridden.center_separator(), Some(" :: "));
+    /// ```
+    pub fn center_separator(&self) -> Option<&str> {
+        self.center_separator.as_deref()
+    }
+
+    /// Returns the right-section separator override, if set.
+    ///
+    /// `None` means the right section uses the global `separator()`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use envision::component::StatusBarState;
+    ///
+    /// let plain = StatusBarState::new();
+    /// assert_eq!(plain.right_separator(), None);
+    ///
+    /// let overridden = plain.with_right_separator(" ");
+    /// assert_eq!(overridden.right_separator(), Some(" "));
+    /// ```
+    pub fn right_separator(&self) -> Option<&str> {
+        self.right_separator.as_deref()
+    }
+}

--- a/src/component/status_bar/snapshot_tests.rs
+++ b/src/component/status_bar/snapshot_tests.rs
@@ -183,3 +183,79 @@ fn snapshot_status_bar_four_stop_severity_ramp() {
 
     insta::assert_snapshot!(plain);
 }
+
+#[test]
+fn snapshot_status_bar_per_side_separators() {
+    // RENDER-PATH PIN: distinct per-side separators visible in the rendered
+    // output. Pins that the per-side fallback resolution at mod.rs:850-852
+    // correctly routes each section's separator through render_section.
+    //
+    // leadline's actual transformation (the load-bearing motivation):
+    // global " · " separator on left items, but " " (space) between
+    // right-section slowdown segments. Pre-D12, the right section
+    // inherited the global " · " — visually weird. Post-D12, the
+    // right-section override lands.
+    let mut state = StatusBarState::with_separator(" · ").with_right_separator(" ");
+    state.push_left(StatusBarItem::new("L1"));
+    state.push_left(StatusBarItem::new("L2"));
+    state.push_right(StatusBarItem::new("R1"));
+    state.push_right(StatusBarItem::new("R2"));
+
+    let (mut terminal, theme) = test_utils::setup_render(40, 1);
+    terminal
+        .draw(|frame| {
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
+        })
+        .unwrap();
+
+    let plain = terminal.backend().to_string();
+
+    // Left section uses global " · ": "L1 · L2" appears.
+    assert!(
+        plain.contains("L1 · L2"),
+        "expected left section to use global ' · ' separator, got:\n{plain}",
+    );
+
+    // Right section uses override " ": "R1 R2" appears (single space
+    // between, not " · ").
+    assert!(
+        plain.contains("R1 R2"),
+        "expected right section to use override ' ' separator, got:\n{plain}",
+    );
+
+    insta::assert_snapshot!(plain);
+}
+
+#[test]
+fn snapshot_status_bar_per_side_separators_byte_identical_when_unset() {
+    // REGRESSION PIN: when no per-side overrides are set, rendering is
+    // byte-identical to pre-D12 behavior. Consumers who don't opt in to
+    // per-side overrides see zero behavior change.
+    let mut state = StatusBarState::with_separator(" · ");
+    state.push_left(StatusBarItem::new("L1"));
+    state.push_left(StatusBarItem::new("L2"));
+    state.push_right(StatusBarItem::new("R1"));
+    state.push_right(StatusBarItem::new("R2"));
+
+    let (mut terminal, theme) = test_utils::setup_render(40, 1);
+    terminal
+        .draw(|frame| {
+            StatusBar::view(&state, &mut RenderContext::new(frame, frame.area(), &theme));
+        })
+        .unwrap();
+
+    let plain = terminal.backend().to_string();
+
+    // Both sections use the global " · " separator (no per-side override
+    // set, so fallback to global applies everywhere).
+    assert!(
+        plain.contains("L1 · L2"),
+        "expected left section to use global ' · ' separator, got:\n{plain}",
+    );
+    assert!(
+        plain.contains("R1 · R2"),
+        "expected right section to also use global ' · ' separator (no override set), got:\n{plain}",
+    );
+
+    insta::assert_snapshot!(plain);
+}

--- a/src/component/status_bar/snapshots/envision__component__status_bar__snapshot_tests__snapshot_status_bar_per_side_separators.snap
+++ b/src/component/status_bar/snapshots/envision__component__status_bar__snapshot_tests__snapshot_status_bar_per_side_separators.snap
@@ -1,0 +1,5 @@
+---
+source: src/component/status_bar/snapshot_tests.rs
+expression: plain
+---
+L1 · L2                           R1 R2

--- a/src/component/status_bar/snapshots/envision__component__status_bar__snapshot_tests__snapshot_status_bar_per_side_separators_byte_identical_when_unset.snap
+++ b/src/component/status_bar/snapshots/envision__component__status_bar__snapshot_tests__snapshot_status_bar_per_side_separators_byte_identical_when_unset.snap
@@ -1,0 +1,5 @@
+---
+source: src/component/status_bar/snapshot_tests.rs
+expression: plain
+---
+L1 · L2                        R1 · R2

--- a/src/component/status_bar/tests/state.rs
+++ b/src/component/status_bar/tests/state.rs
@@ -545,3 +545,77 @@ fn test_section_copy() {
     assert_eq!(section, Section::Right);
     assert_eq!(copied, Section::Right);
 }
+
+// Per-side separator tests
+
+#[test]
+fn test_default_per_side_separators_none() {
+    // Defaults: all three per-side overrides are None.
+    let state = StatusBarState::default();
+    assert_eq!(state.left_separator(), None);
+    assert_eq!(state.center_separator(), None);
+    assert_eq!(state.right_separator(), None);
+    // Global separator unchanged from existing default.
+    assert_eq!(state.separator(), " | ");
+}
+
+#[test]
+fn test_with_left_separator_sets_field() {
+    let state = StatusBarState::new().with_left_separator(" | ");
+    assert_eq!(state.left_separator(), Some(" | "));
+    // Other per-side overrides remain None.
+    assert_eq!(state.center_separator(), None);
+    assert_eq!(state.right_separator(), None);
+    // Global separator unchanged.
+    assert_eq!(state.separator(), " | ");
+}
+
+#[test]
+fn test_with_center_separator_sets_field() {
+    let state = StatusBarState::new().with_center_separator(" :: ");
+    assert_eq!(state.center_separator(), Some(" :: "));
+    // Other per-side overrides remain None.
+    assert_eq!(state.left_separator(), None);
+    assert_eq!(state.right_separator(), None);
+}
+
+#[test]
+fn test_with_right_separator_sets_field() {
+    let state = StatusBarState::new().with_right_separator(" ");
+    assert_eq!(state.right_separator(), Some(" "));
+    // Other per-side overrides remain None.
+    assert_eq!(state.left_separator(), None);
+    assert_eq!(state.center_separator(), None);
+}
+
+#[test]
+fn test_with_separator_then_per_side_override() {
+    // LAYERED SEMANTICS PIN: per-side override doesn't clear the global.
+    // Chain with_separator(...) then with_right_separator(...) — both
+    // fields populated; render-time precedence resolves per section.
+    let state = StatusBarState::with_separator(" · ").with_right_separator(" ");
+
+    // Global separator unchanged by the per-side override.
+    assert_eq!(state.separator(), " · ");
+    // Right-side override is set.
+    assert_eq!(state.right_separator(), Some(" "));
+    // Other per-side overrides remain None.
+    assert_eq!(state.left_separator(), None);
+    assert_eq!(state.center_separator(), None);
+}
+
+#[test]
+fn test_per_side_separator_independent_setters() {
+    // Setting all three per-side overrides leaves the global unchanged;
+    // each per-side field is independent of the others.
+    let state = StatusBarState::with_separator(" · ")
+        .with_left_separator(" | ")
+        .with_center_separator(" :: ")
+        .with_right_separator(" ");
+
+    assert_eq!(state.left_separator(), Some(" | "));
+    assert_eq!(state.center_separator(), Some(" :: "));
+    assert_eq!(state.right_separator(), Some(" "));
+    // Global separator unchanged.
+    assert_eq!(state.separator(), " · ");
+}


### PR DESCRIPTION
## Summary

Implementation of leadline gap **D12** — adds three per-section separator overrides on \`StatusBarState\`. Per-side override takes precedence over the existing global \`separator\` at render time. Purely additive; default behavior unchanged.

- Spec: PR #493 (\`docs/superpowers/specs/2026-05-20-status-bar-per-side-separators-design.md\`)
- Plan: PR #494 (\`docs/superpowers/plans/2026-05-20-status-bar-per-side-separators.md\`)

## What changed

**New fields on \`StatusBarState\`** (all with \`#[serde(default)]\`):
- \`left_separator: Option<String>\`
- \`center_separator: Option<String>\`
- \`right_separator: Option<String>\`

Clustered next to the existing global \`separator\` field.

**Six new public methods** (in new sibling file \`src/component/status_bar/per_side_separators.rs\`):
- \`with_left_separator(impl Into<String>)\`, \`with_center_separator(...)\`, \`with_right_separator(...)\` — true builders taking \`mut self\`, consistent with existing \`with_disabled\`
- \`left_separator(&self) -> Option<&str>\`, \`center_separator(...)\`, \`right_separator(...)\` — getters

Sibling-file split triggered during Task 1 (naive in-place would push \`mod.rs\` to 1065 lines; cap is 1000). Same multi-module impl pattern as \`pane_layout/title_style.rs\` from G4.

**Render path:**
- 3-line per-side fallback inserted at \`status_bar/mod.rs:850-852\`
- \`render_section\` signature unchanged (already takes \`&str\`)

**Layered semantics, not last-call-wins:** per-side override independent of global \`separator\`. Same model as G4/G5.

## leadline use case

\`leadline/src/app.rs:278\` gains one new builder call on the chain:

\`\`\`rust
StatusBarState::with_separator(" · ")
    .with_right_separator(" ")  // <-- new
    // ... push items ...
\`\`\`

Right-section slowdown segments now use \`" "\` while the rest of the bar continues to use the global \`" · "\`.

## Stats

- 4 signed commits (Task 1 production + Task 2 tests + fmt cleanup + Task 4 CHANGELOG)
- 8 new tests (6 unit + 2 render-path snapshots)
- 6 new public methods, each with \`# Example\` doc test
- File-size: \`mod.rs\` 919 → 941 (sibling-file split absorbed the bulk); \`per_side_separators.rs\` (new) 122 lines

## Verification

- \`cargo build --all-features\`: clean
- \`cargo build --no-default-features\`: clean
- \`cargo clippy --all-features --all-targets -- -D warnings\`: clean
- \`cargo fmt --all -- --check\`: clean
- \`cargo nextest run --all-features\`: **7442/7442** passed
- \`cargo test --all-features --doc\`: clean
- \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --all-features --no-deps\`: clean
- \`./tools/audit/target/release/envision-audit scorecard\`: **8/9** (baseline preserved)

## Notable execution detail

Sibling-file split triggered as expected — Task 1 Step 7's pre-emptive line-count check identified the cap crossing before commit (would have been 1065 lines in \`mod.rs\` if methods stayed in-place). Plan's mitigation (per_side_separators.rs, same G4 pattern) applied cleanly; final \`mod.rs\` size is 941 lines.

## Test plan

- [ ] CI green on all platforms
- [ ] Tracking-doc PR (next, parallel branch) marks D10 + D12 + D13 ✅ resolved in one coherent punch-list closure
- [ ] leadline migrates \`leadline/src/app.rs:278\` to add the \`.with_right_separator(\" \")\` call on the StatusBar construction chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)