### PR TITLE
Impl: Cadence D — selection-accessor completion (v0.18.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Selection accessors completed on `selected_index()`
 
-Cadence A unified selection accessors across six components. This release finishes the job: every component whose selection accessor was spelled `selected` now spells it `selected_index`, and every corresponding mutator is `set_selected_index`.
+Cadence A unified selection accessors across six components. This release finishes the getter/setter half: every component whose selection accessor was spelled `selected` now spells it `selected_index`, and every corresponding mutator is `set_selected_index`. The `with_selected` builder leg is untouched and remains deferred.
 
 The motivation is that `selected` was ambiguous about return type. Four different signatures shared the spelling: `Option<usize>` (15 components), `Option<(usize, usize)>` (`heatmap`), bare `usize` (`box_plot`), and a `bool` builder (`annotation::widget`). The `selected_index` / `selected_item` / `value_at_selection` system makes the name predict the type.
 
@@ -41,6 +41,8 @@ Added: `Assertion`, `MessageSendError`, `Snapshot`, `TrySendError`.
 
 - **Selection-index accessors under domain-specific names.** `chart::active_series`, `log_correlation::active_stream`, `diff_viewer::current_hunk`, `step_indicator::active_step_index`, `paginator::current_page`, `breadcrumb::focused_index`. Surveyed during Cadence D and deliberately excluded: each name carries domain meaning that a generic rename would erase. Open question for a future cadence.
 - **`box_plot::selected_index()` returns a bare `usize`**, so "no selection" is unrepresentable. Whether it should become `Option<usize>` is a semantic question, deferred — the naming half closed in this release.
+- **The `with_selected` builder leg was not renamed.** `menu`, `tabs`, `tree`, `loading_list`, `selectable_list`, `radio_group`, `table`, and `tab_bar` still expose `with_selected(i)` alongside `set_selected_index()` and `selected_index()`, so one type now carries two spellings of the same concept. Renaming it to `with_selected_index` is a second breaking change that belongs in its own cadence, not bolted onto this one.
+- **Three `selected_item()` one-line aliases survive** — `file_browser::selected_item()` → `selected_entry()`, `tree::selected_item()` → `selected_node()`, `accordion::selected_item()` → `focused_panel()`. These are the same "pure redundancy" shape this release deleted twelve times, kept only because `selected_item()` is the canonical cross-component spelling Cadence A established. Delete-or-keep is an open question.
 - **`accordion::selected_index()` remains a convenience alias for `focused_index()`.** It performs real work (Option-normalizing the empty case) so it is not redundant, but the indirection stands.
 - **`compact_str` adoption is sporadic** — 2 non-test source files (`src/component/cell.rs`, `src/backend/cell/mod.rs`). Needs a commit-or-drop decision.
 - **Naming outliers** — `is_checked`, `label_text` (the `tab_bar` setter outlier previously grouped here is closed by this release). Plus `restore_terminal` → `restore`, `AppShell` placement in the README component table, five files near the 1000-line cap, and snapshot-coverage concentration in ~20 of 74 components.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Breaking Changes
+
+#### Selection accessors completed on `selected_index()`
+
+Cadence A unified selection accessors across six components. This release finishes the job: every component whose selection accessor was spelled `selected` now spells it `selected_index`, and every corresponding mutator is `set_selected_index`.
+
+The motivation is that `selected` was ambiguous about return type. Four different signatures shared the spelling: `Option<usize>` (15 components), `Option<(usize, usize)>` (`heatmap`), bare `usize` (`box_plot`), and a `bool` builder (`annotation::widget`). The `selected_index` / `selected_item` / `value_at_selection` system makes the name predict the type.
+
+**Aliases deleted** (body was exactly `self.selected_index()`) — `accordion`, `dropdown`, `file_browser`, `loading_list`, `menu`, `metrics_dashboard`, `radio_group`, `searchable_list`, `select`, `selectable_list`, `tabs`, `tree`.
+
+**Primary accessors renamed** (no `selected_index()` sibling existed) — `alert_panel`, `diagram`, `multi_progress`, `box_plot`.
+
+**Setters renamed** `set_selected` → `set_selected_index` on all twelve components that had one.
+
+`box_plot::selected_index()` keeps its bare `usize` return, matching the existing `flame_graph::selected_index()`. Whether it should become `Option<usize>` is a separate question, deferred.
+
+`heatmap::selected()` is **unchanged** — it returns `Option<(usize, usize)>` coordinates, not an index, and was disentangled from this pattern during Cadence A.
+
+See `MIGRATION.md` § *v0.17.x to v0.18.0* for the full before/after table.
+
+### Added
+
+#### Harness types available from the prelude
+
+`envision::prelude::*` now re-exports the seven harness types available at the crate root. Previously only `AppHarness`, `MessageSender`, and `TestHarness` were included, so consumers matching on `TrySendError::{Full, Closed}`, destructuring `MessageSendError`, or using `Assertion` / `Snapshot` needed a second explicit import.
+
+Added: `Assertion`, `MessageSendError`, `Snapshot`, `TrySendError`.
+
+### Known Deferred Findings
+
+> Supersedes the Known Deferred Findings block under `[0.17.0]`. The Cadence D item listed there — selection-accessor aliases, including `box_plot` — is **closed** by this release.
+
+- **Selection-index accessors under domain-specific names.** `chart::active_series`, `log_correlation::active_stream`, `diff_viewer::current_hunk`, `step_indicator::active_step_index`, `paginator::current_page`, `breadcrumb::focused_index`. Surveyed during Cadence D and deliberately excluded: each name carries domain meaning that a generic rename would erase. Open question for a future cadence.
+- **`box_plot::selected_index()` returns a bare `usize`**, so "no selection" is unrepresentable. Whether it should become `Option<usize>` is a semantic question, deferred — the naming half closed in this release.
+- **`accordion::selected_index()` remains a convenience alias for `focused_index()`.** It performs real work (Option-normalizing the empty case) so it is not redundant, but the indirection stands.
+- **`compact_str` adoption is sporadic** — 2 non-test source files (`src/component/cell.rs`, `src/backend/cell/mod.rs`). Needs a commit-or-drop decision.
+- **Naming outliers** — `is_checked`, `label_text` (the `tab_bar` setter outlier previously grouped here is closed by this release). Plus `restore_terminal` → `restore`, `AppShell` placement in the README component table, five files near the 1000-line cap, and snapshot-coverage concentration in ~20 of 74 components.
+
 ## [0.17.0] - 2026-07-26
 
 ### Breaking Changes

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,54 @@
 # Migration Guide
 
+## v0.17.x to v0.18.0
+
+### Selection accessors completed on `selected_index()`
+
+Every component whose selection accessor was spelled `selected` now spells it `selected_index`; every corresponding mutator is `set_selected_index`.
+
+| Component | Old | New |
+|---|---|---|
+| `accordion` | `state.selected()` | `state.selected_index()` |
+| `alert_panel` | `state.selected()` | `state.selected_index()` |
+| `box_plot` | `state.selected()` | `state.selected_index()` |
+| `box_plot` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `diagram` | `state.selected()` | `state.selected_index()` |
+| `dropdown` | `state.selected()` | `state.selected_index()` |
+| `dropdown` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `file_browser` | `state.selected()` | `state.selected_index()` |
+| `loading_list` | `state.selected()` | `state.selected_index()` |
+| `loading_list` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `menu` | `state.selected()` | `state.selected_index()` |
+| `menu` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `metrics_dashboard` | `state.selected()` | `state.selected_index()` |
+| `metrics_dashboard` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `multi_progress` | `state.selected()` | `state.selected_index()` |
+| `multi_progress` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `radio_group` | `state.selected()` | `state.selected_index()` |
+| `radio_group` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `searchable_list` | `state.selected()` | `state.selected_index()` |
+| `searchable_list` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `select` | `state.selected()` | `state.selected_index()` |
+| `select` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `selectable_list` | `state.selected()` | `state.selected_index()` |
+| `selectable_list` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `tabs` | `state.selected()` | `state.selected_index()` |
+| `tabs` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+| `tree` | `state.selected()` | `state.selected_index()` |
+| `tree` | `state.set_selected(i)` | `state.set_selected_index(i)` |
+
+Return types are unchanged in every case, including `box_plot`, whose accessor stays a bare `usize`.
+
+**Finding your call sites.** Search for `.selected()` and `.set_selected(` on the sixteen components above.
+
+`heatmap::selected()` returns `Option<(usize, usize)>` coordinates and is **unchanged** — do not migrate it.
+
+Because these are renames, `cargo build` identifies every site and the compiler error names the receiver type, which disambiguates `heatmap` from the rest. Note that method references (`SelectState::selected`, or `.map(SelectState::selected)`) will not match a `.selected()` grep but will still fail to compile.
+
+### Harness types available from the prelude
+
+`envision::prelude::*` now re-exports `Assertion`, `MessageSendError`, `Snapshot`, and `TrySendError` alongside the three it already provided. The explicit `use envision::{Assertion, MessageSendError, Snapshot, TrySendError};` import is no longer required.
+
 ## v0.16.x to v0.17.0
 
 ### `App::init` takes args; `RuntimeBuilder` split

--- a/src/component/accordion/mod.rs
+++ b/src/component/accordion/mod.rs
@@ -343,26 +343,6 @@ impl AccordionState {
         }
     }
 
-    /// Returns the currently focused panel index as an `Option`.
-    ///
-    /// This is an alias for [`selected_index()`](Self::selected_index) that provides a
-    /// consistent accessor name across all selection-based components.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::AccordionState;
-    ///
-    /// let state = AccordionState::from_pairs(vec![("A", "1"), ("B", "2")]);
-    /// assert_eq!(state.selected(), Some(0));
-    ///
-    /// let empty = AccordionState::new(vec![]);
-    /// assert_eq!(empty.selected(), None);
-    /// ```
-    pub fn selected(&self) -> Option<usize> {
-        self.selected_index()
-    }
-
     /// Returns the currently focused panel.
     ///
     /// This is an alias for [`focused_panel()`](Self::focused_panel) that provides a

--- a/src/component/accordion/tests.rs
+++ b/src/component/accordion/tests.rs
@@ -792,19 +792,6 @@ fn test_selected_index_returns_none_when_empty() {
 }
 
 #[test]
