### PR TITLE
Impl: docs suite D3+D7+D8 (May 2026 closure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -347,6 +347,18 @@ as `None` — behavior identical to pre-D12.
 **No struct-literal break** for external consumers — fields are private
 (matches existing field visibility on the struct).
 
+### Added
+
+- `Column::new` now documents the canonical Length+Min multi-column idiom and emits a `tracing::warn!` (feature-gated) when a `Constraint::Length(n)` or `Constraint::Min(n)` column resolves to fewer cells than declared. Best-effort observability; no behavior change for consumers without `tracing` enabled. `Percentage` constraints are never flagged (no declared floor).
+- `src/harness` module docs now include a "Choosing a Harness" decision table comparing `TestHarness`, `AppHarness`, and `Runtime::virtual_builder`.
+- `src/harness/snapshot` module docs now include a runnable canonical golden-file snapshot-diff recipe (dependency-free, `std::fs` + manual diff; `insta` linked as the upgrade path).
+- `examples/drilldown.rs` — master+detail drill-down pattern using `TableState`, `PaneLayout::view_with`, `styled_line`, per-view `KeyHints`, and `App::handle_event_with_state` for screen-gated key bindings; selection preserved across drill-in/drill-out.
+- `Router` module docs now include guidance on choosing between `Router` (history stack) and an in-state enum (mutual-exclusion screens with restored selection).
+
+### Changed
+
+- `examples/router.rs` screen-render bodies now use `PaneLayout::view_with` (was: raw `ratatui::widgets::Paragraph` + `Block::borders`). No behavior change; better showcase of envision surface.
+
 ## [Unreleased] — Breaking: `App::init` takes args; `RuntimeBuilder` split
 
 ### Breaking changes — `App::init` takes args

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,6 +219,10 @@ name = "key_hints"
 required-features = ["display-components"]
 
 [[example]]
+name = "drilldown"
+required-features = ["data-components", "display-components", "navigation-components"]
+
+[[example]]
 name = "loading_list"
 required-features = ["data-components"]
 

--- a/examples/drilldown.rs
+++ b/examples/drilldown.rs
@@ -17,7 +17,7 @@
 //! Surface exercised:
 //! - TableState<Operation> for the Roster
 //! - PaneLayout::view_with for the PerOp split (header + body)
-//! - styled_line + InlineStyle for emphasized metrics
+//! - styled_line + StyledInline for emphasized metrics
 //! - PaneConfig::with_title_style for the PerOp header pane
 //! - KeyHints for per-view affordance hints
 //! - App::handle_event_with_state for screen-gated key bindings

--- a/examples/drilldown.rs
+++ b/examples/drilldown.rs
@@ -1,0 +1,279 @@
+//! Drilldown example — master+detail pattern with selection preservation.
+//!
+//! Demonstrates the in-state-enum approach to navigation (Screen enum)
+//! as the lightweight alternative to Router for cases where you don't
+//! need a history stack. The user lands on the Roster screen (a Table
+//! of operations), presses Enter on a selected row to drill into the
+//! PerOp detail screen, and presses Esc to return to the Roster with
+//! the original selection preserved.
+//!
+//! Per-view KeyHints + state-aware event handling: the bottom row of
+//! each screen renders a `KeyHints` bar listing only the keys active
+//! on that screen, and `handle_event_with_state` gates Up/Down to the
+//! Roster (no roster-selection ticks while drilled in) and Esc to the
+//! PerOp (no drill-out attempts from the Roster). `q` quits from any
+//! screen.
+//!
+//! Surface exercised:
+//! - TableState<Operation> for the Roster
+//! - PaneLayout::view_with for the PerOp split (header + body)
+//! - styled_line + InlineStyle for emphasized metrics
+//! - PaneConfig::with_title_style for the PerOp header pane
+//! - KeyHints for per-view affordance hints
+//! - App::handle_event_with_state for screen-gated key bindings
+//!
+//! Compare with examples/router.rs (history-stack navigation via
+//! RouterState). See src/component/router/mod.rs module docs for
+//! "When to use Router vs an in-state enum".
+//!
+//! Run with: cargo run --example drilldown --all-features
+
+use envision::prelude::*;
+
+/// One operation row in the Roster.
+#[derive(Clone, Debug, PartialEq)]
+struct Operation {
+    id: String,
+    duration_ms: f64,
+    status: String,
+}
+
+impl TableRow for Operation {
+    fn cells(&self) -> Vec<Cell> {
+        vec![
+            Cell::from(self.id.clone()),
+            Cell::from(format!("{:.1} ms", self.duration_ms)),
+            Cell::from(self.status.clone()),
+        ]
+    }
+}
+
+/// Application screen state.
+#[derive(Clone, Debug)]
+enum Screen {
+    Roster,
+    PerOp { selected: usize },
+}
+
+struct DrillApp;
+
+#[derive(Clone)]
+struct State {
+    screen: Screen,
+    roster: TableState<Operation>,
+    operations: Vec<Operation>,
+    roster_hints: KeyHintsState,
+    perop_hints: KeyHintsState,
+}
+
+#[derive(Clone, Debug)]
+enum Msg {
+    DrillIn,
+    DrillOut,
+    SelectNext,
+    SelectPrev,
+    Quit,
+}
+
+/// Carve out the bottom row for KeyHints; return (main_area, hints_area).
+fn split_hints_row(area: Rect) -> (Rect, Rect) {
+    let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
+    (chunks[0], chunks[1])
+}
+
+impl App for DrillApp {
+    type State = State;
+    type Message = Msg;
+    type Args = ();
+
+    fn init(_args: ()) -> (State, Command<Msg>) {
+        let operations = vec![
+            Operation {
+                id: "op-001".into(),
+                duration_ms: 12.4,
+                status: "ok".into(),
+            },
+            Operation {
+                id: "op-002".into(),
+                duration_ms: 837.2,
+                status: "slow".into(),
+            },
+            Operation {
+                id: "op-003".into(),
+                duration_ms: 4.1,
+                status: "ok".into(),
+            },
+        ];
+        let columns = vec![
+            Column::new("ID", Constraint::Length(12)),
+            Column::new("Duration", Constraint::Length(14)),
+            Column::new("Status", Constraint::Min(10)),
+        ];
+        let mut roster = TableState::new(operations.clone(), columns);
+        roster.set_selected(Some(0));
+
+        let roster_hints = KeyHintsState::new()
+            .hint("↑/↓", "select")
+            .hint("Enter", "open")
+            .hint("q", "quit");
+        let perop_hints = KeyHintsState::new().hint("Esc", "back").hint("q", "quit");
+
+        (
+            State {
+                screen: Screen::Roster,
+                roster,
+                operations,
+                roster_hints,
+                perop_hints,
+            },
+            Command::none(),
+        )
+    }
+
+    fn update(state: &mut State, msg: Msg) -> Command<Msg> {
+        match msg {
+            Msg::DrillIn => {
+                if let Some(idx) = state.roster.selected() {
+                    state.screen = Screen::PerOp { selected: idx };
+                }
+            }
+            Msg::DrillOut => {
+                if let Screen::PerOp { selected } = state.screen {
+                    state.roster.set_selected(Some(selected));
+                    state.screen = Screen::Roster;
+                }
+            }
+            Msg::SelectNext => {
+                let next = state
+                    .roster
+                    .selected()
+                    .map(|i| i + 1)
+                    .unwrap_or(0)
+                    .min(state.operations.len().saturating_sub(1));
+                state.roster.set_selected(Some(next));
+            }
+            Msg::SelectPrev => {
+                let prev = state.roster.selected().unwrap_or(0).saturating_sub(1);
+                state.roster.set_selected(Some(prev));
+            }
+            Msg::Quit => return Command::quit(),
+        }
+        Command::none()
+    }
+
+    fn view(state: &State, frame: &mut Frame) {
+        use envision::component::pane_layout::{
+            PaneConfig, PaneDirection, PaneLayout, PaneLayoutState,
+        };
+        let area = frame.area();
+        let theme = Theme::default();
+        let (main_area, hints_area) = split_hints_row(area);
+
+        match &state.screen {
+            Screen::Roster => {
+                let mut ctx = RenderContext::new(frame, main_area, &theme).focused(true);
+                <Table<Operation> as Component>::view(&state.roster, &mut ctx);
+                let mut hints_ctx = RenderContext::new(frame, hints_area, &theme).focused(true);
+                <KeyHints as Component>::view(&state.roster_hints, &mut hints_ctx);
+            }
+            Screen::PerOp { selected } => {
+                use envision::component::styled_text::StyledInline;
+                use envision::render::styled_line;
+
+                let op = &state.operations[*selected];
+                let layout = PaneLayoutState::new(
+                    PaneDirection::Vertical,
+                    vec![
+                        PaneConfig::new("header")
+                            .with_title(format!(" {} ", op.id))
+                            .with_title_style(
+                                Style::default()
+                                    .add_modifier(Modifier::BOLD)
+                                    .fg(Color::Cyan),
+                            )
+                            .with_proportion(0.25),
+                        PaneConfig::new("body")
+                            .with_title(" Details ")
+                            .with_proportion(0.75),
+                    ],
+                );
+
+                PaneLayout::view_with(
+                    &layout,
+                    &mut RenderContext::new(frame, main_area, &theme).focused(true),
+                    |pane_id, child_ctx| match pane_id {
+                        "header" => {
+                            let inlines = vec![
+                                StyledInline::Plain("duration: ".to_string()),
+                                StyledInline::bold(format!("{:.1} ms", op.duration_ms)),
+                            ];
+                            styled_line(child_ctx.frame, child_ctx.area, &inlines, child_ctx.theme);
+                        }
+                        "body" => {
+                            let inlines = vec![
+                                StyledInline::Plain("status: ".to_string()),
+                                StyledInline::colored(op.status.clone(), Color::Green),
+                            ];
+                            styled_line(child_ctx.frame, child_ctx.area, &inlines, child_ctx.theme);
+                        }
+                        _ => {}
+                    },
+                );
+
+                let mut hints_ctx = RenderContext::new(frame, hints_area, &theme).focused(true);
+                <KeyHints as Component>::view(&state.perop_hints, &mut hints_ctx);
+            }
+        }
+    }
+
+    /// State-aware key handling: each screen owns only the keys it
+    /// advertises. Up/Down moves the Roster selection only when the
+    /// Roster is the active screen; Esc returns to the Roster only
+    /// from PerOp. `q` quits from any screen.
+    fn handle_event_with_state(state: &State, event: &Event) -> Option<Msg> {
+        let key = event.as_key()?;
+        if matches!(key.code, Key::Char('q')) {
+            return Some(Msg::Quit);
+        }
+        match state.screen {
+            Screen::Roster => match key.code {
+                Key::Down => Some(Msg::SelectNext),
+                Key::Up => Some(Msg::SelectPrev),
+                Key::Enter => Some(Msg::DrillIn),
+                _ => None,
+            },
+            Screen::PerOp { .. } => match key.code {
+                Key::Esc => Some(Msg::DrillOut),
+                _ => None,
+            },
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 16 rows: ~13 for the main content + 1 for hints + table chrome.
+    let mut vt = Runtime::<DrillApp, _>::virtual_builder(60, 16).build()?;
+
+    println!("=== Drilldown Example ===\n");
+
+    vt.tick()?;
+    println!("Roster (initial):");
+    println!("{}\n", vt.display());
+
+    vt.dispatch(Msg::SelectNext);
+    vt.tick()?;
+    println!("After selecting row 1:");
+    println!("{}\n", vt.display());
+
+    vt.dispatch(Msg::DrillIn);
+    vt.tick()?;
+    println!("After Enter (PerOp detail for op-002, PerOp hints active):");
+    println!("{}\n", vt.display());
+
+    vt.dispatch(Msg::DrillOut);
+    vt.tick()?;
+    println!("After Esc (back to Roster, selection preserved, Roster hints restored):");
+    println!("{}\n", vt.display());
+
+    Ok(())
+}

--- a/examples/router.rs
+++ b/examples/router.rs
@@ -98,12 +98,27 @@ impl App for RouterApp {
             ),
         };
 
-        let widget = ratatui::widgets::Paragraph::new(body).block(
-            ratatui::widgets::Block::default()
-                .borders(ratatui::widgets::Borders::ALL)
-                .title(title),
+        use envision::component::pane_layout::{
+            PaneConfig, PaneDirection, PaneLayout, PaneLayoutState,
+        };
+        let theme = Theme::default();
+        let pane_layout = PaneLayoutState::new(
+            PaneDirection::Vertical,
+            vec![
+                PaneConfig::new("screen")
+                    .with_title(format!(" {} ", title))
+                    .with_proportion(1.0),
+            ],
         );
-        frame.render_widget(widget, chunks[0]);
+        PaneLayout::view_with(
+            &pane_layout,
+            &mut RenderContext::new(frame, chunks[0], &theme).focused(true),
+            |_pane_id, child_ctx| {
+                child_ctx
+                    .frame
+                    .render_widget(ratatui::widgets::Paragraph::new(body), child_ctx.area);
+            },
+        );
 
         let history_len = state.router.history_len();
         let can_back = state.router.can_go_back();

--- a/examples/test_harness.rs
+++ b/examples/test_harness.rs
@@ -1,5 +1,9 @@
 //! Test Harness example demonstrating testing utilities.
 //!
+//! See `envision::harness` module docs for the "Choosing a Harness"
+//! decision table that contextualizes the three approaches demonstrated
+//! here.
+//!
 //! This example shows different ways to test TUI applications:
 //! - TestHarness for basic render testing with closures
 //! - Runtime::headless for testing App implementations

--- a/src/component/router/mod.rs
+++ b/src/component/router/mod.rs
@@ -53,6 +53,22 @@
 //!     }
 //! }
 //! ```
+//!
+//! # Choosing Router vs. an in-state enum
+//!
+//! `Router` provides a history stack with back navigation, breadcrumbs,
+//! and deep-link semantics. Reach for it when:
+//!
+//! - Users need a "Back" button or breadcrumb trail
+//! - Screens can be revisited in different orders
+//! - You want to model "where did the user come from?"
+//!
+//! For simpler navigation — where screens are mutually exclusive and
+//! "back" just means "return to the prior selection" — an in-state
+//! enum (e.g., `enum Screen { Roster, PerOp { selected: usize } }`) is
+//! lighter and clearer. See `examples/drilldown.rs` for the
+//! in-state-enum pattern and `examples/router.rs` for the Router
+//! pattern.
 
 use super::{Component, RenderContext};
 

--- a/src/component/table/clip_warn.rs
+++ b/src/component/table/clip_warn.rs
@@ -1,0 +1,13 @@
+//! Transient observability state for clip-warning dedup.
+//!
+//! Kept in a sibling module to keep `mod.rs` from creeping toward the
+//! 1000-line cap. Used exclusively from the render path; not exposed
+//! beyond `pub(super)`.
+
+use std::collections::HashSet;
+
+#[derive(Default, Debug, Clone)]
+pub(super) struct ClipWarnState {
+    pub(super) last_area_width: Option<u16>,
+    pub(super) warned_cols: HashSet<usize>,
+}

--- a/src/component/table/mod.rs
+++ b/src/component/table/mod.rs
@@ -54,14 +54,18 @@
 //! }));
 //! ```
 
+mod clip_warn;
 mod render;
 mod state;
 mod types;
 
 pub use types::{Column, InitialSort, SortDirection, TableMessage, TableOutput, TableRow};
 
+use std::cell::RefCell;
 use std::collections::HashSet;
 use std::marker::PhantomData;
+
+use clip_warn::ClipWarnState;
 
 use ratatui::prelude::*;
 
@@ -99,13 +103,23 @@ pub struct TableState<T: TableRow> {
     /// serialized.
     #[cfg_attr(feature = "serialization", serde(skip))]
     cross_variant_warned_cols: HashSet<usize>,
+    /// Transient observability state for clip-warning dedup. Tracks the
+    /// last area width at which clipping was evaluated and the set of
+    /// column indices already warned about. Reset when the area width
+    /// changes (terminal resize re-arms detection).
+    ///
+    /// Runtime-only state; not part of logical equality and not
+    /// serialized.
+    #[cfg_attr(feature = "serialization", serde(skip))]
+    clip_warn_state: RefCell<ClipWarnState>,
 }
 
 impl<T: TableRow + PartialEq> PartialEq for TableState<T> {
     fn eq(&self, other: &Self) -> bool {
-        // `cross_variant_warned_cols` is intentionally excluded — it's
-        // transient, render-pass-scoped diagnostics state, not part of
-        // the logical equality of the table.
+        // `cross_variant_warned_cols` and `clip_warn_state` are
+        // intentionally excluded — both are transient diagnostics state
+        // (sort-pass and render-pass respectively), not part of the
+        // logical equality of the table.
         self.rows == other.rows
             && self.columns == other.columns
             && self.selected == other.selected
@@ -126,6 +140,7 @@ impl<T: TableRow> Default for TableState<T> {
             filter_text: String::new(),
             scroll: ScrollState::default(),
             cross_variant_warned_cols: HashSet::new(),
+            clip_warn_state: RefCell::new(ClipWarnState::default()),
         }
     }
 }
@@ -508,6 +523,8 @@ mod filter_tests;
 mod multi_sort_tests;
 #[cfg(test)]
 mod resize_tests;
+#[cfg(test)]
+mod snapshot_tests;
 #[cfg(test)]
 mod sort_proptests;
 #[cfg(test)]

--- a/src/component/table/render.rs
+++ b/src/component/table/render.rs
@@ -25,6 +25,7 @@ pub(crate) enum ClipKind {
     Min,
 }
 
+#[cfg(feature = "tracing")]
 impl ClipKind {
     /// Renders as `"Length"` or `"Min"` for warning text.
     pub(crate) fn label(self) -> &'static str {
@@ -281,10 +282,6 @@ pub(super) fn render_table<T: TableRow>(
                     clip.resolved,
                     area.width,
                 );
-                // `clip` referenced inside cfg-gated block; suppress
-                // unused-binding lint when tracing is disabled.
-                #[cfg(not(feature = "tracing"))]
-                let _ = clip;
             }
         }
     }
@@ -424,6 +421,7 @@ mod tests {
         assert_eq!(result[1].kind, ClipKind::Min);
     }
 
+    #[cfg(feature = "tracing")]
     #[test]
     fn clip_kind_label_returns_constraint_name() {
         assert_eq!(ClipKind::Length.label(), "Length");

--- a/src/component/table/render.rs
+++ b/src/component/table/render.rs
@@ -9,6 +9,65 @@ use ratatui::widgets::{Block, Borders, Cell as RatatuiCell, Row};
 use super::*;
 use crate::component::cell::CellStyle;
 
+/// Identifies columns whose declared lower-bound width constraint was
+/// violated by the resolved layout.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ClippedColumn {
+    pub idx: usize,
+    pub declared: u16,
+    pub resolved: u16,
+    pub kind: ClipKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ClipKind {
+    Length,
+    Min,
+}
+
+impl ClipKind {
+    /// Renders as `"Length"` or `"Min"` for warning text.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            ClipKind::Length => "Length",
+            ClipKind::Min => "Min",
+        }
+    }
+}
+
+/// Returns the set of columns whose declared lower-bound width
+/// (`Length(n)` or `Min(n)`) was violated by the resolved layout.
+///
+/// `Length` declares an exact width that doubles as both upper and lower
+/// bound; `Min` declares an explicit lower bound. Both are floors the
+/// consumer wrote into their column declaration. `Percentage` is a share
+/// of the resolved area with no absolute floor, so it is never flagged.
+pub(crate) fn detect_clipped_columns(
+    columns: &[Column],
+    resolved_widths: &[u16],
+) -> Vec<ClippedColumn> {
+    use ratatui::layout::Constraint;
+
+    columns
+        .iter()
+        .zip(resolved_widths.iter())
+        .enumerate()
+        .filter_map(|(idx, (col, &resolved))| {
+            let (declared, kind) = match col.width() {
+                Constraint::Length(n) if resolved < n => (n, ClipKind::Length),
+                Constraint::Min(n) if resolved < n => (n, ClipKind::Min),
+                _ => return None,
+            };
+            Some(ClippedColumn {
+                idx,
+                declared,
+                resolved,
+                kind,
+            })
+        })
+        .collect()
+}
+
 /// Translates a semantic [`CellStyle`] into a concrete `ratatui::Style`.
 ///
 /// `disabled` overrides everything (theme + per-cell semantics) with a
