### PR TITLE
Plan: Cadence D — selection-accessor completion (v0.18.0)

### DIFF
--- a/docs/superpowers/plans/2026-07-26-cadence-d-selection-accessor-completion.md
+++ b/docs/superpowers/plans/2026-07-26-cadence-d-selection-accessor-completion.md
@@ -1,0 +1,830 @@
+# Cadence D — selection-accessor completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish the selection-accessor unification Cadence A began — after this cadence, `grep -rn 'pub fn selected(&self)' src/component/` returns exactly one hit (`heatmap`, whose accessor returns coordinates and is a different concept).
+
+**Architecture:** Three units, each a signed commit. Unit 1 deletes 12 literal `selected()` aliases and renames 10 setters. Unit 2 renames 4 primary accessors (`alert_panel`, `diagram`, `multi_progress`, `box_plot`) and 2 more setters. Unit 3 adds four missing harness types to the prelude and writes CHANGELOG + MIGRATION. Setter renames land in the *same commit* as their getter change — this is a design constraint, not a convenience, because deleting a getter orphans its setter and drops the audit scorecard.
+
+**Tech Stack:** Rust (edition 2024, MSRV 1.85), ratatui 0.29, cargo-nextest, insta snapshots.
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+- Signed commits required. If `git commit -S` fails, STOP and ask the user — never bypass with `--no-gpg-sign`.
+- Files must stay under 1000 lines.
+- `cargo clippy --all-features -- -D warnings` must be clean.
+- `cargo doc --no-deps --all-features` must produce zero intra-doc-link warnings.
+- `cargo build --no-default-features` AND `cargo test --no-default-features --no-run` must both pass (D8 lesson).
+- **Audit scorecard 9/9 AND doctest coverage at 100%** — verified at the end of **each unit**, not deferred to a final task. Two independent regression vectors exist; see the doctest hazard below.
+- **`heatmap` is OUT OF SCOPE and must not be touched.** Its 29 `src/component/` call sites and 6 `tests/` call sites must survive unchanged.
+- **`box_plot` return types stay bare `usize`** — do NOT convert to `Option<usize>`. Naming only.
+- Docstring notes use plain backticks, matching the shipped Cadence A form at `table/state.rs:422-423`. Do **not** introduce intra-doc links.
+- Tautology alias-equivalence tests are **deleted**, not renamed.
+
+### The doctest-coverage hazard (read before editing any docstring)
+
+The scorecard gates doctest coverage at **100% (1777/1777)** — a hard equality, not a threshold — and counts a `pub fn` as covered only when a ` ``` ` fence appears in the `///` block **immediately above** it (`tools/audit/src/scorecard.rs`, `has_doc_test_above`).
+
+When adding a "Renamed from…" note to a renamed method, **place it adjacent to existing prose, never between the prose and the closing fence.** Splitting the doc block drops coverage below 100% and fails the scorecard for a reason unrelated to symmetry.
+
+Correct:
+
+```rust
+/// Returns the selected index.
+///
+/// Renamed from `set_selected()` in v0.18.0 for symmetry with
+/// `selected_index()`. See MIGRATION.md.
+///
+/// # Example
+/// ```rust
+/// # …
+/// ```
+pub fn set_selected_index(&mut self, index: Option<usize>) {
+```
+
+Wrong — note inserted after the fence, orphaning it:
+
+```rust
+/// # Example
+/// ```rust
+/// # …
+/// ```
+///
+/// Renamed from `set_selected()` in v0.18.0.
+pub fn set_selected_index(&mut self, index: Option<usize>) {
+```
+
+---
+
+## Pre-execution gotchas (read once before Task 1)
+
+- **Two components keep their accessors in `state.rs`, not `mod.rs`:** `diagram/state.rs` and `box_plot/state.rs`. Both are behind a private `mod state;` (`diagram/mod.rs:61`, `box_plot/mod.rs:31`), which means the audit tool **cannot see them at all** (`scorecard.rs:275-295` reads `mod.rs` plus only files named by `pub mod X;` / `pub use X::`). The scorecard will not catch mistakes in those two files. The compiler will.
+- **`file_browser/helper_tests.rs` is a non-standard test filename.** A search scoped to `tests.rs` misses it. It holds one of the two tautology tests.
+- **`loading_list` has 30 `.set_selected(` call sites** — by far the largest single-component migration. `multi_progress` has 14, `menu` 9, `box_plot` 8.
+- **`alert_panel` (20) and `box_plot` (17) have the most `.selected()` call sites**, despite being one-line signature changes.
+- All Category A and B setters share the signature `(&mut self, index: Option<usize>)`. **`box_plot`'s is `(&mut self, index: usize)`** — different, and it stays that way.
+- These are breaking renames, so the compiler finds every missed site. Grep gates are a backstop, not the primary mechanism.
+
+## File structure
+
+Files modified in Unit 1 (12 components):
+`accordion`, `dropdown`, `file_browser`, `loading_list`, `menu`, `metrics_dashboard`, `radio_group`, `searchable_list`, `select`, `selectable_list`, `tabs`, `tree` — each `mod.rs` plus its test files.
+
+Files modified in Unit 2 (4 components):
+`alert_panel/mod.rs`, `diagram/state.rs`, `multi_progress/mod.rs`, `box_plot/state.rs` — plus their test files and `tests/integration_stress.rs` (5 `DiagramState` call sites).
+
+Files modified in Unit 3:
+`src/lib.rs`, `CHANGELOG.md`, `MIGRATION.md`.
+
+---
+
+## Task 1: Unit 1 — Category A (12 alias deletions + 10 setter renames)
+
+**Files:**
+- Modify: `src/component/{accordion,dropdown,file_browser,loading_list,menu,metrics_dashboard,radio_group,searchable_list,select,selectable_list,tabs,tree}/mod.rs`
+- Modify: those components' `tests.rs` / `tests/` files
+- Modify: `src/component/file_browser/helper_tests.rs`
+- Modify: `src/component/accordion/tests.rs`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces: 12 components exposing only `selected_index()`; 10 renamed to `set_selected_index()`. Unit 3 renders these into the MIGRATION table.
+
+### Step 1: Delete the 12 `selected()` aliases
+
+- [ ] For each component below, delete the `pub fn selected(&self) -> Option<usize>` method **and its full docstring**. Each body is exactly `self.selected_index()` — verified. Leave `selected_index()` untouched.
+
+| Component | Delete at |
+|---|---|
+| `accordion` | `accordion/mod.rs:362` |
+| `dropdown` | `dropdown/mod.rs:234` |
+| `file_browser` | `file_browser/mod.rs:446` |
+| `loading_list` | `loading_list/mod.rs:357` |
+| `menu` | `menu/mod.rs:322` |
+| `metrics_dashboard` | `metrics_dashboard/mod.rs:359` |
+| `radio_group` | `radio_group/mod.rs:199` |
+| `searchable_list` | `searchable_list/mod.rs:322` |
+| `select` | `select/mod.rs:222` |
+| `selectable_list` | `selectable_list/mod.rs:242` |
+| `tabs` | `tabs/mod.rs:164` |
+| `tree` | `tree/mod.rs:528` |
+
+Line numbers shift as you delete — work bottom-up within a file, or re-grep between edits.
+
+Three of these docstrings contain a doctest that asserts alias-equivalence (`dropdown/mod.rs:232`, `metrics_dashboard/mod.rs:357`, `searchable_list/mod.rs:320`). Those die with the method — no separate action.
+
+### Step 2: Rename the 10 Category A setters
+
+- [ ] Rename `set_selected` → `set_selected_index` at each site. Signature is unchanged: `(&mut self, index: Option<usize>)`.
+
+| Component | Rename at |
+|---|---|
+| `dropdown` | `dropdown/mod.rs:267` |
+| `loading_list` | `loading_list/mod.rs:417` |
+| `menu` | `menu/mod.rs:345` |
+| `metrics_dashboard` | `metrics_dashboard/mod.rs:380` |
+| `radio_group` | `radio_group/mod.rs:233` |
+| `searchable_list` | `searchable_list/mod.rs:361` |
+| `select` | `select/mod.rs:255` |
+| `selectable_list` | `selectable_list/mod.rs:305` |
+| `tabs` | `tabs/mod.rs:198` |
+| `tree` | `tree/mod.rs:550` |
+
+`accordion` and `file_browser` have **no** setter — getter deletion only.
+
+- [ ] Add the rename note to each renamed setter's docstring, **adjacent to existing prose, above any `# Example` fence**:
+
+```rust
+/// Renamed from `set_selected()` in v0.18.0 for symmetry with
+/// `selected_index()`. See MIGRATION.md.
+```
+
+### Step 3: Delete the two tautology tests
+
+- [ ] `src/component/accordion/tests.rs:795-799` — delete the entire test function. Its body is nothing but the tautology:
+
+```rust
+#[test]
+fn test_selected_alias_matches_selected_index() {
+    let panels = vec![AccordionPanel::new("A", "1"), AccordionPanel::new("B", "2")];
+    let state = AccordionState::new(panels);
+    assert_eq!(state.selected(), state.selected_index());
+}
+```
+
+- [ ] `src/component/file_browser/helper_tests.rs:257-262` — this one is **not** pure tautology. Current body:
+
+```rust
+#[test]
+fn test_selected_alias() {
+    let state = FileBrowserState::new("/", sample_entries());
+    assert_eq!(state.selected(), state.selected_index());
+    assert_eq!(state.selected(), Some(0));
+}
+```
+
+The first assertion is the tautology; the second is real coverage (default selection is index 0). Delete the tautology line, migrate the second, and rename the function since "alias" no longer describes it:
+
+```rust
+#[test]
+fn test_selected_index_defaults_to_first_entry() {
+    let state = FileBrowserState::new("/", sample_entries());
+    assert_eq!(state.selected_index(), Some(0));
+}
+```
+
+- [ ] Verify no other alias-equivalence assertions remain:
+
+```bash
+grep -rn 'selected(), *state.selected_index()\|selected_index(), *state.selected()' src/component/
+```
+
+Expected: zero hits.
+
+### Step 4: Migrate remaining call sites in the 12 components
+
+- [ ] Compile to find them:
+
+```bash
+cargo check --all-features 2>&1 | tail -30
+```
+
+Every remaining `.selected()` on these 12 types and every `.set_selected(` is now a compile error. Migrate each: `.selected()` → `.selected_index()`, `.set_selected(` → `.set_selected_index(`.
+
+Per-component call-site counts to expect (getter / setter):
+
+| Component | `.selected()` | `.set_selected(` |
+|---|---|---|
+| `accordion` | 5 | 0 |
+| `dropdown` | 1 | 4 |
+| `file_browser` | 5 | 0 |
+| `loading_list` | 1 | 30 |
+| `menu` | 1 | 9 |
+| `metrics_dashboard` | 1 | 2 |
+| `radio_group` | 1 | 6 |
+| `searchable_list` | 2 | 1 |
+| `select` | 1 | 4 |
+| `selectable_list` | 6 | 2 |
+| `tabs` | 1 | 4 |
+| `tree` | 1 | 2 |
+
+- [ ] Repeat `cargo check --all-features` until clean.
+
+### Step 5: Unit 1 verification
+
+- [ ] Scoped grep gates:
+
+```bash
+grep -rn 'pub fn selected(&self)' src/component/{accordion,dropdown,file_browser,loading_list,menu,metrics_dashboard,radio_group,searchable_list,select,selectable_list,tabs,tree}/
+# expect: zero hits
+
+grep -rn '\.selected()\|\.set_selected(' src/component/{accordion,dropdown,file_browser,loading_list,menu,metrics_dashboard,radio_group,searchable_list,select,selectable_list,tabs,tree}/
+# expect: zero hits
+```
+
+- [ ] **heatmap must be untouched:**
+
+```bash
+grep -rn '\.selected()' src/component/heatmap/ | wc -l    # expect: 29
+grep -c 'pub fn selected(&self) -> Option<(usize, usize)>' src/component/heatmap/mod.rs   # expect: 1
+```
+
+- [ ] Test + lint:
+
+```bash
+cargo fmt --check
+cargo clippy --all-features -- -D warnings
+cargo nextest run --all-features
+cargo test --all-features --doc
+```
+
+Expected: all clean. Test count drops by 1 (the deleted accordion tautology test) plus 3 doctests.
+
+- [ ] **Audit gate — do not defer this to a later task:**
+
+```bash
+./tools/audit/target/release/envision-audit all 2>&1 | grep -A3 "Accessor symmetry"
+./tools/audit/target/release/envision-audit all 2>&1 | grep -i "doc test coverage"
+```
+
+Expected: "All setters have matching getters" and coverage at **100.0%**. If symmetry regressed, a setter rename was missed. If coverage dropped, a docstring note split a doc block from its fence.
+
+### Step 6: Commit Unit 1
+
+- [ ] Stage and commit:
+
+```bash
+git add src/component/{accordion,dropdown,file_browser,loading_list,menu,metrics_dashboard,radio_group,searchable_list,select,selectable_list,tabs,tree}/
+git commit -S -m "$(cat <<'EOF'
+cadence-d/unit-1: delete 12 selected() aliases, rename 10 setters
+
+Category A of the selection-accessor completion. Each deleted method
+had a body of exactly `self.selected_index()` — pure redundancy.
+
+Deleted `selected()` from: accordion, dropdown, file_browser,
+loading_list, menu, metrics_dashboard, radio_group, searchable_list,
+select, selectable_list, tabs, tree.
+
+Renamed `set_selected` -> `set_selected_index` on the 10 of those that
+have a setter (accordion and file_browser have none). The rename lands
+in this same commit by design: deleting `selected()` orphans
+`set_selected()` under the audit tool's symmetry rule
+(tools/audit/src/code_analysis.rs:238-266), which is exactly the 9/9 ->
+8/9 regression Cadence A discovered mid-implementation and had to fix
+in an unplanned follow-up.
+
+Deleted two alias-equivalence tests rather than renaming them — post
+deletion they assert `x == x`. accordion's test body was nothing else,
+so the whole fn went; file_browser's also carried a real
+default-selection assertion, which is preserved under a name that
+describes what it actually checks. Three more alias doctests died with
+the methods whose docstrings held them.
+
+heatmap is untouched (29 call sites intact) — its `selected()` returns
+`Option<(usize, usize)>` coordinates, a different concept, excluded
+since Cadence A.
+
+Audit verified in-commit: 9/9 scorecard, symmetry clean, doctest
+coverage still 100%.
+EOF
+)"
+```
+
+- [ ] Verify the signature: `git log --show-signature -1 HEAD | head -5`
+
+---
+
+## Task 2: Unit 2 — Categories B and C (4 getter renames + 2 setter renames)
+
+**Files:**
+- Modify: `src/component/alert_panel/mod.rs`
+- Modify: `src/component/diagram/state.rs`
+- Modify: `src/component/multi_progress/mod.rs`
+- Modify: `src/component/box_plot/state.rs`
+- Modify: those components' test files
+- Modify: `tests/integration_stress.rs` (5 `DiagramState` call sites)
+
+**Interfaces:**
+- Consumes: nothing from Unit 1 (independent components).
+- Produces: 4 more components on `selected_index()`; 2 more on `set_selected_index()`. With Unit 1, this completes the rename set that Unit 3 documents.
+
+### Step 1: Rename the 4 getters
+
+- [ ] Rename `selected` → `selected_index` at each site. **Bodies are unchanged** — each reads a private field, which is *not* renamed.
+
+| Component | Site | Signature after rename |
+|---|---|---|
+| `alert_panel` | `alert_panel/mod.rs:347` | `pub fn selected_index(&self) -> Option<usize>` |
+| `diagram` | `diagram/state.rs:263` | `pub fn selected_index(&self) -> Option<usize>` |
+| `multi_progress` | `multi_progress/mod.rs:434` | `pub fn selected_index(&self) -> Option<usize>` |
+| `box_plot` | `box_plot/state.rs:249` | `pub fn selected_index(&self) -> usize` |
+
+**`box_plot` keeps its bare `usize` return.** Do not convert to `Option<usize>` — that is a separate semantic question, deferred. The bare-`usize` shape already has precedent at `flame_graph/mod.rs:369`.
+
+The private field `selected` on each state struct stays as-is. `self.selected` behind `pub fn selected_index()` is ordinary Rust, and unlike Cadence A's `data_grid::selected_row` there is no grep collision to break (that rename existed because a *deleted method* shared the field's spelling).
+
+- [ ] Add the rename note to each, adjacent to existing prose and above any fence:
+
+```rust
+/// Renamed from `selected()` in v0.18.0 for consistency with the
+/// `selected_index()` accessor used across every other component.
+/// See MIGRATION.md.
+```
+
+### Step 2: Rename the 2 setters
+
+- [ ] `multi_progress/mod.rs:466` — `set_selected` → `set_selected_index`, signature `(&mut self, index: Option<usize>)` unchanged.
+- [ ] `box_plot/state.rs:267` — `set_selected` → `set_selected_index`, signature `(&mut self, index: usize)` unchanged.
+
+- [ ] Add the same style of rename note to both.
+
+`alert_panel` and `diagram` have no setter.
+
+### Step 3: Migrate call sites
+
+- [ ] Compile to find them:
+
+```bash
+cargo check --all-features 2>&1 | tail -30
+```
+
+Per-component counts to expect (getter / setter):
+
+| Component | `.selected()` | `.set_selected(` |
+|---|---|---|
+| `alert_panel` | 20 | 0 |
+| `box_plot` | 17 | 8 |
+| `diagram` | 5 | 0 |
+| `multi_progress` | 15 | 14 |
+
+- [ ] **`tests/integration_stress.rs` has 5 `DiagramState` call sites** at lines 427, 441, 450, 470, 488. Migrate those.
+
+- [ ] **Do NOT touch `tests/integration_new_components.rs`** — its 6 `.selected()` calls are `HeatmapState` and must stay. Verify:
+
+```bash
+grep -rn '\.selected()' tests/
+# expect: exactly 6, all in integration_new_components.rs, all HeatmapState
+```
+
+- [ ] Repeat `cargo check --all-features` until clean.
+
+### Step 4: Unit 2 verification
+
+- [ ] Whole-tree gate — this is the payoff:
+
+```bash
+grep -rn 'pub fn selected(&self)' src/component/
+# expect: exactly 1 — heatmap/mod.rs (Option<(usize, usize)>)
+
+grep -rn '\.set_selected(' src/ tests/ examples/ benches/
+# expect: zero hits
+```
+
+The setter gate is tree-wide and honest only because `box_plot` is in scope. If it returns hits, a setter was missed.
+
+- [ ] heatmap still untouched:
+
+```bash
+grep -rn '\.selected()' src/component/heatmap/ | wc -l   # expect: 29
+grep -rn '\.selected()' tests/ | wc -l                    # expect: 6
+```
+
+- [ ] Full gauntlet:
+
+```bash
+cargo fmt --check
+cargo clippy --all-features -- -D warnings
+cargo nextest run --all-features
+cargo test --all-features --doc
+cargo build --no-default-features
+cargo test --no-default-features --no-run
+cargo build --examples --all-features
+cargo doc --no-deps --all-features 2>&1 | grep -iE "warning|error" | head -5
+```
+
+- [ ] **Audit gate again:**
+
+```bash
+./tools/audit/target/release/envision-audit all 2>&1 | grep -iE "scorecard|Accessor symmetry|doc test coverage" -A2 | head -20
+```
+
+Expected: 9/9, symmetry clean, doctest coverage 100%.
+
+Note that `diagram/state.rs` and `box_plot/state.rs` are invisible to the audit tool (private `mod state;`), so a clean scorecard is **not** evidence those two files are correct. The compiler and the grep gates are the real checks there.
+
+### Step 5: Commit Unit 2
+
+```bash
+git add src/component/{alert_panel,box_plot,diagram,multi_progress}/ tests/integration_stress.rs
+git commit -S -m "$(cat <<'EOF'
+cadence-d/unit-2: rename 4 primary selected() accessors + 2 setters
+
+Categories B and C. Unlike Unit 1's aliases, these four components have
+no `selected_index()` sibling — `selected()` IS the accessor, reading a
+private field. Renaming is pure naming consistency, not
+redundancy removal.
+
+Renamed `selected` -> `selected_index` on alert_panel (mod.rs:347),
+diagram (state.rs:263), multi_progress (mod.rs:434), and box_plot
+(state.rs:249). Renamed `set_selected` -> `set_selected_index` on
+multi_progress (mod.rs:466) and box_plot (state.rs:267).
+
+box_plot keeps its bare `usize` return rather than gaining `Option`.
+The bare shape already has precedent at flame_graph/mod.rs:369, so this
+is a pure rename needing no semantic decision; whether "no selection"
+should be representable is a separate question, deferred under the new
+name.
+
+box_plot was excluded in the spec's first draft on the grounds that
+normalizing it forced that decision. Adversarial review showed the
+dilemma was false, and that CHANGELOG.md:192 names box_plot BY NAME in
+the published Cadence D backlog — deferring it would have left the crate
+with exactly one component still pairing selected() with set_selected(),
+a worse outlier after the sweep than before it.
+
+Private `selected` fields are NOT renamed. `self.selected` behind
+`pub fn selected_index()` is ordinary Rust; Cadence A's analogous field
+rename existed only to break a grep collision with a deleted method of
+the same spelling, which does not apply here.
+
+Whole-tree gates now pass: exactly one `pub fn selected(&self)` remains
+in src/component/ (heatmap, returning coordinates), and
+`grep -rn '\.set_selected(' src/ tests/ examples/ benches/` returns
+zero.
+
+heatmap untouched: 29 call sites in src/component/, 6 in
+tests/integration_new_components.rs.
+
+Audit verified in-commit: 9/9, symmetry clean, doctest coverage 100%.
+Note that diagram/state.rs and box_plot/state.rs sit behind a private
+`mod state;` and are invisible to the audit tool — the compiler and grep
+gates are the real verification for those two.
+EOF
+)"
+```
+
+- [ ] Verify the signature.
+
+---
+
+## Task 3: Unit 3 — prelude + CHANGELOG + MIGRATION
+
+**Files:**
+- Modify: `src/lib.rs:478`
+- Modify: `CHANGELOG.md`
+- Modify: `MIGRATION.md`
+
+**Interfaces:**
+- Consumes: the complete rename set from Units 1 and 2 (28 rows).
+- Produces: consumer-facing documentation.
+
+### Step 1: Extend the prelude with all four missing harness types
+
+- [ ] `src/lib.rs:478` currently reads:
+
+```rust
+    pub use crate::harness::{AppHarness, MessageSender, TestHarness};
+```
+
+Replace with:
+
+```rust
+    pub use crate::harness::{
+        AppHarness, Assertion, MessageSendError, MessageSender, Snapshot, TestHarness,
+        TrySendError,
+    };
+```
+
+This mirrors the crate-root export at `src/lib.rs:408-410` exactly. Cadence A's review flagged only `MessageSendError` + `TrySendError`; fixing 2 of 4 would recreate the inconsistency one level down, so `Assertion` and `Snapshot` come along.
+
+- [ ] Verify:
+
+```bash
+cargo check --all-features 2>&1 | tail -3
+```
+
+### Step 2: CHANGELOG — new `[Unreleased]` block
+
+- [ ] **Leave `## [0.17.0] - 2026-07-26` byte-identical.** It is released and tagged; Keep a Changelog treats released sections as immutable. Its Known Deferred Findings block stays exactly as shipped.
+
+- [ ] Insert a fresh `## [Unreleased]` block directly above `## [0.17.0] - 2026-07-26` (i.e. after the format preamble):
+
+```markdown
+## [Unreleased]
+
+### Breaking Changes
+
+#### Selection accessors completed on `selected_index()`
+
+Cadence A unified selection accessors across six components. This release finishes the job: every component whose selection accessor was spelled `selected` now spells it `selected_index`, and every corresponding mutator is `set_selected_index`.
+
+The motivation is that `selected` was ambiguous about return type. Four different signatures shared the spelling: `Option<usize>` (15 components), `Option<(usize, usize)>` (`heatmap`), bare `usize` (`box_plot`), and a `bool` builder (`annotation::widget`). The `selected_index` / `selected_item` / `value_at_selection` system makes the name predict the type.
+
+**Aliases deleted** (body was exactly `self.selected_index()`) — `accordion`, `dropdown`, `file_browser`, `loading_list`, `menu`, `metrics_dashboard`, `radio_group`, `searchable_list`, `select`, `selectable_list`, `tabs`, `tree`.
+
+**Primary accessors renamed** (no `selected_index()` sibling existed) — `alert_panel`, `diagram`, `multi_progress`, `box_plot`.
+
+**Setters renamed** `set_selected` → `set_selected_index` on all twelve components that had one.
+
+`box_plot::selected_index()` keeps its bare `usize` return, matching the existing `flame_graph::selected_index()`. Whether it should become `Option<usize>` is a separate question, deferred.
+
+`heatmap::selected()` is **unchanged** — it returns `Option<(usize, usize)>` coordinates, not an index, and was disentangled from this pattern during Cadence A.
+
+See `MIGRATION.md` § *v0.17.x to v0.18.0* for the full before/after table.
+
+### Added
+
+#### Harness types available from the prelude
+
+`envision::prelude::*` now re-exports all seven harness types, matching the crate root. Previously only `AppHarness`, `MessageSender`, and `TestHarness` were included, so consumers matching on `TrySendError::{Full, Closed}`, destructuring `MessageSendError`, or using `Assertion` / `Snapshot` needed a second explicit import.
+
+Added: `Assertion`, `MessageSendError`, `Snapshot`, `TrySendError`.
+
+### Known Deferred Findings
+
+> Supersedes the Known Deferred Findings block under `[0.17.0]`. The Cadence D item listed there — selection-accessor aliases, including `box_plot` — is **closed** by this release.
+
+- **Selection-index accessors under domain-specific names.** `chart::active_series`, `log_correlation::active_stream`, `diff_viewer::current_hunk`, `step_indicator::active_step_index`, `paginator::current_page`, `breadcrumb::focused_index`. Surveyed during Cadence D and deliberately excluded: each name carries domain meaning that a generic rename would erase. Open question for a future cadence.
+- **`box_plot::selected_index()` returns a bare `usize`**, so "no selection" is unrepresentable. Whether it should become `Option<usize>` is a semantic question, deferred — the naming half closed in this release.
+- **`accordion::selected_index()` remains a convenience alias for `focused_index()`.** It performs real work (Option-normalizing the empty case) so it is not redundant, but the indirection stands.
+- **`compact_str` adoption is sporadic** — 2 non-test source files (`src/component/cell.rs`, `src/backend/cell/mod.rs`). Needs a commit-or-drop decision.
+- **Naming outliers** — `is_checked`, `label_text` (the `tab_bar` setter outlier previously grouped here is closed by this release). Plus `restore_terminal` → `restore`, `AppShell` placement in the README component table, five files near the 1000-line cap, and snapshot-coverage concentration in ~20 of 74 components.
+```
+
+### Step 3: MIGRATION.md — new `## v0.17.x to v0.18.0` section
+
+- [ ] Insert directly above `## v0.16.x to v0.17.0` (currently at line 3):
+
+```markdown
+## v0.17.x to v0.18.0
+
+### Selection accessors completed on `selected_index()`
+
+Every component whose selection accessor was spelled `selected` now spells it `selected_index`; every corresponding mutator is `set_selected_index`.
+
+| Component | Old | New |
+|---|---|---|
+| `accordion` | `state.selected()` | `state.selected_index()` |
+| `alert_panel` | `state.selected()` | `state.selected_index()` |
+| `box_plot` | `state.selected()` | `state.selected_index()` |
+| `box_plot` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `diagram` | `state.selected()` | `state.selected_index()` |
+| `dropdown` | `state.selected()` | `state.selected_index()` |
+| `dropdown` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `file_browser` | `state.selected()` | `state.selected_index()` |
+| `loading_list` | `state.selected()` | `state.selected_index()` |
+| `loading_list` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `menu` | `state.selected()` | `state.selected_index()` |
+| `menu` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `metrics_dashboard` | `state.selected()` | `state.selected_index()` |
+| `metrics_dashboard` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `multi_progress` | `state.selected()` | `state.selected_index()` |
+| `multi_progress` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `radio_group` | `state.selected()` | `state.selected_index()` |
+| `radio_group` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `searchable_list` | `state.selected()` | `state.selected_index()` |
+| `searchable_list` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `select` | `state.selected()` | `state.selected_index()` |
+| `select` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `selectable_list` | `state.selected()` | `state.selected_index()` |
+| `selectable_list` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `tabs` | `state.selected()` | `state.selected_index()` |
+| `tabs` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `tree` | `state.selected()` | `state.selected_index()` |
+| `tree` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+
+Return types are unchanged in every case, including `box_plot`, whose accessor stays a bare `usize`.
+
+**Finding your call sites.** Search for `.selected()` and `.set_selected(` on the sixteen components above.
+
+`heatmap::selected()` returns `Option<(usize, usize)>` coordinates and is **unchanged** — do not migrate it.
+
+Because these are renames, `cargo build` identifies every site and the compiler error names the receiver type, which disambiguates `heatmap` from the rest. Note that method references (`SelectState::selected`, or `.map(SelectState::selected)`) will not match a `.selected()` grep but will still fail to compile.
+
+### Harness types available from the prelude
+
+`envision::prelude::*` now re-exports `Assertion`, `MessageSendError`, `Snapshot`, and `TrySendError` alongside the three it already provided. The explicit `use envision::{Assertion, MessageSendError, Snapshot, TrySendError};` import is no longer required.
+```
+
+- [ ] **Archiving policy note:** PR #510 set a last-3-versions boundary for `MIGRATION.md`. This addition makes four sections and takes the file to roughly 254 lines — far below the 1000-line cap — so the policy is waived this cycle. Archive `v0.14.x → v0.15.0` at v0.19.0. No action now; this is recorded so the next maintainer does not rediscover the rule.
+
+### Step 4: Unit 3 verification
+
+```bash
+grep -c '^## \[Unreleased\]' CHANGELOG.md    # expect: 1
+grep -c '^## \[0.17.0\]' CHANGELOG.md        # expect: 1
+grep -c '^## v0.17.x to v0.18.0' MIGRATION.md # expect: 1
+cargo test --all-features --doc 2>&1 | tail -3
+cargo doc --no-deps --all-features 2>&1 | grep -iE "warning|error" | head -5
+```
+
+- [ ] Confirm `[0.17.0]` is unmodified:
+
+```bash
+git diff HEAD -- CHANGELOG.md | grep '^-' | grep -v '^---' | head -5
+```
+
+Expected: no deletions inside the `[0.17.0]` section — only additions above it.
+
+### Step 5: Commit Unit 3
+
+```bash
+git add src/lib.rs CHANGELOG.md MIGRATION.md
+git commit -S -m "$(cat <<'EOF'
+cadence-d/unit-3: prelude harness types + CHANGELOG + MIGRATION
+
+Extends the prelude to re-export all seven harness types, matching the
+crate root at src/lib.rs:408-410. Cadence A's final review flagged only
+MessageSendError and TrySendError; adding just those two would have
+recreated the same inconsistency one level down, so Assertion and
+Snapshot come along. Additive, non-breaking. Bundling this with Cadence D
+was sanctioned by the Cadence A closure record
+(docs/audits/2026-07-05-post-consistency-cleanup.md:100).
+
+CHANGELOG gains a fresh [Unreleased] block. The [0.17.0] section is left
+byte-identical — it is released and tagged, and Keep a Changelog treats
+released sections as immutable. The new Known Deferred Findings block
+opens with an explicit pointer that it supersedes the one under
+[0.17.0], and drops the now-closed Cadence D entry.
+
+What remains deferred is stated precisely rather than by reference:
+selection-index accessors under domain-specific names (active_series,
+current_page, focused_index, and three others — surveyed during this
+cadence and excluded because each name carries domain meaning a generic
+rename would erase); box_plot's bare-usize return; accordion's
+focused_index indirection; compact_str's 2-file adoption; and the
+residual naming/size/coverage items.
+
+MIGRATION gains § v0.17.x to v0.18.0 with a 28-row before/after table
+and a grep hint that explicitly warns off heatmap and notes that method
+references won't match a `.selected()` grep but will still fail to
+compile.
+
+The last-3-versions archiving policy from PR #510 is waived this cycle —
+four sections lands the file near 254 lines, nowhere near the 1000-line
+cap. Archive v0.14.x -> v0.15.0 at v0.19.0.
+EOF
+)"
+```
+
+- [ ] Verify the signature.
+
+---
+
+## Task 4: Full verification gauntlet
+
+**Files:** none — verification only, no commit.
+
+### Step 1: Complete gauntlet
+
+```bash
+cargo fmt --check
+cargo clippy --all-features -- -D warnings
+cargo nextest run --all-features
+cargo test --all-features --doc
+cargo build --no-default-features
+cargo test --no-default-features --no-run
+cargo build --examples --all-features
+cargo doc --no-deps --all-features 2>&1 | grep -iE "warning|error" | head -10
+./tools/audit/target/release/envision-audit all 2>&1 | grep -iE "scorecard|PASS|FAIL" | head -20
+```
+
+Expected: everything clean; scorecard 9/9; doctest coverage 100%.
+
+### Step 2: Final success-criteria gates
+
+```bash
+# 1. Exactly one selected() left in components — heatmap's coordinate accessor
+grep -rn 'pub fn selected(&self)' src/component/
+
+# 2. No set_selected anywhere
+grep -rn '\.set_selected(' src/ tests/ examples/ benches/
+
+# 3. heatmap intact
+grep -rn '\.selected()' src/component/heatmap/ | wc -l   # 29
+grep -rn '\.selected()' tests/ | wc -l                    # 6
+
+# 4. box_plot kept bare usize
+grep -n 'pub fn selected_index(&self) -> usize' src/component/box_plot/state.rs
+grep -n 'pub fn set_selected_index(&mut self, index: usize)' src/component/box_plot/state.rs
+
+# 5. prelude has all seven harness types
+grep -A3 'pub use crate::harness::' src/lib.rs
+
+# 6. CHANGELOG structure
+grep -c '^## \[Unreleased\]' CHANGELOG.md   # 1
+```
+
+If any gate fails, backtrack to the offending unit and fix before proceeding.
+
+### Step 3: No commit
+
+Task 4 is verification-only. Units 1–3 carry the commits.
+
+---
+
+## Task 5: Push + open impl PR
+
+### Step 1: Confirm branch state
+
+```bash
+git log --oneline -4
+```
+
+Expected, most recent first: Unit 3, Unit 2, Unit 1, then the branch parent.
+
+### Step 2: Merge latest main
+
+```bash
+git fetch origin main
+git merge origin/main --no-ff -S -m "Merge origin/main into cadence-d-impl"
+```
+
+`CHANGELOG.md` is the likely conflict candidate if anything landed on main meanwhile. If signing fails, STOP and ask the user.
+
+### Step 3: Push
+
+```bash
+git push -u origin cadence-d-impl
+```
+
+### Step 4: Open the PR
+
+```bash
+gh pr create --title "Impl: Cadence D — selection-accessor completion (v0.18.0)" --body "$(cat <<'EOF'
+## Summary
+
+Finishes the selection-accessor unification Cadence A began. After this PR, `grep -rn 'pub fn selected(&self)' src/component/` returns **exactly one** hit — `heatmap`, whose accessor returns coordinates and is a genuinely different concept.
+
+- **Unit 1** — deleted 12 literal `selected()` aliases (body was exactly `self.selected_index()`), renamed 10 setters to `set_selected_index`.
+- **Unit 2** — renamed 4 primary accessors (`alert_panel`, `diagram`, `multi_progress`, `box_plot`) plus 2 more setters. These had no `selected_index()` sibling, so this is naming consistency rather than redundancy removal.
+- **Unit 3** — prelude gains all four missing harness types; CHANGELOG `[Unreleased]`; MIGRATION § v0.17.x to v0.18.0 with a 28-row table.
+
+## Why `selected_index`
+
+`selected` was ambiguous about return type, and the codebase proved it — four signatures shared the spelling: `Option<usize>` (15 components), `Option<(usize, usize)>` (`heatmap`), bare `usize` (`box_plot`), and a `bool` builder (`annotation::widget:75`). The `selected_index` / `selected_item` / `value_at_selection` system makes the name predict the type.
+
+## Setter symmetry, pre-empted
+
+Deleting a `selected()` getter orphans its `set_selected()` under the audit tool's symmetry rule — the 9/9 → 8/9 regression Cadence A hit mid-implementation and fixed in an unplanned follow-up commit. Here every setter renames in the **same commit** as its getter, and the audit runs at the end of **each unit**.
+
+## box_plot
+
+The spec's first draft excluded it. Adversarial review showed that was wrong on two counts: `flame_graph::selected_index() -> usize` already ships the bare-`usize` shape, so the rename needs no semantic decision; and `CHANGELOG.md:192` names `box_plot` by name in the published Cadence D backlog. Excluding it would have left the crate with exactly one component still pairing `selected()` with `set_selected()`.
+
+Its return types stay bare `usize`. The `Option` question is deferred under the new name.
+
+## Verification
+
+- [x] `grep -rn 'pub fn selected(&self)' src/component/` → 1 (heatmap)
+- [x] `grep -rn '\.set_selected(' src/ tests/ examples/ benches/` → 0
+- [x] heatmap untouched — 29 `src/component/` sites, 6 `tests/` sites
+- [x] `cargo fmt --check` / `clippy --all-features -D warnings` clean
+- [x] `cargo nextest run --all-features` passing
+- [x] `cargo test --all-features --doc` passing
+- [x] `cargo build --no-default-features` + `cargo test --no-default-features --no-run` clean
+- [x] `cargo build --examples --all-features` clean
+- [x] `cargo doc --no-deps --all-features` zero warnings
+- [x] Audit scorecard **9/9**, doctest coverage **100%**
+
+## Spec / plan
+
+- Spec: `docs/superpowers/specs/2026-07-26-cadence-d-selection-accessor-completion-design.md` (PR #514)
+- Plan: `docs/superpowers/plans/2026-07-26-cadence-d-selection-accessor-completion.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### Step 5: CI watch
+
+- [ ] `gh pr checks <PR>` until required checks complete. The Coverage job has a known tarpaulin timeout flake — if it fails *after* the test summary shows all tests passed, retrigger with `gh run rerun <RUN_ID> --failed`. Coverage is not a required check.
+
+---
+
+## Out of scope for this plan
+
+- Tracking-doc PR (separate branch after impl merges) — closure record at `docs/audits/2026-07-26-post-cadence-d.md`.
+- Renaming the domain-specific accessors (`active_series`, `current_page`, `focused_index`, …) — surveyed and deferred.
+- Converting `box_plot` to `Option<usize>` — semantic question, deferred.
+- `accordion::selected_index()` → `focused_index()` indirection.
+- The v0.18.0 release itself.
+
+## Recovery patterns
+
+- **`git commit -S` fails** → STOP, ask the user. Never `--no-gpg-sign`.
+- **Audit symmetry regresses mid-unit** → a setter rename was missed. `./tools/audit/target/release/envision-audit all | grep -A5 "Accessor symmetry"` names the component.
+- **Doctest coverage drops below 100%** → a "Renamed from…" note split a doc block from its fence. Move the note adjacent to existing prose, above the fence.
+- **heatmap gate returns a count other than 29 / 6** → over-migration. Revert the heatmap changes; its accessor is out of scope.
+- **`cargo fmt --check` drifts** → run `cargo fmt`, stage, add a small follow-up signed commit. Don't amend.
+- **Merge conflict on CHANGELOG.md in Task 5** → keep both, ordering `[Unreleased]` above `[0.17.0]`.
+
+## Reference
+
+- Spec: `docs/superpowers/specs/2026-07-26-cadence-d-selection-accessor-completion-design.md` (PR #514, commits `d80988a` + `bbe5ba7`).
+- Cadence A: spec #506, plan #507, impl #508, tracking #509. Closure record at `docs/audits/2026-07-05-post-consistency-cleanup.md`.
+- Audit tool symmetry rule: `tools/audit/src/code_analysis.rs:238-266`. Source-selection rule (the `state.rs` blind spot): `tools/audit/src/scorecard.rs:275-295`.
+- CLAUDE.md: PRs required; signed commits; squash-merge; merge `origin/main` before push; files under 1000 lines; no clippy warnings.

--- a/docs/superpowers/specs/2026-07-26-cadence-d-selection-accessor-completion-design.md
+++ b/docs/superpowers/specs/2026-07-26-cadence-d-selection-accessor-completion-design.md
@@ -2,83 +2,123 @@
 
 ## Purpose
 
-Finish the selection-accessor unification that Cadence A began. Cadence A canonicalized `selected_item()` / `selected_index()` / `set_selected_index()` across six components (`dropdown`, `select`, `heatmap`, `tab_bar`, `data_grid`, `table`) but deliberately scoped out the remaining components carrying a `selected()` accessor. That deferral was documented in the CHANGELOG's Known Deferred Findings block and in the Cadence A closure record as "Cadence D (v0.18+)".
+Finish the selection-accessor unification that Cadence A began. Cadence A canonicalized `selected_item()` / `selected_index()` / `set_selected_index()` across six components (`dropdown`, `select`, `heatmap`, `tab_bar`, `data_grid`, `table`) but deliberately scoped out the remaining components carrying a `selected()` accessor. That deferral is documented in `CHANGELOG.md:188-192` and in the Cadence A closure record as "Cadence D (v0.18+)".
 
-This cadence closes it. After Cadence D, **every** envision component that exposes a selection index calls it `selected_index()`, and every corresponding mutator is `set_selected_index()`.
+**Terminal state:** every component whose selection accessor is *spelled* `selected` now spells it `selected_index`. Concretely — after this cadence, `grep -rn 'pub fn selected(&self)' src/component/` returns exactly one hit: `heatmap`, whose accessor returns coordinates rather than an index and is a genuinely different concept.
+
+That is a narrower and truer claim than "every component exposing a selection index calls it `selected_index()`", which is false — see [Surveyed and deliberately excluded](#surveyed-and-deliberately-excluded).
 
 - **Prior cadence:** Cadence A (spec PR #506, plan PR #507, impl PR #508, tracking PR #509), closure record at [`docs/audits/2026-07-05-post-consistency-cleanup.md`](../../audits/2026-07-05-post-consistency-cleanup.md).
-- **Release target:** v0.18.0. v0.17.0 shipped 2026-07-26 at commit `ec023ee`.
-- **Terminal state:** zero `pub fn selected(&self) -> Option<usize>` in `src/component/`; audit scorecard stays 9/9; the Known Deferred Findings block loses its Cadence D entry.
+- **Release target:** v0.18.0. `Cargo.toml` is at `0.17.0`; this cadence is breaking; pre-1.0 semver → minor bump.
+
+## Why `selected_index` is the right destination name
+
+The spec's first draft justified the destination purely by "consistency." That is the weaker case and invites the obvious counter: `selected()` is shorter, `_index` is redundant when the return type already says `Option<usize>`, and Rust convention favors terseness (`Vec::len`, not `Vec::element_count`).
+
+The real argument is that **`selected` is ambiguous about return type**, and this codebase proves it. Four different signatures share the spelling today:
+
+| Signature | Where |
+|---|---|
+| `selected(&self) -> Option<usize>` | 15 components (this cadence) |
+| `selected(&self) -> Option<(usize, usize)>` | `heatmap/mod.rs:449` — coordinates |
+| `selected(&self) -> usize` | `box_plot/state.rs:249` |
+| `selected(mut self, selected: bool) -> Self` | `annotation/widget.rs:75` — a *builder* |
+
+`selected_index` / `selected_item` / `value_at_selection` is a system where **the name predicts the type**. Across a 74-component library consumed by downstream apps, that predictability is worth more than four characters.
 
 ## Scope survey (verified against the tree at `ec023ee`)
 
-The prior audit described this backlog as "~15 components with a `selected()` alias". That framing is imprecise: the 15 sites split into **three materially different categories**, and only 12 are actually aliases.
+The inherited backlog description (`CHANGELOG.md:192`) calls all ~15 sites "literal aliases for `selected_index()`". That is flatly wrong for four of them, which have no `selected_index()` sibling at all. The sites split into **three in-scope categories plus one exclusion**.
 
 ### Category A — literal aliases (12 components)
 
-Body is exactly `self.selected_index()`. Pure redundancy; delete outright.
+Body is exactly `self.selected_index()`. Delete outright.
 
-| Component | `selected()` site | Has `set_selected`? |
+| Component | `selected()` site | `set_selected` site |
 |---|---|---|
-| `loading_list` | `loading_list/mod.rs:357` | yes — `mod.rs:417` |
-| `select` | `select/mod.rs:222` | yes — `mod.rs:255` |
-| `radio_group` | `radio_group/mod.rs:199` | yes — `mod.rs:233` |
-| `accordion` | `accordion/mod.rs:362` | **no** |
-| `dropdown` | `dropdown/mod.rs:234` | yes — `mod.rs:267` |
-| `selectable_list` | `selectable_list/mod.rs:242` | yes — `mod.rs:305` |
-| `menu` | `menu/mod.rs:322` | yes — `mod.rs:345` |
-| `metrics_dashboard` | `metrics_dashboard/mod.rs:359` | yes — `mod.rs:380` |
-| `tabs` | `tabs/mod.rs:164` | yes — `mod.rs:198` |
-| `tree` | `tree/mod.rs:528` | yes — `mod.rs:550` |
-| `searchable_list` | `searchable_list/mod.rs:322` | yes — `mod.rs:361` |
-| `file_browser` | `file_browser/mod.rs:446` | **no** |
+| `accordion` | `accordion/mod.rs:362` | — |
+| `dropdown` | `dropdown/mod.rs:234` | `mod.rs:267` |
+| `file_browser` | `file_browser/mod.rs:446` | — |
+| `loading_list` | `loading_list/mod.rs:357` | `mod.rs:417` |
+| `menu` | `menu/mod.rs:322` | `mod.rs:345` |
+| `metrics_dashboard` | `metrics_dashboard/mod.rs:359` | `mod.rs:380` |
+| `radio_group` | `radio_group/mod.rs:199` | `mod.rs:233` |
+| `searchable_list` | `searchable_list/mod.rs:322` | `mod.rs:361` |
+| `select` | `select/mod.rs:222` | `mod.rs:255` |
+| `selectable_list` | `selectable_list/mod.rs:242` | `mod.rs:305` |
+| `tabs` | `tabs/mod.rs:164` | `mod.rs:198` |
+| `tree` | `tree/mod.rs:528` | `mod.rs:550` |
+
+**Caveat on "pure redundancy":** for `accordion` this is a layer shallower than it looks. `accordion/mod.rs:320-323` documents `selected_index()` as a convenience alias for `focused_index()` (`mod.rs:302`, returns bare `usize`), Option-normalizing the empty case at `mod.rs:339-343`. So accordion has a chain `selected()` → `selected_index()` → `focused_index()`. Deleting the outer layer is still correct — `selected_index()` does real type-normalization work, so it is not itself a byte-identical alias — but this cadence does **not** touch `focused_index()`, and the spec should not oversell the deletion as removing all indirection.
 
 ### Category B — primary accessors (3 components)
 
-Body is `self.selected` (a direct field read). These components have **no** `selected_index()` sibling, so there is no redundancy to remove — renaming them is a pure naming-consistency change.
+Body is `self.selected` (a direct field read). **No** `selected_index()` sibling, so there is no redundancy to remove — renaming is a pure naming-consistency change.
 
-| Component | `selected()` site | Has `set_selected`? |
+| Component | `selected()` site | `set_selected` site |
 |---|---|---|
-| `diagram` | `diagram/state.rs:263` | **no** |
-| `alert_panel` | `alert_panel/mod.rs:347` | **no** |
-| `multi_progress` | `multi_progress/mod.rs:434` | yes — `mod.rs:466` |
+| `alert_panel` | `alert_panel/mod.rs:347` | — |
+| `diagram` | `diagram/state.rs:263` | — |
+| `multi_progress` | `multi_progress/mod.rs:434` | `mod.rs:466` |
 
-**Decision: rename Category B to `selected_index()`** rather than leaving them. Leaving them would end Cadence D with 3 components exposing `selected()` while 12 expose `selected_index()` — the exact inconsistency this cadence exists to eliminate, and a guaranteed re-flag at the next audit. Approved during brainstorm.
+**Decision: rename to `selected_index()`.** Leaving them would end Cadence D with 3 components on `selected()` and 12 on `selected_index()` — the exact inconsistency this cadence exists to eliminate.
 
-### Setter-symmetry consequence (the Cadence A trap, pre-empted)
+### Category C — `box_plot` (1 component)
 
-The audit tool's accessor-symmetry check (`tools/audit/src/code_analysis.rs:238-266`) requires every `set_X()` to have a matching getter named `X`, `is_X`, or `X_value`. Deleting or renaming `selected()` orphans `set_selected()` and regresses the scorecard from 9/9 to 8/9.
+`box_plot/state.rs:249` — `pub fn selected(&self) -> usize`, with `set_selected(&mut self, index: usize)` at `state.rs:267`.
 
-Cadence A hit exactly this mid-implementation: Task 4's verification gauntlet caught it after Task 1's alias deletions, forcing an unplanned fix commit. **Cadence D pre-empts it** by renaming the setters in the same commits as the getter changes.
+**Decision: in scope.** The first draft excluded it, arguing that normalizing the bare-`usize` return would force a semantic decision about representing "no selection". That was a false dilemma, for two reasons:
 
-**11 setters need renaming** — all with the identical signature `pub fn set_selected(&mut self, index: Option<usize>)`:
+1. **A bare-`usize` `selected_index()` is already shipped and canonical.** `flame_graph/mod.rs:369` is `pub fn selected_index(&self) -> usize`. So `box_plot::selected() -> selected_index()` is a *pure rename requiring zero semantic decision*. The `Option`-shape question is genuinely separate and stays deferred — under the new name.
+2. **`CHANGELOG.md:192` names `box_plot` by name** in the published Cadence D backlog. Deferring the one component the public CHANGELOG promised would repeat the Cadence A M3 failure — a "sweep" that leaves the identical divergence in place — and would leave `box_plot` as the *only* component in the crate still pairing `selected()` with `set_selected()`: a strictly worse outlier after the sweep than before it.
 
-10 from Category A (`loading_list`, `select`, `radio_group`, `dropdown`, `selectable_list`, `menu`, `metrics_dashboard`, `tabs`, `tree`, `searchable_list`) plus `multi_progress` from Category B.
+Rename `selected` → `selected_index` and `set_selected` → `set_selected_index`, **both keeping `usize`**.
 
-`accordion`, `file_browser`, `diagram`, and `alert_panel` have no setter — getter change only.
+### Surveyed and deliberately excluded
 
-### Explicitly out of scope
+**`heatmap::selected(&self) -> Option<(usize, usize)>`** (`heatmap/mod.rs:449`) — returns cursor *coordinates*, not an index. Already excluded during Cadence A, whose companion rename (`selected_value` → `value_at_selection`, `CHANGELOG.md:65`) exists precisely to disentangle heatmap's accessors from the selection-index pattern. Unchanged, and its 35 call sites must be left alone.
 
-Two components expose a `selected()` whose return type makes it a genuinely different concept, not an index accessor:
+**Selection-index accessors under different names — surveyed, out of scope, no action:**
 
-- **`heatmap::selected(&self) -> Option<(usize, usize)>`** at `heatmap/mod.rs:449` — returns cursor *coordinates*, not an index. Already established as out-of-scope during Cadence A, whose companion rename (`selected_value` → `value_at_selection`) exists precisely to disentangle heatmap's value accessor from the selection-accessor pattern. Unchanged.
-- **`box_plot::selected(&self) -> usize`** at `box_plot/state.rs:249` — returns a bare `usize`, not `Option<usize>`. Normalizing it would require deciding whether the return type becomes `Option<usize>` (a semantic change about whether "no selection" is representable), which is a different question from naming consistency. Deferred; noted in the CHANGELOG as a known remaining item.
+| Site | Signature |
+|---|---|
+| `chart/state.rs:111` | `active_series(&self) -> usize` |
+| `log_correlation/mod.rs:504` | `active_stream(&self) -> usize` |
+| `diff_viewer/mod.rs:442` | `current_hunk(&self) -> usize` |
+| `step_indicator/state.rs:262` | `active_step_index(&self) -> Option<usize>` |
+| `paginator/mod.rs:270` | `current_page(&self) -> usize` |
+| `breadcrumb/mod.rs:321` | `focused_index(&self) -> usize` |
+
+These are genuinely index-shaped and arguably belong in a naming-consistency sweep — Cadence A established the precedent by renaming `tab_bar::active_tab()` → `selected_item()` as a "semantic outlier" (`CHANGELOG.md:67`). They are excluded here because each carries **domain meaning the generic name would erase**: `current_page` is pagination state, `active_step_index` is workflow position, `current_hunk` is diff navigation. Collapsing them to `selected_index` would be a semantic flattening, not a consistency win — a different judgment call than the mechanical rename this cadence performs.
+
+Recorded in the CHANGELOG's deferred block as an open question for a future cadence, so the next audit does not read this cadence as claiming they were missed.
 
 ### Verification that Cadence A holds
 
-`table`, `data_grid`, and `tab_bar` each have zero `pub fn selected(&self) -> Option<usize>` — confirmed at `ec023ee`. Cadence A's work is intact and is not re-touched here.
+`grep -rn 'pub fn selected(' src/component/{table,data_grid,tab_bar}/` → zero hits at `ec023ee`. Cadence A's work is intact and is not re-touched.
 
-### Migration surface
+## Setter symmetry: pre-empted as a design constraint
 
-209 call sites across the tree:
+The audit tool's accessor-symmetry check (`tools/audit/src/code_analysis.rs:238-266`) requires every `set_X()` to have a getter named `X`, `is_X`, or `X_value`. Deleting or renaming `selected()` orphans `set_selected()`.
 
-| Area | `.selected()` | `.set_selected(` |
-|---|---|---|
-| `src/component/` | 112 | 86 |
-| `tests/` | 11 | 0 |
-| `src/app/`, `src/harness/`, `examples/`, `benches/` | 0 | 0 |
+Cadence A hit exactly this mid-implementation — its Task 4 gauntlet caught the 9/9 → 8/9 regression after Task 1's deletions, forcing an unplanned fix commit and a mid-flight decision. The Cadence A closure record predicted the recurrence by name (`docs/audits/2026-07-05-post-consistency-cleanup.md:89`).
 
-Note that the 112 `src/component/` `.selected()` hits include calls on `heatmap` and `box_plot` (out of scope) — the implementer must migrate only in-scope call sites. Per-component grep gates in the plan handle this.
+**Cadence D pre-empts it:** every affected setter renames in the *same commit* as its getter change, and the audit tool runs at the end of **each unit** rather than only in a final gauntlet task.
+
+**12 setters** need renaming — 10 from Category A, plus `multi_progress` (B) and `box_plot` (C). Categories A and B use the identical signature `(&mut self, index: Option<usize>)`; `box_plot` uses `(&mut self, index: usize)`.
+
+`accordion`, `file_browser`, `alert_panel`, and `diagram` have no setter — getter change only.
+
+### Audit-tool blind spot (relevant to what the scorecard can prove)
+
+`tools/audit/src/scorecard.rs:275-295` (`read_non_test_sources`) reads a component's `mod.rs` plus only those sibling files named by a `pub mod X;` or `pub use X::…` line. Files behind a **private** `mod X;` are invisible to every scorecard check.
+
+Verified: `diagram/mod.rs:61`, `box_plot/mod.rs:31`, and `table/mod.rs:59` are all `mod state;` — private. So `diagram/state.rs` and `box_plot/state.rs` contribute nothing to the current 9/9 scorecard or to the `100.0% (1777/1777)` doctest-coverage metric.
+
+Two consequences the implementer must hold:
+
+1. **"Scorecard stays 9/9" is not evidence that `box_plot` is fine.** Its `selected`/`set_selected` pair was never measured. We bring it in scope for real consistency, not to satisfy the tool.
+2. **The symmetry-regression prediction remains correct**, because all 12 setters that matter to the tool live in `mod.rs`. Verified individually.
 
 ## Cadence structure
 
@@ -89,73 +129,37 @@ Standard 4-PR pattern, matching Cadence A:
 3. Impl PR — three signed commits (Unit 1 / Unit 2 / Unit 3)
 4. Tracking-doc PR — closure record at `docs/audits/2026-07-26-post-cadence-d.md`
 
-Full ceremony is warranted: 15 breaking renames across 15 components, ~209 call sites, and a real design decision (Category B). Cadence A was the same magnitude and its adversarial spec review surfaced four must-fix design bugs — worth the gate.
-
 ## Unit 1 — Category A: delete 12 aliases, rename 10 setters
-
-Files touched: the 12 components' `mod.rs` files, their `tests.rs`/`tests/` files, plus any in-tree caller.
-
-### Per-component change
 
 For each of the 12 Category A components:
 
 - **Delete** `pub fn selected(&self) -> Option<usize> { self.selected_index() }` and its docstring.
-- **Keep** `selected_index()` unchanged — it is already the canonical accessor.
-- **Rename** `set_selected` → `set_selected_index` where present (10 of 12), updating the docstring to reference `selected_index()` as its getter counterpart and noting the rename with a MIGRATION.md pointer.
-
-### Docstring convention for renamed setters
-
-Each renamed setter gains a line matching the Cadence A precedent:
-
-```rust
-/// Renamed from `set_selected()` in v0.18.0 for symmetry with
-/// [`selected_index()`](Self::selected_index). See MIGRATION.md.
-```
-
-### Migration table (rendered in Unit 3)
-
-```markdown
-| Component | Old | New |
-|---|---|---|
-| `accordion` | `state.selected()` | `state.selected_index()` |
-| `dropdown` | `state.selected()` | `state.selected_index()` |
-| `dropdown` | `state.set_selected(i)` | `state.set_selected_index(i)` |
-| `file_browser` | `state.selected()` | `state.selected_index()` |
-| `loading_list` | `state.selected()` | `state.selected_index()` |
-| `loading_list` | `state.set_selected(i)` | `state.set_selected_index(i)` |
-| `menu` | `state.selected()` | `state.selected_index()` |
-| `menu` | `state.set_selected(i)` | `state.set_selected_index(i)` |
-| `metrics_dashboard` | `state.selected()` | `state.selected_index()` |
-| `metrics_dashboard` | `state.set_selected(i)` | `state.set_selected_index(i)` |
-| `radio_group` | `state.selected()` | `state.selected_index()` |
-| `radio_group` | `state.set_selected(i)` | `state.set_selected_index(i)` |
-| `searchable_list` | `state.selected()` | `state.selected_index()` |
-| `searchable_list` | `state.set_selected(i)` | `state.set_selected_index(i)` |
-| `select` | `state.selected()` | `state.selected_index()` |
-| `select` | `state.set_selected(i)` | `state.set_selected_index(i)` |
-| `selectable_list` | `state.selected()` | `state.selected_index()` |
-| `selectable_list` | `state.set_selected(i)` | `state.set_selected_index(i)` |
-| `tabs` | `state.selected()` | `state.selected_index()` |
-| `tabs` | `state.set_selected(i)` | `state.set_selected_index(i)` |
-| `tree` | `state.selected()` | `state.selected_index()` |
-| `tree` | `state.set_selected(i)` | `state.set_selected_index(i)` |
-```
-
-## Unit 2 — Category B: rename 3 primary accessors, 1 setter
-
-Files touched: `diagram/state.rs`, `alert_panel/mod.rs`, `multi_progress/mod.rs`, plus their tests and callers.
-
-### Per-component change
-
-- **`diagram`** (`state.rs:263`): rename `selected()` → `selected_index()`. Body unchanged (`self.selected`). No setter.
-- **`alert_panel`** (`mod.rs:347`): rename `selected()` → `selected_index()`. Body unchanged. No setter.
-- **`multi_progress`** (`mod.rs:434`): rename `selected()` → `selected_index()`. Body unchanged. **Also** rename `set_selected` → `set_selected_index` (`mod.rs:466`).
-
-The private field `selected` on each state struct is **not** renamed — it is private, carries no ambiguity with the public method name once the method is `selected_index()`, and renaming it would inflate the diff without benefit. This differs from Cadence A's `data_grid::selected_row` field rename, which was necessary there specifically to break a *grep collision* with a deleted method name of the same spelling. No such collision exists here.
+- **Keep** `selected_index()` unchanged.
+- **Rename** `set_selected` → `set_selected_index` where present (10 of 12), updating the docstring.
 
 ### Docstring convention
 
-Each renamed getter gains:
+Matching the *actual* Cadence A precedent at `table/state.rs:422-423` — plain backticks, no intra-doc link:
+
+```rust
+/// Renamed from `set_selected()` in v0.18.0 for symmetry with
+/// `selected_index()`. See MIGRATION.md.
+```
+
+An intra-doc link form (`[`selected_index()`](Self::selected_index)`) would be nicer in rustdoc, but adopting it here would create a *new* inconsistency with the three components Cadence A already shipped unless those were retrofitted too. Out of scope; keep the shipped form.
+
+## Unit 2 — Categories B and C: 4 getter renames, 2 setter renames
+
+- **`alert_panel`** (`mod.rs:347`): `selected()` → `selected_index()`. Body unchanged. No setter.
+- **`diagram`** (`state.rs:263` — note: *not* `mod.rs`): `selected()` → `selected_index()`. Body unchanged. No setter.
+- **`multi_progress`** (`mod.rs:434`): `selected()` → `selected_index()`. Body unchanged. Also `set_selected` → `set_selected_index` (`mod.rs:466`).
+- **`box_plot`** (`state.rs:249`, `state.rs:267` — note: *not* `mod.rs`): `selected() -> usize` → `selected_index() -> usize`; `set_selected(usize)` → `set_selected_index(usize)`. **Return types unchanged** — bare `usize` matches the shipped `flame_graph::selected_index()` precedent.
+
+### Private fields are NOT renamed
+
+Category B and C bodies read a private field named `selected`. Leave it. This differs from Cadence A's `data_grid::selected_row` field rename, which was necessary there specifically to break a **grep collision** with a deleted method of the same spelling (commit `09608d6` states this reason). No such collision exists here: `self.selected` is a field read, invisible to the callsite-form (`\.selected()`) gates this cadence uses. `self.selected` behind `pub fn selected_index()` is ordinary Rust.
+
+### Docstring convention
 
 ```rust
 /// Renamed from `selected()` in v0.18.0 for consistency with the
@@ -163,91 +167,136 @@ Each renamed getter gains:
 /// See MIGRATION.md.
 ```
 
-### Migration table addition (rendered in Unit 3)
-
-```markdown
-| `alert_panel` | `state.selected()` | `state.selected_index()` |
-| `diagram` | `state.selected()` | `state.selected_index()` |
-| `multi_progress` | `state.selected()` | `state.selected_index()` |
-| `multi_progress` | `state.set_selected(i)` | `state.set_selected_index(i)` |
-```
-
 ## Unit 3 — prelude carry-over + CHANGELOG + MIGRATION
 
-Files touched: `src/lib.rs`, `CHANGELOG.md`, `MIGRATION.md`.
+### 3a. Prelude harness re-exports
 
-### 3a. Prelude re-export of the MessageSender error types
+Sanctioned by the Cadence A closure record, which parks this item in Cadence D (`docs/audits/2026-07-05-post-consistency-cleanup.md:100`) — it is bundled by prior agreement, not smuggled in.
 
-Cadence A's final whole-branch review raised this as Minor #3: `MessageSendError` and `TrySendError` are re-exported at the crate root (`src/lib.rs:408`) but **not** in the prelude (`src/lib.rs:478` re-exports only `AppHarness`, `MessageSender`, `TestHarness`). A consumer doing `use envision::prelude::*` who wants to `match` on `TrySendError::{Full, Closed}` or destructure `MessageSendError(msg)` must add an explicit second import.
+Cadence A's final review raised only `MessageSendError` + `TrySendError`. Fixing 2 of 4 would recreate the inconsistency one level down: the crate root (`src/lib.rs:408-410`) exports **seven** harness types while the prelude (`src/lib.rs:478`) re-exports **three**.
 
-Extend the prelude line at `src/lib.rs:478`:
+| Crate root | In prelude today |
+|---|---|
+| `AppHarness` | ✅ |
+| `MessageSender` | ✅ |
+| `TestHarness` | ✅ |
+| `Assertion` | ❌ |
+| `MessageSendError` | ❌ |
+| `Snapshot` | ❌ |
+| `TrySendError` | ❌ |
+
+**Add all four.** Non-breaking, additive:
 
 ```rust
 pub use crate::harness::{
-    AppHarness, MessageSendError, MessageSender, TestHarness, TrySendError,
+    AppHarness, Assertion, MessageSendError, MessageSender, Snapshot, TestHarness, TrySendError,
 };
 ```
 
-Non-breaking, additive.
-
 ### 3b. CHANGELOG
 
-v0.17.0 shipped, so the `[Unreleased]` block was renamed to `[0.17.0]` during the release. Unit 3 creates a **fresh `[Unreleased]` block** above it, containing:
+There is currently **no** `[Unreleased]` block — it was renamed to `[0.17.0]` during the v0.17.0 release. Unit 3 creates a fresh one above `## [0.17.0] - 2026-07-26`.
 
-- `### Breaking Changes` → `#### Selection accessors completed on selected_index()` — narrative covering both units, cross-referencing the MIGRATION.md table.
-- `### Added` → `#### MessageSendError + TrySendError in prelude`.
-- `### Known Deferred Findings` — **rewritten**. The Cadence D entry is removed (this cadence closes it). What remains:
-  - `box_plot::selected() -> usize` non-Option shape — needs a semantic decision about representability of "no selection" before it can be normalized.
-  - `compact_str` sporadic adoption (3 files) — needs a commit-or-drop decision.
-  - The N3–N7 cosmetic items from the 2026-07-05 audit (naming outliers `is_checked` / `label_text`, `restore_terminal` → `restore`, `AppShell` README placement, files near the 1000-line cap, snapshot-coverage concentration).
+**The `[0.17.0]` section is released and tagged; leave it byte-identical.** Keep a Changelog treats released sections as immutable, and mutating it would rewrite history a consumer may already have read. The existing Known Deferred Findings block at `CHANGELOG.md:188` stays exactly as shipped.
 
-This also satisfies Cadence A final-review Minor #2, which asked that the deferred-findings block name the setter renames explicitly rather than only the alias removal — moot once the block's Cadence D entry is deleted, but the rewrite makes the remaining scope precise.
+The new `[Unreleased]` block contains:
+
+- `### Breaking Changes` → `#### Selection accessors completed on selected_index()` — narrative covering all three units, cross-referencing the MIGRATION table.
+- `### Added` → `#### Harness types available from the prelude` — the four additions.
+- `### Known Deferred Findings` — a **new** block that opens with an explicit supersedes pointer:
+
+  > Supersedes the Known Deferred Findings block under `[0.17.0]`. The Cadence D item listed there (selection-accessor aliases, including `box_plot`) is **closed** by this release.
+
+  Remaining items:
+  - **Selection-index accessors under domain-specific names** — `chart::active_series`, `log_correlation::active_stream`, `diff_viewer::current_hunk`, `step_indicator::active_step_index`, `paginator::current_page`, `breadcrumb::focused_index`. Surveyed during Cadence D and deliberately excluded: each name carries domain meaning a generic rename would erase. Open question for a future cadence.
+  - **`box_plot::selected_index() -> usize` returns a bare `usize`**, so "no selection" is unrepresentable. Whether it should become `Option<usize>` is a semantic question, deferred. (The *naming* half closed in this release.)
+  - **`accordion::selected_index()` remains a convenience alias for `focused_index()`.** Type-normalizing, not redundant, but the indirection stands.
+  - **`compact_str` adoption is sporadic** — 2 non-test source files (`src/component/cell.rs`, `src/backend/cell/mod.rs`). Needs a commit-or-drop decision.
+  - **N3 (partially closed)** — the `tab_bar` setter-naming outlier is resolved by this cadence; the residue is `is_checked` and `label_text`. Plus N4–N7: `restore_terminal` → `restore`, `AppShell` README placement, five files near the 1000-line cap, snapshot-coverage concentration.
+
+  N2 (the README `version = "0.17"` pin) is **not** listed — it is a release-checklist item handled during `/release`, not a code deferral. It becomes `version = "0.18"` when v0.18.0 ships.
 
 ### 3c. MIGRATION.md
 
-New `## v0.17.x to v0.18.0` section inserted **above** the existing `## v0.16.x to v0.17.0`, containing:
+New `## v0.17.x to v0.18.0` section inserted above `## v0.16.x to v0.17.0`, containing:
 
-- `### Selection accessors completed on selected_index()` — the combined 26-row table from Units 1 and 2, alphabetized by component.
-- A grep hint for consumers, in the style of the v0.17 section:
+- `### Selection accessors completed on selected_index()` — a **28-row** table (16 getter changes + 12 setter renames), alphabetized by component.
+- A grep hint, extending the v0.17 section's style:
 
   ```
-  Search your codebase for `.selected()` and `.set_selected(` on any of the
-  15 components listed below. Note that `heatmap::selected()` (returns
-  `Option<(usize, usize)>` coordinates) and `box_plot::selected()` (returns
-  bare `usize`) are unchanged and should NOT be migrated.
+  Search for `.selected()` and `.set_selected(` on the 16 components below.
+
+  `heatmap::selected()` returns `Option<(usize, usize)>` coordinates and is
+  UNCHANGED — do not migrate it.
+
+  Because these are renames, `cargo build` identifies every site and the
+  compiler error names the receiver type. Note that method references
+  (`SelectState::selected`, or `.map(SelectState::selected)`) do not match a
+  `.selected()` grep but will still fail to compile.
   ```
 
-- `### MessageSendError + TrySendError available from the prelude` — a short note that the explicit `use envision::{MessageSendError, TrySendError};` import is no longer required.
+- `### Harness types available from the prelude` — a short note that the explicit `use envision::{Assertion, MessageSendError, Snapshot, TrySendError};` import is no longer required.
+
+**Archiving policy note:** PR #510 set a last-3-versions boundary for MIGRATION.md. Adding a fourth section takes the file to ~254 lines — nowhere near the 1000-line cap — so the policy is **waived this cycle**. Archive `v0.14.x → v0.15.0` at v0.19.0.
+
+## Rejected alternative: `#[deprecated]` shims
+
+The pre-v0.17.0 audit recommends the opposite of what this spec does (`docs/audits/2026-07-25-pre-v0.17.0-release.md:106`):
+
+> Add `#[deprecated(note = "use selected_index()/selected_item()")]` to the 17 `selected()` aliases (Cadence D) — turns the backlog into a compiler-guided consumer migration.
+
+**This spec rejects that recommendation**, and records the rejection rather than diverging silently:
+
+- Deprecation costs consumers **two upgrade hops** for a pure rename.
+- The fix is mechanically obvious from the compiler error — rustc emits `no method named 'selected' … did you mean 'selected_index'?` for exactly this shape.
+- Deprecation shims earn their keep for *semantic* changes, where the old call still compiles but means something subtly different. A rename is not that.
+- Delete-outright is the established pre-1.0 precedent across D5, D14, G7, D12, D3, D8, `resource_gauge::new`, `FileSortDirection`, and Cadence A's own ten renames.
 
 ## Testing strategy
 
 - Every test referencing a renamed accessor migrates mechanically.
-- Any test that exists *purely* to assert alias-equivalence (`assert_eq!(state.selected(), state.selected_index())`) is **deleted**, not renamed — post-deletion it becomes `assert_eq!(x, x)`. This is the Cadence A A2 lesson.
-- Doc-tests on the renamed methods update in place.
+- Tests that exist *purely* to assert alias-equivalence are **deleted**, not renamed — post-deletion they become `assert_eq!(x, x)`. This is the Cadence A A2 lesson. Two exist: `accordion/tests.rs:798` and `file_browser/helper_tests.rs:260`. Three more live in doctests (`dropdown/mod.rs:232`, `metrics_dashboard/mod.rs:357`, `searchable_list/mod.rs:320`) and die with their methods. **Note the non-standard filename `helper_tests.rs`** — scoping a search to `tests.rs` would miss it.
+
+### Migration surface (in-scope vs out-of-scope)
+
+The first draft cited "209 call sites" without separating out-of-scope hits. Corrected:
+
+| Area | Total `.selected()` | In scope | Out of scope |
+|---|---|---|---|
+| `src/component/` (16 in-scope dirs) | 83 | **83** | — |
+| `src/component/heatmap/` | 29 | — | 29 |
+| `tests/integration_stress.rs` | 5 | **5** (`DiagramState`) | — |
+| `tests/integration_new_components.rs` | 6 | — | 6 (`HeatmapState`) |
+| **`.selected()` subtotal** | 123 | **88** | 35 |
+| `.set_selected(` (all in `src/component/`) | 86 | **86** | — |
+| **Total** | **209** | **174** | **35** |
+
+The per-component directory greps used as gates **cannot** scope `tests/`, since integration tests are not organized by component. A tree-wide `sed` over `tests/` would break the six heatmap assertions. Hence the explicit `tests/` gate below.
 
 ### Grep gates (callsite form, per Cadence A's M1/M2 lesson)
 
-Token-boundary greps collide with private fields named `selected` and with out-of-scope components. All gates use callsite form and are scoped:
+Token-boundary greps collide with the private `selected` fields that Category B and C bodies read. All gates use callsite form.
 
 ```bash
-# In-scope components must have zero `.selected()` and zero `.set_selected(`
-grep -rn '\.selected()' \
-  src/component/{loading_list,select,radio_group,accordion,dropdown,selectable_list,menu,metrics_dashboard,tabs,tree,searchable_list,file_browser,diagram,alert_panel,multi_progress}/
-# expect: zero hits
+# No component exposes the index-shaped accessor any more.
+grep -rn 'pub fn selected(&self)' src/component/
+# expect: exactly 1 — heatmap/mod.rs:449 (Option<(usize, usize)>)
 
+# Every setter renamed — box_plot is in scope, so this is now tree-wide and honest.
 grep -rn '\.set_selected(' src/ tests/ examples/ benches/
-# expect: zero hits (no component retains the old setter name)
-
-# Out-of-scope components must be UNCHANGED
-grep -c 'pub fn selected(&self) -> Option<(usize, usize)>' src/component/heatmap/mod.rs   # expect 1
-grep -c 'pub fn selected(&self) -> usize' src/component/box_plot/state.rs                 # expect 1
-
-# Whole-tree: no component exposes the index-shaped alias any more
-grep -rn 'pub fn selected(&self) -> Option<usize>' src/component/
 # expect: zero hits
+
+# In-scope components carry no `.selected()` call sites.
+grep -rn '\.selected()' src/component/{accordion,alert_panel,box_plot,diagram,dropdown,file_browser,loading_list,menu,metrics_dashboard,multi_progress,radio_group,searchable_list,select,selectable_list,tabs,tree}/
+# expect: zero hits
+
+# Out-of-scope heatmap is UNCHANGED — these must NOT go to zero.
+grep -rnc '\.selected()' src/component/heatmap/     # expect: 29
+grep -rn '\.selected()' tests/                      # expect: 6, all HeatmapState in integration_new_components.rs
+grep -c 'pub fn selected(&self) -> Option<(usize, usize)>' src/component/heatmap/mod.rs   # expect: 1
 ```
 
-### Full gauntlet (unchanged from prior cadences)
+### Full gauntlet
 
 - `cargo fmt --check`
 - `cargo clippy --all-features -- -D warnings`
@@ -257,41 +306,44 @@ grep -rn 'pub fn selected(&self) -> Option<usize>' src/component/
 - `cargo test --no-default-features --no-run` (D8 lesson)
 - `cargo build --examples --all-features`
 - `cargo doc --no-deps --all-features` — zero intra-doc-link warnings
-- `./tools/audit/target/release/envision-audit all` — **scorecard 9/9**, "Accessor Symmetry: All setters have matching getters"
+- `./tools/audit/target/release/envision-audit all` — **scorecard 9/9**, "Accessor Symmetry: All setters have matching getters", **doctest coverage still 100%**
 
 ## Success criteria
 
-1. `grep -rn 'pub fn selected(&self) -> Option<usize>' src/component/` returns zero hits.
+1. `grep -rn 'pub fn selected(&self)' src/component/` returns exactly one hit (heatmap).
 2. `grep -rn '\.set_selected(' src/ tests/ examples/ benches/` returns zero hits.
-3. `heatmap::selected() -> Option<(usize, usize)>` and `box_plot::selected() -> usize` unchanged.
-4. Audit scorecard 9/9 with zero accessor-symmetry gaps — verified *within* each unit's commit, not deferred to a final gauntlet (the Cadence A lesson).
-5. `envision::prelude::*` exposes `MessageSendError` and `TrySendError`.
-6. CHANGELOG has a fresh `[Unreleased]` block whose Known Deferred Findings no longer lists Cadence D.
-7. MIGRATION.md has a `## v0.17.x to v0.18.0` section with the 26-row table and the grep hint.
-8. Full verification gauntlet clean.
+3. `heatmap` unchanged: 29 `src/component/` call sites, 6 `tests/` call sites, signature intact.
+4. `box_plot` renamed with return types unchanged (`usize`, not `Option<usize>`).
+5. Audit scorecard 9/9 **with doctest coverage still at 100%** — verified *within* each unit's commit, not deferred to a final gauntlet.
+6. `envision::prelude::*` exposes all seven harness types.
+7. CHANGELOG has a fresh `[Unreleased]` block; the `[0.17.0]` block is byte-identical to what shipped.
+8. MIGRATION.md has a `## v0.17.x to v0.18.0` section with the 28-row table and grep hint.
+9. Full verification gauntlet clean.
 
 ## Risk register
 
-- **Setter-symmetry regression mid-cadence.** This is the known Cadence A failure mode. Mitigated by renaming each setter in the *same commit* as its getter change, and by running the audit tool at the end of Unit 1 and Unit 2 rather than only in a final gauntlet task.
-- **Over-migrating out-of-scope call sites.** 112 of the `.selected()` hits are in `src/component/`, and some belong to `heatmap` / `box_plot`. Mitigated by per-component scoped greps rather than a tree-wide search-and-replace, and by explicit "expect 1" gates on the two out-of-scope signatures.
-- **Private field named `selected` confusing a naive grep.** Category B bodies read `self.selected`. A token-boundary grep for `selected` will hit these legitimately. Mitigated by callsite-form gates (`\.selected()`) throughout.
-- **`diagram`'s accessor lives in `state.rs`, not `mod.rs`.** The audit tool parses `mod.rs` preferentially for some checks. `diagram` has no setter, so there is no symmetry risk, but the implementer must not assume every component keeps its accessors in `mod.rs`. File paths are enumerated per-component in this spec and will be repeated in the plan.
-- **Large mechanical diff (~209 call sites).** Volume raises the chance of a missed site. Mitigated by the compiler (these are breaking renames — a missed site fails to build) plus the grep gates.
-- **Tautology tests.** Components with both `selected()` and `selected_index()` may have tests asserting they agree. Those must be deleted, not renamed. Enumerated at implementation time via `grep -rn 'assert_eq!(.*selected(),.*selected_index()' src/component/`.
+- **Setter-symmetry regression mid-cadence.** The known Cadence A failure mode. Mitigated by renaming each setter in the same commit as its getter, and running the audit tool at the end of each unit.
+- **Doctest-coverage regression — a second, independent way to drop the scorecard.** The scorecard gates doctest coverage at **100% (1777/1777)**, not a threshold, and counts a `pub fn` as covered only when a ` ``` ` fence appears in the `///` block immediately above it (`scorecard.rs`, `has_doc_test_above`). Inserting the "Renamed from…" line in a way that separates the doc block from its example fence — or dropping a fence while editing — silently drops coverage below 100% and fails the scorecard for a reason unrelated to symmetry. **Add the note adjacent to existing prose, never between the prose and the fence.** Each unit's audit run catches it.
+- **Over-migrating heatmap.** 35 out-of-scope call sites, 6 of them in `tests/` where per-component directory scoping is structurally impossible. Mitigated by the explicit "expect 29 / expect 6" gates, which fail loudly on over-migration rather than silently passing.
+- **`diagram` and `box_plot` accessors live in `state.rs`, not `mod.rs`** — and those files are invisible to the audit tool (private `mod state;`). The tool will not catch mistakes there. File paths are enumerated per-component here and repeated in the plan.
+- **Large mechanical diff (~174 in-scope call sites).** These are breaking renames, so the compiler catches misses; grep gates back it up.
+- **Tautology tests in a non-standard file.** `file_browser/helper_tests.rs:260` — a search scoped to `tests.rs` would miss it.
 
 ## Open questions
 
-None. Decisions resolved during the 2026-07-26 brainstorm:
+None. Decisions resolved during the 2026-07-26 brainstorm and the subsequent adversarial spec review:
 
-- **Category B treatment:** rename to `selected_index()` (chosen over leaving them, which would guarantee a Cadence E).
-- **`box_plot` normalization:** out of scope — the non-`Option` return type raises a semantic question distinct from naming.
-- **Prelude carry-over:** included (Cadence A final-review Minor #3).
-- **Known Deferred Findings rewrite:** included (Cadence A final-review Minor #2).
-- **Ceremony:** full 4-PR cadence, matching Cadence A's magnitude.
+- **Category B treatment:** rename to `selected_index()` (brainstorm).
+- **`box_plot`:** brought in scope after review — the `flame_graph::selected_index() -> usize` precedent makes it a pure rename, and `CHANGELOG.md:192` publicly promised it.
+- **Differently-named accessors** (`active_series`, `current_page`, …): surveyed, excluded with per-item reasoning, recorded as an open question.
+- **Prelude scope:** all four missing harness types, not the two the Cadence A review named.
+- **`#[deprecated]`:** rejected, with the audit recommendation cited and the reasoning recorded.
+- **CHANGELOG mechanics:** `[0.17.0]` left immutable; new block supersedes with an explicit pointer.
+- **Ceremony:** full 4-PR cadence.
 
 ## Reference
 
 - **Cadence A** — spec PR #506 (`cfb7cec`), plan PR #507 (`70c44bf`), impl PR #508 (`09608d6`), tracking PR #509 (`4f3bd06`). Closure record: [`docs/audits/2026-07-05-post-consistency-cleanup.md`](../../audits/2026-07-05-post-consistency-cleanup.md).
-- **Final pre-v0.17.0 audit** — `A` (3.95 GPA), [`docs/audits/2026-07-25-pre-v0.17.0-release.md`](../../audits/2026-07-25-pre-v0.17.0-release.md). Names the Cadence D backlog as the largest remaining consistency item.
-- **Delete-outright precedent (pre-1.0):** D5 `paragraph`→`line`, D14, G7, D12, D3, D8, `resource_gauge::new`, `FileSortDirection`, and Cadence A's own ten renames. No `#[deprecated]` shims.
-- **Cadence A lessons carried forward:** callsite-form grep gates (M1/M2); tautology tests deleted not renamed (A2); setter symmetry fixed in the same commit as the getter change (the Task 4 fix, promoted here to a design constraint).
+- **Final pre-v0.17.0 audit** — `A` (3.95 GPA), [`docs/audits/2026-07-25-pre-v0.17.0-release.md`](../../audits/2026-07-25-pre-v0.17.0-release.md).
+- **Delete-outright precedent (pre-1.0):** D5 `paragraph`→`line`, D14, G7, D12, D3, D8, `resource_gauge::new`, `FileSortDirection`, Cadence A's ten renames.
+- **Cadence A lessons carried forward:** callsite-form grep gates that can actually pass (M1/M2); no out-of-scope exclusion that makes the sweep dishonest (M3); tautology tests deleted not renamed (A2); setter symmetry fixed in-commit (the Task 4 fix, promoted to a design constraint).

--- a/docs/superpowers/specs/2026-07-26-cadence-d-selection-accessor-completion-design.md
+++ b/docs/superpowers/specs/2026-07-26-cadence-d-selection-accessor-completion-design.md
@@ -1,0 +1,297 @@
+# Cadence D — selection-accessor completion (v0.18.0) — design
+
+## Purpose
+
+Finish the selection-accessor unification that Cadence A began. Cadence A canonicalized `selected_item()` / `selected_index()` / `set_selected_index()` across six components (`dropdown`, `select`, `heatmap`, `tab_bar`, `data_grid`, `table`) but deliberately scoped out the remaining components carrying a `selected()` accessor. That deferral was documented in the CHANGELOG's Known Deferred Findings block and in the Cadence A closure record as "Cadence D (v0.18+)".
+
+This cadence closes it. After Cadence D, **every** envision component that exposes a selection index calls it `selected_index()`, and every corresponding mutator is `set_selected_index()`.
+
+- **Prior cadence:** Cadence A (spec PR #506, plan PR #507, impl PR #508, tracking PR #509), closure record at [`docs/audits/2026-07-05-post-consistency-cleanup.md`](../../audits/2026-07-05-post-consistency-cleanup.md).
+- **Release target:** v0.18.0. v0.17.0 shipped 2026-07-26 at commit `ec023ee`.
+- **Terminal state:** zero `pub fn selected(&self) -> Option<usize>` in `src/component/`; audit scorecard stays 9/9; the Known Deferred Findings block loses its Cadence D entry.
+
+## Scope survey (verified against the tree at `ec023ee`)
+
+The prior audit described this backlog as "~15 components with a `selected()` alias". That framing is imprecise: the 15 sites split into **three materially different categories**, and only 12 are actually aliases.
+
+### Category A — literal aliases (12 components)
+
+Body is exactly `self.selected_index()`. Pure redundancy; delete outright.
+
+| Component | `selected()` site | Has `set_selected`? |
+|---|---|---|
+| `loading_list` | `loading_list/mod.rs:357` | yes — `mod.rs:417` |
+| `select` | `select/mod.rs:222` | yes — `mod.rs:255` |
+| `radio_group` | `radio_group/mod.rs:199` | yes — `mod.rs:233` |
+| `accordion` | `accordion/mod.rs:362` | **no** |
+| `dropdown` | `dropdown/mod.rs:234` | yes — `mod.rs:267` |
+| `selectable_list` | `selectable_list/mod.rs:242` | yes — `mod.rs:305` |
+| `menu` | `menu/mod.rs:322` | yes — `mod.rs:345` |
+| `metrics_dashboard` | `metrics_dashboard/mod.rs:359` | yes — `mod.rs:380` |
+| `tabs` | `tabs/mod.rs:164` | yes — `mod.rs:198` |
+| `tree` | `tree/mod.rs:528` | yes — `mod.rs:550` |
+| `searchable_list` | `searchable_list/mod.rs:322` | yes — `mod.rs:361` |
+| `file_browser` | `file_browser/mod.rs:446` | **no** |
+
+### Category B — primary accessors (3 components)
+
+Body is `self.selected` (a direct field read). These components have **no** `selected_index()` sibling, so there is no redundancy to remove — renaming them is a pure naming-consistency change.
+
+| Component | `selected()` site | Has `set_selected`? |
+|---|---|---|
+| `diagram` | `diagram/state.rs:263` | **no** |
+| `alert_panel` | `alert_panel/mod.rs:347` | **no** |
+| `multi_progress` | `multi_progress/mod.rs:434` | yes — `mod.rs:466` |
+
+**Decision: rename Category B to `selected_index()`** rather than leaving them. Leaving them would end Cadence D with 3 components exposing `selected()` while 12 expose `selected_index()` — the exact inconsistency this cadence exists to eliminate, and a guaranteed re-flag at the next audit. Approved during brainstorm.
+
+### Setter-symmetry consequence (the Cadence A trap, pre-empted)
+
+The audit tool's accessor-symmetry check (`tools/audit/src/code_analysis.rs:238-266`) requires every `set_X()` to have a matching getter named `X`, `is_X`, or `X_value`. Deleting or renaming `selected()` orphans `set_selected()` and regresses the scorecard from 9/9 to 8/9.
+
+Cadence A hit exactly this mid-implementation: Task 4's verification gauntlet caught it after Task 1's alias deletions, forcing an unplanned fix commit. **Cadence D pre-empts it** by renaming the setters in the same commits as the getter changes.
+
+**11 setters need renaming** — all with the identical signature `pub fn set_selected(&mut self, index: Option<usize>)`:
+
+10 from Category A (`loading_list`, `select`, `radio_group`, `dropdown`, `selectable_list`, `menu`, `metrics_dashboard`, `tabs`, `tree`, `searchable_list`) plus `multi_progress` from Category B.
+
+`accordion`, `file_browser`, `diagram`, and `alert_panel` have no setter — getter change only.
+
+### Explicitly out of scope
+
+Two components expose a `selected()` whose return type makes it a genuinely different concept, not an index accessor:
+
+- **`heatmap::selected(&self) -> Option<(usize, usize)>`** at `heatmap/mod.rs:449` — returns cursor *coordinates*, not an index. Already established as out-of-scope during Cadence A, whose companion rename (`selected_value` → `value_at_selection`) exists precisely to disentangle heatmap's value accessor from the selection-accessor pattern. Unchanged.
+- **`box_plot::selected(&self) -> usize`** at `box_plot/state.rs:249` — returns a bare `usize`, not `Option<usize>`. Normalizing it would require deciding whether the return type becomes `Option<usize>` (a semantic change about whether "no selection" is representable), which is a different question from naming consistency. Deferred; noted in the CHANGELOG as a known remaining item.
+
+### Verification that Cadence A holds
+
+`table`, `data_grid`, and `tab_bar` each have zero `pub fn selected(&self) -> Option<usize>` — confirmed at `ec023ee`. Cadence A's work is intact and is not re-touched here.
+
+### Migration surface
+
+209 call sites across the tree:
+
+| Area | `.selected()` | `.set_selected(` |
+|---|---|---|
+| `src/component/` | 112 | 86 |
+| `tests/` | 11 | 0 |
+| `src/app/`, `src/harness/`, `examples/`, `benches/` | 0 | 0 |
+
+Note that the 112 `src/component/` `.selected()` hits include calls on `heatmap` and `box_plot` (out of scope) — the implementer must migrate only in-scope call sites. Per-component grep gates in the plan handle this.
+
+## Cadence structure
+
+Standard 4-PR pattern, matching Cadence A:
+
+1. Spec PR (this document)
+2. Plan PR
+3. Impl PR — three signed commits (Unit 1 / Unit 2 / Unit 3)
+4. Tracking-doc PR — closure record at `docs/audits/2026-07-26-post-cadence-d.md`
+
+Full ceremony is warranted: 15 breaking renames across 15 components, ~209 call sites, and a real design decision (Category B). Cadence A was the same magnitude and its adversarial spec review surfaced four must-fix design bugs — worth the gate.
+
+## Unit 1 — Category A: delete 12 aliases, rename 10 setters
+
+Files touched: the 12 components' `mod.rs` files, their `tests.rs`/`tests/` files, plus any in-tree caller.
+
+### Per-component change
+
+For each of the 12 Category A components:
+
+- **Delete** `pub fn selected(&self) -> Option<usize> { self.selected_index() }` and its docstring.
+- **Keep** `selected_index()` unchanged — it is already the canonical accessor.
+- **Rename** `set_selected` → `set_selected_index` where present (10 of 12), updating the docstring to reference `selected_index()` as its getter counterpart and noting the rename with a MIGRATION.md pointer.
+
+### Docstring convention for renamed setters
+
+Each renamed setter gains a line matching the Cadence A precedent:
+
+```rust
+/// Renamed from `set_selected()` in v0.18.0 for symmetry with
+/// [`selected_index()`](Self::selected_index). See MIGRATION.md.
+```
+
+### Migration table (rendered in Unit 3)
+
+```markdown
+| Component | Old | New |
+|---|---|---|
+| `accordion` | `state.selected()` | `state.selected_index()` |
+| `dropdown` | `state.selected()` | `state.selected_index()` |
+| `dropdown` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `file_browser` | `state.selected()` | `state.selected_index()` |
+| `loading_list` | `state.selected()` | `state.selected_index()` |
+| `loading_list` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `menu` | `state.selected()` | `state.selected_index()` |
+| `menu` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `metrics_dashboard` | `state.selected()` | `state.selected_index()` |
+| `metrics_dashboard` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `radio_group` | `state.selected()` | `state.selected_index()` |
+| `radio_group` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `searchable_list` | `state.selected()` | `state.selected_index()` |
+| `searchable_list` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `select` | `state.selected()` | `state.selected_index()` |
+| `select` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `selectable_list` | `state.selected()` | `state.selected_index()` |
+| `selectable_list` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `tabs` | `state.selected()` | `state.selected_index()` |
+| `tabs` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `tree` | `state.selected()` | `state.selected_index()` |
+| `tree` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+```
+
+## Unit 2 — Category B: rename 3 primary accessors, 1 setter
+
+Files touched: `diagram/state.rs`, `alert_panel/mod.rs`, `multi_progress/mod.rs`, plus their tests and callers.
+
+### Per-component change
+
+- **`diagram`** (`state.rs:263`): rename `selected()` → `selected_index()`. Body unchanged (`self.selected`). No setter.
+- **`alert_panel`** (`mod.rs:347`): rename `selected()` → `selected_index()`. Body unchanged. No setter.
+- **`multi_progress`** (`mod.rs:434`): rename `selected()` → `selected_index()`. Body unchanged. **Also** rename `set_selected` → `set_selected_index` (`mod.rs:466`).
+
+The private field `selected` on each state struct is **not** renamed — it is private, carries no ambiguity with the public method name once the method is `selected_index()`, and renaming it would inflate the diff without benefit. This differs from Cadence A's `data_grid::selected_row` field rename, which was necessary there specifically to break a *grep collision* with a deleted method name of the same spelling. No such collision exists here.
+
+### Docstring convention
+
+Each renamed getter gains:
+
+```rust
+/// Renamed from `selected()` in v0.18.0 for consistency with the
+/// `selected_index()` accessor used across every other component.
+/// See MIGRATION.md.
+```
+
+### Migration table addition (rendered in Unit 3)
+
+```markdown
+| `alert_panel` | `state.selected()` | `state.selected_index()` |
+| `diagram` | `state.selected()` | `state.selected_index()` |
+| `multi_progress` | `state.selected()` | `state.selected_index()` |
+| `multi_progress` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+```
+
+## Unit 3 — prelude carry-over + CHANGELOG + MIGRATION
+
+Files touched: `src/lib.rs`, `CHANGELOG.md`, `MIGRATION.md`.
+
+### 3a. Prelude re-export of the MessageSender error types
+
+Cadence A's final whole-branch review raised this as Minor #3: `MessageSendError` and `TrySendError` are re-exported at the crate root (`src/lib.rs:408`) but **not** in the prelude (`src/lib.rs:478` re-exports only `AppHarness`, `MessageSender`, `TestHarness`). A consumer doing `use envision::prelude::*` who wants to `match` on `TrySendError::{Full, Closed}` or destructure `MessageSendError(msg)` must add an explicit second import.
+
+Extend the prelude line at `src/lib.rs:478`:
+
+```rust
+pub use crate::harness::{
+    AppHarness, MessageSendError, MessageSender, TestHarness, TrySendError,
+};
+```
+
+Non-breaking, additive.
+
+### 3b. CHANGELOG
+
+v0.17.0 shipped, so the `[Unreleased]` block was renamed to `[0.17.0]` during the release. Unit 3 creates a **fresh `[Unreleased]` block** above it, containing:
+
+- `### Breaking Changes` → `#### Selection accessors completed on selected_index()` — narrative covering both units, cross-referencing the MIGRATION.md table.
+- `### Added` → `#### MessageSendError + TrySendError in prelude`.
+- `### Known Deferred Findings` — **rewritten**. The Cadence D entry is removed (this cadence closes it). What remains:
+  - `box_plot::selected() -> usize` non-Option shape — needs a semantic decision about representability of "no selection" before it can be normalized.
+  - `compact_str` sporadic adoption (3 files) — needs a commit-or-drop decision.
+  - The N3–N7 cosmetic items from the 2026-07-05 audit (naming outliers `is_checked` / `label_text`, `restore_terminal` → `restore`, `AppShell` README placement, files near the 1000-line cap, snapshot-coverage concentration).
+
+This also satisfies Cadence A final-review Minor #2, which asked that the deferred-findings block name the setter renames explicitly rather than only the alias removal — moot once the block's Cadence D entry is deleted, but the rewrite makes the remaining scope precise.
+
+### 3c. MIGRATION.md
+
+New `## v0.17.x to v0.18.0` section inserted **above** the existing `## v0.16.x to v0.17.0`, containing:
+
+- `### Selection accessors completed on selected_index()` — the combined 26-row table from Units 1 and 2, alphabetized by component.
+- A grep hint for consumers, in the style of the v0.17 section:
+
+  ```
+  Search your codebase for `.selected()` and `.set_selected(` on any of the
+  15 components listed below. Note that `heatmap::selected()` (returns
+  `Option<(usize, usize)>` coordinates) and `box_plot::selected()` (returns
+  bare `usize`) are unchanged and should NOT be migrated.
+  ```
+
+- `### MessageSendError + TrySendError available from the prelude` — a short note that the explicit `use envision::{MessageSendError, TrySendError};` import is no longer required.
+
+## Testing strategy
+
+- Every test referencing a renamed accessor migrates mechanically.
+- Any test that exists *purely* to assert alias-equivalence (`assert_eq!(state.selected(), state.selected_index())`) is **deleted**, not renamed — post-deletion it becomes `assert_eq!(x, x)`. This is the Cadence A A2 lesson.
+- Doc-tests on the renamed methods update in place.
+
+### Grep gates (callsite form, per Cadence A's M1/M2 lesson)
+
+Token-boundary greps collide with private fields named `selected` and with out-of-scope components. All gates use callsite form and are scoped:
+
+```bash
+# In-scope components must have zero `.selected()` and zero `.set_selected(`
+grep -rn '\.selected()' \
+  src/component/{loading_list,select,radio_group,accordion,dropdown,selectable_list,menu,metrics_dashboard,tabs,tree,searchable_list,file_browser,diagram,alert_panel,multi_progress}/
+# expect: zero hits
+
+grep -rn '\.set_selected(' src/ tests/ examples/ benches/
+# expect: zero hits (no component retains the old setter name)
+
+# Out-of-scope components must be UNCHANGED
+grep -c 'pub fn selected(&self) -> Option<(usize, usize)>' src/component/heatmap/mod.rs   # expect 1
+grep -c 'pub fn selected(&self) -> usize' src/component/box_plot/state.rs                 # expect 1
+
+# Whole-tree: no component exposes the index-shaped alias any more
+grep -rn 'pub fn selected(&self) -> Option<usize>' src/component/
+# expect: zero hits
+```
+
+### Full gauntlet (unchanged from prior cadences)
+
+- `cargo fmt --check`
+- `cargo clippy --all-features -- -D warnings`
+- `cargo nextest run --all-features`
+- `cargo test --all-features --doc`
+- `cargo build --no-default-features`
+- `cargo test --no-default-features --no-run` (D8 lesson)
+- `cargo build --examples --all-features`
+- `cargo doc --no-deps --all-features` — zero intra-doc-link warnings
+- `./tools/audit/target/release/envision-audit all` — **scorecard 9/9**, "Accessor Symmetry: All setters have matching getters"
+
+## Success criteria
+
+1. `grep -rn 'pub fn selected(&self) -> Option<usize>' src/component/` returns zero hits.
+2. `grep -rn '\.set_selected(' src/ tests/ examples/ benches/` returns zero hits.
+3. `heatmap::selected() -> Option<(usize, usize)>` and `box_plot::selected() -> usize` unchanged.
+4. Audit scorecard 9/9 with zero accessor-symmetry gaps — verified *within* each unit's commit, not deferred to a final gauntlet (the Cadence A lesson).
+5. `envision::prelude::*` exposes `MessageSendError` and `TrySendError`.
+6. CHANGELOG has a fresh `[Unreleased]` block whose Known Deferred Findings no longer lists Cadence D.
+7. MIGRATION.md has a `## v0.17.x to v0.18.0` section with the 26-row table and the grep hint.
+8. Full verification gauntlet clean.
+
+## Risk register
+
+- **Setter-symmetry regression mid-cadence.** This is the known Cadence A failure mode. Mitigated by renaming each setter in the *same commit* as its getter change, and by running the audit tool at the end of Unit 1 and Unit 2 rather than only in a final gauntlet task.
+- **Over-migrating out-of-scope call sites.** 112 of the `.selected()` hits are in `src/component/`, and some belong to `heatmap` / `box_plot`. Mitigated by per-component scoped greps rather than a tree-wide search-and-replace, and by explicit "expect 1" gates on the two out-of-scope signatures.
+- **Private field named `selected` confusing a naive grep.** Category B bodies read `self.selected`. A token-boundary grep for `selected` will hit these legitimately. Mitigated by callsite-form gates (`\.selected()`) throughout.
+- **`diagram`'s accessor lives in `state.rs`, not `mod.rs`.** The audit tool parses `mod.rs` preferentially for some checks. `diagram` has no setter, so there is no symmetry risk, but the implementer must not assume every component keeps its accessors in `mod.rs`. File paths are enumerated per-component in this spec and will be repeated in the plan.
+- **Large mechanical diff (~209 call sites).** Volume raises the chance of a missed site. Mitigated by the compiler (these are breaking renames — a missed site fails to build) plus the grep gates.
+- **Tautology tests.** Components with both `selected()` and `selected_index()` may have tests asserting they agree. Those must be deleted, not renamed. Enumerated at implementation time via `grep -rn 'assert_eq!(.*selected(),.*selected_index()' src/component/`.
+
+## Open questions
+
+None. Decisions resolved during the 2026-07-26 brainstorm:
+
+- **Category B treatment:** rename to `selected_index()` (chosen over leaving them, which would guarantee a Cadence E).
+- **`box_plot` normalization:** out of scope — the non-`Option` return type raises a semantic question distinct from naming.
+- **Prelude carry-over:** included (Cadence A final-review Minor #3).
+- **Known Deferred Findings rewrite:** included (Cadence A final-review Minor #2).
+- **Ceremony:** full 4-PR cadence, matching Cadence A's magnitude.
+
+## Reference
+
+- **Cadence A** — spec PR #506 (`cfb7cec`), plan PR #507 (`70c44bf`), impl PR #508 (`09608d6`), tracking PR #509 (`4f3bd06`). Closure record: [`docs/audits/2026-07-05-post-consistency-cleanup.md`](../../audits/2026-07-05-post-consistency-cleanup.md).
+- **Final pre-v0.17.0 audit** — `A` (3.95 GPA), [`docs/audits/2026-07-25-pre-v0.17.0-release.md`](../../audits/2026-07-25-pre-v0.17.0-release.md). Names the Cadence D backlog as the largest remaining consistency item.
+- **Delete-outright precedent (pre-1.0):** D5 `paragraph`→`line`, D14, G7, D12, D3, D8, `resource_gauge::new`, `FileSortDirection`, and Cadence A's own ten renames. No `#[deprecated]` shims.
+- **Cadence A lessons carried forward:** callsite-form grep gates (M1/M2); tautology tests deleted not renamed (A2); setter symmetry fixed in the same commit as the getter change (the Task 4 fix, promoted here to a design constraint).


### PR DESCRIPTION
## Summary

830-line implementation plan for the 5-task cadence in spec PR #514. Every step carries verbatim code or an exact command; no placeholders.

## Tasks

| Task | Deliverable | Commit? |
|---|---|---|
| 1 | Unit 1 — delete 12 aliases, rename 10 setters, delete 2 tautology tests | ✅ signed |
| 2 | Unit 2 — rename 4 primary accessors + 2 setters (`box_plot` keeps bare `usize`) | ✅ signed |
| 3 | Unit 3 — prelude (all 4 missing harness types), CHANGELOG `[Unreleased]`, MIGRATION § v0.17.x→v0.18.0 | ✅ signed |
| 4 | Full gauntlet + success-criteria gates | — verification only |
| 5 | Merge main, push, open impl PR | — |

## Every cited line number verified against the tree

Before writing: all 16 getter sites, all 12 setter sites, both tautology tests (including the non-standard filename `file_browser/helper_tests.rs`), the 5 `DiagramState` sites in `tests/integration_stress.rs` at 427/441/450/470/488, `src/lib.rs:478`, and MIGRATION.md's line-3 insertion point.

## Per-component migration counts are tabulated

So the implementer knows what to expect rather than discovering it:

- `loading_list` — **30** setter sites (largest single component)
- `multi_progress` — 14 setter, 15 getter
- `alert_panel` — **20** getter sites
- `box_plot` — 17 getter, 8 setter
- `menu` — 9 setter

Total in scope: **174**.

## Two verification constraints promoted into Global Constraints

**1. The audit gate runs at the end of *each unit*, not in a final task.** Cadence A deferred it and paid with an unplanned fix commit when setter symmetry regressed mid-implementation.

**2. The doctest-coverage hazard gets its own section** with correct/incorrect examples. Coverage gates at a hard **100% (1777/1777)** and counts a `pub fn` as covered only when a fence sits immediately above it — so a "Renamed from…" note placed *after* the fence silently fails the scorecard for a reason unrelated to symmetry. This is a second, independent regression vector the spec's first draft didn't guard.

## Gotchas surfaced up front

- `diagram/state.rs` and `box_plot/state.rs` sit behind a **private `mod state;`** and are invisible to every audit-tool check (`scorecard.rs:275-295`). A clean scorecard is *not* evidence those two files are correct — the compiler and grep gates are.
- `file_browser/helper_tests.rs` — non-standard filename; a search scoped to `tests.rs` misses one of the two tautology tests.
- That same test isn't pure tautology: it also asserts default selection is index 0. The plan preserves that assertion under a name describing what it actually checks, rather than deleting the whole function.

## Grep gates fail loudly on over-migration

Gates use callsite form throughout and include explicit **`expect 29` / `expect 6`** assertions on `heatmap` — so migrating it by mistake fails rather than passing silently. The `tests/` gate exists because per-component directory scoping structurally cannot reach integration tests, where 6 of the out-of-scope hits live.

## Test plan

- [x] Doc-only PR — no code changes
- [x] Signed commit verified locally
- [x] Self-review: spec coverage complete, no placeholders, every line number re-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)