-fn test_selected_alias_matches_selected_index() {
-    let panels = vec![AccordionPanel::new("A", "1"), AccordionPanel::new("B", "2")];
-    let state = AccordionState::new(panels);
-    assert_eq!(state.selected(), state.selected_index());
-}
-
-#[test]
-fn test_selected_alias_returns_none_when_empty() {
-    let state = AccordionState::new(vec![]);
-    assert_eq!(state.selected(), None);
-}
-
-#[test]
 fn test_selected_index_after_focus_change() {
     let panels = vec![
         AccordionPanel::new("A", "1"),
@@ -814,5 +801,5 @@ fn test_selected_index_after_focus_change() {
     let mut state = AccordionState::new(panels);
     Accordion::update(&mut state, AccordionMessage::Down);
     assert_eq!(state.selected_index(), Some(1));
-    assert_eq!(state.selected(), Some(1));
+    assert_eq!(state.selected_index(), Some(1));
 }

--- a/src/component/accordion/tests.rs
+++ b/src/component/accordion/tests.rs
@@ -801,5 +801,4 @@ fn test_selected_index_after_focus_change() {
     let mut state = AccordionState::new(panels);
     Accordion::update(&mut state, AccordionMessage::Down);
     assert_eq!(state.selected_index(), Some(1));
-    assert_eq!(state.selected_index(), Some(1));
 }

--- a/src/component/alert_panel/mod.rs
+++ b/src/component/alert_panel/mod.rs
@@ -334,6 +334,10 @@ impl AlertPanelState {
 
     /// Returns the selected metric index.
     ///
+    /// Renamed from `selected()` in v0.18.0 for consistency with the
+    /// `selected_index()` accessor used across every other component.
+    /// See MIGRATION.md.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -342,9 +346,9 @@ impl AlertPanelState {
     /// let state = AlertPanelState::new().with_metrics(vec![
     ///     AlertMetric::new("cpu", "CPU", AlertThreshold::new(70.0, 90.0)),
     /// ]);
-    /// assert_eq!(state.selected(), Some(0));
+    /// assert_eq!(state.selected_index(), Some(0));
     /// ```
-    pub fn selected(&self) -> Option<usize> {
+    pub fn selected_index(&self) -> Option<usize> {
         self.selected
     }
 
@@ -447,7 +451,7 @@ impl AlertPanelState {
     ///     AlertMetric::new("cpu", "CPU", AlertThreshold::new(70.0, 90.0))
     /// );
     /// assert_eq!(state.metrics().len(), 1);
-    /// assert_eq!(state.selected(), Some(0));
+    /// assert_eq!(state.selected_index(), Some(0));
     /// ```
     pub fn add_metric(&mut self, metric: AlertMetric) {
         self.metrics.push(metric);

--- a/src/component/alert_panel/render.rs
+++ b/src/component/alert_panel/render.rs
@@ -96,7 +96,7 @@ pub(super) fn render_alert_panel(
         for (col_idx, col_area) in col_areas.iter().enumerate() {
             let metric_idx = row_idx * cols + col_idx;
             if let Some(metric) = state.metrics().get(metric_idx) {
-                let is_selected = state.selected() == Some(metric_idx);
+                let is_selected = state.selected_index() == Some(metric_idx);
                 render_metric_card(
                     MetricCardInput {
                         metric,

--- a/src/component/alert_panel/tests.rs
+++ b/src/component/alert_panel/tests.rs
@@ -34,7 +34,7 @@ fn test_new() {
     let state = AlertPanelState::new();
     assert!(state.metrics().is_empty());
     assert_eq!(state.columns(), 2);
-    assert_eq!(state.selected(), None);
+    assert_eq!(state.selected_index(), None);
     assert!(state.show_sparklines());
     assert!(!state.show_thresholds());
     assert_eq!(state.title(), None);
@@ -44,7 +44,7 @@ fn test_new() {
 fn test_with_metrics() {
     let state = AlertPanelState::new().with_metrics(sample_metrics());
     assert_eq!(state.metrics().len(), 4);
-    assert_eq!(state.selected(), Some(0));
+    assert_eq!(state.selected_index(), Some(0));
 }
 
 #[test]
@@ -222,14 +222,14 @@ fn test_update_value_recomputes_state() {
 #[test]
 fn test_add_metric() {
     let mut state = AlertPanelState::new();
-    assert_eq!(state.selected(), None);
+    assert_eq!(state.selected_index(), None);
     state.add_metric(AlertMetric::new(
         "cpu",
         "CPU",
         AlertThreshold::new(70.0, 90.0),
     ));
     assert_eq!(state.metrics().len(), 1);
-    assert_eq!(state.selected(), Some(0));
+    assert_eq!(state.selected_index(), Some(0));
 }
 
 #[test]
@@ -241,7 +241,7 @@ fn test_add_metric_preserves_selection() {
         AlertThreshold::new(50.0, 80.0),
     ));
     assert_eq!(state.metrics().len(), 5);
-    assert_eq!(state.selected(), Some(0));
+    assert_eq!(state.selected_index(), Some(0));
 }
 
 #[test]
@@ -363,7 +363,7 @@ fn test_mixed_state_counts() {
 fn test_select_next() {
     let mut state = focused_state();
     let output = AlertPanel::update(&mut state, AlertPanelMessage::SelectNext);
-    assert_eq!(state.selected(), Some(1));
+    assert_eq!(state.selected_index(), Some(1));
     assert_eq!(output, Some(AlertPanelOutput::MetricSelected("mem".into())));
 }
 
@@ -372,7 +372,7 @@ fn test_select_prev() {
     let mut state = focused_state();
     AlertPanel::update(&mut state, AlertPanelMessage::SelectNext);
     let output = AlertPanel::update(&mut state, AlertPanelMessage::SelectPrev);
-    assert_eq!(state.selected(), Some(0));
+    assert_eq!(state.selected_index(), Some(0));
     assert_eq!(output, Some(AlertPanelOutput::MetricSelected("cpu".into())));
 }
 
@@ -381,7 +381,7 @@ fn test_select_next_at_row_end() {
     let mut state = focused_state();
     AlertPanel::update(&mut state, AlertPanelMessage::SelectNext);
     let output = AlertPanel::update(&mut state, AlertPanelMessage::SelectNext);
-    assert_eq!(state.selected(), Some(1));
+    assert_eq!(state.selected_index(), Some(1));
     assert_eq!(output, None);
 }
 
@@ -389,7 +389,7 @@ fn test_select_next_at_row_end() {
 fn test_select_prev_at_row_start() {
     let mut state = focused_state();
     let output = AlertPanel::update(&mut state, AlertPanelMessage::SelectPrev);
-    assert_eq!(state.selected(), Some(0));
+    assert_eq!(state.selected_index(), Some(0));
     assert_eq!(output, None);
 }
 
@@ -397,7 +397,7 @@ fn test_select_prev_at_row_start() {
 fn test_select_down() {
     let mut state = focused_state();
     let output = AlertPanel::update(&mut state, AlertPanelMessage::SelectDown);
-    assert_eq!(state.selected(), Some(2));
+    assert_eq!(state.selected_index(), Some(2));
     assert_eq!(
         output,
         Some(AlertPanelOutput::MetricSelected("disk".into()))
@@ -409,7 +409,7 @@ fn test_select_up() {
     let mut state = focused_state();
     AlertPanel::update(&mut state, AlertPanelMessage::SelectDown);
     let output = AlertPanel::update(&mut state, AlertPanelMessage::SelectUp);
-    assert_eq!(state.selected(), Some(0));
+    assert_eq!(state.selected_index(), Some(0));
     assert_eq!(output, Some(AlertPanelOutput::MetricSelected("cpu".into())));
 }
 
@@ -507,7 +507,7 @@ fn test_remove_last_metric_clears_selection() {
         AlertThreshold::new(70.0, 90.0),
     )]);
     AlertPanel::update(&mut state, AlertPanelMessage::RemoveMetric("cpu".into()));
-    assert_eq!(state.selected(), None);
+    assert_eq!(state.selected_index(), None);
 }
 
 #[test]
@@ -518,10 +518,10 @@ fn test_remove_metric_adjusts_selection() {
     ]);
     // Select last item
     AlertPanel::update(&mut state, AlertPanelMessage::SelectNext);
-    assert_eq!(state.selected(), Some(1));
+    assert_eq!(state.selected_index(), Some(1));
     // Remove last item
     AlertPanel::update(&mut state, AlertPanelMessage::RemoveMetric("b".into()));
-    assert_eq!(state.selected(), Some(0));
+    assert_eq!(state.selected_index(), Some(0));
 }
 
 #[test]
@@ -530,7 +530,7 @@ fn test_set_metrics_message() {
     let metrics = sample_metrics();
     AlertPanel::update(&mut state, AlertPanelMessage::SetMetrics(metrics));
     assert_eq!(state.metrics().len(), 4);
-    assert_eq!(state.selected(), Some(0));
+    assert_eq!(state.selected_index(), Some(0));
 }
 
 #[test]
@@ -538,7 +538,7 @@ fn test_set_metrics_empty_message() {
     let mut state = AlertPanelState::new().with_metrics(sample_metrics());
     AlertPanel::update(&mut state, AlertPanelMessage::SetMetrics(vec![]));
     assert!(state.metrics().is_empty());
-    assert_eq!(state.selected(), None);
+    assert_eq!(state.selected_index(), None);
 }
 
 #[test]
@@ -753,7 +753,7 @@ fn test_render_with_history() {
 #[test]
 fn test_empty_metrics_selected_none() {
     let state = AlertPanelState::new();
-    assert_eq!(state.selected(), None);
+    assert_eq!(state.selected_index(), None);
     assert!(state.selected_metric().is_none());
 }
 

--- a/src/component/box_plot/render.rs
+++ b/src/component/box_plot/render.rs
@@ -78,7 +78,7 @@ pub(super) fn render_vertical(
         };
         let box_style = Style::default().fg(box_color);
 
-        let selected_indicator = if i == state.selected() && focused {
+        let selected_indicator = if i == state.selected_index() && focused {
             Style::default().fg(box_color).add_modifier(Modifier::BOLD)
         } else {
             box_style
@@ -266,7 +266,7 @@ pub(super) fn render_horizontal(
         };
         let box_style = Style::default().fg(box_color);
 
-        let selected_indicator = if i == state.selected() && focused {
+        let selected_indicator = if i == state.selected_index() && focused {
             Style::default().fg(box_color).add_modifier(Modifier::BOLD)
         } else {
             box_style

--- a/src/component/box_plot/state.rs
+++ b/src/component/box_plot/state.rs
@@ -236,6 +236,10 @@ impl BoxPlotState {
 
     /// Returns the currently selected dataset index.
     ///
+    /// Renamed from `selected()` in v0.18.0 for consistency with the
+    /// `selected_index()` accessor used across every other component.
+    /// See MIGRATION.md.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -244,13 +248,16 @@ impl BoxPlotState {
     /// let state = BoxPlotState::new(vec![
     ///     BoxPlotData::new("A", 1.0, 2.0, 3.0, 4.0, 5.0),
     /// ]);
-    /// assert_eq!(state.selected(), 0);
+    /// assert_eq!(state.selected_index(), 0);
     /// ```
-    pub fn selected(&self) -> usize {
+    pub fn selected_index(&self) -> usize {
         self.selected
     }
 
     /// Sets the selected dataset index.
+    ///
+    /// Renamed from `set_selected()` in v0.18.0 for symmetry with
+    /// `selected_index()`. See MIGRATION.md.
     ///
     /// # Example
     ///
@@ -261,10 +268,10 @@ impl BoxPlotState {
     ///     BoxPlotData::new("A", 1.0, 2.0, 3.0, 4.0, 5.0),
     ///     BoxPlotData::new("B", 2.0, 3.0, 4.0, 5.0, 6.0),
     /// ]);
-    /// state.set_selected(1);
-    /// assert_eq!(state.selected(), 1);
+    /// state.set_selected_index(1);
+    /// assert_eq!(state.selected_index(), 1);
     /// ```
-    pub fn set_selected(&mut self, index: usize) {
+    pub fn set_selected_index(&mut self, index: usize) {
         if !self.datasets.is_empty() {
             self.selected = index.min(self.datasets.len() - 1);
         }

--- a/src/component/box_plot/tests.rs
+++ b/src/component/box_plot/tests.rs
@@ -245,7 +245,7 @@ fn test_state_set_orientation() {
 }
 
 #[test]
-fn test_state_set_selected() {
+fn test_state_set_selected_index() {
     let mut state = BoxPlotState::new(vec![
         BoxPlotData::new("A", 1.0, 2.0, 3.0, 4.0, 5.0),
         BoxPlotData::new("B", 6.0, 7.0, 8.0, 9.0, 10.0),
@@ -255,14 +255,14 @@ fn test_state_set_selected() {
 }
 
 #[test]
-fn test_state_set_selected_clamps_to_last() {
+fn test_state_set_selected_index_clamps_to_last() {
     let mut state = BoxPlotState::new(vec![BoxPlotData::new("A", 1.0, 2.0, 3.0, 4.0, 5.0)]);
     state.set_selected_index(10);
     assert_eq!(state.selected_index(), 0); // Only one item, clamped to index 0
 }
 
 #[test]
-fn test_state_set_selected_empty() {
+fn test_state_set_selected_index_empty() {
     let mut state = BoxPlotState::default();
     state.set_selected_index(5); // No-op on empty datasets
     assert_eq!(state.selected_index(), 0);

--- a/src/component/box_plot/tests.rs
+++ b/src/component/box_plot/tests.rs
@@ -163,7 +163,7 @@ fn test_state_default() {
     assert_eq!(state.title(), None);
     assert!(state.show_outliers());
     assert_eq!(state.orientation(), &BoxPlotOrientation::Vertical);
-    assert_eq!(state.selected(), 0);
+    assert_eq!(state.selected_index(), 0);
 }
 
 #[test]
@@ -250,22 +250,22 @@ fn test_state_set_selected() {
         BoxPlotData::new("A", 1.0, 2.0, 3.0, 4.0, 5.0),
         BoxPlotData::new("B", 6.0, 7.0, 8.0, 9.0, 10.0),
     ]);
-    state.set_selected(1);
-    assert_eq!(state.selected(), 1);
+    state.set_selected_index(1);
+    assert_eq!(state.selected_index(), 1);
 }
 
 #[test]
 fn test_state_set_selected_clamps_to_last() {
     let mut state = BoxPlotState::new(vec![BoxPlotData::new("A", 1.0, 2.0, 3.0, 4.0, 5.0)]);
-    state.set_selected(10);
-    assert_eq!(state.selected(), 0); // Only one item, clamped to index 0
+    state.set_selected_index(10);
+    assert_eq!(state.selected_index(), 0); // Only one item, clamped to index 0
 }
 
 #[test]
 fn test_state_set_selected_empty() {
     let mut state = BoxPlotState::default();
-    state.set_selected(5); // No-op on empty datasets
-    assert_eq!(state.selected(), 0);
+    state.set_selected_index(5); // No-op on empty datasets
+    assert_eq!(state.selected_index(), 0);
 }
 
 #[test]
@@ -304,10 +304,10 @@ fn test_state_clear_datasets() {
         BoxPlotData::new("A", 1.0, 2.0, 3.0, 4.0, 5.0),
         BoxPlotData::new("B", 6.0, 7.0, 8.0, 9.0, 10.0),
     ]);
-    state.set_selected(1);
+    state.set_selected_index(1);
     state.clear_datasets();
     assert!(state.is_empty());
-    assert_eq!(state.selected(), 0);
+    assert_eq!(state.selected_index(), 0);
 }
 
 // =============================================================================
@@ -512,7 +512,7 @@ fn test_update_next_dataset() {
         BoxPlotData::new("B", 6.0, 7.0, 8.0, 9.0, 10.0),
     ]);
     BoxPlot::update(&mut state, BoxPlotMessage::NextDataset);
-    assert_eq!(state.selected(), 1);
+    assert_eq!(state.selected_index(), 1);
 }
 
 #[test]
@@ -521,16 +521,16 @@ fn test_update_next_dataset_wraps() {
         BoxPlotData::new("A", 1.0, 2.0, 3.0, 4.0, 5.0),
         BoxPlotData::new("B", 6.0, 7.0, 8.0, 9.0, 10.0),
     ]);
-    state.set_selected(1);
+    state.set_selected_index(1);
     BoxPlot::update(&mut state, BoxPlotMessage::NextDataset);
-    assert_eq!(state.selected(), 0);
+    assert_eq!(state.selected_index(), 0);
 }
 
 #[test]
 fn test_update_next_dataset_empty() {
     let mut state = BoxPlotState::default();
     BoxPlot::update(&mut state, BoxPlotMessage::NextDataset);
-    assert_eq!(state.selected(), 0);
+    assert_eq!(state.selected_index(), 0);
 }
 
 #[test]
@@ -539,9 +539,9 @@ fn test_update_prev_dataset() {
         BoxPlotData::new("A", 1.0, 2.0, 3.0, 4.0, 5.0),
         BoxPlotData::new("B", 6.0, 7.0, 8.0, 9.0, 10.0),
     ]);
-    state.set_selected(1);
+    state.set_selected_index(1);
     BoxPlot::update(&mut state, BoxPlotMessage::PrevDataset);
-    assert_eq!(state.selected(), 0);
+    assert_eq!(state.selected_index(), 0);
 }
 
 #[test]
@@ -551,14 +551,14 @@ fn test_update_prev_dataset_wraps() {
         BoxPlotData::new("B", 6.0, 7.0, 8.0, 9.0, 10.0),
     ]);
     BoxPlot::update(&mut state, BoxPlotMessage::PrevDataset);
-    assert_eq!(state.selected(), 1);
+    assert_eq!(state.selected_index(), 1);
 }
 
 #[test]
 fn test_update_prev_dataset_empty() {
     let mut state = BoxPlotState::default();
     BoxPlot::update(&mut state, BoxPlotMessage::PrevDataset);
-    assert_eq!(state.selected(), 0);
+    assert_eq!(state.selected_index(), 0);
 }
 
 #[test]
@@ -574,7 +574,7 @@ fn test_update_toggle_outliers() {
 #[test]
 fn test_update_set_datasets() {
     let mut state = BoxPlotState::new(vec![BoxPlotData::new("A", 1.0, 2.0, 3.0, 4.0, 5.0)]);
-    state.set_selected(0);
+    state.set_selected_index(0);
     BoxPlot::update(
         &mut state,
         BoxPlotMessage::SetDatasets(vec![
@@ -583,7 +583,7 @@ fn test_update_set_datasets() {
         ]),
     );
     assert_eq!(state.dataset_count(), 2);
-    assert_eq!(state.selected(), 0); // Reset on SetDatasets
+    assert_eq!(state.selected_index(), 0); // Reset on SetDatasets
     assert_eq!(state.datasets()[0].label(), "X");
 }
 
@@ -602,7 +602,7 @@ fn test_update_clear_datasets() {
     let mut state = BoxPlotState::new(vec![BoxPlotData::new("A", 1.0, 2.0, 3.0, 4.0, 5.0)]);
     BoxPlot::update(&mut state, BoxPlotMessage::ClearDatasets);
     assert!(state.is_empty());
-    assert_eq!(state.selected(), 0);
+    assert_eq!(state.selected_index(), 0);
 }
 
 #[test]

--- a/src/component/diagram/mod.rs
+++ b/src/component/diagram/mod.rs
@@ -87,7 +87,7 @@ pub use viewport::{BoundingBox, Viewport2D};
 ///
 /// assert_eq!(state.nodes().len(), 2);
 /// assert_eq!(state.edges().len(), 1);
-/// assert_eq!(state.selected(), None);
+/// assert_eq!(state.selected_index(), None);
 /// ```
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(

--- a/src/component/diagram/state.rs
+++ b/src/component/diagram/state.rs
@@ -252,15 +252,19 @@ impl DiagramState {
 
     /// Returns the selected node index, if any.
     ///
+    /// Renamed from `selected()` in v0.18.0 for consistency with the
+    /// `selected_index()` accessor used across every other component.
+    /// See MIGRATION.md.
+    ///
     /// # Examples
     ///
     /// ```
     /// use envision::component::diagram::DiagramState;
     ///
     /// let state = DiagramState::new();
-    /// assert_eq!(state.selected(), None);
+    /// assert_eq!(state.selected_index(), None);
     /// ```
-    pub fn selected(&self) -> Option<usize> {
+    pub fn selected_index(&self) -> Option<usize> {
         self.selected
     }
 
@@ -562,9 +566,9 @@ impl DiagramState {
     ///     .with_node(DiagramNode::new("a", "A"))
     ///     .with_node(DiagramNode::new("b", "B"));
     /// assert!(state.select_next());
-    /// assert_eq!(state.selected(), Some(0));
+    /// assert_eq!(state.selected_index(), Some(0));
     /// assert!(state.select_next());
-    /// assert_eq!(state.selected(), Some(1));
+    /// assert_eq!(state.selected_index(), Some(1));
     /// ```
     pub fn select_next(&mut self) -> bool {
         if self.nodes.is_empty() {
@@ -589,7 +593,7 @@ impl DiagramState {
     ///     .with_node(DiagramNode::new("b", "B"));
     /// state.select_next(); // select "a"
     /// state.select_prev(); // wrap to "b"
-    /// assert_eq!(state.selected(), Some(1));
+    /// assert_eq!(state.selected_index(), Some(1));
     /// ```
     pub fn select_prev(&mut self) -> bool {
         if self.nodes.is_empty() {

--- a/src/component/dropdown/mod.rs
+++ b/src/component/dropdown/mod.rs
@@ -221,20 +221,6 @@ impl DropdownState {
         self.selected_index
     }
 
-    /// Alias for [`selected_index()`](Self::selected_index).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use envision::prelude::*;
-    ///
-    /// let state = DropdownState::with_selection(vec!["A", "B"], 1);
-    /// assert_eq!(state.selected(), state.selected_index());
-    /// ```
-    pub fn selected(&self) -> Option<usize> {
-        self.selected_index()
-    }
-
     /// Returns the selected option value as a string reference.
     ///
     /// # Examples
@@ -252,19 +238,22 @@ impl DropdownState {
 
     /// Sets the selected option index.
     ///
+    /// Renamed from `set_selected()` in v0.18.0 for symmetry with
+    /// `selected_index()`. See MIGRATION.md.
+    ///
     /// # Examples
     ///
     /// ```
     /// use envision::prelude::*;
     ///
     /// let mut state = DropdownState::new(vec!["A", "B", "C"]);
-    /// state.set_selected(Some(2));
+    /// state.set_selected_index(Some(2));
     /// assert_eq!(state.selected_item(), Some("C"));
     ///
-    /// state.set_selected(None);
+    /// state.set_selected_index(None);
     /// assert_eq!(state.selected_item(), None);
     /// ```
-    pub fn set_selected(&mut self, index: Option<usize>) {
+    pub fn set_selected_index(&mut self, index: Option<usize>) {
         if let Some(idx) = index {
             if idx < self.options.len() {
                 self.selected_index = Some(idx);

--- a/src/component/dropdown/tests.rs
+++ b/src/component/dropdown/tests.rs
@@ -70,7 +70,7 @@ fn test_set_options_resets_invalid_selection() {
 }
 
 #[test]
-fn test_set_selected() {
+fn test_set_selected_index() {
     let mut state = DropdownState::new(vec!["A", "B", "C"]);
     state.set_selected_index(Some(1));
     assert_eq!(state.selected_index(), Some(1));
@@ -78,7 +78,7 @@ fn test_set_selected() {
 }
 
 #[test]
-fn test_set_selected_out_of_bounds() {
+fn test_set_selected_index_out_of_bounds() {
     let mut state = DropdownState::new(vec!["A", "B"]);
     state.set_selected_index(Some(5));
     assert_eq!(state.selected_index(), None);

--- a/src/component/dropdown/tests.rs
+++ b/src/component/dropdown/tests.rs
@@ -72,7 +72,7 @@ fn test_set_options_resets_invalid_selection() {
 #[test]
 fn test_set_selected() {
     let mut state = DropdownState::new(vec!["A", "B", "C"]);
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
     assert_eq!(state.selected_index(), Some(1));
     assert_eq!(state.selected_item(), Some("B"));
 }
@@ -80,7 +80,7 @@ fn test_set_selected() {
 #[test]
 fn test_set_selected_out_of_bounds() {
     let mut state = DropdownState::new(vec!["A", "B"]);
-    state.set_selected(Some(5));
+    state.set_selected_index(Some(5));
     assert_eq!(state.selected_index(), None);
 }
 

--- a/src/component/file_browser/helper_tests.rs
+++ b/src/component/file_browser/helper_tests.rs
@@ -261,7 +261,7 @@ fn test_selected_index_defaults_to_first_entry() {
 }
 
 #[test]
-fn test_selected_alias_none_when_empty() {
+fn test_selected_index_none_when_empty() {
     let state = FileBrowserState::new("/empty", vec![]);
     assert_eq!(state.selected_index(), None);
 }

--- a/src/component/file_browser/helper_tests.rs
+++ b/src/component/file_browser/helper_tests.rs
@@ -255,16 +255,15 @@ fn test_with_provider() {
 }
 
 #[test]
-fn test_selected_alias() {
+fn test_selected_index_defaults_to_first_entry() {
     let state = FileBrowserState::new("/", sample_entries());
-    assert_eq!(state.selected(), state.selected_index());
-    assert_eq!(state.selected(), Some(0));
+    assert_eq!(state.selected_index(), Some(0));
 }
 
 #[test]
 fn test_selected_alias_none_when_empty() {
     let state = FileBrowserState::new("/empty", vec![]);
-    assert_eq!(state.selected(), None);
+    assert_eq!(state.selected_index(), None);
 }
 
 #[test]

--- a/src/component/file_browser/mod.rs
+++ b/src/component/file_browser/mod.rs
@@ -430,23 +430,6 @@ impl FileBrowserState {
         self.selected_index
     }
 
-    /// Returns the selected index within the filtered list.
-    ///
-    /// This is an alias for [`selected_index()`](Self::selected_index) that provides a
-    /// consistent accessor name across all selection-based components.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::file_browser::{FileEntry, FileBrowserState};
-    ///
-    /// let state = FileBrowserState::new("/", vec![FileEntry::file("a.txt", "/a.txt")]);
-    /// assert_eq!(state.selected(), Some(0));
-    /// ```
-    pub fn selected(&self) -> Option<usize> {
-        self.selected_index()
-    }
-
     /// Returns the currently selected file entry.
     ///
     /// This is an alias for [`selected_entry()`](Self::selected_entry) that provides a

--- a/src/component/loading_list/mod.rs
+++ b/src/component/loading_list/mod.rs
@@ -341,23 +341,6 @@ impl<T: Clone> LoadingListState<T> {
         self.selected
     }
 
-    /// Alias for [`selected_index()`](Self::selected_index).
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::LoadingListState;
-    ///
-    /// let state = LoadingListState::with_items(
-    ///     vec!["a".to_string()],
-    ///     |s| s.clone(),
-    /// ).with_selected(0);
-    /// assert_eq!(state.selected(), Some(0));
-    /// ```
-    pub fn selected(&self) -> Option<usize> {
-        self.selected_index()
-    }
-
     /// Returns the selected item.
     ///
     /// Returns `None` if no item is selected.
@@ -376,7 +359,7 @@ impl<T: Clone> LoadingListState<T> {
     /// );
     /// assert!(state.selected_item().is_none());
     ///
-    /// state.set_selected(Some(0));
+    /// state.set_selected_index(Some(0));
     /// assert_eq!(state.selected_item().unwrap().label(), "Build");
     /// ```
     pub fn selected_item(&self) -> Option<&LoadingListItem<T>> {
@@ -402,6 +385,9 @@ impl<T: Clone> LoadingListState<T> {
 
     /// Sets the selected index.
     ///
+    /// Renamed from `set_selected()` in v0.18.0 for symmetry with
+    /// `selected_index()`. See MIGRATION.md.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -411,10 +397,10 @@ impl<T: Clone> LoadingListState<T> {
     ///     vec!["a".to_string(), "b".to_string()],
     ///     |s| s.clone(),
     /// );
-    /// state.set_selected(Some(1));
+    /// state.set_selected_index(Some(1));
     /// assert_eq!(state.selected_index(), Some(1));
     /// ```
-    pub fn set_selected(&mut self, index: Option<usize>) {
+    pub fn set_selected_index(&mut self, index: Option<usize>) {
         self.selected = index.map(|i| i.min(self.items.len().saturating_sub(1)));
     }
 

--- a/src/component/loading_list/snapshot_tests.rs
+++ b/src/component/loading_list/snapshot_tests.rs
@@ -100,7 +100,7 @@ fn test_snapshot_mixed_states() {
     let mut state = LoadingListState::with_items(tasks, |t| t.name.clone());
     state.set_loading(0);
     state.set_error(2, "Timeout");
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
     let (mut terminal, theme) = test_utils::setup_render(50, 10);
     terminal
         .draw(|frame| {

--- a/src/component/loading_list/tests/component.rs
+++ b/src/component/loading_list/tests/component.rs
@@ -113,7 +113,7 @@ fn test_update_down() {
 fn test_update_down_wrap() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items, |i| i.name.clone());
-    state.set_selected(Some(2)); // Last item
+    state.set_selected_index(Some(2)); // Last item
 
     LoadingList::update(&mut state, LoadingListMessage::Down);
     assert_eq!(state.selected_index(), Some(0)); // Wraps
@@ -123,7 +123,7 @@ fn test_update_down_wrap() {
 fn test_update_up() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items, |i| i.name.clone());
-    state.set_selected(Some(2));
+    state.set_selected_index(Some(2));
 
     LoadingList::update(&mut state, LoadingListMessage::Up);
     assert_eq!(state.selected_index(), Some(1));
@@ -133,7 +133,7 @@ fn test_update_up() {
 fn test_update_up_wrap() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items, |i| i.name.clone());
-    state.set_selected(Some(0));
+    state.set_selected_index(Some(0));
 
     LoadingList::update(&mut state, LoadingListMessage::Up);
     assert_eq!(state.selected_index(), Some(2)); // Wraps
@@ -143,7 +143,7 @@ fn test_update_up_wrap() {
 fn test_update_first() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items, |i| i.name.clone());
-    state.set_selected(Some(2));
+    state.set_selected_index(Some(2));
 
     LoadingList::update(&mut state, LoadingListMessage::First);
     assert_eq!(state.selected_index(), Some(0));
@@ -162,7 +162,7 @@ fn test_update_last() {
 fn test_update_select() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items.clone(), |i| i.name.clone());
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
 
     let output = LoadingList::update(&mut state, LoadingListMessage::Select);
 
@@ -202,7 +202,7 @@ fn test_navigation_empty_list() {
 #[test]
 fn test_update_set_items() {
     let mut state: LoadingListState<TestItem> = LoadingListState::new();
-    state.set_selected(Some(0));
+    state.set_selected_index(Some(0));
 
     let items = make_items();
     LoadingList::update(&mut state, LoadingListMessage::SetItems(items));
@@ -557,7 +557,7 @@ fn test_down_output_value() {
 fn test_up_output_value() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items, |i| i.name.clone());
-    state.set_selected(Some(2));
+    state.set_selected_index(Some(2));
 
     let output = LoadingList::update(&mut state, LoadingListMessage::Up);
     assert_eq!(output, Some(LoadingListOutput::SelectionChanged(1)));
@@ -574,7 +574,7 @@ fn test_up_output_value() {
 fn test_first_output_value() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items, |i| i.name.clone());
-    state.set_selected(Some(2));
+    state.set_selected_index(Some(2));
 
     let output = LoadingList::update(&mut state, LoadingListMessage::First);
     assert_eq!(output, Some(LoadingListOutput::SelectionChanged(0)));
@@ -655,7 +655,7 @@ fn test_single_item_select() {
         name: "Only".to_string(),
     }];
     let mut state = LoadingListState::with_items(items, |i| i.name.clone());
-    state.set_selected(Some(0));
+    state.set_selected_index(Some(0));
 
     let output = LoadingList::update(&mut state, LoadingListMessage::Select);
     assert!(matches!(
@@ -733,7 +733,7 @@ fn test_set_items_default_labeling() {
 fn test_set_items_clears_selection() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items, |i| i.name.clone());
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
 
     let new_items = vec![
         TestItem {

--- a/src/component/loading_list/tests/events.rs
+++ b/src/component/loading_list/tests/events.rs
@@ -327,7 +327,7 @@ fn test_dispatch_event_up_navigation() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items, |i| i.name.clone());
 
-    state.set_selected(Some(2));
+    state.set_selected_index(Some(2));
 
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,
@@ -357,7 +357,7 @@ fn test_dispatch_event_enter_selects() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items, |i| i.name.clone());
 
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
 
     let output = LoadingList::<TestItem>::dispatch_event(
         &mut state,

--- a/src/component/loading_list/tests/state.rs
+++ b/src/component/loading_list/tests/state.rs
@@ -315,11 +315,11 @@ fn test_state_partial_eq_different_indicators() {
 }
 
 // ========================================
-// set_selected Edge Case Tests
+// set_selected_index Edge Case Tests
 // ========================================
 
 #[test]
-fn test_set_selected_none() {
+fn test_set_selected_index_none() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items, |i| i.name.clone());
     state.set_selected_index(Some(1));
@@ -332,9 +332,9 @@ fn test_set_selected_none() {
 }
 
 #[test]
-fn test_set_selected_on_empty_list() {
+fn test_set_selected_index_on_empty_list() {
     let mut state: LoadingListState<TestItem> = LoadingListState::new();
-    // set_selected with Some on empty list should clamp to 0 but saturating_sub(1) on 0 == 0
+    // set_selected_index with Some on empty list should clamp to 0 but saturating_sub(1) on 0 == 0
     state.set_selected_index(Some(0));
     // With empty list, index 0 is clamped via min(0.saturating_sub(1)) = min(0, 0) = Some(0)
     // But get will return None since items is empty

--- a/src/component/loading_list/tests/state.rs
+++ b/src/component/loading_list/tests/state.rs
@@ -87,7 +87,7 @@ fn test_state_selected_index() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items, |i| i.name.clone());
 
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
     assert_eq!(state.selected_index(), Some(1));
     assert_eq!(state.selected_item().unwrap().label(), "Item Two");
     assert_eq!(state.selected_data().unwrap().id, 2);
@@ -102,13 +102,13 @@ fn test_selected_item_returns_item() {
     assert!(state.selected_item().is_none());
 
     // With selection returns the item
-    state.set_selected(Some(0));
+    state.set_selected_index(Some(0));
     let item = state.selected_item().unwrap();
     assert_eq!(item.label(), "Item One");
     assert_eq!(item.data().id, 1);
 
     // Verify selected item at different index
-    state.set_selected(Some(2));
+    state.set_selected_index(Some(2));
     assert_eq!(state.selected_item().unwrap().label(), "Item Three");
 }
 
@@ -117,7 +117,7 @@ fn test_state_selected_clamped() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items, |i| i.name.clone());
 
-    state.set_selected(Some(100)); // Too high
+    state.set_selected_index(Some(100)); // Too high
     assert_eq!(state.selected_index(), Some(2)); // Clamped to last
 }
 
@@ -134,7 +134,7 @@ fn test_state_get() {
 fn test_state_clear() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items, |i| i.name.clone());
-    state.set_selected(Some(0));
+    state.set_selected_index(Some(0));
 
     state.clear();
     assert!(state.is_empty());
@@ -322,10 +322,10 @@ fn test_state_partial_eq_different_indicators() {
 fn test_set_selected_none() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items, |i| i.name.clone());
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
     assert_eq!(state.selected_index(), Some(1));
 
-    state.set_selected(None);
+    state.set_selected_index(None);
     assert_eq!(state.selected_index(), None);
     assert!(state.selected_item().is_none());
     assert!(state.selected_data().is_none());
@@ -335,7 +335,7 @@ fn test_set_selected_none() {
 fn test_set_selected_on_empty_list() {
     let mut state: LoadingListState<TestItem> = LoadingListState::new();
     // set_selected with Some on empty list should clamp to 0 but saturating_sub(1) on 0 == 0
-    state.set_selected(Some(0));
+    state.set_selected_index(Some(0));
     // With empty list, index 0 is clamped via min(0.saturating_sub(1)) = min(0, 0) = Some(0)
     // But get will return None since items is empty
     assert!(state.selected_item().is_none());
@@ -356,7 +356,7 @@ fn test_selected_data_none_when_no_selection() {
 fn test_selected_data_returns_data() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items, |i| i.name.clone());
-    state.set_selected(Some(0));
+    state.set_selected_index(Some(0));
     let data = state.selected_data().unwrap();
     assert_eq!(data.id, 1);
     assert_eq!(data.name, "Item One");

--- a/src/component/loading_list/tests/view.rs
+++ b/src/component/loading_list/tests/view.rs
@@ -24,7 +24,7 @@ fn test_view_empty() {
 fn test_view_with_items() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items, |i| i.name.clone());
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
 
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
@@ -101,7 +101,7 @@ fn test_view_zero_size_area() {
 fn test_view_without_indicators() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items, |i| i.name.clone()).with_indicators(false);
-    state.set_selected(Some(0));
+    state.set_selected_index(Some(0));
 
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
@@ -139,7 +139,7 @@ fn test_view_without_indicators_with_error() {
 fn test_view_focused() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items, |i| i.name.clone());
-    state.set_selected(Some(0));
+    state.set_selected_index(Some(0));
 
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
@@ -178,7 +178,7 @@ fn test_view_with_mixed_states() {
     let mut state = LoadingListState::with_items(items, |i| i.name.clone());
     state.set_loading(0);
     state.set_error(2, "Connection refused");
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
 
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
@@ -214,7 +214,7 @@ fn test_view_single_item() {
 fn test_view_disabled() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items, |i| i.name.clone());
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
 
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 
@@ -234,7 +234,7 @@ fn test_view_disabled() {
 fn test_view_with_title_and_selection() {
     let items = make_items();
     let mut state = LoadingListState::with_items(items, |i| i.name.clone()).with_title("Tasks");
-    state.set_selected(Some(2));
+    state.set_selected_index(Some(2));
 
     let (mut terminal, theme) = crate::component::test_utils::setup_render(60, 10);
 

--- a/src/component/menu/mod.rs
+++ b/src/component/menu/mod.rs
@@ -309,25 +309,14 @@ impl MenuState {
         self.selected_index
     }
 
-    /// Alias for [`selected_index()`](Self::selected_index).
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::{MenuState, MenuItem};
-    ///
-    /// let state = MenuState::new(vec![MenuItem::new("File"), MenuItem::new("Edit")]);
-    /// assert_eq!(state.selected(), Some(0));
-    /// ```
-    pub fn selected(&self) -> Option<usize> {
-        self.selected_index()
-    }
-
     /// Sets the selected item index.
     ///
     /// Pass `Some(index)` to select an item (clamped to valid range), or
     /// `None` to clear the selection. Has no effect on an empty menu when
     /// selecting.
+    ///
+    /// Renamed from `set_selected()` in v0.18.0 for symmetry with
+    /// `selected_index()`. See MIGRATION.md.
     ///
     /// # Example
     ///
@@ -339,10 +328,10 @@ impl MenuState {
     ///     MenuItem::new("Edit"),
     ///     MenuItem::new("View"),
     /// ]);
-    /// state.set_selected(Some(2));
+    /// state.set_selected_index(Some(2));
     /// assert_eq!(state.selected_index(), Some(2));
     /// ```
-    pub fn set_selected(&mut self, index: Option<usize>) {
+    pub fn set_selected_index(&mut self, index: Option<usize>) {
         match index {
             Some(i) => {
                 if !self.items.is_empty() {
@@ -371,7 +360,7 @@ impl MenuState {
     /// assert_eq!(state.selected_index(), Some(1));
     /// ```
     pub fn with_selected(mut self, index: usize) -> Self {
-        self.set_selected(Some(index));
+        self.set_selected_index(Some(index));
         self
     }
 

--- a/src/component/menu/tests.rs
+++ b/src/component/menu/tests.rs
@@ -61,7 +61,7 @@ fn test_set_items_resets_invalid_selection() {
         MenuItem::new("B"),
         MenuItem::new("C"),
     ]);
-    state.set_selected(Some(2));
+    state.set_selected_index(Some(2));
 
     state.set_items(vec![MenuItem::new("X")]);
     assert_eq!(state.selected_index(), Some(0));
@@ -81,7 +81,7 @@ fn test_set_items_preserves_valid_selection() {
         MenuItem::new("B"),
         MenuItem::new("C"),
     ]);
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
     state.set_items(vec![
         MenuItem::new("X"),
         MenuItem::new("Y"),
@@ -126,7 +126,7 @@ fn test_remove_item_adjusts_selection() {
         MenuItem::new("Edit"),
         MenuItem::new("View"),
     ]);
-    state.set_selected(Some(2));
+    state.set_selected_index(Some(2));
 
     // Remove last item, selection should clamp
     state.remove_item(2);
@@ -156,10 +156,10 @@ fn test_selected_index() {
         MenuItem::new("C"),
     ]);
 
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
     assert_eq!(state.selected_index(), Some(1));
 
-    state.set_selected(Some(2));
+    state.set_selected_index(Some(2));
     assert_eq!(state.selected_index(), Some(2));
 }
 
@@ -167,7 +167,7 @@ fn test_selected_index() {
 fn test_selected_index_clamps() {
     let mut state = MenuState::new(vec![MenuItem::new("A"), MenuItem::new("B")]);
 
-    state.set_selected(Some(10));
+    state.set_selected_index(Some(10));
     assert_eq!(state.selected_index(), Some(1));
 }
 
@@ -349,7 +349,7 @@ fn test_view_selected() {
         MenuItem::new("Edit"),
         MenuItem::new("View"),
     ]);
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
 
     let (mut terminal, theme) = crate::component::test_utils::setup_render(80, 24);
 

--- a/src/component/metrics_dashboard/mod.rs
+++ b/src/component/metrics_dashboard/mod.rs
@@ -344,25 +344,12 @@ impl MetricsDashboardState {
         self.selected
     }
 
-    /// Alias for [`selected_index()`](Self::selected_index).
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::{MetricsDashboardState, MetricWidget};
-    ///
-    /// let state = MetricsDashboardState::new(vec![
-    ///     MetricWidget::counter("A", 0),
-    /// ], 1);
-    /// assert_eq!(state.selected(), state.selected_index());
-    /// ```
-    pub fn selected(&self) -> Option<usize> {
-        self.selected_index()
-    }
-
     /// Sets the selected widget index.
     ///
     /// The index is clamped to the valid range. Has no effect on empty dashboards.
+    ///
+    /// Renamed from `set_selected()` in v0.18.0 for symmetry with
+    /// `selected_index()`. See MIGRATION.md.
     ///
     /// # Example
     ///
@@ -374,10 +361,10 @@ impl MetricsDashboardState {
     ///     MetricWidget::counter("B", 0),
     ///     MetricWidget::counter("C", 0),
     /// ], 3);
-    /// state.set_selected(Some(2));
+    /// state.set_selected_index(Some(2));
     /// assert_eq!(state.selected_index(), Some(2));
     /// ```
-    pub fn set_selected(&mut self, index: Option<usize>) {
+    pub fn set_selected_index(&mut self, index: Option<usize>) {
         match index {
             Some(i) => {
                 if self.widgets.is_empty() {
@@ -418,7 +405,7 @@ impl MetricsDashboardState {
     ///     MetricWidget::counter("C", 0),
     ///     MetricWidget::counter("D", 0),
     /// ], 3);
-    /// state.set_selected(Some(3)); // 4th widget
+    /// state.set_selected_index(Some(3)); // 4th widget
     /// assert_eq!(state.selected_position(), Some((1, 0))); // row 1, col 0
     /// ```
     pub fn selected_position(&self) -> Option<(usize, usize)> {

--- a/src/component/multi_progress/mod.rs
+++ b/src/component/multi_progress/mod.rs
@@ -422,6 +422,10 @@ impl MultiProgressState {
 
     /// Returns the currently selected item index.
     ///
+    /// Renamed from `selected()` in v0.18.0 for consistency with the
+    /// `selected_index()` accessor used across every other component.
+    /// See MIGRATION.md.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -429,9 +433,9 @@ impl MultiProgressState {
     ///
     /// let mut state = MultiProgressState::new();
     /// state.add("t1", "Task 1");
-    /// assert_eq!(state.selected(), Some(0));
+    /// assert_eq!(state.selected_index(), Some(0));
     /// ```
-    pub fn selected(&self) -> Option<usize> {
+    pub fn selected_index(&self) -> Option<usize> {
         self.selected
     }
 
@@ -452,6 +456,9 @@ impl MultiProgressState {
 
     /// Sets the selected item index. Clamped to valid range.
     ///
+    /// Renamed from `set_selected()` in v0.18.0 for symmetry with
+    /// `selected_index()`. See MIGRATION.md.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -460,17 +467,17 @@ impl MultiProgressState {
     /// let mut state = MultiProgressState::new();
     /// state.add("t1", "Task 1");
     /// state.add("t2", "Task 2");
-    /// state.set_selected(Some(1));
-    /// assert_eq!(state.selected(), Some(1));
+    /// state.set_selected_index(Some(1));
+    /// assert_eq!(state.selected_index(), Some(1));
     /// ```
-    pub fn set_selected(&mut self, index: Option<usize>) {
+    pub fn set_selected_index(&mut self, index: Option<usize>) {
         self.selected = index.map(|i| i.min(self.items.len().saturating_sub(1)));
     }
 
     /// Sets the viewport scroll offset.
     ///
     /// This controls which items are visible in the viewport, independent
-    /// of which item is selected. Use [`set_selected`](Self::set_selected)
+    /// of which item is selected. Use [`set_selected_index`](Self::set_selected_index)
     /// to change the highlighted item. Keyboard navigation (Up/Down)
     /// adjusts both selection and scroll together.
     ///

--- a/src/component/multi_progress/tests/component.rs
+++ b/src/component/multi_progress/tests/component.rs
@@ -173,7 +173,7 @@ fn test_scroll_down() {
     }
 
     MultiProgress::update(&mut state, MultiProgressMessage::ScrollDown);
-    assert_eq!(state.selected(), Some(1));
+    assert_eq!(state.selected_index(), Some(1));
 }
 
 #[test]
@@ -182,10 +182,10 @@ fn test_scroll_up() {
     for i in 0..10 {
         state.add(format!("id{}", i), format!("Item {}", i));
     }
-    state.set_selected(Some(5));
+    state.set_selected_index(Some(5));
 
     MultiProgress::update(&mut state, MultiProgressMessage::ScrollUp);
-    assert_eq!(state.selected(), Some(4));
+    assert_eq!(state.selected_index(), Some(4));
 }
 
 #[test]
@@ -194,7 +194,7 @@ fn test_scroll_to_top() {
     for i in 0..10 {
         state.add(format!("id{}", i), format!("Item {}", i));
     }
-    state.set_selected(Some(5));
+    state.set_selected_index(Some(5));
 
     MultiProgress::update(&mut state, MultiProgressMessage::ScrollToTop);
     assert_eq!(state.scroll_offset(), 0);
@@ -208,7 +208,7 @@ fn test_scroll_to_bottom() {
     }
 
     MultiProgress::update(&mut state, MultiProgressMessage::ScrollToBottom);
-    assert_eq!(state.selected(), Some(9));
+    assert_eq!(state.selected_index(), Some(9));
 }
 
 #[test]
@@ -218,7 +218,7 @@ fn test_scroll_up_at_top() {
     assert_eq!(state.scroll_offset(), 0);
 
     MultiProgress::update(&mut state, MultiProgressMessage::ScrollUp);
-    assert_eq!(state.selected(), Some(0)); // Should stay at 0
+    assert_eq!(state.selected_index(), Some(0)); // Should stay at 0
 }
 
 #[test]
@@ -226,10 +226,10 @@ fn test_scroll_down_at_bottom() {
     let mut state = MultiProgressState::new();
     state.add("id1", "Item 1");
     state.add("id2", "Item 2");
-    state.set_selected(Some(1)); // At the last item
+    state.set_selected_index(Some(1)); // At the last item
 
     MultiProgress::update(&mut state, MultiProgressMessage::ScrollDown);
-    assert_eq!(state.selected(), Some(1)); // Should stay at 1
+    assert_eq!(state.selected_index(), Some(1)); // Should stay at 1
 }
 
 // ========================================

--- a/src/component/multi_progress/tests/events.rs
+++ b/src/component/multi_progress/tests/events.rs
@@ -63,7 +63,7 @@ fn test_dispatch_event() {
     for i in 0..10 {
         state.add(format!("id{}", i), format!("Item {}", i));
     }
-    state.set_selected(Some(5));
+    state.set_selected_index(Some(5));
 
     // Down arrow dispatches ScrollDown
     MultiProgress::dispatch_event(
@@ -71,7 +71,7 @@ fn test_dispatch_event() {
         &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
-    assert_eq!(state.selected(), Some(6));
+    assert_eq!(state.selected_index(), Some(6));
 }
 
 // ========================================
@@ -84,7 +84,7 @@ fn test_instance_methods() {
     for i in 0..10 {
         state.add(format!("id{}", i), format!("Item {}", i));
     }
-    state.set_selected(Some(3));
+    state.set_selected_index(Some(3));
 
     // handle_event via associated function
     let msg = MultiProgress::handle_event(
@@ -96,7 +96,7 @@ fn test_instance_methods() {
 
     // instance update
     state.update(MultiProgressMessage::ScrollUp);
-    assert_eq!(state.selected(), Some(2));
+    assert_eq!(state.selected_index(), Some(2));
 
     // dispatch_event via associated function
     MultiProgress::dispatch_event(
@@ -104,7 +104,7 @@ fn test_instance_methods() {
         &Event::key(Key::Down),
         &EventContext::new().focused(true),
     );
-    assert_eq!(state.selected(), Some(3));
+    assert_eq!(state.selected_index(), Some(3));
 }
 
 // ========================================
@@ -150,14 +150,14 @@ fn test_dispatch_event_ignored_when_disabled() {
     for i in 0..10 {
         state.add(format!("id{}", i), format!("Item {}", i));
     }
-    state.set_selected(Some(5));
+    state.set_selected_index(Some(5));
 
     MultiProgress::dispatch_event(
         &mut state,
         &Event::key(Key::Down),
         &EventContext::new().focused(true).disabled(true),
     );
-    assert_eq!(state.selected(), Some(5)); // Should not change
+    assert_eq!(state.selected_index(), Some(5)); // Should not change
 }
 
 // ========================================
@@ -271,14 +271,14 @@ fn test_dispatch_event_scroll_up() {
     for i in 0..10 {
         state.add(format!("id{}", i), format!("Item {}", i));
     }
-    state.set_selected(Some(5));
+    state.set_selected_index(Some(5));
 
     MultiProgress::dispatch_event(
         &mut state,
         &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
-    assert_eq!(state.selected(), Some(4));
+    assert_eq!(state.selected_index(), Some(4));
 }
 
 #[test]
@@ -287,14 +287,14 @@ fn test_dispatch_event_scroll_up_vim_k() {
     for i in 0..10 {
         state.add(format!("id{}", i), format!("Item {}", i));
     }
-    state.set_selected(Some(5));
+    state.set_selected_index(Some(5));
 
     MultiProgress::dispatch_event(
         &mut state,
         &Event::char('k'),
         &EventContext::new().focused(true),
     );
-    assert_eq!(state.selected(), Some(4));
+    assert_eq!(state.selected_index(), Some(4));
 }
 
 #[test]
@@ -303,14 +303,14 @@ fn test_dispatch_event_scroll_down_vim_j() {
     for i in 0..10 {
         state.add(format!("id{}", i), format!("Item {}", i));
     }
-    state.set_selected(Some(3));
+    state.set_selected_index(Some(3));
 
     MultiProgress::dispatch_event(
         &mut state,
         &Event::char('j'),
         &EventContext::new().focused(true),
     );
-    assert_eq!(state.selected(), Some(4));
+    assert_eq!(state.selected_index(), Some(4));
 }
 
 #[test]
@@ -319,14 +319,14 @@ fn test_instance_dispatch_event_scroll_up() {
     for i in 0..10 {
         state.add(format!("id{}", i), format!("Item {}", i));
     }
-    state.set_selected(Some(5));
+    state.set_selected_index(Some(5));
 
     MultiProgress::dispatch_event(
         &mut state,
         &Event::key(Key::Up),
         &EventContext::new().focused(true),
     );
-    assert_eq!(state.selected(), Some(4));
+    assert_eq!(state.selected_index(), Some(4));
 }
 
 // ========================================
@@ -377,7 +377,7 @@ fn test_update_select_emits_selected_output() {
     state.add("id1", "Item 1");
     state.add("id2", "Item 2");
     state.add("id3", "Item 3");
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
 
     let output = MultiProgress::update(&mut state, MultiProgressMessage::Select);
     assert_eq!(output, Some(MultiProgressOutput::Selected(1)));
@@ -399,7 +399,7 @@ fn test_update_select_last_item() {
     state.add("id1", "Item 1");
     state.add("id2", "Item 2");
     state.add("id3", "Item 3");
-    state.set_selected(Some(2));
+    state.set_selected_index(Some(2));
 
     let output = MultiProgress::update(&mut state, MultiProgressMessage::Select);
     assert_eq!(output, Some(MultiProgressOutput::Selected(2)));
@@ -418,7 +418,7 @@ fn test_dispatch_event_enter_selects_item() {
     let mut state = MultiProgressState::new();
     state.add("id1", "Item 1");
     state.add("id2", "Item 2");
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
 
     let output = MultiProgress::dispatch_event(
         &mut state,

--- a/src/component/radio_group/mod.rs
+++ b/src/component/radio_group/mod.rs
@@ -186,20 +186,6 @@ impl<T: Clone> RadioGroupState<T> {
         self.selected
     }
 
-    /// Alias for [`selected_index()`](Self::selected_index).
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::RadioGroupState;
-    ///
-    /// let state = RadioGroupState::with_selected(vec!["A", "B", "C"], 2);
-    /// assert_eq!(state.selected(), Some(2));
-    /// ```
-    pub fn selected(&self) -> Option<usize> {
-        self.selected_index()
-    }
-
     /// Returns a reference to the currently selected item.
     ///
     /// Returns `None` if the options are empty or no selection exists.
@@ -221,16 +207,19 @@ impl<T: Clone> RadioGroupState<T> {
     /// Pass `Some(index)` to select an option (out-of-bounds indices are
     /// ignored), or `None` to clear the selection.
     ///
+    /// Renamed from `set_selected()` in v0.18.0 for symmetry with
+    /// `selected_index()`. See MIGRATION.md.
+    ///
     /// # Example
     ///
     /// ```rust
     /// use envision::component::RadioGroupState;
     ///
     /// let mut state = RadioGroupState::new(vec!["A", "B", "C"]);
-    /// state.set_selected(Some(2));
+    /// state.set_selected_index(Some(2));
     /// assert_eq!(state.selected_index(), Some(2));
     /// ```
-    pub fn set_selected(&mut self, index: Option<usize>) {
+    pub fn set_selected_index(&mut self, index: Option<usize>) {
         match index {
             Some(i) if i < self.options.len() => self.selected = Some(i),
             Some(_) => {} // Out of bounds, ignore

--- a/src/component/radio_group/tests.rs
+++ b/src/component/radio_group/tests.rs
@@ -53,12 +53,12 @@ fn test_selected_accessors() {
     assert_eq!(state.selected_index(), Some(0));
     assert_eq!(state.selected_item(), Some(&"A"));
 
-    state.set_selected(Some(2));
+    state.set_selected_index(Some(2));
     assert_eq!(state.selected_index(), Some(2));
     assert_eq!(state.selected_item(), Some(&"C"));
 
     // Out of bounds is ignored
-    state.set_selected(Some(100));
+    state.set_selected_index(Some(100));
     assert_eq!(state.selected_index(), Some(2));
 }
 
@@ -98,7 +98,7 @@ fn test_navigate_at_bounds() {
     assert_eq!(state.selected_index(), Some(0));
 
     // Go to last
-    state.set_selected(Some(2));
+    state.set_selected_index(Some(2));
 
     // At last, Down returns None
     let output = RadioGroup::<&str>::update(&mut state, RadioGroupMessage::Down);
@@ -362,7 +362,7 @@ fn test_selected_item() {
     let mut state = RadioGroupState::new(vec!["A", "B", "C"]);
     assert_eq!(state.selected_item(), Some(&"A"));
 
-    state.set_selected(Some(2));
+    state.set_selected_index(Some(2));
     assert_eq!(state.selected_item(), Some(&"C"));
     assert_eq!(state.selected_item(), Some(&"C"));
 }
@@ -386,7 +386,7 @@ fn test_set_options_updates_options() {
 #[test]
 fn test_set_options_preserves_valid_selection() {
     let mut state = RadioGroupState::new(vec!["A", "B", "C"]);
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
     state.set_options(vec!["X", "Y", "Z"]);
     assert_eq!(state.selected_index(), Some(1));
 }

--- a/src/component/searchable_list/mod.rs
+++ b/src/component/searchable_list/mod.rs
@@ -309,20 +309,6 @@ impl<T: Clone> SearchableListState<T> {
         self.selected
     }
 
-    /// Alias for [`selected_index()`](Self::selected_index).
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::SearchableListState;
-    ///
-    /// let state = SearchableListState::new(vec!["A".to_string(), "B".to_string()]);
-    /// assert_eq!(state.selected(), state.selected_index());
-    /// ```
-    pub fn selected(&self) -> Option<usize> {
-        self.selected_index()
-    }
-
     /// Returns a reference to the currently selected item.
     ///
     /// # Example
@@ -344,6 +330,9 @@ impl<T: Clone> SearchableListState<T> {
     /// The index is clamped to the valid range of filtered items. Has no effect
     /// on empty filtered lists.
     ///
+    /// Renamed from `set_selected()` in v0.18.0 for symmetry with
+    /// `selected_index()`. See MIGRATION.md.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -354,11 +343,11 @@ impl<T: Clone> SearchableListState<T> {
     ///     "Banana".to_string(),
     ///     "Cherry".to_string(),
     /// ]);
-    /// state.set_selected(Some(2));
+    /// state.set_selected_index(Some(2));
     /// assert_eq!(state.selected_index(), Some(2));
     /// assert_eq!(state.selected_item(), Some(&"Cherry".to_string()));
     /// ```
-    pub fn set_selected(&mut self, index: Option<usize>) {
+    pub fn set_selected_index(&mut self, index: Option<usize>) {
         match index {
             Some(i) => {
                 if self.filtered_indices.is_empty() {

--- a/src/component/select/mod.rs
+++ b/src/component/select/mod.rs
@@ -209,20 +209,6 @@ impl SelectState {
         self.selected_index
     }
 
-    /// Alias for [`selected_index()`](Self::selected_index).
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::{SelectState};
-    ///
-    /// let state = SelectState::with_selection(vec!["A", "B", "C"], 1);
-    /// assert_eq!(state.selected(), Some(1));
-    /// ```
-    pub fn selected(&self) -> Option<usize> {
-        self.selected_index()
-    }
-
     /// Returns the selected option value as a string reference.
     ///
     /// # Examples
@@ -240,19 +226,22 @@ impl SelectState {
 
     /// Sets the selected option index.
     ///
+    /// Renamed from `set_selected()` in v0.18.0 for symmetry with
+    /// `selected_index()`. See MIGRATION.md.
+    ///
     /// # Examples
     ///
     /// ```
     /// use envision::prelude::*;
     ///
     /// let mut state = SelectState::new(vec!["A", "B", "C"]);
-    /// state.set_selected(Some(2));
+    /// state.set_selected_index(Some(2));
     /// assert_eq!(state.selected_item(), Some("C"));
     ///
-    /// state.set_selected(None);
+    /// state.set_selected_index(None);
     /// assert_eq!(state.selected_item(), None);
     /// ```
-    pub fn set_selected(&mut self, index: Option<usize>) {
+    pub fn set_selected_index(&mut self, index: Option<usize>) {
         if let Some(idx) = index {
             if idx < self.options.len() {
                 self.selected_index = Some(idx);

--- a/src/component/select/tests.rs
+++ b/src/component/select/tests.rs
@@ -44,7 +44,7 @@ fn test_set_options_resets_invalid_selection() {
 }
 
 #[test]
-fn test_set_selected() {
+fn test_set_selected_index() {
     let mut state = SelectState::new(vec!["A", "B", "C"]);
     state.set_selected_index(Some(1));
     assert_eq!(state.selected_index(), Some(1));
@@ -52,7 +52,7 @@ fn test_set_selected() {
 }
 
 #[test]
-fn test_set_selected_out_of_bounds() {
+fn test_set_selected_index_out_of_bounds() {
     let mut state = SelectState::new(vec!["A", "B"]);
     state.set_selected_index(Some(5));
     assert_eq!(state.selected_index(), None);

--- a/src/component/select/tests.rs
+++ b/src/component/select/tests.rs
@@ -46,7 +46,7 @@ fn test_set_options_resets_invalid_selection() {
 #[test]
 fn test_set_selected() {
     let mut state = SelectState::new(vec!["A", "B", "C"]);
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
     assert_eq!(state.selected_index(), Some(1));
     assert_eq!(state.selected_item(), Some("B"));
 }
@@ -54,7 +54,7 @@ fn test_set_selected() {
 #[test]
 fn test_set_selected_out_of_bounds() {
     let mut state = SelectState::new(vec!["A", "B"]);
-    state.set_selected(Some(5));
+    state.set_selected_index(Some(5));
     assert_eq!(state.selected_index(), None);
 }
 

--- a/src/component/selectable_list/mod.rs
+++ b/src/component/selectable_list/mod.rs
@@ -229,20 +229,6 @@ impl<T: Clone> SelectableListState<T> {
             .and_then(|i| self.filtered_indices.get(i).copied())
     }
 
-    /// Alias for [`selected_index()`](Self::selected_index).
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::SelectableListState;
-    ///
-    /// let state = SelectableListState::new(vec!["a", "b", "c"]);
-    /// assert_eq!(state.selected(), Some(0));
-    /// ```
-    pub fn selected(&self) -> Option<usize> {
-        self.selected_index()
-    }
-
     /// Returns a reference to the currently selected item.
     ///
     /// # Examples
@@ -289,20 +275,23 @@ impl<T: Clone> SelectableListState<T> {
     /// `None` to clear the selection. Has no effect on empty lists when
     /// selecting.
     ///
+    /// Renamed from `set_selected()` in v0.18.0 for symmetry with
+    /// `selected_index()`. See MIGRATION.md.
+    ///
     /// # Examples
     ///
     /// ```
     /// use envision::prelude::*;
     ///
     /// let mut state = SelectableListState::new(vec!["a", "b", "c"]);
-    /// state.set_selected(Some(2));
+    /// state.set_selected_index(Some(2));
     /// assert_eq!(state.selected_index(), Some(2));
     /// assert_eq!(state.selected_item(), Some(&"c"));
     ///
-    /// state.set_selected(None);
+    /// state.set_selected_index(None);
     /// assert_eq!(state.selected_index(), None);
     /// ```
-    pub fn set_selected(&mut self, index: Option<usize>) {
+    pub fn set_selected_index(&mut self, index: Option<usize>) {
         match index {
             Some(i) => {
                 if self.items.is_empty() {

--- a/src/component/tab_bar/tests.rs
+++ b/src/component/tab_bar/tests.rs
@@ -133,7 +133,7 @@ fn test_state_builder_methods() {
 }
 
 #[test]
-fn test_state_set_selected() {
+fn test_state_set_selected_index() {
     let mut state = TabBarState::new(vec![
         Tab::new("a", "A"),
         Tab::new("b", "B"),
@@ -148,7 +148,7 @@ fn test_state_set_selected() {
 }
 
 #[test]
-fn test_state_set_selected_empty() {
+fn test_state_set_selected_index_empty() {
     let mut state = TabBarState::new(vec![]);
     state.set_selected_index(Some(0));
     assert_eq!(state.selected_index(), None);

--- a/src/component/table/tests.rs
+++ b/src/component/table/tests.rs
@@ -220,7 +220,7 @@ fn test_set_rows_clamps_selection() {
 }
 
 #[test]
-fn test_set_selected() {
+fn test_set_selected_index() {
     let mut state = TableState::new(test_rows(), test_columns());
     state.set_selected_index(Some(2));
     assert_eq!(state.selected_index(), Some(2));
@@ -578,7 +578,7 @@ fn test_set_rows_with_no_prior_selection() {
 }
 
 #[test]
-fn test_set_selected_out_of_bounds() {
+fn test_set_selected_index_out_of_bounds() {
     let mut state = TableState::new(test_rows(), test_columns());
     // Try to set selection out of bounds
     state.set_selected_index(Some(100));

--- a/src/component/tabs/mod.rs
+++ b/src/component/tabs/mod.rs
@@ -151,20 +151,6 @@ impl<T: Clone> TabsState<T> {
         self.selected
     }
 
-    /// Alias for [`selected_index()`](Self::selected_index).
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::TabsState;
-    ///
-    /// let state = TabsState::with_selected(vec!["A", "B", "C"], 2);
-    /// assert_eq!(state.selected(), Some(2));
-    /// ```
-    pub fn selected(&self) -> Option<usize> {
-        self.selected_index()
-    }
-
     /// Returns the currently selected item.
     ///
     /// Returns `None` if there are no tabs or no selection.
@@ -186,16 +172,19 @@ impl<T: Clone> TabsState<T> {
     /// Pass `Some(index)` to select a tab (clamped to valid range), or
     /// `None` to clear the selection.
     ///
+    /// Renamed from `set_selected()` in v0.18.0 for symmetry with
+    /// `selected_index()`. See MIGRATION.md.
+    ///
     /// # Example
     ///
     /// ```rust
     /// use envision::component::TabsState;
     ///
     /// let mut state = TabsState::new(vec!["A", "B", "C"]);
-    /// state.set_selected(Some(2));
+    /// state.set_selected_index(Some(2));
     /// assert_eq!(state.selected_index(), Some(2));
     /// ```
-    pub fn set_selected(&mut self, index: Option<usize>) {
+    pub fn set_selected_index(&mut self, index: Option<usize>) {
         match index {
             Some(i) => {
                 if self.tabs.is_empty() {

--- a/src/component/tabs/tests.rs
+++ b/src/component/tabs/tests.rs
@@ -68,11 +68,11 @@ fn test_selected_empty() {
 #[test]
 fn test_set_selected() {
     let mut state = TabsState::new(vec!["A", "B", "C"]);
-    state.set_selected(Some(2));
+    state.set_selected_index(Some(2));
     assert_eq!(state.selected_index(), Some(2));
 
     // Test clamping
-    state.set_selected(Some(100));
+    state.set_selected_index(Some(100));
     assert_eq!(state.selected_index(), Some(2));
 }
 
@@ -589,7 +589,7 @@ fn test_set_tabs_updates_tabs() {
 #[test]
 fn test_set_tabs_preserves_valid_selection() {
     let mut state = TabsState::new(vec!["A", "B", "C"]);
-    state.set_selected(Some(1));
+    state.set_selected_index(Some(1));
     state.set_tabs(vec!["X", "Y", "Z"]);
     assert_eq!(state.selected_index(), Some(1));
 }

--- a/src/component/tabs/tests.rs
+++ b/src/component/tabs/tests.rs
@@ -66,7 +66,7 @@ fn test_selected_empty() {
 }
 
 #[test]
-fn test_set_selected() {
+fn test_set_selected_index() {
     let mut state = TabsState::new(vec!["A", "B", "C"]);
     state.set_selected_index(Some(2));
     assert_eq!(state.selected_index(), Some(2));

--- a/src/component/tree/mod.rs
+++ b/src/component/tree/mod.rs
@@ -515,24 +515,13 @@ impl<T: Clone> TreeState<T> {
         self.selected_index
     }
 
-    /// Alias for [`selected_index()`](Self::selected_index).
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use envision::component::{TreeState, TreeNode};
-    ///
-    /// let state = TreeState::new(vec![TreeNode::new("Root", ())]);
-    /// assert_eq!(state.selected(), Some(0));
-    /// ```
-    pub fn selected(&self) -> Option<usize> {
-        self.selected_index()
-    }
-
     /// Sets the selected index in the flattened view.
     ///
     /// The index is clamped to the valid range of visible nodes.
     /// Has no effect on empty trees.
+    ///
+    /// Renamed from `set_selected()` in v0.18.0 for symmetry with
+    /// `selected_index()`. See MIGRATION.md.
     ///
     /// # Example
     ///
@@ -544,10 +533,10 @@ impl<T: Clone> TreeState<T> {
     /// root.add_child(TreeNode::new("Child 2", ()));
     ///
     /// let mut state = TreeState::new(vec![root]);
-    /// state.set_selected(Some(2));
+    /// state.set_selected_index(Some(2));
     /// assert_eq!(state.selected_index(), Some(2));
     /// ```
-    pub fn set_selected(&mut self, index: Option<usize>) {
+    pub fn set_selected_index(&mut self, index: Option<usize>) {
         match index {
             Some(i) => {
                 if self.roots.is_empty() {

--- a/src/component/tree/snapshot_tests.rs
+++ b/src/component/tree/snapshot_tests.rs
@@ -66,7 +66,7 @@ fn test_snapshot_focused_selected() {
     root.add_child(TreeNode::new("Child 2", ()));
     root.add_child(TreeNode::new("Child 3", ()));
     let mut state = TreeState::new(vec![root]);
-    state.set_selected(Some(2));
+    state.set_selected_index(Some(2));
     let (mut terminal, theme) = test_utils::setup_render(40, 10);
     terminal
         .draw(|frame| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,7 +475,9 @@ pub mod prelude {
 
     // Testing essentials
     pub use crate::backend::{CaptureBackend, EnhancedCell};
-    pub use crate::harness::{AppHarness, MessageSender, TestHarness};
+    pub use crate::harness::{
+        AppHarness, Assertion, MessageSendError, MessageSender, Snapshot, TestHarness, TrySendError,
+    };
 
     // Layout and style re-exports (replacing `pub use ratatui::prelude::*`)
     pub use crate::layout::{

--- a/tests/integration_stress.rs
+++ b/tests/integration_stress.rs
@@ -424,7 +424,7 @@ fn test_diagram_stress_500_nodes_navigation() {
             Diagram::update(&mut state, msg);
         }
     }
-    assert!(state.selected().is_some());
+    assert!(state.selected_index().is_some());
 }
 
 #[test]
@@ -438,7 +438,7 @@ fn test_diagram_stress_edge_following() {
     if let Some(msg) = Diagram::handle_event(&state, &tab, &ctx) {
         Diagram::update(&mut state, msg);
     }
-    assert_eq!(state.selected(), Some(0));
+    assert_eq!(state.selected_index(), Some(0));
 
     // Follow edges 50 times
     for _ in 0..50 {
@@ -447,7 +447,7 @@ fn test_diagram_stress_edge_following() {
         }
     }
     // Should have followed the chain without panicking
-    assert!(state.selected().is_some());
+    assert!(state.selected_index().is_some());
 }
 
 #[test]
@@ -467,7 +467,7 @@ fn test_diagram_stress_search() {
     Diagram::update(&mut state, DiagramMessage::SearchNext);
     Diagram::update(&mut state, DiagramMessage::ConfirmSearch);
     assert!(!state.is_searching());
-    assert!(state.selected().is_some());
+    assert!(state.selected_index().is_some());
 }
 
 #[test]
@@ -485,7 +485,7 @@ fn test_diagram_full_lifecycle() {
 
     // Navigate
     Diagram::update(&mut state, DiagramMessage::SelectNext);
-    assert_eq!(state.selected(), Some(0));
+    assert_eq!(state.selected_index(), Some(0));
     assert_eq!(state.selected_node().unwrap().id(), "api");
 
     // Follow edge


### PR DESCRIPTION
Completes the selection-accessor unification that Cadence A began. Implements the spec in #514 and the plan in #515.

## What changed

Every component whose selection accessor was spelled `selected` now spells it `selected_index`, and every corresponding mutator is `set_selected_index`.

The motivation is that `selected` was ambiguous about return type — four different signatures shared the spelling:

| Signature | Where |
|---|---|
| `Option<usize>` | 15 components |
| `Option<(usize, usize)>` | `heatmap` |
| bare `usize` | `box_plot` |
| `bool` builder | `annotation::widget` |

The `selected_index` / `selected_item` / `value_at_selection` system makes the name predict the type.

## Commits

- **Unit 1** — deletes 12 `selected()` aliases whose body was exactly `self.selected_index()`; renames 10 setters.
- **Unit 2** — renames 4 primary accessors (`alert_panel`, `diagram`, `multi_progress`, `box_plot`) that had no `selected_index()` sibling; renames 2 more setters.
- **Unit 3** — prelude gains the four missing harness types; CHANGELOG `[Unreleased]`; MIGRATION § v0.17.x to v0.18.0.

Setters were renamed in the same commit as their getter. This is deliberate: during Cadence A, deleting a getter without its setter orphaned `tab_bar::set_selected` and dropped the audit scorecard from 9/9 to 8/9.

## Deliberately unchanged

`heatmap::selected()` returns `Option<(usize, usize)>` coordinates, not an index. It was disentangled from this pattern during Cadence A and MIGRATION explicitly warns users off migrating it.

`box_plot::selected_index()` keeps its bare `usize`, matching `flame_graph::selected_index()`. Whether it should become `Option<usize>` is a semantic question, deferred and recorded.

Six domain-named accessors (`chart::active_series`, `paginator::current_page`, and four others) were surveyed and excluded — each name carries domain meaning a generic rename would erase.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --check` | clean |
| clippy `--all-features --all-targets -D warnings` | 0 warnings |
| nextest | 7464/7464 |
| doc tests | 2579/2579 |
| `--no-default-features` build | pass |
| `cargo doc --no-deps --all-features` | 0 warnings |
| audit scorecard | **9/9**, accessor symmetry gaps 0 |

Payoff gates: `.set_selected(` is gone tree-wide; `pub fn selected(` in `src/` is down to the two intentional survivors.

Each unit was reviewed by an independent subagent before the next began. The Unit 3 reviewer verified all 28 MIGRATION rows against shipped code and confirmed `[0.17.0]` is byte-identical — it is released and tagged, so the new Known Deferred Findings block supersedes the old one by explicit pointer rather than rewriting it. That review also caught a false claim of "all seven harness types" (the `harness` module exports eleven), fixed before push.

## Breaking

Yes — v0.18.0. All renames, so `cargo build` locates every call site and the compiler error names the receiver type, which disambiguates `heatmap` from the rest.