@@ -135,6 +194,101 @@ pub(super) fn render_table<T: TableRow>(
         widths.push(col.width());
     }
 
+    // Best-effort clip-warning diagnostic: compute resolved column
+    // widths via a one-shot Layout split that mirrors what ratatui
+    // feeds the Table widget — full `widths` vec (incl. status
+    // reservation) over the column-distribution area — then slice
+    // off the status reservation before mapping back to user
+    // columns. Detects Length/Min declared-floor violations, dedups
+    // per (column index, area width) across the TableState's
+    // lifetime, and emits a tracing warning on first detection.
+    //
+    // Skipped entirely when the table has no user columns.
+    if !state.columns.is_empty() {
+        // Mirror the full ratatui 0.29 Table width formula so detection
+        // matches what the renderer actually distributes columns over.
+        // Every term below corresponds to a row in the spec's "Canonical
+        // reservation contract" table.
+        //
+        //   1. Border margin: when !chrome_owned the table is wrapped in
+        //      Block::default().borders(Borders::ALL) below, which
+        //      shrinks the inner rect by 1 cell on each side. When
+        //      chrome_owned, `area` is already inner.
+        //   2. Highlight-symbol reservation: the Table is constructed
+        //      with .highlight_symbol("> ") (display width 2) and no
+        //      explicit .highlight_spacing(...) call, so ratatui's
+        //      default HighlightSpacing::WhenSelected applies — when
+        //      state.selected.is_some(), ratatui reserves 2 cells from
+        //      the column-distribution area before laying out columns.
+        //   3. column_spacing: the Table is constructed with no explicit
+        //      .column_spacing(...) call, so ratatui's default of 1 cell
+        //      between columns applies. Layout::horizontal's default
+        //      spacing is 0, so detection must opt into .spacing(1) to
+        //      mirror what ratatui actually does — otherwise it
+        //      over-distributes by (num_columns - 1) cells.
+        //   4. has_status offset: see slicing comment below.
+        //
+        // Flex::Start is the default for both Table and Layout::horizontal
+        // — no explicit .flex(...) call needed.
+        const HIGHLIGHT_SYMBOL_WIDTH: u16 = 2; // matches "> " set at render.rs:153
+        const COLUMN_SPACING: u16 = 1; // matches ratatui Table default; render.rs:150-153 sets no override
+        let mut col_dist_area = if chrome_owned {
+            area
+        } else {
+            area.inner(ratatui::layout::Margin {
+                horizontal: 1,
+                vertical: 1,
+            })
+        };
+        if state.selected.is_some() {
+            col_dist_area.width = col_dist_area.width.saturating_sub(HIGHLIGHT_SYMBOL_WIDTH);
+        }
+        let resolved_rects = ratatui::layout::Layout::horizontal(widths.iter().copied())
+            .spacing(COLUMN_SPACING)
+            .split(col_dist_area);
+        // Skip the status reservation when mapping back to user columns.
+        // resolved_rects[has_status as usize..] aligns 1:1 with state.columns.
+        let user_resolved: Vec<u16> = resolved_rects
+            .iter()
+            .skip(has_status as usize)
+            .map(|r| r.width)
+            .collect();
+        let clipped = detect_clipped_columns(state.columns.as_slice(), &user_resolved);
+
+        // Always track area width so resize re-arms detection, even
+        // when the current render has no clipped columns.
+        {
+            let mut dedup = state.clip_warn_state.borrow_mut();
+            if dedup.last_area_width != Some(area.width) {
+                dedup.warned_cols.clear();
+                dedup.last_area_width = Some(area.width);
+            }
+        }
+
+        for clip in &clipped {
+            let mut dedup = state.clip_warn_state.borrow_mut();
+            if dedup.warned_cols.insert(clip.idx) {
+                #[cfg(feature = "tracing")]
+                tracing::warn!(
+                    column_header = %state.columns[clip.idx].header(),
+                    declared_kind = clip.kind.label(),
+                    declared = clip.declared,
+                    resolved = clip.resolved,
+                    area_width = area.width,
+                    "table column clipped: declared {}({}), resolved {} (table area {})",
+                    clip.kind.label(),
+                    clip.declared,
+                    clip.resolved,
+                    area.width,
+                );
+                // `clip` referenced inside cfg-gated block; suppress
+                // unused-binding lint when tracing is disabled.
+                #[cfg(not(feature = "tracing"))]
+                let _ = clip;
+            }
+        }
+    }
+
     let border_style = if focused && !disabled {
         theme.focused_border_style()
     } else {
@@ -185,5 +339,94 @@ pub(super) fn render_table<T: TableRow>(
         } else {
             crate::scroll::render_scrollbar_inside_border(&bar_scroll, frame, area, theme);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::layout::Constraint;
+
+    fn cols(widths: &[Constraint]) -> Vec<Column> {
+        widths
+            .iter()
+            .enumerate()
+            .map(|(i, &w)| Column::new(format!("col{i}"), w))
+            .collect()
+    }
+
+    #[test]
+    fn detect_clipped_columns_returns_empty_when_widths_fit() {
+        let columns = cols(&[Constraint::Length(8), Constraint::Length(10)]);
+        let resolved = vec![8, 10];
+        assert!(detect_clipped_columns(&columns, &resolved).is_empty());
+    }
+
+    #[test]
+    fn detect_clipped_columns_identifies_truncated_length_columns() {
+        let columns = cols(&[Constraint::Length(20)]);
+        let resolved = vec![10];
+        let result = detect_clipped_columns(&columns, &resolved);
+        assert_eq!(
+            result,
+            vec![ClippedColumn {
+                idx: 0,
+                declared: 20,
+                resolved: 10,
+                kind: ClipKind::Length,
+            }]
+        );
+    }
+
+    #[test]
+    fn detect_clipped_columns_identifies_violated_min_constraints() {
+        let columns = cols(&[Constraint::Min(20)]);
+        let resolved = vec![10];
+        let result = detect_clipped_columns(&columns, &resolved);
+        assert_eq!(
+            result,
+            vec![ClippedColumn {
+                idx: 0,
+                declared: 20,
+                resolved: 10,
+                kind: ClipKind::Min,
+            }]
+        );
+    }
+
+    #[test]
+    fn detect_clipped_columns_ignores_min_when_resolved_meets_floor() {
+        let columns = cols(&[Constraint::Min(10)]);
+        let resolved = vec![20];
+        assert!(detect_clipped_columns(&columns, &resolved).is_empty());
+    }
+
+    #[test]
+    fn detect_clipped_columns_ignores_percentage_constraints() {
+        let columns = cols(&[Constraint::Percentage(50)]);
+        let resolved = vec![5];
+        assert!(detect_clipped_columns(&columns, &resolved).is_empty());
+    }
+
+    #[test]
+    fn detect_clipped_columns_multiple_violations_mixed_kinds() {
+        let columns = cols(&[
+            Constraint::Length(20),
+            Constraint::Min(20),
+            Constraint::Percentage(50),
+        ]);
+        let resolved = vec![10, 10, 5];
+        let result = detect_clipped_columns(&columns, &resolved);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].idx, 0);
+        assert_eq!(result[0].kind, ClipKind::Length);
+        assert_eq!(result[1].idx, 1);
+        assert_eq!(result[1].kind, ClipKind::Min);
+    }
+
+    #[test]
+    fn clip_kind_label_returns_constraint_name() {
+        assert_eq!(ClipKind::Length.label(), "Length");
+        assert_eq!(ClipKind::Min.label(), "Min");
     }
 }

