### PR TITLE
Impl: consistency-cleanup cadence (v0.17.0 pre-release, Cadence A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,29 @@ New accessor: `state.values() -> ResourceValues` (closes accessor-symmetry gap w
 
 See `MIGRATION.md#v016x-to-v0170`.
 
+#### Component selection accessors unified on `selected_item()`
+
+Six components had divergent accessor shapes for "which is selected?" — literal aliases (`selected_value()` / `selected_row()` / `selected()`), semantic outliers (`active_tab()` on tab_bar), and type-incoherent overloads (heatmap's `selected_value() -> f64` returning the data value at coordinates, not the selection itself). Unified on canonical `selected_item()` returning `Option<&T>` where the concept fits; renamed the semantic outliers to disambiguate:
+
+- `dropdown::selected_value()` — deleted; use `selected_item() -> Option<&str>`
+- `select::selected_value()` — deleted; use `selected_item() -> Option<&str>`
+- `heatmap::selected_value() -> Option<f64>` — renamed to `value_at_selection() -> Option<f64>` (returns data value at cursor coords; not a selection accessor)
+- `tab_bar::selected()` — deleted; use `selected_index()`
+- `tab_bar::active_tab() -> Option<&Tab>` — renamed to `selected_item() -> Option<&Tab>`
+- `tab_bar::active_tab_mut() -> Option<&mut Tab>` — renamed to `selected_item_mut() -> Option<&mut Tab>`
+- `data_grid::selected()` — deleted; use `selected_index()`
+- `data_grid::selected_row()` — deleted; use `selected_item()`
+- `table::selected()` — deleted; use `selected_index()`
+- `table::selected_row()` — deleted; use `selected_item()`
+
+Closes audit finding #6 (`selected_value` / `selected_item` / `active_tab` divergence). See `MIGRATION.md#v016x-to-v0170` for the full migration table.
+
+#### `MessageSender<M>` replaces `tokio::sync::mpsc::Sender` in AppHarness surface
+
+`AppHarness::message_sender()` now returns a first-party `MessageSender<A::Message>` newtype instead of raw `tokio::sync::mpsc::Sender<A::Message>`. Consumers no longer need `tokio` as a direct dependency to use the accessor. Full tokio Sender semantics preserved through passthrough methods; an explicit `MessageSender::into_inner()` escape hatch is available for consumers needing `reserve` / `send_timeout` / `same_channel` / `downgrade` / `closed()` future.
+
+Closes audit finding #8 (dependency leakage on AppHarness surface). See `MIGRATION.md#v016x-to-v0170` for the migration table.
+
 ### Added
 
 #### Chrome ownership protocol (G2 + D2 + D11)
@@ -140,6 +163,14 @@ Removed leaf variants: `Bold`, `Italic`, `Underline`, `Strikethrough`, `Colored`
 - `ResourceGaugeState::values(&self) -> ResourceValues` — matching accessor for the existing `set_values` multi-field mutator; closes the audit's 9/9 scorecard gap.
 - New `examples/resource_gauge.rs` — K8s pod-quota shape.
 
+#### `MessageSender<M>` + `MessageSendError<T>` + `TrySendError<T>` (this cadence, Unit 2)
+
+New first-party types in `envision::harness` (re-exported at crate root and prelude):
+
+- `MessageSender<M: Send + 'static>` — newtype wrapper around `tokio::sync::mpsc::Sender<M>`. Full passthrough surface: `send()`, `try_send()`, `is_closed()`, `capacity()`, `max_capacity()`, plus `into_inner()` explicit escape hatch. `Clone + Debug + Send + Sync` (when `M: Send`).
+- `MessageSendError<T>(pub T)` — returned by `send()` when the receiver has been dropped. Carries the message back so the caller can inspect it. Implements `Debug + Display + Error`.
+- `TrySendError<T>::{Full(T), Closed(T)}` — returned by `try_send()`. Preserves tokio's Full/Closed distinction so consumers can retry-on-full or exit-on-closed with a match arm. Includes `into_inner(self) -> T` extractor.
+
 ### Changed
 
 #### Chrome ownership protocol
@@ -153,10 +184,11 @@ Removed leaf variants: `Bold`, `Italic`, `Underline`, `Strikethrough`, `Colored`
 
 ### Known Deferred Findings
 
-The 2026-07-04 audit (Fable) surfaced two API incoherences deliberately deferred beyond v0.17.0. Both are tracked as follow-up cadences and will be addressed in v0.18.0 or later:
+The 2026-07-04 audit surfaced items that remain deferred beyond v0.17.0:
 
-- **`selected_value` / `selected_item` / `active_tab` accessor shape divergence** across `dropdown`, `select`, `heatmap`, `tab_bar`, and `data_grid`. `dropdown::selected_value()` and `dropdown::selected_item()` are literal `&str` aliases; `heatmap::selected_value()` returns `f64` (type-incoherent with the string variant); `tab_bar` uses `active_tab()` instead of `selected_item()`; `data_grid` has four selection accessors (`selected`, `selected_index`, `selected_row`, `selected_item`). Requires a dedicated consistency-sweep cadence.
-- **Dependency leakage in 8 public signatures** (`ratatui::layout::Position`, `ratatui::buffer::Cell`, `ratatui::style::Color`, `ratatui::style::Style`, `ratatui::widgets::Widget`, `tokio::sync::mpsc::Sender` at `harness/app_harness/mod.rs:264`, plus 2 others). Architectural discussion; not release-blocking.
+- **`selected()` alias on ~15 additional components** (accordion, tabs, radio_group, searchable_list, selectable_list, tree, menu, box_plot, loading_list, alert_panel, and others) — these components have `selected() -> Option<usize>` as a literal alias for `selected_index()`, similar to the aliases just removed from tab_bar/data_grid/table in this release but without the additional divergence that motivated their inclusion this round. Scheduled for **Cadence D** (v0.18+): finish the consistency sweep across the remaining alias sites.
+
+If audit findings #6 (selected_value/selected_item/active_tab across 5 originally-flagged components) and #8 (dependency leakage in 8 public signatures) previously appeared here, they were closed by the v0.17.0 consistency-cleanup cadence (see Breaking Changes / Added subsections above).
 
 ## [0.16.0] - 2026-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@ Six components had divergent accessor shapes for "which is selected?" — litera
 - `data_grid::selected_row()` — deleted; use `selected_item()`
 - `table::selected()` — deleted; use `selected_index()`
 - `table::selected_row()` — deleted; use `selected_item()`
+- `tab_bar::set_selected()` — renamed to `set_selected_index()` for symmetry
+- `data_grid::set_selected()` — renamed to `set_selected_index()` for symmetry
+- `table::set_selected()` — renamed to `set_selected_index()` for symmetry
 
 Closes audit finding #6 (`selected_value` / `selected_item` / `active_tab` divergence). See `MIGRATION.md#v016x-to-v0170` for the full migration table.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -83,6 +83,43 @@ Bonus: `SortDirection::toggle()` is available; use it to replace hand-rolled asc
 
 **New type**: `envision::component::ResourceValues { actual, request, limit }` — also available at `envision::prelude::ResourceValues`.
 
+### Component selection accessors unified on `selected_item()`
+
+Six components had divergent shapes for "which is selected?"; unified on canonical `selected_item()` returning `Option<&T>` where the concept fits. Semantic outliers renamed to disambiguate.
+
+| Component | Old | New |
+|---|---|---|
+| `dropdown` | `state.selected_value()` | `state.selected_item()` (was already the canonical name; the alias is what's deleted) |
+| `select` | `state.selected_value()` | `state.selected_item()` (same shape) |
+| `heatmap` | `state.selected_value() -> Option<f64>` (returns data value at cursor coordinates) | `state.value_at_selection() -> Option<f64>` (renamed — the `value_` prefix disambiguates from selection-accessor pattern; the coordinate accessor `state.selected() -> Option<(usize, usize)>` is unchanged) |
+| `tab_bar` | `state.active_tab() -> Option<&Tab>` | `state.selected_item() -> Option<&Tab>` |
+| `tab_bar` | `state.active_tab_mut() -> Option<&mut Tab>` | `state.selected_item_mut() -> Option<&mut Tab>` |
+| `tab_bar` | `state.selected() -> Option<usize>` (was: literal alias for `selected_index()`) | `state.selected_index()` |
+| `data_grid` | `state.selected()` (was: literal alias for `selected_index()`) | `state.selected_index()` |
+| `data_grid` | `state.selected_row()` (was: literal alias for `selected_item()`) | `state.selected_item()` |
+| `table` | `state.selected()` (was: literal alias for `selected_index()`) | `state.selected_index()` |
+| `table` | `state.selected_row()` (was: literal alias for `selected_item()`) | `state.selected_item()` |
+
+Grep hint for consumers: search your codebase for `\.selected_value(`, `\.active_tab(`, `\.active_tab_mut(`, `\.selected_row(`, and `\.selected(` (the last only on tab_bar / data_grid / table state) — every hit needs to migrate to the new form per the table above.
+
+### `MessageSender<M>` wraps `tokio::sync::mpsc::Sender<M>`
+
+`AppHarness::message_sender()` now returns a first-party `MessageSender<M>` newtype instead of raw `tokio::sync::mpsc::Sender<M>`. Consumer code changes are limited to type spellings; call sites are identical.
+
+| Old | New |
+|---|---|
+| `let sender: tokio::sync::mpsc::Sender<MyMsg> = harness.message_sender();` | `let sender: envision::MessageSender<MyMsg> = harness.message_sender();` (or use `envision::prelude::MessageSender`) |
+| `sender.send(msg).await` — returns `Result<(), tokio::sync::mpsc::error::SendError<MyMsg>>` | `sender.send(msg).await` — returns `Result<(), envision::MessageSendError<MyMsg>>` |
+| `sender.try_send(msg)` — returns `Result<(), tokio::sync::mpsc::error::TrySendError<MyMsg>>` | `sender.try_send(msg)` — returns `Result<(), envision::TrySendError<MyMsg>>` |
+| `sender.is_closed()` — still available | `sender.is_closed()` — still available (passthrough) |
+| `sender.capacity()` — still available | `sender.capacity()` — still available (passthrough) |
+| `sender.max_capacity()` — still available | `sender.max_capacity()` — still available (passthrough) |
+| `sender.reserve()`, `.send_timeout()`, `.same_channel()`, `.downgrade()`, `.closed()` future | `let tokio_sender = sender.into_inner();` — explicit escape hatch that re-couples to tokio |
+
+`MessageSender<M>` is `Clone + Debug + Send + Sync` (when `M: Send`). Its `send`/`try_send` methods have the same semantics as tokio's Sender (bounded channel, receiver-dropped errors carry the message back).
+
+**Generic parameter note:** `MessageSender<M>` is parameterized on the message type `M`, not on an App type. This means portable helper functions like `fn spawn_watcher<M: Send + 'static>(sender: MessageSender<M>) { ... }` work without depending on envision's `App` trait.
+
 ## v0.15.x to v0.16.0
 
 ### `DependencyGraph` removed; use `Diagram`

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -99,8 +99,11 @@ Six components had divergent shapes for "which is selected?"; unified on canonic
 | `data_grid` | `state.selected_row()` (was: literal alias for `selected_item()`) | `state.selected_item()` |
 | `table` | `state.selected()` (was: literal alias for `selected_index()`) | `state.selected_index()` |
 | `table` | `state.selected_row()` (was: literal alias for `selected_item()`) | `state.selected_item()` |
+| `tab_bar` | `state.set_selected(idx)` | `state.set_selected_index(idx)` (renamed for symmetry with `selected_index()`) |
+| `data_grid` | `state.set_selected(idx)` | `state.set_selected_index(idx)` (renamed for symmetry with `selected_index()`) |
+| `table` | `state.set_selected(idx)` | `state.set_selected_index(idx)` (renamed for symmetry with `selected_index()`) |
 
-Grep hint for consumers: search your codebase for `\.selected_value(`, `\.active_tab(`, `\.active_tab_mut(`, `\.selected_row(`, and `\.selected(` (the last only on tab_bar / data_grid / table state) — every hit needs to migrate to the new form per the table above.
+Grep hint for consumers: search your codebase for `\.selected_value(`, `\.active_tab(`, `\.active_tab_mut(`, `\.selected_row(`, `\.selected(` (the last only on tab_bar / data_grid / table state), and `\.set_selected(` (only on tab_bar / data_grid / table state) — every hit needs to migrate to the new form per the table above.
 
 ### `MessageSender<M>` wraps `tokio::sync::mpsc::Sender<M>`
 

--- a/examples/chat_client.rs
+++ b/examples/chat_client.rs
@@ -239,7 +239,7 @@ impl App for ChatClient {
                     state.message_count += 1;
 
                     // Mark tab as modified
-                    if let Some(tab) = state.tab_bar.active_tab_mut() {
+                    if let Some(tab) = state.tab_bar.selected_item_mut() {
                         tab.set_modified(true);
                     }
 

--- a/examples/chat_client.rs
+++ b/examples/chat_client.rs
@@ -198,7 +198,7 @@ impl App for ChatClient {
                                 if state.active_tab >= state.conversations.len() {
                                     state.active_tab = state.conversations.len().saturating_sub(1);
                                 }
-                                state.tab_bar.set_selected(Some(state.active_tab));
+                                state.tab_bar.set_selected_index(Some(state.active_tab));
                             }
                         }
                         _ => {}
@@ -296,7 +296,7 @@ impl App for ChatClient {
                     ),
                 );
                 state.active_tab = state.conversations.len() - 1;
-                state.tab_bar.set_selected(Some(state.active_tab));
+                state.tab_bar.set_selected_index(Some(state.active_tab));
             }
 
             Msg::CloseTab => {
@@ -309,7 +309,7 @@ impl App for ChatClient {
                     if state.active_tab >= state.conversations.len() {
                         state.active_tab = state.conversations.len().saturating_sub(1);
                     }
-                    state.tab_bar.set_selected(Some(state.active_tab));
+                    state.tab_bar.set_selected_index(Some(state.active_tab));
                 }
             }
 

--- a/examples/drilldown.rs
+++ b/examples/drilldown.rs
@@ -110,7 +110,7 @@ impl App for DrillApp {
             Column::new("Status", Constraint::Min(10)),
         ];
         let mut roster = TableState::new(operations.clone(), columns);
-        roster.set_selected(Some(0));
+        roster.set_selected_index(Some(0));
 
         let roster_hints = KeyHintsState::new()
             .hint("↑/↓", "select")
@@ -139,7 +139,7 @@ impl App for DrillApp {
             }
             Msg::DrillOut => {
                 if let Screen::PerOp { selected } = state.screen {
-                    state.roster.set_selected(Some(selected));
+                    state.roster.set_selected_index(Some(selected));
                     state.screen = Screen::Roster;
                 }
             }
@@ -150,11 +150,11 @@ impl App for DrillApp {
                     .map(|i| i + 1)
                     .unwrap_or(0)
                     .min(state.operations.len().saturating_sub(1));
-                state.roster.set_selected(Some(next));
+                state.roster.set_selected_index(Some(next));
             }
             Msg::SelectPrev => {
                 let prev = state.roster.selected_index().unwrap_or(0).saturating_sub(1);
-                state.roster.set_selected(Some(prev));
+                state.roster.set_selected_index(Some(prev));
             }
             Msg::Quit => return Command::quit(),
         }

--- a/examples/drilldown.rs
+++ b/examples/drilldown.rs
@@ -133,7 +133,7 @@ impl App for DrillApp {
     fn update(state: &mut State, msg: Msg) -> Command<Msg> {
         match msg {
             Msg::DrillIn => {
-                if let Some(idx) = state.roster.selected() {
+                if let Some(idx) = state.roster.selected_index() {
                     state.screen = Screen::PerOp { selected: idx };
                 }
             }
@@ -146,14 +146,14 @@ impl App for DrillApp {
             Msg::SelectNext => {
                 let next = state
                     .roster
-                    .selected()
+                    .selected_index()
                     .map(|i| i + 1)
                     .unwrap_or(0)
                     .min(state.operations.len().saturating_sub(1));
                 state.roster.set_selected(Some(next));
             }
             Msg::SelectPrev => {
-                let prev = state.roster.selected().unwrap_or(0).saturating_sub(1);
+                let prev = state.roster.selected_index().unwrap_or(0).saturating_sub(1);
                 state.roster.set_selected(Some(prev));
             }
             Msg::Quit => return Command::quit(),

--- a/examples/dropdown.rs
+++ b/examples/dropdown.rs
@@ -66,7 +66,7 @@ impl App for DropdownApp {
             &mut RenderContext::new(frame, chunks[0], &theme),
         );
 
-        let selected = state.language.selected_value().unwrap_or("None");
+        let selected = state.language.selected_item().unwrap_or("None");
         let status = format!(" Selected: {}", selected);
         frame.render_widget(
             ratatui::widgets::Paragraph::new(status).style(Style::default().fg(Color::DarkGray)),

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -97,8 +97,8 @@ impl App for SelectApp {
         );
 
         // Summary
-        let color_val = state.color.selected_value().unwrap_or("none");
-        let size_val = state.size.selected_value().unwrap_or("none");
+        let color_val = state.color.selected_item().unwrap_or("none");
+        let size_val = state.size.selected_item().unwrap_or("none");
         let summary = format!("  Color: {}  Size: {}", color_val, size_val);
         let summary_widget = ratatui::widgets::Paragraph::new(summary).block(
             ratatui::widgets::Block::default()

--- a/examples/tab_bar.rs
+++ b/examples/tab_bar.rs
@@ -90,12 +90,12 @@ impl App for TabBarApp {
 
         let tab_name = state
             .tab_bar
-            .active_tab()
+            .selected_item()
             .map(|t| t.label().to_string())
             .unwrap_or_else(|| "No tab selected".into());
         let modified_str = state
             .tab_bar
-            .active_tab()
+            .selected_item()
             .map(|t| if t.modified() { " [modified]" } else { "" })
             .unwrap_or("");
         let content_text = format!("  Editing: {}{}", tab_name, modified_str);

--- a/src/app/runtime/virtual_terminal.rs
+++ b/src/app/runtime/virtual_terminal.rs
@@ -144,7 +144,7 @@ impl<A: App> Runtime<A, CaptureBackend> {
     }
 
     /// Finds all positions of the given text in the display.
-    pub fn find_text(&self, needle: &str) -> Vec<ratatui::layout::Position> {
+    pub fn find_text(&self, needle: &str) -> Vec<crate::layout::Position> {
         self.core.terminal.backend().find_text(needle)
     }
 }

--- a/src/component/data_grid/mod.rs
+++ b/src/component/data_grid/mod.rs
@@ -136,7 +136,7 @@ pub struct DataGridState<T: TableRow> {
     /// Column definitions.
     columns: Vec<Column>,
     /// Currently selected row index.
-    selected_row: Option<usize>,
+    selected_row_index: Option<usize>,
     /// Currently selected column index.
     selected_column: usize,
     /// Whether the cell editor is active.
@@ -155,7 +155,7 @@ impl<T: TableRow + PartialEq> PartialEq for DataGridState<T> {
     fn eq(&self, other: &Self) -> bool {
         self.rows == other.rows
             && self.columns == other.columns
-            && self.selected_row == other.selected_row
+            && self.selected_row_index == other.selected_row_index
             && self.selected_column == other.selected_column
             && self.editing == other.editing
     }
@@ -166,7 +166,7 @@ impl<T: TableRow> Default for DataGridState<T> {
         Self {
             rows: Vec::new(),
             columns: Vec::new(),
-            selected_row: None,
+            selected_row_index: None,
             selected_column: 0,
             editing: false,
             editor: InputFieldState::new(),
@@ -262,7 +262,7 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
                 DataGridMessage::Enter => {
                     // Confirm edit
                     let value = state.editor.value().to_string();
-                    let row = state.selected_row.unwrap_or(0);
+                    let row = state.selected_row_index.unwrap_or(0);
                     let col = state.selected_column;
                     state.cancel_editing();
                     Some(DataGridOutput::CellEdited {
@@ -300,14 +300,14 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
         } else {
             // Navigation mode
             let len = state.rows.len();
-            let current_row = state.selected_row.unwrap_or(0);
+            let current_row = state.selected_row_index.unwrap_or(0);
             let col_count = state.columns.len();
 
             match msg {
                 DataGridMessage::Up => {
                     let new_index = current_row.saturating_sub(1);
                     if new_index != current_row {
-                        state.selected_row = Some(new_index);
+                        state.selected_row_index = Some(new_index);
                         Some(DataGridOutput::SelectionChanged(new_index))
                     } else {
                         None
@@ -316,7 +316,7 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
                 DataGridMessage::Down => {
                     let new_index = (current_row + 1).min(len - 1);
                     if new_index != current_row {
-                        state.selected_row = Some(new_index);
+                        state.selected_row_index = Some(new_index);
                         Some(DataGridOutput::SelectionChanged(new_index))
                     } else {
                         None
@@ -324,7 +324,7 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
                 }
                 DataGridMessage::First => {
                     if current_row != 0 {
-                        state.selected_row = Some(0);
+                        state.selected_row_index = Some(0);
                         Some(DataGridOutput::SelectionChanged(0))
                     } else {
                         None
@@ -333,7 +333,7 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
                 DataGridMessage::Last => {
                     let last = len - 1;
                     if current_row != last {
-                        state.selected_row = Some(last);
+                        state.selected_row_index = Some(last);
                         Some(DataGridOutput::SelectionChanged(last))
                     } else {
                         None
@@ -469,7 +469,7 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
                     .enumerate()
                     .map(|(col_idx, cell)| {
                         if state.editing
-                            && state.selected_row == Some(row_idx)
+                            && state.selected_row_index == Some(row_idx)
                             && col_idx == state.selected_column
                         {
                             // Show editor content for the cell being edited
@@ -511,7 +511,7 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
         }
 
         let mut table_state = ratatui::widgets::TableState::default();
-        table_state.select(state.selected_row);
+        table_state.select(state.selected_row_index);
         ctx.frame
             .render_stateful_widget(table, ctx.area, &mut table_state);
 
@@ -542,7 +542,7 @@ impl<T: TableRow + 'static> Component for DataGrid<T> {
 
         // Show cursor when editing
         if state.editing && ctx.focused {
-            if let Some(row_idx) = state.selected_row {
+            if let Some(row_idx) = state.selected_row_index {
                 // Calculate cursor position for the edit cell
                 // This is approximate — exact positioning depends on column widths
                 let content_area = ctx.area.inner(Margin::new(1, 1));

--- a/src/component/data_grid/state.rs
+++ b/src/component/data_grid/state.rs
@@ -149,6 +149,9 @@ impl<T: TableRow> DataGridState<T> {
     /// The index is clamped to the valid range. Has no effect on empty grids.
     /// Cancels any active edit.
     ///
+    /// Renamed from `set_selected()` in v0.17.0 for symmetry with
+    /// `selected_index()`. See MIGRATION.md.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -165,10 +168,10 @@ impl<T: TableRow> DataGridState<T> {
     ///     vec![Item { name: "A".into() }, Item { name: "B".into() }],
     ///     vec![Column::new("Name", Constraint::Min(10))],
     /// );
-    /// state.set_selected(Some(1));
+    /// state.set_selected_index(Some(1));
     /// assert_eq!(state.selected_index(), Some(1));
     /// ```
-    pub fn set_selected(&mut self, index: Option<usize>) {
+    pub fn set_selected_index(&mut self, index: Option<usize>) {
         match index {
             Some(i) => {
                 if self.rows.is_empty() {

--- a/src/component/data_grid/state.rs
+++ b/src/component/data_grid/state.rs
@@ -33,12 +33,12 @@ impl<T: TableRow> DataGridState<T> {
     /// assert_eq!(state.selected_column(), 0);
     /// ```
     pub fn new(rows: Vec<T>, columns: Vec<Column>) -> Self {
-        let selected_row = if rows.is_empty() { None } else { Some(0) };
+        let selected_row_index = if rows.is_empty() { None } else { Some(0) };
         let scroll = ScrollState::new(rows.len());
         Self {
             rows,
             columns,
-            selected_row,
+            selected_row_index,
             selected_column: 0,
             editing: false,
             editor: InputFieldState::new(),
@@ -117,55 +117,7 @@ impl<T: TableRow> DataGridState<T> {
     /// assert_eq!(state.selected_index(), Some(0));
     /// ```
     pub fn selected_index(&self) -> Option<usize> {
-        self.selected_row
-    }
-
-    /// Alias for [`selected_index()`](Self::selected_index).
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::{Cell, DataGridState, TableRow, Column};
-    /// use ratatui::layout::Constraint;
-    ///
-    /// #[derive(Clone)]
-    /// struct Item { name: String }
-    /// impl TableRow for Item {
-    ///     fn cells(&self) -> Vec<Cell> { vec![Cell::new(&self.name)] }
-    /// }
-    ///
-    /// let state = DataGridState::new(
-    ///     vec![Item { name: "A".into() }],
-    ///     vec![Column::new("Name", Constraint::Min(10))],
-    /// );
-    /// assert_eq!(state.selected(), Some(0));
-    /// ```
-    pub fn selected(&self) -> Option<usize> {
-        self.selected_index()
-    }
-
-    /// Returns a reference to the currently selected row.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::{Cell, DataGridState, TableRow, Column};
-    /// use ratatui::layout::Constraint;
-    ///
-    /// #[derive(Clone)]
-    /// struct Item { name: String }
-    /// impl TableRow for Item {
-    ///     fn cells(&self) -> Vec<Cell> { vec![Cell::new(&self.name)] }
-    /// }
-    ///
-    /// let state = DataGridState::new(
-    ///     vec![Item { name: "Alice".into() }],
-    ///     vec![Column::new("Name", Constraint::Min(10))],
-    /// );
-    /// assert_eq!(state.selected_row().unwrap().name, "Alice");
-    /// ```
-    pub fn selected_row(&self) -> Option<&T> {
-        self.selected_row.and_then(|i| self.rows.get(i))
+        self.selected_row_index
     }
 
     /// Returns a reference to the currently selected item.
@@ -189,7 +141,7 @@ impl<T: TableRow> DataGridState<T> {
     /// assert_eq!(state.selected_item().unwrap().name, "Bob");
     /// ```
     pub fn selected_item(&self) -> Option<&T> {
-        self.selected_row()
+        self.selected_row_index.and_then(|i| self.rows.get(i))
     }
 
     /// Sets the selected row index.
@@ -223,11 +175,11 @@ impl<T: TableRow> DataGridState<T> {
                     return;
                 }
                 self.editing = false;
-                self.selected_row = Some(i.min(self.rows.len() - 1));
+                self.selected_row_index = Some(i.min(self.rows.len() - 1));
             }
             None => {
                 self.editing = false;
-                self.selected_row = None;
+                self.selected_row_index = None;
             }
         }
     }
@@ -325,7 +277,7 @@ impl<T: TableRow> DataGridState<T> {
     /// assert_eq!(state.current_cell_value(), Some("Alice".to_string()));
     /// ```
     pub fn current_cell_value(&self) -> Option<String> {
-        self.selected_row
+        self.selected_row_index
             .and_then(|ri| self.rows.get(ri))
             .map(|row| {
                 let cells = row.cells();
@@ -433,10 +385,10 @@ impl<T: TableRow> DataGridState<T> {
         self.rows = rows;
         self.scroll.set_content_length(self.rows.len());
         if self.rows.is_empty() {
-            self.selected_row = None;
+            self.selected_row_index = None;
         } else {
-            let current = self.selected_row.unwrap_or(0);
-            self.selected_row = Some(current.min(self.rows.len() - 1));
+            let current = self.selected_row_index.unwrap_or(0);
+            self.selected_row_index = Some(current.min(self.rows.len() - 1));
         }
     }
 }

--- a/src/component/data_grid/tests.rs
+++ b/src/component/data_grid/tests.rs
@@ -75,16 +75,10 @@ fn test_default() {
 // =============================================================================
 
 #[test]
-fn test_selected_row() {
-    let state = DataGridState::new(sample_rows(), sample_columns());
-    let row = state.selected_row().unwrap();
-    assert_eq!(row.name, "Alice");
-}
-
-#[test]
 fn test_selected_item() {
     let state = DataGridState::new(sample_rows(), sample_columns());
-    assert_eq!(state.selected_item(), state.selected_row());
+    let row = state.selected_item().unwrap();
+    assert_eq!(row.name, "Alice");
 }
 
 #[test]

--- a/src/component/dropdown/mod.rs
+++ b/src/component/dropdown/mod.rs
@@ -142,7 +142,7 @@ impl DropdownState {
     ///
     /// let state = DropdownState::with_selection(vec!["A", "B", "C"], 1);
     /// assert_eq!(state.selected_index(), Some(1));
-    /// assert_eq!(state.selected_value(), Some("B"));
+    /// assert_eq!(state.selected_item(), Some("B"));
     /// ```
     pub fn with_selection<S: Into<String>>(options: Vec<S>, selected: usize) -> Self {
         let options: Vec<String> = options.into_iter().map(|s| s.into()).collect();
@@ -235,28 +235,7 @@ impl DropdownState {
         self.selected_index()
     }
 
-    /// Returns the selected option value.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use envision::prelude::*;
-    ///
-    /// let state = DropdownState::with_selection(vec!["Apple", "Banana"], 1);
-    /// assert_eq!(state.selected_value(), Some("Banana"));
-    ///
-    /// let state = DropdownState::new(vec!["Apple", "Banana"]);
-    /// assert_eq!(state.selected_value(), None);
-    /// ```
-    pub fn selected_value(&self) -> Option<&str> {
-        self.selected_index
-            .and_then(|idx| self.options.get(idx).map(|s| s.as_str()))
-    }
-
     /// Returns the selected option value as a string reference.
-    ///
-    /// This is an alias for [`selected_value()`](Self::selected_value) that provides a
-    /// consistent accessor name across all selection-based components.
     ///
     /// # Examples
     ///
@@ -267,7 +246,8 @@ impl DropdownState {
     /// assert_eq!(state.selected_item(), Some("Apple"));
     /// ```
     pub fn selected_item(&self) -> Option<&str> {
-        self.selected_value()
+        self.selected_index
+            .and_then(|idx| self.options.get(idx).map(|s| s.as_str()))
     }
 
     /// Sets the selected option index.
@@ -279,10 +259,10 @@ impl DropdownState {
     ///
     /// let mut state = DropdownState::new(vec!["A", "B", "C"]);
     /// state.set_selected(Some(2));
-    /// assert_eq!(state.selected_value(), Some("C"));
+    /// assert_eq!(state.selected_item(), Some("C"));
     ///
     /// state.set_selected(None);
-    /// assert_eq!(state.selected_value(), None);
+    /// assert_eq!(state.selected_item(), None);
     /// ```
     pub fn set_selected(&mut self, index: Option<usize>) {
         if let Some(idx) = index {
@@ -690,7 +670,7 @@ impl Component for Dropdown {
                 .with_focus(ctx.focused)
                 .with_disabled(ctx.disabled)
                 .with_expanded(state.is_open);
-            if let Some(val) = state.selected_value() {
+            if let Some(val) = state.selected_item() {
                 ann = ann.with_value(val.to_string());
             }
             reg.register(ctx.area, ann);
@@ -719,21 +699,18 @@ impl Component for Dropdown {
             } else {
                 format!("{}█ {}", state.filter_text, arrow)
             }
-        } else if let Some(value) = state.selected_value() {
+        } else if let Some(value) = state.selected_item() {
             format!("{} ▼", value)
         } else {
             format!("{} ▼", state.placeholder)
         };
 
-        let text_style = if !state.is_open
-            && state.selected_value().is_none()
-            && !ctx.disabled
-            && !ctx.focused
-        {
-            ctx.theme.placeholder_style()
-        } else {
-            style
-        };
+        let text_style =
+            if !state.is_open && state.selected_item().is_none() && !ctx.disabled && !ctx.focused {
+                ctx.theme.placeholder_style()
+            } else {
+                style
+            };
 
         let paragraph = Paragraph::new(display_text).style(text_style).block(
             Block::default()

--- a/src/component/dropdown/tests.rs
+++ b/src/component/dropdown/tests.rs
@@ -15,7 +15,7 @@ fn test_new() {
 fn test_with_selection() {
     let state = DropdownState::with_selection(vec!["A", "B", "C"], 1);
     assert_eq!(state.selected_index(), Some(1));
-    assert_eq!(state.selected_value(), Some("B"));
+    assert_eq!(state.selected_item(), Some("B"));
 }
 
 #[test]
@@ -74,7 +74,7 @@ fn test_set_selected() {
     let mut state = DropdownState::new(vec!["A", "B", "C"]);
     state.set_selected(Some(1));
     assert_eq!(state.selected_index(), Some(1));
-    assert_eq!(state.selected_value(), Some("B"));
+    assert_eq!(state.selected_item(), Some("B"));
 }
 
 #[test]
@@ -414,7 +414,7 @@ fn test_confirm_with_filter() {
 
     let output = Dropdown::update(&mut state, DropdownMessage::Confirm);
     assert_eq!(output, Some(DropdownOutput::Selected("Banana".to_string())));
-    assert_eq!(state.selected_value(), Some("Banana"));
+    assert_eq!(state.selected_item(), Some("Banana"));
 }
 
 // ========== Disabled State Tests ==========
@@ -567,7 +567,7 @@ fn test_full_workflow() {
         output,
         Some(DropdownOutput::Selected("Apricot".to_string()))
     );
-    assert_eq!(state.selected_value(), Some("Apricot"));
+    assert_eq!(state.selected_item(), Some("Apricot"));
     assert!(!state.is_open());
     assert_eq!(state.filter_text(), ""); // Filter cleared
 }
@@ -761,13 +761,6 @@ fn test_instance_update() {
     let output = state.update(DropdownMessage::Toggle);
     assert!(output.is_none()); // Toggle just opens, returns None
     assert!(state.is_open());
-}
-
-#[test]
-fn test_selected_item() {
-    let state = DropdownState::with_selection(vec!["A", "B", "C"], 1);
-    assert_eq!(state.selected_item(), Some("B"));
-    assert_eq!(state.selected_item(), state.selected_value());
 }
 
 #[test]

--- a/src/component/heatmap/mod.rs
+++ b/src/component/heatmap/mod.rs
@@ -453,7 +453,16 @@ impl HeatmapState {
         }
     }
 
-    /// Returns the value of the currently selected cell.
+    /// Returns the data value at the currently selected cell, or `None` if
+    /// no cell is selected.
+    ///
+    /// This is distinct from [`selected`](Self::selected), which returns
+    /// the `(row, col)` coordinate pair — `value_at_selection()` reads that
+    /// coordinate out of the underlying data grid.
+    ///
+    /// Renamed from `selected_value()` in v0.17.0 to disambiguate from the
+    /// collection-selection pattern used by other components (see
+    /// MIGRATION.md `v0.16.x to v0.17.0`).
     ///
     /// # Example
     ///
@@ -461,9 +470,9 @@ impl HeatmapState {
     /// use envision::component::HeatmapState;
     ///
     /// let state = HeatmapState::with_data(vec![vec![7.5, 3.2]]);
-    /// assert_eq!(state.selected_value(), Some(7.5));
+    /// assert_eq!(state.value_at_selection(), Some(7.5));
     /// ```
-    pub fn selected_value(&self) -> Option<f64> {
+    pub fn value_at_selection(&self) -> Option<f64> {
         let (r, c) = self.selected()?;
         self.get(r, c)
     }

--- a/src/component/heatmap/tests.rs
+++ b/src/component/heatmap/tests.rs
@@ -227,17 +227,17 @@ fn test_navigation_full_traversal() {
     state.update(HeatmapMessage::SelectDown);
     state.update(HeatmapMessage::SelectRight);
     assert_eq!(state.selected(), Some((1, 1)));
-    assert_eq!(state.selected_value(), Some(5.0));
+    assert_eq!(state.value_at_selection(), Some(5.0));
 
     // Go up
     state.update(HeatmapMessage::SelectUp);
     assert_eq!(state.selected(), Some((0, 1)));
-    assert_eq!(state.selected_value(), Some(2.0));
+    assert_eq!(state.value_at_selection(), Some(2.0));
 
     // Go left
     state.update(HeatmapMessage::SelectLeft);
     assert_eq!(state.selected(), Some((0, 0)));
-    assert_eq!(state.selected_value(), Some(1.0));
+    assert_eq!(state.value_at_selection(), Some(1.0));
 }
 
 // =============================================================================
@@ -245,15 +245,15 @@ fn test_navigation_full_traversal() {
 // =============================================================================
 
 #[test]
-fn test_selected_value() {
+fn test_value_at_selection() {
     let state = HeatmapState::with_data(vec![vec![42.0, 7.5]]);
-    assert_eq!(state.selected_value(), Some(42.0));
+    assert_eq!(state.value_at_selection(), Some(42.0));
 }
 
 #[test]
-fn test_selected_value_empty() {
+fn test_value_at_selection_empty() {
     let state = HeatmapState::default();
-    assert_eq!(state.selected_value(), None);
+    assert_eq!(state.value_at_selection(), None);
 }
 
 // =============================================================================
@@ -497,7 +497,7 @@ fn test_1x1_grid() {
     let mut state = HeatmapState::with_data(vec![vec![42.0]]);
 
     assert_eq!(state.selected(), Some((0, 0)));
-    assert_eq!(state.selected_value(), Some(42.0));
+    assert_eq!(state.value_at_selection(), Some(42.0));
 
     // Navigation should produce None (nowhere to go)
     let output = state.update(HeatmapMessage::SelectUp);

--- a/src/component/select/mod.rs
+++ b/src/component/select/mod.rs
@@ -223,28 +223,7 @@ impl SelectState {
         self.selected_index()
     }
 
-    /// Returns the selected option value.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use envision::prelude::*;
-    ///
-    /// let state = SelectState::with_selection(vec!["Red", "Green", "Blue"], 2);
-    /// assert_eq!(state.selected_value(), Some("Blue"));
-    ///
-    /// let state = SelectState::new(vec!["Red", "Green", "Blue"]);
-    /// assert_eq!(state.selected_value(), None);
-    /// ```
-    pub fn selected_value(&self) -> Option<&str> {
-        self.selected_index
-            .and_then(|idx| self.options.get(idx).map(|s| s.as_str()))
-    }
-
     /// Returns the selected option value as a string reference.
-    ///
-    /// This is an alias for [`selected_value()`](Self::selected_value) that provides a
-    /// consistent accessor name across all selection-based components.
     ///
     /// # Examples
     ///
@@ -255,7 +234,8 @@ impl SelectState {
     /// assert_eq!(state.selected_item(), Some("Red"));
     /// ```
     pub fn selected_item(&self) -> Option<&str> {
-        self.selected_value()
+        self.selected_index
+            .and_then(|idx| self.options.get(idx).map(|s| s.as_str()))
     }
 
     /// Sets the selected option index.
@@ -267,10 +247,10 @@ impl SelectState {
     ///
     /// let mut state = SelectState::new(vec!["A", "B", "C"]);
     /// state.set_selected(Some(2));
-    /// assert_eq!(state.selected_value(), Some("C"));
+    /// assert_eq!(state.selected_item(), Some("C"));
     ///
     /// state.set_selected(None);
-    /// assert_eq!(state.selected_value(), None);
+    /// assert_eq!(state.selected_item(), None);
     /// ```
     pub fn set_selected(&mut self, index: Option<usize>) {
         if let Some(idx) = index {
@@ -523,7 +503,7 @@ impl Component for Select {
                 .with_focus(ctx.focused)
                 .with_disabled(ctx.disabled)
                 .with_expanded(state.is_open);
-            if let Some(val) = state.selected_value() {
+            if let Some(val) = state.selected_item() {
                 ann = ann.with_value(val.to_string());
             }
             reg.register(ctx.area, ann);
@@ -544,7 +524,7 @@ impl Component for Select {
         };
 
         // Display selected value or placeholder
-        let display_text = if let Some(value) = state.selected_value() {
+        let display_text = if let Some(value) = state.selected_item() {
             let arrow = if state.is_open { "▲" } else { "▼" };
             format!("{} {}", value, arrow)
         } else {

--- a/src/component/select/tests.rs
+++ b/src/component/select/tests.rs
@@ -12,7 +12,7 @@ fn test_new() {
 fn test_with_selection() {
     let state = SelectState::with_selection(vec!["A", "B", "C"], 1);
     assert_eq!(state.selected_index(), Some(1));
-    assert_eq!(state.selected_value(), Some("B"));
+    assert_eq!(state.selected_item(), Some("B"));
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn test_set_selected() {
     let mut state = SelectState::new(vec!["A", "B", "C"]);
     state.set_selected(Some(1));
     assert_eq!(state.selected_index(), Some(1));
-    assert_eq!(state.selected_value(), Some("B"));
+    assert_eq!(state.selected_item(), Some("B"));
 }
 
 #[test]
@@ -414,13 +414,6 @@ fn test_instance_methods() {
         &EventContext::new().focused(true),
     );
     assert_eq!(output, Some(SelectOutput::SelectionChanged(1)));
-}
-
-#[test]
-fn test_selected_item() {
-    let state = SelectState::with_selection(vec!["A", "B", "C"], 1);
-    assert_eq!(state.selected_item(), Some("B"));
-    assert_eq!(state.selected_item(), state.selected_value());
 }
 
 #[test]

--- a/src/component/tab_bar/mod.rs
+++ b/src/component/tab_bar/mod.rs
@@ -401,6 +401,9 @@ impl TabBarState {
     ///
     /// `None` clears the selection. `Some(i)` is clamped to the valid range.
     ///
+    /// Renamed from `set_selected()` in v0.17.0 for symmetry with
+    /// `selected_index()`. See MIGRATION.md.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -410,13 +413,13 @@ impl TabBarState {
     ///     Tab::new("a", "A"),
     ///     Tab::new("b", "B"),
     /// ]);
-    /// state.set_selected(Some(1));
+    /// state.set_selected_index(Some(1));
     /// assert_eq!(state.selected_index(), Some(1));
     ///
-    /// state.set_selected(None);
+    /// state.set_selected_index(None);
     /// assert_eq!(state.selected_index(), None);
     /// ```
-    pub fn set_selected(&mut self, index: Option<usize>) {
+    pub fn set_selected_index(&mut self, index: Option<usize>) {
         match index {
             Some(i) if !self.tabs.is_empty() => {
                 self.active = Some(i.min(self.tabs.len() - 1));

--- a/src/component/tab_bar/mod.rs
+++ b/src/component/tab_bar/mod.rs
@@ -23,7 +23,7 @@
 //! let mut state = TabBarState::new(tabs);
 //!
 //! assert_eq!(state.selected_index(), Some(0));
-//! assert_eq!(state.active_tab().map(|t| t.label()), Some("main.rs"));
+//! assert_eq!(state.selected_item().map(|t| t.label()), Some("main.rs"));
 //!
 //! // Navigate to the next tab
 //! let output = TabBar::update(&mut state, TabBarMessage::NextTab);
@@ -298,32 +298,11 @@ impl TabBarState {
         self.active
     }
 
-    /// Returns the selected tab index, or `None` if the tab bar is empty.
+    /// Returns the currently selected tab, or `None` if empty.
     ///
-    /// This is the getter counterpart to [`set_selected`](Self::set_selected).
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::{Tab, TabBarState};
-    ///
-    /// let mut state = TabBarState::new(vec![
-    ///     Tab::new("a", "A"),
-    ///     Tab::new("b", "B"),
-    /// ]);
-    /// assert_eq!(state.selected(), Some(0));
-    ///
-    /// state.set_selected(Some(1));
-    /// assert_eq!(state.selected(), Some(1));
-    ///
-    /// state.set_selected(None);
-    /// assert_eq!(state.selected(), None);
-    /// ```
-    pub fn selected(&self) -> Option<usize> {
-        self.active
-    }
-
-    /// Returns the currently active tab, or `None` if empty.
+    /// Renamed from `active_tab()` in v0.17.0 for consistency with the
+    /// `selected_item()` accessor pattern used by other components (see
+    /// MIGRATION.md `v0.16.x to v0.17.0`).
     ///
     /// # Example
     ///
@@ -331,13 +310,16 @@ impl TabBarState {
     /// use envision::component::{Tab, TabBarState};
     ///
     /// let state = TabBarState::new(vec![Tab::new("a", "Alpha")]);
-    /// assert_eq!(state.active_tab().unwrap().label(), "Alpha");
+    /// assert_eq!(state.selected_item().unwrap().label(), "Alpha");
     /// ```
-    pub fn active_tab(&self) -> Option<&Tab> {
+    pub fn selected_item(&self) -> Option<&Tab> {
         self.tabs.get(self.active?)
     }
 
-    /// Returns a mutable reference to the active tab.
+    /// Returns a mutable reference to the currently selected tab, or `None` if empty.
+    ///
+    /// Renamed from `active_tab_mut()` in v0.17.0 (see MIGRATION.md
+    /// `v0.16.x to v0.17.0`).
     ///
     /// # Example
     ///
@@ -345,12 +327,13 @@ impl TabBarState {
     /// use envision::component::{Tab, TabBarState};
     ///
     /// let mut state = TabBarState::new(vec![Tab::new("a", "Alpha")]);
-    /// state.active_tab_mut().unwrap().set_modified(true);
-    /// assert!(state.active_tab().unwrap().modified());
+    /// if let Some(tab) = state.selected_item_mut() {
+    ///     tab.set_label("Alpha!");
+    /// }
+    /// assert_eq!(state.selected_item().unwrap().label(), "Alpha!");
     /// ```
-    pub fn active_tab_mut(&mut self) -> Option<&mut Tab> {
-        let idx = self.active?;
-        self.tabs.get_mut(idx)
+    pub fn selected_item_mut(&mut self) -> Option<&mut Tab> {
+        self.tabs.get_mut(self.active?)
     }
 
     /// Returns the number of tabs.

--- a/src/component/tab_bar/tests.rs
+++ b/src/component/tab_bar/tests.rs
@@ -139,18 +139,18 @@ fn test_state_set_selected() {
         Tab::new("b", "B"),
         Tab::new("c", "C"),
     ]);
-    state.set_selected(Some(2));
+    state.set_selected_index(Some(2));
     assert_eq!(state.selected_index(), Some(2));
-    state.set_selected(Some(100));
+    state.set_selected_index(Some(100));
     assert_eq!(state.selected_index(), Some(2)); // clamped
-    state.set_selected(None);
+    state.set_selected_index(None);
     assert_eq!(state.selected_index(), None);
 }
 
 #[test]
 fn test_state_set_selected_empty() {
     let mut state = TabBarState::new(vec![]);
-    state.set_selected(Some(0));
+    state.set_selected_index(Some(0));
     assert_eq!(state.selected_index(), None);
 }
 
@@ -166,7 +166,7 @@ fn test_state_mutators() {
 #[test]
 fn test_state_set_tabs() {
     let mut state = TabBarState::new(vec![Tab::new("a", "A"), Tab::new("b", "B")]);
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
     state.set_tabs(vec![Tab::new("x", "X")]);
     assert_eq!(state.len(), 1);
     assert_eq!(state.selected_index(), Some(0)); // clamped
@@ -332,7 +332,7 @@ fn test_close_tab_before_active() {
         Tab::new("b", "B").with_closable(true),
         Tab::new("c", "C").with_closable(true),
     ]);
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
     let output = TabBar::update(&mut state, TabBarMessage::CloseTab(0));
     assert_eq!(output, Some(TabBarOutput::TabClosed(0)));
     assert_eq!(state.len(), 2);
@@ -347,7 +347,7 @@ fn test_close_tab_active() {
         Tab::new("b", "B").with_closable(true),
         Tab::new("c", "C").with_closable(true),
     ]);
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
     let output = TabBar::update(&mut state, TabBarMessage::CloseTab(1));
     assert_eq!(output, Some(TabBarOutput::TabClosed(1)));
     assert_eq!(state.selected_index(), Some(1));
@@ -360,7 +360,7 @@ fn test_close_tab_last_becomes_new_last() {
         Tab::new("a", "A").with_closable(true),
         Tab::new("b", "B").with_closable(true),
     ]);
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
     let output = TabBar::update(&mut state, TabBarMessage::CloseTab(1));
     assert_eq!(output, Some(TabBarOutput::TabClosed(1)));
     assert_eq!(state.selected_index(), Some(0));

--- a/src/component/tab_bar/tests.rs
+++ b/src/component/tab_bar/tests.rs
@@ -84,7 +84,7 @@ fn test_state_new() {
     assert_eq!(state.len(), 2);
     assert!(!state.is_empty());
     assert_eq!(state.selected_index(), Some(0));
-    assert_eq!(state.active_tab().map(|t| t.label()), Some("Alpha"));
+    assert_eq!(state.selected_item().map(|t| t.label()), Some("Alpha"));
 }
 
 #[test]
@@ -92,7 +92,7 @@ fn test_state_new_empty() {
     let state = TabBarState::new(vec![]);
     assert!(state.is_empty());
     assert_eq!(state.selected_index(), None);
-    assert!(state.active_tab().is_none());
+    assert!(state.selected_item().is_none());
 }
 
 #[test]
@@ -111,7 +111,7 @@ fn test_state_with_selected() {
         1,
     );
     assert_eq!(state.selected_index(), Some(1));
-    assert_eq!(state.active_tab().map(|t| t.label()), Some("B"));
+    assert_eq!(state.selected_item().map(|t| t.label()), Some("B"));
 }
 
 #[test]
@@ -195,10 +195,10 @@ fn test_state_find_tab_by_id() {
 }
 
 #[test]
-fn test_state_active_tab_mut() {
+fn test_state_selected_item_mut() {
     let mut state = TabBarState::new(vec![Tab::new("a", "Alpha")]);
-    state.active_tab_mut().unwrap().set_label("Modified");
-    assert_eq!(state.active_tab().map(|t| t.label()), Some("Modified"));
+    state.selected_item_mut().unwrap().set_label("Modified");
+    assert_eq!(state.selected_item().map(|t| t.label()), Some("Modified"));
 }
 
 #[test]
@@ -337,7 +337,7 @@ fn test_close_tab_before_active() {
     assert_eq!(output, Some(TabBarOutput::TabClosed(0)));
     assert_eq!(state.len(), 2);
     assert_eq!(state.selected_index(), Some(0));
-    assert_eq!(state.active_tab().map(|t| t.label()), Some("B"));
+    assert_eq!(state.selected_item().map(|t| t.label()), Some("B"));
 }
 
 #[test]
@@ -351,7 +351,7 @@ fn test_close_tab_active() {
     let output = TabBar::update(&mut state, TabBarMessage::CloseTab(1));
     assert_eq!(output, Some(TabBarOutput::TabClosed(1)));
     assert_eq!(state.selected_index(), Some(1));
-    assert_eq!(state.active_tab().map(|t| t.label()), Some("C"));
+    assert_eq!(state.selected_item().map(|t| t.label()), Some("C"));
 }
 
 #[test]
@@ -387,7 +387,7 @@ fn test_close_active_tab() {
     ]);
     let output = TabBar::update(&mut state, TabBarMessage::CloseActiveTab);
     assert_eq!(output, Some(TabBarOutput::TabClosed(0)));
-    assert_eq!(state.active_tab().map(|t| t.label()), Some("B"));
+    assert_eq!(state.selected_item().map(|t| t.label()), Some("B"));
 }
 
 #[test]
@@ -427,7 +427,7 @@ fn test_add_tab() {
     assert_eq!(output, Some(TabBarOutput::TabAdded(1)));
     assert_eq!(state.len(), 2);
     assert_eq!(state.selected_index(), Some(1));
-    assert_eq!(state.active_tab().map(|t| t.label()), Some("B"));
+    assert_eq!(state.selected_item().map(|t| t.label()), Some("B"));
 }
 
 #[test]
@@ -754,7 +754,7 @@ fn test_full_workflow() {
     TabBar::update(&mut state, TabBarMessage::NextTab);
     TabBar::update(&mut state, TabBarMessage::NextTab);
     assert_eq!(state.selected_index(), Some(2));
-    assert_eq!(state.active_tab().map(|t| t.label()), Some("test.rs"));
+    assert_eq!(state.selected_item().map(|t| t.label()), Some("test.rs"));
 
     TabBar::update(&mut state, TabBarMessage::PrevTab);
     assert_eq!(state.selected_index(), Some(1));
@@ -762,7 +762,7 @@ fn test_full_workflow() {
     let output = TabBar::update(&mut state, TabBarMessage::CloseActiveTab);
     assert_eq!(output, Some(TabBarOutput::TabClosed(1)));
     assert_eq!(state.len(), 2);
-    assert_eq!(state.active_tab().map(|t| t.label()), Some("test.rs"));
+    assert_eq!(state.selected_item().map(|t| t.label()), Some("test.rs"));
 
     TabBar::update(&mut state, TabBarMessage::First);
     assert_eq!(state.selected_index(), Some(0));
@@ -772,7 +772,7 @@ fn test_full_workflow() {
         TabBarMessage::AddTab(Tab::new("f4", "new.rs").with_closable(true)),
     );
     assert_eq!(output, Some(TabBarOutput::TabAdded(2)));
-    assert_eq!(state.active_tab().map(|t| t.label()), Some("new.rs"));
+    assert_eq!(state.selected_item().map(|t| t.label()), Some("new.rs"));
 }
 
 #[test]

--- a/src/component/table/filter_tests.rs
+++ b/src/component/table/filter_tests.rs
@@ -95,7 +95,7 @@ fn test_clear_filter() {
 fn test_filter_preserves_selection() {
     let mut state = TableState::new(test_rows(), test_columns());
     // Select Apricot (display index 3)
-    state.set_selected(Some(3));
+    state.set_selected_index(Some(3));
     assert_eq!(state.selected_item().unwrap().name, "Apricot");
 
     // Filter to "ap" — Apple(0), Apricot(3)
@@ -108,7 +108,7 @@ fn test_filter_preserves_selection() {
 fn test_filter_resets_selection_when_row_hidden() {
     let mut state = TableState::new(test_rows(), test_columns());
     // Select Carrot (display index 2)
-    state.set_selected(Some(2));
+    state.set_selected_index(Some(2));
     assert_eq!(state.selected_item().unwrap().name, "Carrot");
 
     // Filter to "fruit" — Carrot is "Vegetable", gets filtered out

--- a/src/component/table/filter_tests.rs
+++ b/src/component/table/filter_tests.rs
@@ -61,7 +61,7 @@ fn test_filter_matches_any_cell() {
     let mut state = TableState::new(test_rows(), test_columns());
     state.set_filter_text("vegetable");
     assert_eq!(state.visible_count(), 1); // Carrot (category = Vegetable)
-    assert_eq!(state.selected_row().unwrap().name, "Carrot");
+    assert_eq!(state.selected_item().unwrap().name, "Carrot");
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn test_filter_case_insensitive() {
     let mut state = TableState::new(test_rows(), test_columns());
     state.set_filter_text("APPLE");
     assert_eq!(state.visible_count(), 1);
-    assert_eq!(state.selected_row().unwrap().name, "Apple");
+    assert_eq!(state.selected_item().unwrap().name, "Apple");
 }
 
 #[test]
@@ -77,7 +77,7 @@ fn test_filter_no_matches() {
     let mut state = TableState::new(test_rows(), test_columns());
     state.set_filter_text("xyz");
     assert_eq!(state.visible_count(), 0);
-    assert_eq!(state.selected_row(), None);
+    assert_eq!(state.selected_item(), None);
 }
 
 #[test]
@@ -96,12 +96,12 @@ fn test_filter_preserves_selection() {
     let mut state = TableState::new(test_rows(), test_columns());
     // Select Apricot (display index 3)
     state.set_selected(Some(3));
-    assert_eq!(state.selected_row().unwrap().name, "Apricot");
+    assert_eq!(state.selected_item().unwrap().name, "Apricot");
 
     // Filter to "ap" — Apple(0), Apricot(3)
     state.set_filter_text("ap");
     assert_eq!(state.visible_count(), 2);
-    assert_eq!(state.selected_row().unwrap().name, "Apricot");
+    assert_eq!(state.selected_item().unwrap().name, "Apricot");
 }
 
 #[test]
@@ -109,13 +109,13 @@ fn test_filter_resets_selection_when_row_hidden() {
     let mut state = TableState::new(test_rows(), test_columns());
     // Select Carrot (display index 2)
     state.set_selected(Some(2));
-    assert_eq!(state.selected_row().unwrap().name, "Carrot");
+    assert_eq!(state.selected_item().unwrap().name, "Carrot");
 
     // Filter to "fruit" — Carrot is "Vegetable", gets filtered out
     state.set_filter_text("fruit");
     assert_eq!(state.visible_count(), 3); // Apple, Banana, Apricot
     // Selection moves to first visible
-    assert_eq!(state.selected_row().unwrap().name, "Apple");
+    assert_eq!(state.selected_item().unwrap().name, "Apple");
 }
 
 #[test]
@@ -124,10 +124,10 @@ fn test_filter_navigation() {
     state.set_filter_text("ap");
     // Filtered: Apple(0), Apricot(3)
     assert_eq!(state.visible_count(), 2);
-    assert_eq!(state.selected_row().unwrap().name, "Apple");
+    assert_eq!(state.selected_item().unwrap().name, "Apple");
 
     let output = Table::<TestRow>::update(&mut state, TableMessage::Down);
-    assert_eq!(state.selected_row().unwrap().name, "Apricot");
+    assert_eq!(state.selected_item().unwrap().name, "Apricot");
     assert_eq!(output, Some(TableOutput::SelectionChanged(1)));
 
     // At end, stay
@@ -159,10 +159,10 @@ fn test_filter_with_sort() {
     // Filter to "ap" — should show Apple and Apricot, sorted
     state.set_filter_text("ap");
     assert_eq!(state.visible_count(), 2);
-    assert_eq!(state.selected_row().unwrap().name, "Apple");
+    assert_eq!(state.selected_item().unwrap().name, "Apple");
 
     Table::<TestRow>::update(&mut state, TableMessage::Down);
-    assert_eq!(state.selected_row().unwrap().name, "Apricot");
+    assert_eq!(state.selected_item().unwrap().name, "Apricot");
 }
 
 #[test]

--- a/src/component/table/mod.rs
+++ b/src/component/table/mod.rs
@@ -280,7 +280,7 @@ impl<T: TableRow + 'static> Component for Table<T> {
                 }
             }
             TableMessage::Select => {
-                if let Some(row) = state.selected_row().cloned() {
+                if let Some(row) = state.selected_item().cloned() {
                     return Some(TableOutput::Selected(row));
                 }
             }

--- a/src/component/table/multi_sort_tests.rs
+++ b/src/component/table/multi_sort_tests.rs
@@ -178,7 +178,7 @@ fn test_multi_sort_preserves_selection() {
     Table::<TestRow>::update(&mut state, TableMessage::SortAsc(0));
     Table::<TestRow>::update(&mut state, TableMessage::AddSortAsc(1));
 
-    let selected = state.selected_row().unwrap();
+    let selected = state.selected_item().unwrap();
     assert_eq!(selected.name, "Alice");
     assert_eq!(selected.value, "10");
 }

--- a/src/component/table/state.rs
+++ b/src/component/table/state.rs
@@ -247,61 +247,9 @@ impl<T: TableRow> TableState<T> {
         self.selected
     }
 
-    /// Alias for [`selected_index()`](Self::selected_index).
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::{Cell, Column, TableRow, TableState};
-    /// use ratatui::layout::Constraint;
-    ///
-    /// #[derive(Clone)]
-    /// struct Item { name: String }
-    /// impl TableRow for Item {
-    ///     fn cells(&self) -> Vec<Cell> { vec![Cell::new(&self.name)] }
-    /// }
-    ///
-    /// let state = TableState::new(
-    ///     vec![Item { name: "A".into() }],
-    ///     vec![Column::fixed("Name", 10)],
-    /// );
-    /// assert_eq!(state.selected(), Some(0));
-    /// ```
-    pub fn selected(&self) -> Option<usize> {
-        self.selected_index()
-    }
-
-    /// Returns a reference to the currently selected row.
-    ///
-    /// Returns `None` if no row is selected or the table is empty.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use envision::prelude::*;
-    ///
-    /// #[derive(Clone, Debug, PartialEq)]
-    /// struct Item { name: String }
-    /// impl TableRow for Item {
-    ///     fn cells(&self) -> Vec<Cell> { vec![Cell::new(&self.name)] }
-    /// }
-    ///
-    /// let state = TableState::new(
-    ///     vec![Item { name: "first".into() }, Item { name: "second".into() }],
-    ///     vec![Column::fixed("Name", 10)],
-    /// );
-    /// assert_eq!(state.selected_row().unwrap().name, "first");
-    /// ```
-    pub fn selected_row(&self) -> Option<&T> {
-        self.selected
-            .and_then(|i| self.display_order.get(i))
-            .and_then(|&idx| self.rows.get(idx))
-    }
-
     /// Returns a reference to the currently selected item.
     ///
-    /// This is an alias for [`selected_row()`](Self::selected_row) that provides a
-    /// consistent accessor name across all selection-based components.
+    /// Returns `None` if no row is selected or the table is empty.
     ///
     /// # Example
     ///
@@ -321,7 +269,9 @@ impl<T: TableRow> TableState<T> {
     /// assert_eq!(state.selected_item().unwrap().name, "First");
     /// ```
     pub fn selected_item(&self) -> Option<&T> {
-        self.selected_row()
+        self.selected
+            .and_then(|i| self.display_order.get(i))
+            .and_then(|&idx| self.rows.get(idx))
     }
 
     /// Returns the primary (highest-priority) sort column and direction.

--- a/src/component/table/state.rs
+++ b/src/component/table/state.rs
@@ -419,6 +419,9 @@ impl<T: TableRow> TableState<T> {
     /// Pass `None` to clear the selection.
     /// Out of bounds indices are ignored.
     ///
+    /// Renamed from `set_selected()` in v0.17.0 for symmetry with
+    /// `selected_index()`. See MIGRATION.md.
+    ///
     /// # Examples
     ///
     /// ```
@@ -434,10 +437,10 @@ impl<T: TableRow> TableState<T> {
     ///     vec![Item { name: "A".into() }, Item { name: "B".into() }],
     ///     vec![Column::fixed("Name", 10)],
     /// );
-    /// state.set_selected(Some(1));
+    /// state.set_selected_index(Some(1));
     /// assert_eq!(state.selected_index(), Some(1));
     /// ```
-    pub fn set_selected(&mut self, index: Option<usize>) {
+    pub fn set_selected_index(&mut self, index: Option<usize>) {
         match index {
             Some(i) if i < self.display_order.len() => self.selected = Some(i),
             Some(_) => {} // Out of bounds, ignore

--- a/src/component/table/tests.rs
+++ b/src/component/table/tests.rs
@@ -164,9 +164,9 @@ fn test_selected_index() {
 }
 
 #[test]
-fn test_selected_row() {
+fn test_selected_item() {
     let state = TableState::with_selected(test_rows(), test_columns(), 1);
-    let row = state.selected_row().unwrap();
+    let row = state.selected_item().unwrap();
     assert_eq!(row.name, "Alice");
 }
 
@@ -407,7 +407,7 @@ fn test_sort_preserves_selection() {
     Table::<TestRow>::update(&mut state, TableMessage::SortAsc(0)); // Sort ascending
 
     // After sort, Alice should still be selected but at a different display index
-    let selected = state.selected_row().unwrap();
+    let selected = state.selected_item().unwrap();
     assert_eq!(selected.name, "Alice");
 }
 
@@ -494,7 +494,7 @@ fn test_full_workflow() {
 
     // Navigate after sort
     Table::<TestRow>::update(&mut state, TableMessage::First);
-    assert_eq!(state.selected_row().unwrap().name, "Alice");
+    assert_eq!(state.selected_item().unwrap().name, "Alice");
 
     // Select
     let output = Table::<TestRow>::update(&mut state, TableMessage::Select);
@@ -515,18 +515,18 @@ fn test_navigation_with_sort() {
 
     // Now display order is: Alice, Bob, Charlie
     // But selection is preserved on the same ROW (Charlie), now at position 2
-    assert_eq!(state.selected_row().unwrap().name, "Charlie");
+    assert_eq!(state.selected_item().unwrap().name, "Charlie");
     assert_eq!(state.selected_index(), Some(2));
 
     // Navigate to first to get to Alice
     Table::<TestRow>::update(&mut state, TableMessage::First);
-    assert_eq!(state.selected_row().unwrap().name, "Alice");
+    assert_eq!(state.selected_item().unwrap().name, "Alice");
 
     Table::<TestRow>::update(&mut state, TableMessage::Down);
-    assert_eq!(state.selected_row().unwrap().name, "Bob");
+    assert_eq!(state.selected_item().unwrap().name, "Bob");
 
     Table::<TestRow>::update(&mut state, TableMessage::Down);
-    assert_eq!(state.selected_row().unwrap().name, "Charlie");
+    assert_eq!(state.selected_item().unwrap().name, "Charlie");
 }
 
 #[test]
@@ -599,7 +599,7 @@ fn test_clear_sort_preserves_selection() {
     Table::<TestRow>::update(&mut state, TableMessage::SortClear);
 
     // Selection should still point to Alice (back at index 1)
-    let selected = state.selected_row().unwrap();
+    let selected = state.selected_item().unwrap();
     assert_eq!(selected.name, "Alice");
 }
 
@@ -830,12 +830,6 @@ mod handle_event_tests {
         );
         assert_eq!(msg, Some(TableMessage::Up));
     }
-}
-#[test]
-fn test_selected_item() {
-    let state = TableState::with_selected(test_rows(), test_columns(), 1);
-    assert_eq!(state.selected_item().unwrap().name, "Alice");
-    assert_eq!(state.selected_item(), state.selected_row());
 }
 
 // Column convenience constructor tests

--- a/src/component/table/tests.rs
+++ b/src/component/table/tests.rs
@@ -222,10 +222,10 @@ fn test_set_rows_clamps_selection() {
 #[test]
 fn test_set_selected() {
     let mut state = TableState::new(test_rows(), test_columns());
-    state.set_selected(Some(2));
+    state.set_selected_index(Some(2));
     assert_eq!(state.selected_index(), Some(2));
 
-    state.set_selected(None);
+    state.set_selected_index(None);
     assert_eq!(state.selected_index(), None);
 }
 
@@ -569,7 +569,7 @@ fn test_set_rows_to_empty() {
 #[test]
 fn test_set_rows_with_no_prior_selection() {
     let mut state = TableState::new(test_rows(), test_columns());
-    state.set_selected(None);
+    state.set_selected_index(None);
     assert_eq!(state.selected_index(), None);
 
     state.set_rows(vec![TestRow::new("New", "1")]);
@@ -581,7 +581,7 @@ fn test_set_rows_with_no_prior_selection() {
 fn test_set_selected_out_of_bounds() {
     let mut state = TableState::new(test_rows(), test_columns());
     // Try to set selection out of bounds
-    state.set_selected(Some(100));
+    state.set_selected_index(Some(100));
     // Should be ignored, selection unchanged
     assert_eq!(state.selected_index(), Some(0));
 }

--- a/src/component/table/view_tests.rs
+++ b/src/component/table/view_tests.rs
@@ -296,7 +296,7 @@ fn styled_columns() -> Vec<Column> {
 /// output (for color-level assertions). Centralizes the per-style
 /// boilerplate.
 ///
-/// Selection is explicitly cleared via `set_selected(None)` because
+/// Selection is explicitly cleared via `set_selected_index(None)` because
 /// ratatui's row-highlight style overrides per-cell fg colors on the
 /// selected row — leaving the default `Some(0)` selection in place would
 /// mask the very styling these tests are meant to pin.
@@ -306,7 +306,7 @@ fn styled_columns() -> Vec<Column> {
 /// only place where the per-cell style is observable in test output.
 fn render_styled_single_row(cells: Vec<crate::component::cell::Cell>) -> (String, String) {
     let mut state = TableState::new(vec![StyledRow { cells }], styled_columns());
-    state.set_selected(None);
+    state.set_selected_index(None);
 
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
 
@@ -429,7 +429,7 @@ fn snapshot_table_cells_mixed_styles_in_one_row() {
     let mut state = TableState::new(vec![row], columns);
     // See `render_styled_single_row` — clearing selection prevents the
     // row-highlight style from overriding per-cell fg colors.
-    state.set_selected(None);
+    state.set_selected_index(None);
 
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
 
@@ -583,7 +583,7 @@ fn snapshot_table_cells_with_severity_style() {
         Cell::severity("crit", Severity::Critical),
     ];
     let mut state = TableState::new(vec![StyledRow { cells }], columns);
-    state.set_selected(None);
+    state.set_selected_index(None);
 
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal
@@ -640,7 +640,7 @@ fn snapshot_table_cells_severity_disabled_renders_dark_gray_no_bold() {
         Cell::new("crit").with_style(CellStyle::Severity(Severity::Critical)),
     ];
     let mut state = TableState::new(vec![StyledRow { cells }], columns);
-    state.set_selected(None);
+    state.set_selected_index(None);
 
     let (mut terminal, theme) = crate::component::test_utils::setup_render(40, 10);
     terminal

--- a/src/harness/app_harness/mod.rs
+++ b/src/harness/app_harness/mod.rs
@@ -260,9 +260,17 @@ impl<A: App> AppHarness<A> {
         }
     }
 
-    /// Returns a sender that can be used to send messages to the runtime.
-    pub fn message_sender(&self) -> tokio::sync::mpsc::Sender<A::Message> {
-        self.runtime.message_sender()
+    /// Returns a [`MessageSender<A::Message>`](crate::harness::MessageSender) for
+    /// injecting messages into this AppHarness's Runtime from subscription
+    /// callbacks, spawned tasks, or any other non-App-loop code path.
+    ///
+    /// Returns the envision-native newtype rather than the raw
+    /// `tokio::sync::mpsc::Sender<A::Message>` so consumers don't need `tokio`
+    /// as a direct dependency. Use
+    /// [`MessageSender::into_inner`](crate::harness::MessageSender::into_inner)
+    /// as an explicit escape hatch if you need tokio-specific functionality.
+    pub fn message_sender(&self) -> crate::harness::MessageSender<A::Message> {
+        crate::harness::MessageSender::new(self.runtime.message_sender())
     }
 
     // -------------------------------------------------------------------------

--- a/src/harness/message_sender.rs
+++ b/src/harness/message_sender.rs
@@ -1,0 +1,319 @@
+//! `MessageSender<M>` — first-party wrapper around the async message channel
+//! that carries messages into an [`AppHarness`](crate::harness::AppHarness).
+//!
+//! Hides the underlying `tokio::sync::mpsc::Sender<M>` so envision consumers
+//! don't need `tokio` as a direct dependency to use the message-injection
+//! surface. Full tokio Sender semantics are preserved through passthrough
+//! methods (`send`, `try_send`, `is_closed`, `capacity`, `max_capacity`)
+//! plus an explicit [`into_inner`](MessageSender::into_inner) escape hatch
+//! for the small number of consumers who need tokio-specific functionality
+//! (`reserve`, `send_timeout`, `same_channel`, `downgrade`, `closed()` future).
+
+use tokio::sync::mpsc;
+
+/// Hands the caller a way to inject messages into the AppHarness's Runtime
+/// asynchronously — from subscription callbacks, spawned tasks, or any other
+/// non-App-loop code path.
+///
+/// Wraps `tokio::sync::mpsc::Sender<M>` so envision consumers don't need
+/// `tokio` as a direct dependency to use `AppHarness::message_sender()`.
+/// The Sender's semantics are preserved (bounded, cloneable, `send` returns
+/// `Result` on receiver-dropped) and its non-mutating query surface
+/// (`is_closed`, `capacity`, `max_capacity`) is passed through. Consumers
+/// needing tokio-specific functionality beyond what's exposed can call
+/// [`into_inner`](Self::into_inner) as an explicit escape hatch.
+///
+/// # Type parameter
+///
+/// `MessageSender<M>` is parameterized on the message type `M`, not on an
+/// App-typed generic. This means portable helper functions like
+/// `fn spawn_watcher<M: Send + 'static>(sender: MessageSender<M>) { ... }`
+/// work without depending on envision's `App` trait.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use envision::prelude::*;
+///
+/// async fn ingest<M: Send + std::fmt::Debug + 'static>(sender: MessageSender<M>, msg: M) {
+///     sender.send(msg).await.expect("harness still alive");
+/// }
+/// ```
+pub struct MessageSender<M> {
+    inner: mpsc::Sender<M>,
+}
+
+impl<M> MessageSender<M> {
+    /// Wraps the given tokio Sender. Internal constructor — external
+    /// consumers acquire a `MessageSender<M>` via
+    /// [`AppHarness::message_sender()`](crate::harness::AppHarness::message_sender).
+    pub(crate) fn new(inner: mpsc::Sender<M>) -> Self {
+        Self { inner }
+    }
+
+    /// Sends a message into the AppHarness. Returns an error only when the
+    /// AppHarness (and hence the receiver) has been dropped.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use envision::prelude::*;
+    ///
+    /// async fn example<M: Send + std::fmt::Debug + 'static>(sender: MessageSender<M>, msg: M) {
+    ///     sender.send(msg).await.expect("harness still alive");
+    /// }
+    /// ```
+    pub async fn send(&self, msg: M) -> Result<(), MessageSendError<M>> {
+        self.inner
+            .send(msg)
+            .await
+            .map_err(|e| MessageSendError(e.0))
+    }
+
+    /// Attempts to send a message without waiting. Returns an error if the
+    /// channel is full or the AppHarness has been dropped. The message is
+    /// returned inside the error variant when send fails, so the caller can
+    /// retry or handle it.
+    pub fn try_send(&self, msg: M) -> Result<(), TrySendError<M>> {
+        self.inner.try_send(msg).map_err(TrySendError::from_tokio)
+    }
+
+    /// Returns `true` if the receiver end of the channel has been dropped.
+    ///
+    /// Useful for `spawn_watcher`-style loops that want to exit before
+    /// wasting work on messages that would fail to send.
+    pub fn is_closed(&self) -> bool {
+        self.inner.is_closed()
+    }
+
+    /// Returns the current available capacity of the channel — the number
+    /// of messages that can be enqueued without blocking or hitting a
+    /// `TrySendError::Full`.
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity()
+    }
+
+    /// Returns the maximum capacity of the channel (the bound configured
+    /// at AppHarness construction).
+    pub fn max_capacity(&self) -> usize {
+        self.inner.max_capacity()
+    }
+
+    /// Explicit escape hatch: consumes the wrapper and returns the underlying
+    /// `tokio::sync::mpsc::Sender<M>` for consumers who need tokio-specific
+    /// functionality (`reserve`, `send_timeout`, `same_channel`, `downgrade`,
+    /// or a `closed()` Future) that this wrapper deliberately doesn't expose
+    /// to keep the default surface minimal.
+    ///
+    /// Using this method re-couples your code to the tokio dep; it's an
+    /// escape hatch by design, not a routine call.
+    pub fn into_inner(self) -> mpsc::Sender<M> {
+        self.inner
+    }
+}
+
+impl<M> Clone for MessageSender<M> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<M> std::fmt::Debug for MessageSender<M> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MessageSender").finish_non_exhaustive()
+    }
+}
+
+/// Error returned by [`MessageSender::send`] when the AppHarness receiver
+/// has been dropped. Carries the message back so the caller can inspect it.
+#[derive(Debug)]
+pub struct MessageSendError<T>(pub T);
+
+impl<T> std::fmt::Display for MessageSendError<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "message sender: receiver dropped")
+    }
+}
+
+impl<T: std::fmt::Debug> std::error::Error for MessageSendError<T> {}
+
+/// Error returned by [`MessageSender::try_send`].
+///
+/// Preserves tokio's `Full` / `Closed` distinction so consumers can
+/// retry-on-full or exit-on-closed with a match arm.
+#[derive(Debug)]
+pub enum TrySendError<T> {
+    /// Channel is full; the message was NOT sent. Caller may retry later
+    /// once the AppHarness has drained.
+    Full(T),
+    /// AppHarness receiver has been dropped; the message was NOT sent and
+    /// will never succeed on retry.
+    Closed(T),
+}
+
+impl<T> TrySendError<T> {
+    /// Extracts the message from either variant.
+    pub fn into_inner(self) -> T {
+        match self {
+            Self::Full(t) | Self::Closed(t) => t,
+        }
+    }
+
+    /// Internal converter from tokio's `TrySendError<T>` — decouples the
+    /// call sites from tokio's error path.
+    fn from_tokio(err: mpsc::error::TrySendError<T>) -> Self {
+        match err {
+            mpsc::error::TrySendError::Full(t) => TrySendError::Full(t),
+            mpsc::error::TrySendError::Closed(t) => TrySendError::Closed(t),
+        }
+    }
+}
+
+impl<T> std::fmt::Display for TrySendError<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Full(_) => write!(f, "message sender: channel full"),
+            Self::Closed(_) => write!(f, "message sender: receiver dropped"),
+        }
+    }
+}
+
+impl<T: std::fmt::Debug> std::error::Error for TrySendError<T> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Compile-time gate that MessageSender<M> is Send + Sync + Clone when
+    // M is Send. Uses an inline shim rather than the `static_assertions`
+    // crate (not in dev-dependencies).
+    fn _assert_send_sync_clone<T: Send + Sync + Clone>() {}
+
+    fn _compile_assertions() {
+        _assert_send_sync_clone::<MessageSender<u32>>();
+        _assert_send_sync_clone::<MessageSender<String>>();
+    }
+
+    #[tokio::test]
+    async fn test_send_round_trip() {
+        let (tx, mut rx) = mpsc::channel::<u32>(16);
+        let sender = MessageSender::new(tx);
+
+        sender.send(42).await.expect("send succeeds");
+
+        let received = rx.recv().await;
+        assert_eq!(received, Some(42));
+    }
+
+    #[tokio::test]
+    async fn test_try_send_full() {
+        // Channel with capacity 1; fill it, then try_send should return Full.
+        let (tx, _rx) = mpsc::channel::<u32>(1);
+        let sender = MessageSender::new(tx);
+
+        // Fill the buffer without draining.
+        sender.try_send(1).expect("first try_send succeeds");
+        // Second try_send should return Full (buffer full).
+        let err = sender.try_send(2).expect_err("second try_send is Full");
+        assert!(matches!(err, TrySendError::Full(2)));
+    }
+
+    #[tokio::test]
+    async fn test_send_closed() {
+        let (tx, rx) = mpsc::channel::<u32>(16);
+        let sender = MessageSender::new(tx);
+
+        drop(rx);
+
+        let err = sender.send(99).await.expect_err("send fails");
+        assert_eq!(err.0, 99);
+    }
+
+    #[tokio::test]
+    async fn test_try_send_closed() {
+        let (tx, rx) = mpsc::channel::<u32>(16);
+        let sender = MessageSender::new(tx);
+
+        drop(rx);
+
+        let err = sender.try_send(99).expect_err("try_send fails");
+        assert!(matches!(err, TrySendError::Closed(99)));
+    }
+
+    #[tokio::test]
+    async fn test_is_closed() {
+        let (tx, rx) = mpsc::channel::<u32>(16);
+        let sender = MessageSender::new(tx);
+
+        assert!(!sender.is_closed());
+        drop(rx);
+        assert!(sender.is_closed());
+    }
+
+    #[tokio::test]
+    async fn test_capacity_and_max_capacity() {
+        let (tx, _rx) = mpsc::channel::<u32>(4);
+        let sender = MessageSender::new(tx);
+
+        assert_eq!(sender.max_capacity(), 4);
+        assert_eq!(sender.capacity(), 4);
+
+        // After filling one slot, capacity decreases.
+        sender.try_send(1).expect("first try_send");
+        assert_eq!(sender.capacity(), 3);
+        assert_eq!(sender.max_capacity(), 4); // unchanged
+    }
+
+    #[tokio::test]
+    async fn test_clone_shares_channel() {
+        let (tx, mut rx) = mpsc::channel::<u32>(16);
+        let sender = MessageSender::new(tx);
+        let cloned = sender.clone();
+
+        sender.send(1).await.expect("original send");
+        cloned.send(2).await.expect("cloned send");
+
+        assert_eq!(rx.recv().await, Some(1));
+        assert_eq!(rx.recv().await, Some(2));
+    }
+
+    #[tokio::test]
+    async fn test_into_inner_escape_hatch() {
+        let (tx, mut rx) = mpsc::channel::<u32>(16);
+        let sender = MessageSender::new(tx);
+
+        let inner: mpsc::Sender<u32> = sender.into_inner();
+        inner.send(42).await.expect("inner tokio send succeeds");
+
+        assert_eq!(rx.recv().await, Some(42));
+    }
+
+    #[test]
+    fn test_try_send_error_into_inner() {
+        let err = TrySendError::Full(42u32);
+        assert_eq!(err.into_inner(), 42);
+
+        let err = TrySendError::Closed(99u32);
+        assert_eq!(err.into_inner(), 99);
+    }
+
+    #[test]
+    fn test_message_send_error_message_recovered() {
+        let err = MessageSendError(42u32);
+        assert_eq!(err.0, 42);
+    }
+
+    #[test]
+    fn test_display_impls() {
+        let msg_err: MessageSendError<u32> = MessageSendError(42);
+        assert_eq!(msg_err.to_string(), "message sender: receiver dropped");
+
+        let full: TrySendError<u32> = TrySendError::Full(1);
+        assert_eq!(full.to_string(), "message sender: channel full");
+
+        let closed: TrySendError<u32> = TrySendError::Closed(2);
+        assert_eq!(closed.to_string(), "message sender: receiver dropped");
+    }
+}

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -55,11 +55,13 @@
 
 mod app_harness;
 mod assertions;
+mod message_sender;
 mod snapshot;
 mod test_harness;
 
 pub use app_harness::AppHarness;
 pub use assertions::{Assertion, AssertionError, AssertionResult};
+pub use message_sender::{MessageSendError, MessageSender, TrySendError};
 pub use snapshot::{
     Snapshot, SnapshotFormat, SnapshotTest, assert_snapshot_eq, assert_snapshot_text,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,7 +405,9 @@ pub use component::{
 pub use component::{MarkdownRenderer, MarkdownRendererMessage, MarkdownRendererState};
 
 pub use error::{BoxedError, EnvisionError, Result};
-pub use harness::{AppHarness, Assertion, Snapshot, TestHarness};
+pub use harness::{
+    AppHarness, Assertion, MessageSendError, MessageSender, Snapshot, TestHarness, TrySendError,
+};
 pub use input::{
     Event, EventQueue, Key, KeyEvent, KeyEventKind, Modifiers, MouseButton, MouseEvent,
     MouseEventKind,
@@ -473,7 +475,7 @@ pub mod prelude {
 
     // Testing essentials
     pub use crate::backend::{CaptureBackend, EnhancedCell};
-    pub use crate::harness::{AppHarness, TestHarness};
+    pub use crate::harness::{AppHarness, MessageSender, TestHarness};
 
     // Layout and style re-exports (replacing `pub use ratatui::prelude::*`)
     pub use crate::layout::{

--- a/tests/integration_new_components_2.rs
+++ b/tests/integration_new_components_2.rs
@@ -449,19 +449,19 @@ fn test_tab_bar_add_close_navigate() {
 
     assert_eq!(state.len(), 3);
     assert_eq!(state.selected_index(), Some(0));
-    assert_eq!(state.active_tab().map(|t| t.label()), Some("main.rs"));
+    assert_eq!(state.selected_item().map(|t| t.label()), Some("main.rs"));
 
     // Navigate to next tab
     let output = TabBar::update(&mut state, TabBarMessage::NextTab);
     assert_eq!(output, Some(TabBarOutput::TabSelected(1)));
     assert_eq!(state.selected_index(), Some(1));
-    assert_eq!(state.active_tab().map(|t| t.label()), Some("lib.rs"));
-    assert!(state.active_tab().map(|t| t.modified()).unwrap_or(false));
+    assert_eq!(state.selected_item().map(|t| t.label()), Some("lib.rs"));
+    assert!(state.selected_item().map(|t| t.modified()).unwrap_or(false));
 
     // Navigate to last tab
     TabBar::update(&mut state, TabBarMessage::NextTab);
     assert_eq!(state.selected_index(), Some(2));
-    assert_eq!(state.active_tab().map(|t| t.label()), Some("test.rs"));
+    assert_eq!(state.selected_item().map(|t| t.label()), Some("test.rs"));
 
     // NextTab at last position does not wrap - stays at last
     let output = TabBar::update(&mut state, TabBarMessage::NextTab);

--- a/tests/integration_stress.rs
+++ b/tests/integration_stress.rs
@@ -90,12 +90,12 @@ fn test_table_stress_10000_rows() {
     // Jump to last
     Table::<StressRow>::update(&mut state, TableMessage::Last);
     assert_eq!(state.selected_index(), Some(9999));
-    assert_eq!(state.selected_row().unwrap().name, "Item 9999");
+    assert_eq!(state.selected_item().unwrap().name, "Item 9999");
 
     // Jump to first
     Table::<StressRow>::update(&mut state, TableMessage::First);
     assert_eq!(state.selected_index(), Some(0));
-    assert_eq!(state.selected_row().unwrap().name, "Item 0");
+    assert_eq!(state.selected_item().unwrap().name, "Item 0");
 
     // Sort by column 0 (ascending)
     let output = Table::<StressRow>::update(&mut state, TableMessage::SortAsc(0));


### PR DESCRIPTION
## Summary

Closes two of the top trust-eroding findings from the 2026-07-05 audit before cutting v0.17.0. 13 breaking renames total (10 accessor + 3 mutator symmetry) + 1 newtype introduction + 1 cosmetic path change.

- **Unit 1 — Consistency sweep** (`00dab7c`): 10 breaking renames across 6 components (dropdown, select, heatmap, tab_bar, data_grid, table). Delete literal aliases; rename `heatmap::selected_value → value_at_selection` (S2); rename `tab_bar::active_tab*() → selected_item*()`. Rename private `data_grid::selected_row` field → `selected_row_index` to break grep collision. Migrate internal component-body callers. Delete tautology alias-equivalence tests (A2).
- **Unit 2 — `MessageSender<M>` newtype** (`e10f572`): new `src/harness/message_sender.rs` (~250 lines including tests). `MessageSender<M: Send + 'static>` (S1 — NOT `<A: App>`). Full passthrough API (`send`, `try_send`, `is_closed`, `capacity`, `max_capacity`) + `into_inner()` explicit escape hatch (M4). First-party `MessageSendError<T>` + `TrySendError<T>::{Full, Closed}` error types. Inline `Send + Sync + Clone` compile-time gate (A4 — `static_assertions` NOT added). `AppHarness::message_sender()` returns `MessageSender<A::Message>`. `virtual_terminal.rs:147` swaps `ratatui::layout::Position` for `crate::layout::Position` (zero runtime change).
- **Unit 3 — CHANGELOG + MIGRATION.md** (`3b9c150`): Breaking Changes + Added sub-sub-sections; Known Deferred Findings trimmed (findings #6 + #8 REMOVED — closed by this cadence); Cadence D commitment added for ~15 other components with `selected()` alias. Two migration tables under v0.16→v0.17.
- **Task 4 fix — set_selected → set_selected_index** (`f7d4e9d`): Task 4 verification detected an accessor-symmetry regression on tab_bar/data_grid/table (their `set_selected` mutators lost their matching `selected()` getter when the alias was deleted in Task 1). Renamed on all three components (33 call sites) to align with the remaining `selected_index()` getter. Restores audit scorecard 9/9.

## Principled deviations from plan (all reviewer-verified)

- **Task 1**: brief undercounted call sites (had to also migrate `table/filter_tests.rs`, `table/multi_sort_tests.rs`, 5 examples, 2 integration tests). Brief said "verify at impl time" for the broader tree — implementer did that. Also fixed E0283 doctest bug in brief's own `selected_item_mut()` example (`.into()` ambiguity resolved by dropping redundant call).
- **Task 2**: added `+ std::fmt::Debug` bound to TWO doc-example function signatures only (`MessageSendError<T>`'s derived `Debug` implicitly requires `T: Debug` for `.expect()` to compile). Real API's `impl<M> MessageSender<M>` block unchanged — still `M: Send + 'static` only. S1 correction intact.
- **Task 4 fix**: user-approved via clarifying question. Plan's "keep set_selected unchanged" text conflicted with "audit scorecard 9/9 preserved" constraint; user chose the symmetry-restoring rename across all three components.

## Spec / plan

- Spec: `docs/superpowers/specs/2026-07-05-consistency-cleanup-cadence-design.md` (PR #506, `cfb7cec`)
- Plan: `docs/superpowers/plans/2026-07-05-consistency-cleanup-cadence.md` (PR #507, `70c44bf`)

## Design decisions from brainstorm + adversarial review

- Bundle findings #6 + #8 as ONE cadence — both breaking, both fit the same MIGRATION.md section.
- Canonical `selected_item()` across all 6 in-scope components. Table added per M3 (byte-identical divergence to data_grid).
- Heatmap: `value_at_selection()` (S2 — `value_` prefix sorts distinctly from `selected_*`).
- `MessageSender<M: Send + 'static>` NOT `<A: App>` (S1 — no envision trait bound propagation).
- Full passthrough API + escape hatch (M4).
- Delete outright, no `#[deprecated]` — matches D5/D14/G7/D12/D3/D8/resource_gauge/FileSortDirection precedent.
- Grep gates use callsite forms (M1+M2).
- Tautology alias-equivalence tests DELETED not renamed (A2).

## Test plan

- [x] Unit 1: 13 breaking renames (10 accessor + 3 mutator) verified via callsite-form grep gates (zero hits in `src/` `tests/` `examples/`)
- [x] Unit 1: tautology alias-equivalence tests deleted (~4-6 fewer tests, no coverage loss)
- [x] Unit 2: `MessageSender<M>` compile-time `Send + Sync + Clone` gate via inline shim
- [x] Unit 2: 12 unit tests for `MessageSender` (all pass)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-features -- -D warnings` — clean
- [x] `cargo nextest run --all-features` — 7466 pass
- [x] `cargo test --all-features --doc` — 2591 pass
- [x] `cargo build --no-default-features` — clean
- [x] `cargo test --no-default-features --no-run` — clean (D8 lesson)
- [x] `cargo build --examples --all-features` — clean
- [x] `cargo doc --no-deps --all-features` — zero intra-doc-link warnings
- [x] `./tools/audit/target/release/envision-audit all` — **9/9 scorecard restored** (was 8/9 mid-cadence after Task 1's alias deletions; Task 4 fix restored)

## Next steps after this PR merges

- Tracking-doc PR marking audit findings #6 + #8 CLOSED. Verification record at `docs/audits/2026-07-05-post-consistency-cleanup.md`.
- Cadence B (doc-hygiene split of CHANGELOG.md + MIGRATION.md over 1000 lines) — separate brainstorm.
- Cadence D (finish `selected()` alias removal across ~15 remaining components) — deferred to v0.18+.
- `/release minor` → v0.17.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)