--- a/src/component/table/snapshot_tests.rs
+++ b/src/component/table/snapshot_tests.rs
@@ -1,0 +1,36 @@
+use super::*;
+
+#[test]
+fn table_renders_when_columns_clipped() {
+    use crate::component::table::{Column, Table, TableState};
+    use crate::component::test_utils::setup_render;
+    use ratatui::layout::Constraint;
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct R(&'static str, &'static str);
+    impl TableRow for R {
+        fn cells(&self) -> Vec<crate::component::cell::Cell> {
+            vec![
+                crate::component::cell::Cell::from(self.0.to_string()),
+                crate::component::cell::Cell::from(self.1.to_string()),
+            ]
+        }
+    }
+
+    let columns = vec![
+        Column::new("Long", Constraint::Length(20)),
+        Column::new("Also Long", Constraint::Length(20)),
+    ];
+    let state = TableState::new(vec![R("aaa", "bbb"), R("ccc", "ddd")], columns);
+
+    // 20-wide area can't honor 2x Length(20). Both columns clip.
+    // Table must still render without panic and content must appear.
+    let (mut term, theme) = setup_render(20, 6);
+    term.draw(|frame| {
+        let ctx = &mut crate::component::RenderContext::new(frame, frame.area(), &theme);
+        <Table<R> as crate::component::Component>::view(&state, ctx);
+    })
+    .unwrap();
+
+    insta::assert_snapshot!(term.backend().to_string());
+}

--- a/src/component/table/snapshots/envision__component__table__snapshot_tests__table_renders_when_columns_clipped.snap
+++ b/src/component/table/snapshots/envision__component__table__snapshot_tests__table_renders_when_columns_clipped.snap
@@ -1,0 +1,10 @@
+---
+source: src/component/table/snapshot_tests.rs
+expression: term.backend().to_string()
+---
+┌──────────────────┐
+│  Long     Also Lo│
+│                  │
+│> aaa      bbb    │
+│  ccc      ddd    │
+└──────────────────┘

--- a/src/component/table/state.rs
+++ b/src/component/table/state.rs
@@ -2,6 +2,7 @@
 //!
 //! Extracted from the main table module to keep file sizes manageable.
 
+use std::cell::RefCell;
 use std::collections::HashSet;
 
 use super::{
@@ -9,6 +10,7 @@ use super::{
 };
 use crate::component::Component;
 use crate::component::cell::{RowStatus, SortKey};
+use crate::component::table::clip_warn::ClipWarnState;
 use crate::scroll::ScrollState;
 
 impl<T: TableRow> TableState<T> {
@@ -51,6 +53,7 @@ impl<T: TableRow> TableState<T> {
             filter_text: String::new(),
             scroll,
             cross_variant_warned_cols: HashSet::new(),
+            clip_warn_state: RefCell::new(ClipWarnState::default()),
         }
     }
 
@@ -94,6 +97,7 @@ impl<T: TableRow> TableState<T> {
             filter_text: String::new(),
             scroll,
             cross_variant_warned_cols: HashSet::new(),
+            clip_warn_state: RefCell::new(ClipWarnState::default()),
         }
     }
 
@@ -749,5 +753,120 @@ impl<T: TableRow + 'static> TableState<T> {
     /// ```
     pub fn update(&mut self, msg: TableMessage) -> Option<TableOutput<T>> {
         Table::update(self, msg)
+    }
+}
+
+#[cfg(test)]
+impl<T: TableRow> TableState<T> {
+    pub(super) fn clip_warn_state_for_test(
+        &self,
+    ) -> &std::cell::RefCell<crate::component::table::clip_warn::ClipWarnState> {
+        &self.clip_warn_state
+    }
+}
+
+#[cfg(test)]
+mod state_dedup_tests {
+    use super::*;
+    use ratatui::layout::{Constraint, Rect};
+
+    // A trivial TableRow impl for tests.
+    #[derive(Clone, Debug, PartialEq)]
+    struct R {
+        v: String,
+    }
+    impl TableRow for R {
+        fn cells(&self) -> Vec<crate::component::cell::Cell> {
+            vec![crate::component::cell::Cell::from(self.v.clone())]
+        }
+    }
+
+    fn render_with_state(state: &TableState<R>, width: u16) {
+        use super::super::render;
+        use crate::theme::Theme;
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let backend = TestBackend::new(width, 5);
+        let mut term = Terminal::new(backend).unwrap();
+        let theme = Theme::default();
+        term.draw(|frame| {
+            render::render_table(
+                state,
+                frame,
+                Rect::new(0, 0, width, 5),
+                &theme,
+                false,
+                false,
+                false,
+            );
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn clip_warn_state_dedupes_within_same_area_width() {
+        let columns = vec![Column::new("X", Constraint::Length(20))];
+        let state = TableState::new(vec![R { v: "a".into() }], columns);
+        render_with_state(&state, 10);
+        let after_first = state
+            .clip_warn_state_for_test()
+            .borrow()
+            .warned_cols
+            .clone();
+        render_with_state(&state, 10);
+        let after_second = state
+            .clip_warn_state_for_test()
+            .borrow()
+            .warned_cols
+            .clone();
+        assert_eq!(after_first, after_second);
+        assert!(after_first.contains(&0));
+    }
+
+    #[test]
+    fn clip_warn_state_re_arms_on_area_width_change() {
+        let columns = vec![Column::new("X", Constraint::Length(20))];
+        let state = TableState::new(vec![R { v: "a".into() }], columns);
+        render_with_state(&state, 10); // clipped
+        assert!(
+            state
+                .clip_warn_state_for_test()
+                .borrow()
+                .warned_cols
+                .contains(&0)
+        );
+        render_with_state(&state, 50); // not clipped, dedup re-arms
+        assert!(
+            state
+                .clip_warn_state_for_test()
+                .borrow()
+                .warned_cols
+                .is_empty()
+        );
+        render_with_state(&state, 10); // clipped again, fresh re-arm
+        assert!(
+            state
+                .clip_warn_state_for_test()
+                .borrow()
+                .warned_cols
+                .contains(&0)
+        );
+    }
+
+    #[test]
+    fn clip_warn_state_defaults_empty_on_new_table_state() {
+        let state: TableState<R> = TableState::default();
+        let s = state.clip_warn_state_for_test().borrow();
+        assert!(s.last_area_width.is_none());
+        assert!(s.warned_cols.is_empty());
+    }
+
+    #[test]
+    fn clip_warn_state_initialized_in_constructor() {
+        let state = TableState::new(vec![R { v: "x".into() }], vec![]);
+        let s = state.clip_warn_state_for_test().borrow();
+        assert!(s.last_area_width.is_none());
+        assert!(s.warned_cols.is_empty());
     }
 }

--- a/src/component/table/types.rs
+++ b/src/component/table/types.rs
@@ -84,10 +84,10 @@ impl Column {
     /// `Column::new` takes any `ratatui::layout::Constraint`. The most
     /// common patterns:
     ///
-    /// - [`Constraint::Length(n)`] — a hard request for exactly `n` cells.
-    /// - [`Constraint::Min(n)`] — a minimum of `n` cells, growing to fill
+    /// - [`Constraint::Length`] `(n)` — a hard request for exactly `n` cells.
+    /// - [`Constraint::Min`] `(n)` — a minimum of `n` cells, growing to fill
     ///   available space. Typical choice for one "flexible" column.
-    /// - [`Constraint::Percentage(n)`] — `n%` of the resolved area,
+    /// - [`Constraint::Percentage`] `(n)` — `n%` of the resolved area,
     ///   partitioned left-to-right with the other constraints.
     ///
     /// `Length` and `Min` both declare an absolute floor. When the

--- a/src/component/table/types.rs
+++ b/src/component/table/types.rs
@@ -79,18 +79,55 @@ pub struct Column {
 impl Column {
     /// Creates a new column with the given header and width.
     ///
+    /// # Width semantics
+    ///
+    /// `Column::new` takes any `ratatui::layout::Constraint`. The most
+    /// common patterns:
+    ///
+    /// - [`Constraint::Length(n)`] — a hard request for exactly `n` cells.
+    /// - [`Constraint::Min(n)`] — a minimum of `n` cells, growing to fill
+    ///   available space. Typical choice for one "flexible" column.
+    /// - [`Constraint::Percentage(n)`] — `n%` of the resolved area,
+    ///   partitioned left-to-right with the other constraints.
+    ///
+    /// `Length` and `Min` both declare an absolute floor. When the
+    /// resolved area is narrower than the declared floor — a `Length(n)`
+    /// column that got `<n` cells, or a `Min(n)` column that got `<n`
+    /// cells — the column emits a warning (see "Clipping diagnostics").
+    /// `Percentage` is a share of the resolved area and has no absolute
+    /// floor, so it is never flagged.
+    ///
+    /// For these three idioms the shorthand constructors
+    /// [`Column::fixed`], [`Column::min`], and [`Column::percent`] read
+    /// more directly than `Column::new`.
+    ///
     /// The column is not sortable by default.
     ///
     /// # Example
+    ///
+    /// Three-column layout: fixed ID, fixed price, flexible description.
     ///
     /// ```rust
     /// use envision::component::Column;
     /// use ratatui::layout::Constraint;
     ///
-    /// let col = Column::new("Name", Constraint::Length(20));
-    /// assert_eq!(col.header(), "Name");
-    /// assert!(!col.is_sortable());
+    /// let cols = vec![
+    ///     Column::new("ID",          Constraint::Length(8)),
+    ///     Column::new("Price",       Constraint::Length(10)),
+    ///     Column::new("Description", Constraint::Min(20)),
+    /// ];
+    /// assert_eq!(cols.len(), 3);
+    /// assert_eq!(cols[0].width(), Constraint::Length(8));
+    /// assert_eq!(cols[2].width(), Constraint::Min(20));
     /// ```
+    ///
+    /// # Clipping diagnostics
+    ///
+    /// When a `Length(n)` or `Min(n)` column resolves to fewer than `n`
+    /// cells, the column emits a `tracing::warn!` once. Dedup is per
+    /// `(column index, area width)`: the warning re-arms when the
+    /// terminal is resized. This is best-effort observability — the
+    /// table still renders. Enable with the `tracing` feature.
     pub fn new(header: impl Into<String>, width: Constraint) -> Self {
         Self {
             header: header.into(),

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1,12 +1,40 @@
 //! Test harness for headless TUI testing.
 //!
-//! The harness module provides a unified testing interface that combines:
+//! Envision provides three testing entry points. Pick the one that
+//! matches the scope of what you're testing:
 //!
-//! - `CaptureBackend` for headless rendering
-//! - Input simulation for programmatic interaction
-//! - Widget annotations for semantic queries
+//! | Harness | Use when… | Closure or App? | Time control |
+//! |---|---|---|---|
+//! | [`TestHarness`] | Testing a render closure or a widget in isolation | Closure | None (synchronous) |
+//! | [`AppHarness`] | Testing a full `App` with async commands/subscriptions | App | Via `tokio::test(start_paused)` + `advance_time()` |
+//! | [`Runtime::virtual_builder`][vb] | Programmatic control (agents, scripted demos, integration tests) | App | None |
 //!
-//! # Example
+//! [vb]: crate::app::Runtime::virtual_builder
+//!
+//! ## `TestHarness` — widget-level testing
+//!
+//! Wraps a `CaptureBackend` with input simulation and assertion helpers.
+//! Renders closures, not full `App` implementations. Synchronous — no
+//! async runtime.
+//!
+//! ## `AppHarness` — App-level async testing
+//!
+//! Wraps a `Runtime<A, CaptureBackend>` and exposes time-control
+//! primitives that pair with `#[tokio::test(start_paused = true)]`. Use
+//! when your `App` has subscriptions, commands, or any time-dependent
+//! logic.
+//!
+//! ## `Runtime::virtual_builder` — programmatic App control
+//!
+//! Constructed via `Runtime::<A, _>::virtual_builder(w, h).build()`.
+//! Returns a `Runtime<A, CaptureBackend>` with `send()`, `dispatch()`,
+//! `tick()`, and `display()` methods. Useful for AI agents, scripted
+//! demos, and integration tests that need full App semantics without
+//! the time-control ceremony of `AppHarness`.
+//!
+//! See `examples/test_harness.rs` for runnable examples of all three.
+//!
+//! # Example: TestHarness
 //!
 //! ```rust
 //! use envision::harness::{TestHarness, Assertion};

--- a/src/harness/snapshot/mod.rs
+++ b/src/harness/snapshot/mod.rs
@@ -1,4 +1,98 @@
 //! Snapshot testing support.
+//!
+//! # Golden-file snapshot pattern
+//!
+//! Envision keeps snapshot testing dependency-light: a render produces
+//! a string, and you compare it against a fixture on disk. The recipe
+//! below provides two functions — `update_golden` writes the fixture
+//! unconditionally, `assert_matches_golden` reads-and-compares and
+//! panics on mismatch with a unified diff.
+//!
+//! Typical workflow: invoke `update_golden` once (often gated by an
+//! `UPDATE_GOLDEN` env check at the call site) to capture the expected
+//! output, then call `assert_matches_golden` from the test body to
+//! verify on subsequent runs.
+//!
+//! ```rust
+//! use std::fs;
+//! use std::path::Path;
+//!
+//! fn update_golden(path: &Path, content: &str) {
+//!     if let Some(parent) = path.parent() {
+//!         fs::create_dir_all(parent).unwrap();
+//!     }
+//!     fs::write(path, content).unwrap();
+//! }
+//!
+//! fn assert_matches_golden(path: &Path, actual: &str) {
+//!     let expected = fs::read_to_string(path).unwrap_or_else(|e| {
+//!         panic!(
+//!             "golden fixture missing at {}: {} (run with UPDATE_GOLDEN=1 to create)",
+//!             path.display(),
+//!             e,
+//!         )
+//!     });
+//!     if expected != actual {
+//!         panic!(
+//!             "snapshot mismatch at {}:\n{}",
+//!             path.display(),
+//!             unified_diff(&expected, actual),
+//!         );
+//!     }
+//! }
+//!
+//! fn unified_diff(expected: &str, actual: &str) -> String {
+//!     let mut out = String::new();
+//!     let e: Vec<&str> = expected.lines().collect();
+//!     let a: Vec<&str> = actual.lines().collect();
+//!     for i in 0..e.len().max(a.len()) {
+//!         match (e.get(i), a.get(i)) {
+//!             (Some(l), Some(r)) if l == r => out.push_str(&format!("  {l}\n")),
+//!             (Some(l), Some(r)) => {
+//!                 out.push_str(&format!("- {l}\n"));
+//!                 out.push_str(&format!("+ {r}\n"));
+//!             }
+//!             (Some(l), None) => out.push_str(&format!("- {l}\n")),
+//!             (None, Some(r)) => out.push_str(&format!("+ {r}\n")),
+//!             (None, None) => {}
+//!         }
+//!     }
+//!     out
+//! }
+//!
+//! // End-to-end demo using a tempdir so the doc-test is
+//! // self-contained.
+//! let tmp = tempfile::tempdir().unwrap();
+//! let path = tmp.path().join("golden.txt");
+//! let rendered = "row 1\nrow 2\nrow 3\n";
+//!
+//! // First run: capture the fixture.
+//! update_golden(&path, rendered);
+//!
+//! // Subsequent runs: assert match.
+//! assert_matches_golden(&path, rendered);
+//! ```
+//!
+//! ## Real-world call-site sketch
+//!
+//! ```ignore
+//! let path = Path::new("tests/golden/dashboard.txt");
+//! let actual = harness.snapshot_plain();
+//!
+//! if std::env::var("UPDATE_GOLDEN").is_ok() {
+//!     update_golden(path, &actual);
+//! } else {
+//!     assert_matches_golden(path, &actual);
+//! }
+//! ```
+//!
+//! ## When to upgrade
+//!
+//! For richer diffs, review tooling (`cargo insta review`), and
+//! parallel test isolation, switch to the [`insta`](https://docs.rs/insta)
+//! crate. envision's own snapshot tests use `insta` internally; the
+//! pattern above is offered as a starting point for downstream
+//! consumers who want zero new dependencies.
 
 use std::path::Path;
 


### PR DESCRIPTION
## Summary

Implementation of the 10th and FINAL cadence in the May 2026 leadline brief queue. Three documentation-suite items shipped as three logically-separated signed commits:

- **D3** — `Column::new` canonical Length+Min docstring + render-time clipping warning. New `pub(crate)` `detect_clipped_columns` helper returning `Vec<ClippedColumn { idx, declared, resolved, kind: Length|Min }>`. Emission feature-gated on `tracing`; dedup via `RefCell<ClipWarnState>` on TableState (interior mutability required because `Table::view` takes `&state`); keyed by `(column index, area width)` with terminal-resize re-arm. Render-path detection mirrors the full ratatui 0.29 Table width formula — border inset / selection reservation / `column_spacing = 1` / `has_status` offset — per the spec's Canonical Reservation Contract (rounds 1+2+3 of leadline review).
- **D7** — `src/harness` module docs gained "Choosing a Harness" decision table + per-harness blurbs for TestHarness / AppHarness / Runtime::virtual_builder. `src/harness/snapshot` module docs gained runnable canonical golden-file snapshot-diff recipe (dependency-free, `std::fs` + manual diff; `insta` linked as upgrade path).
- **D8** — New `examples/drilldown.rs` showing master+detail pattern using `TableState`, `PaneLayout::view_with`, `styled_line`, per-view `KeyHints`, `App::handle_event_with_state` for screen-gated key bindings (Up/Down only ticks Roster; Esc only fires from PerOp; `q` quits anywhere), and selection preservation across drill-in/drill-out. Router docs gained Router-vs-in-state-enum guidance. `examples/router.rs` refreshed to use `PaneLayout::view_with` chrome instead of raw `ratatui::widgets::Paragraph + Block`.

After this PR + the tracking-doc PR merge, the May 2026 brief queue is closed.

## Spec / plan

- Spec: `docs/superpowers/specs/2026-05-24-docs-suite-d3-d7-d8-design.md` (PR #497)
- Plan: `docs/superpowers/plans/2026-05-24-docs-suite-d3-d7-d8.md` (PR #498)
- Review record: `docs/customer-feedback/2026-05-01-leadline-gaps.md` rounds 1+2+3 (PR #499)

## Lessons baked in from prior cadences

- **Doc-test coverage** (G4+G5 PR #487, G6 PR #491 regressions): new `Column::new` doc-test added; D3 helper is `pub(crate)` so no doc-test needed.
- **`cargo build --no-default-features`** (D5+D14 lesson): tracing-gated emission block has `#[cfg(not(feature = "tracing"))] let _ = clip;` to suppress unused-binding warnings.
- **File-size cap** (G4 `title_style.rs`, D12 `per_side_separators.rs`): `ClipWarnState` lives in sibling `src/component/table/clip_warn.rs` so `mod.rs` stays well under cap.
- **PartialEq exclusion**: `clip_warn_state` excluded from custom `PartialEq for TableState` impl, mirroring the existing `cross_variant_warned_cols` precedent.

## Implementation deviation from plan

Task 1's render-path call site moved the `last_area_width` tracking outside the `if !clipped.is_empty()` guard — a principled fix backed by the spec's stated `(column index, area width)` dedup semantics and the Step 8 test contract (`clip_warn_state_re_arms_on_area_width_change` renders at width=50 with no clipping, then asserts `warned_cols.is_empty()`, which only works if the area-width transition fires during non-clipping renders). Both task reviewer and final review confirm the fix is correct.

## Test plan

- [x] D3: 7 detection helper tests + 4 dedup-state tests + 1 snapshot test (all 12 passing)
- [x] D7: doc-test for snapshot recipe runs end-to-end against tempdir
- [x] D8: `cargo build --examples --all-features` builds both `drilldown` and refreshed `router`; `cargo run --example drilldown` produces all 4 expected output sections (Roster initial / SelectNext / DrillIn / DrillOut)
- [x] `cargo nextest run --all-features` — 7454/7454 pass
- [x] `cargo test --all-features --doc` — 2585 pass
- [x] `cargo clippy --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build --no-default-features` — clean
- [x] `./tools/audit/target/release/envision-audit all` — 8/9 baseline preserved (resource_gauge::set_values pre-existing gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)